### PR TITLE
fix(contentful-apps): Allow changing parents if the page is not mentioned

### DIFF
--- a/apps/contentful-apps/pages/fields/organization-parent-subpage-pages-field.tsx
+++ b/apps/contentful-apps/pages/fields/organization-parent-subpage-pages-field.tsx
@@ -80,7 +80,7 @@ const OrganizationParentSubpagePagesField = () => {
                 ?.sys?.id
 
             if (parentId) {
-              const parentExists = await cma.entry
+              const parentEntry = await cma.entry
                 .get({
                   entryId: parentId,
                 })
@@ -91,7 +91,12 @@ const OrganizationParentSubpagePagesField = () => {
                   }
                 })
 
-              if (parentExists) {
+              if (
+                parentEntry &&
+                parentEntry.fields?.pages?.[DEFAULT_LOCALE]?.some(
+                  (page) => page.sys.id === entries[0]?.sys.id,
+                )
+              ) {
                 sdk.notifier.warning(
                   'Subpage could not be linked since it is already linked to a parent page',
                 )


### PR DESCRIPTION
# Allow changing parents if the page is not mentioned

TODO: test this

When a page is duplicated it'll have a parent subpage set

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation when linking pages to prevent duplicate associations. The system now performs robust verification to detect already-linked pages and displays appropriate warnings to prevent invalid linking states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->