### PR TITLE
fix(application-system): prevent duplicate submission on concurrent state transitions

### DIFF
--- a/apps/api/project.json
+++ b/apps/api/project.json
@@ -16,6 +16,7 @@
         "showCircularDependencies": false,
         "generatePackageJson": true,
         "esbuildConfig": "tools/esbuild.config.js",
+        "external": ["jsdom"],
         "format": ["cjs"]
       },
       "configurations": {

--- a/apps/application-system/api/src/app/modules/application/application-action.service.spec.ts
+++ b/apps/application-system/api/src/app/modules/application/application-action.service.spec.ts
@@ -14,6 +14,7 @@ import {
   TemplateApi,
   defineTemplateApi,
 } from '@island.is/application/types'
+import type { User } from '@island.is/auth-nest-tools'
 
 describe('ApplicationActionService', () => {
   const application = createApplication()
@@ -48,6 +49,15 @@ describe('ApplicationActionService', () => {
       updateApplicationState: jest
         .fn()
         .mockResolvedValue({ updatedApplication: {} }),
+      withApplicationLock: jest.fn(
+        (
+          _id: string,
+          callback: (
+            lockedApplication: unknown,
+            transaction: unknown,
+          ) => unknown,
+        ) => callback({ ...application, toJSON: () => application }, {}),
+      ),
     }
 
     mockHistoryService = {
@@ -113,6 +123,7 @@ describe('ApplicationActionService', () => {
         expect.anything(),
         expect.anything(),
         expect.anything(),
+        undefined,
       )
     })
 
@@ -134,6 +145,7 @@ describe('ApplicationActionService', () => {
         expect.anything(),
         expect.anything(),
         expect.anything(),
+        undefined,
       )
     })
 
@@ -155,6 +167,7 @@ describe('ApplicationActionService', () => {
         expect.anything(),
         expect.anything(),
         expect.anything(),
+        undefined,
       )
     })
 
@@ -191,6 +204,18 @@ describe('ApplicationActionService', () => {
   })
 
   describe('changeState', () => {
+    beforeEach(() => {
+      mockApplicationService.withApplicationLock.mockImplementation(
+        (
+          _id: string,
+          callback: (
+            lockedApplication: unknown,
+            transaction: unknown,
+          ) => unknown,
+        ) => callback({ ...application, toJSON: () => application }, {}),
+      )
+    })
+
     it('should return error if application update fails', async () => {
       mockApplicationService.updateApplicationState.mockRejectedValueOnce(
         new Error('Update failed'),
@@ -210,6 +235,51 @@ describe('ApplicationActionService', () => {
         application: result.application,
         error: 'Could not update application',
       })
+    })
+
+    it('should not run transition actions when locked application is already in another state', async () => {
+      const staleApplication = {
+        ...createApplication(),
+        id: 'application-id',
+        state: 'payment',
+      }
+      const lockedApplication = {
+        ...staleApplication,
+        state: 'done',
+      }
+
+      mockApplicationService.withApplicationLock.mockImplementationOnce(
+        (
+          _id: string,
+          callback: (
+            lockedApplication: unknown,
+            transaction: unknown,
+          ) => unknown,
+        ) =>
+          callback(
+            { ...lockedApplication, toJSON: () => lockedApplication },
+            {},
+          ),
+      )
+
+      const result = await service.changeState(
+        staleApplication,
+        createApplicationTemplate(),
+        'SUBMIT',
+        {} as User,
+        'en',
+      )
+
+      expect(result).toEqual({
+        hasChanged: false,
+        hasError: false,
+        application: lockedApplication,
+      })
+      expect(mockApplicationService.clearNonces).not.toHaveBeenCalled()
+      expect(mockTemplateApiActionRunner.run).not.toHaveBeenCalled()
+      expect(
+        mockApplicationService.updateApplicationState,
+      ).not.toHaveBeenCalled()
     })
   })
 })

--- a/apps/application-system/api/src/app/modules/application/application-action.service.spec.ts
+++ b/apps/application-system/api/src/app/modules/application/application-action.service.spec.ts
@@ -284,7 +284,9 @@ describe('ApplicationActionService', () => {
         },
       )
 
-      expect(mockApplicationService.updateApplicationState).toHaveBeenCalledWith(
+      expect(
+        mockApplicationService.updateApplicationState,
+      ).toHaveBeenCalledWith(
         'application-id',
         expect.any(String),
         {

--- a/apps/application-system/api/src/app/modules/application/application-action.service.spec.ts
+++ b/apps/application-system/api/src/app/modules/application/application-action.service.spec.ts
@@ -49,6 +49,8 @@ describe('ApplicationActionService', () => {
       updateApplicationState: jest
         .fn()
         .mockResolvedValue({ updatedApplication: {} }),
+      cancelScheduledNotifications: jest.fn().mockResolvedValue({}),
+      createScheduledNotifications: jest.fn().mockResolvedValue({}),
       withApplicationLock: jest.fn(
         (
           _id: string,
@@ -237,6 +239,65 @@ describe('ApplicationActionService', () => {
       })
     })
 
+    it('should merge transition updates into the locked application', async () => {
+      const staleApplication = {
+        ...createApplication(),
+        id: 'application-id',
+        answers: {
+          stale: 'answer',
+        },
+        assignees: ['stale-assignee'],
+      }
+      const lockedApplication = {
+        ...staleApplication,
+        answers: {
+          locked: 'answer',
+        },
+        assignees: ['locked-assignee'],
+      }
+
+      mockApplicationService.withApplicationLock.mockImplementationOnce(
+        (
+          _id: string,
+          callback: (
+            lockedApplication: unknown,
+            transaction: unknown,
+          ) => unknown,
+        ) =>
+          callback(
+            { ...lockedApplication, toJSON: () => lockedApplication },
+            {},
+          ),
+      )
+
+      await service.changeState(
+        staleApplication,
+        createApplicationTemplate(),
+        'SUBMIT',
+        {} as User,
+        'en',
+        {
+          answers: {
+            submitted: 'answer',
+          },
+          assignees: ['submitted-assignee'],
+        },
+      )
+
+      expect(mockApplicationService.updateApplicationState).toHaveBeenCalledWith(
+        'application-id',
+        expect.any(String),
+        {
+          locked: 'answer',
+          submitted: 'answer',
+        },
+        ['locked-assignee', 'submitted-assignee'],
+        expect.anything(),
+        expect.anything(),
+        {},
+      )
+    })
+
     it('should not run transition actions when locked application is already in another state', async () => {
       const staleApplication = {
         ...createApplication(),
@@ -280,6 +341,7 @@ describe('ApplicationActionService', () => {
       expect(
         mockApplicationService.updateApplicationState,
       ).not.toHaveBeenCalled()
+      expect(mockHistoryService.saveStateTransition).not.toHaveBeenCalled()
     })
   })
 })

--- a/apps/application-system/api/src/app/modules/application/application-action.service.ts
+++ b/apps/application-system/api/src/app/modules/application/application-action.service.ts
@@ -10,7 +10,10 @@ import {
 } from '@island.is/application/template-loader'
 import { User } from '@island.is/auth-nest-tools'
 import { Inject } from '@nestjs/common'
-import { ApplicationTemplateHelper } from '@island.is/application/core'
+import {
+  ApplicationTemplateHelper,
+  mergeAnswers,
+} from '@island.is/application/core'
 import {
   ApplicationWithAttachments as BaseApplication,
   TemplateApi,
@@ -24,6 +27,18 @@ import { StateChangeResult, TemplateAPIModuleActionResult } from './types'
 import type { Logger } from '@island.is/logging'
 import { LOGGER_PROVIDER } from '@island.is/logging'
 import { Transaction } from 'sequelize'
+
+type StateChangeApplicationUpdates = Partial<
+  Pick<BaseApplication, 'answers' | 'assignees' | 'attachments'>
+>
+
+type StateChangeApplicationUpdateResolver = (
+  application: BaseApplication,
+  transaction: Transaction,
+) =>
+  | StateChangeApplicationUpdates
+  | Promise<StateChangeApplicationUpdates | undefined>
+  | undefined
 
 @Injectable()
 export class ApplicationActionService {
@@ -113,6 +128,9 @@ export class ApplicationActionService {
     event: string,
     auth: User,
     locale: Locale,
+    applicationUpdates?:
+      | StateChangeApplicationUpdates
+      | StateChangeApplicationUpdateResolver,
   ): Promise<StateChangeResult> {
     return this.applicationService.withApplicationLock(
       application.id,
@@ -132,13 +150,16 @@ export class ApplicationActionService {
           }
         }
 
+        const resolvedApplicationUpdates =
+          typeof applicationUpdates === 'function'
+            ? await applicationUpdates(currentApplication, transaction)
+            : applicationUpdates
+
         return this.changeLockedApplicationState(
-          {
-            ...currentApplication,
-            answers: application.answers,
-            assignees: application.assignees,
-            attachments: application.attachments,
-          },
+          this.mergeApplicationUpdates(
+            currentApplication,
+            resolvedApplicationUpdates,
+          ),
           template,
           event,
           auth,
@@ -147,6 +168,39 @@ export class ApplicationActionService {
         )
       },
     )
+  }
+
+  private mergeApplicationUpdates(
+    application: BaseApplication,
+    applicationUpdates?: StateChangeApplicationUpdates,
+  ): BaseApplication {
+    if (!applicationUpdates) {
+      return application
+    }
+
+    return {
+      ...application,
+      answers:
+        applicationUpdates.answers !== undefined
+          ? mergeAnswers(application.answers, applicationUpdates.answers)
+          : application.answers,
+      assignees:
+        applicationUpdates.assignees !== undefined
+          ? Array.from(
+              new Set([
+                ...application.assignees,
+                ...applicationUpdates.assignees,
+              ]),
+            )
+          : application.assignees,
+      attachments:
+        applicationUpdates.attachments !== undefined
+          ? {
+              ...application.attachments,
+              ...applicationUpdates.attachments,
+            }
+          : application.attachments,
+    }
   }
 
   private async changeLockedApplicationState(
@@ -258,8 +312,7 @@ export class ApplicationActionService {
 
       updatedApplication = update.updatedApplication as BaseApplication
 
-      // Wait for both promises in parallel, no fail fast
-      await Promise.allSettled([
+      await Promise.all([
         this.historyService.saveStateTransition(
           application.id,
           newState,

--- a/apps/application-system/api/src/app/modules/application/application-action.service.ts
+++ b/apps/application-system/api/src/app/modules/application/application-action.service.ts
@@ -117,8 +117,7 @@ export class ApplicationActionService {
     return this.applicationService.withApplicationLock(
       application.id,
       async (lockedApplication, transaction) => {
-        const currentApplication =
-          lockedApplication.toJSON() as BaseApplication
+        const currentApplication = lockedApplication.toJSON() as BaseApplication
 
         if (currentApplication.state !== application.state) {
           this.logger.info(

--- a/apps/application-system/api/src/app/modules/application/application-action.service.ts
+++ b/apps/application-system/api/src/app/modules/application/application-action.service.ts
@@ -23,6 +23,7 @@ import {
 import { StateChangeResult, TemplateAPIModuleActionResult } from './types'
 import type { Logger } from '@island.is/logging'
 import { LOGGER_PROVIDER } from '@island.is/logging'
+import { Transaction } from 'sequelize'
 
 @Injectable()
 export class ApplicationActionService {
@@ -41,6 +42,7 @@ export class ApplicationActionService {
     apis: TemplateApi | TemplateApi[],
     locale: Locale,
     event: string,
+    transaction?: Transaction,
   ): Promise<TemplateAPIModuleActionResult> {
     if (!Array.isArray(apis)) {
       apis = [apis]
@@ -73,6 +75,7 @@ export class ApplicationActionService {
       auth,
       locale,
       intl.formatMessage,
+      transaction,
     )
 
     for (const api of apis) {
@@ -111,10 +114,56 @@ export class ApplicationActionService {
     auth: User,
     locale: Locale,
   ): Promise<StateChangeResult> {
+    return this.applicationService.withApplicationLock(
+      application.id,
+      async (lockedApplication, transaction) => {
+        const currentApplication =
+          lockedApplication.toJSON() as BaseApplication
+
+        if (currentApplication.state !== application.state) {
+          this.logger.info(
+            `Application ${application.id} state changed from ${application.state} to ${currentApplication.state} before ${event} could be processed`,
+          )
+
+          return {
+            hasChanged: false,
+            hasError: false,
+            application: currentApplication,
+          }
+        }
+
+        return this.changeLockedApplicationState(
+          {
+            ...currentApplication,
+            answers: application.answers,
+            assignees: application.assignees,
+            attachments: application.attachments,
+          },
+          template,
+          event,
+          auth,
+          locale,
+          transaction,
+        )
+      },
+    )
+  }
+
+  private async changeLockedApplicationState(
+    application: BaseApplication,
+    template: Unwrap<typeof getApplicationTemplateByTypeId>,
+    event: string,
+    auth: User,
+    locale: Locale,
+    transaction: Transaction,
+  ): Promise<StateChangeResult> {
     const helper = new ApplicationTemplateHelper(application, template)
     const onExitStateAction = helper.getOnExitStateAPIAction(application.state)
     let updatedApplication: BaseApplication = application
-    await this.applicationService.clearNonces(updatedApplication.id)
+    await this.applicationService.clearNonces(
+      updatedApplication.id,
+      transaction,
+    )
     if (onExitStateAction) {
       const {
         hasError,
@@ -127,6 +176,7 @@ export class ApplicationActionService {
         onExitStateAction,
         locale,
         event,
+        transaction,
       )
       updatedApplication = withUpdatedExternalData
 
@@ -176,6 +226,7 @@ export class ApplicationActionService {
         onEnterStateAction,
         locale,
         event,
+        transaction,
       )
       updatedApplication = withUpdatedExternalData
 
@@ -202,6 +253,7 @@ export class ApplicationActionService {
         updatedApplication.assignees,
         status,
         getApplicationLifecycle(updatedApplication, template),
+        transaction,
       )
 
       updatedApplication = update.updatedApplication as BaseApplication
@@ -213,6 +265,7 @@ export class ApplicationActionService {
           newState,
           auth,
           event,
+          transaction,
         ),
         handleScheduledNotifications(
           // Clean up old and create new scheduled notifications
@@ -220,6 +273,7 @@ export class ApplicationActionService {
           updatedApplication,
           template,
           newState,
+          transaction,
         ),
       ])
     } catch (e) {

--- a/apps/application-system/api/src/app/modules/application/application.controller.ts
+++ b/apps/application-system/api/src/app/modules/application/application.controller.ts
@@ -557,22 +557,18 @@ export class ApplicationController {
 
     const assignees = [user.nationalId]
 
-    const mergedApplication: BaseApplication = {
-      ...(existingApplication.toJSON() as BaseApplication),
-      assignees,
-    }
-
     const {
       hasChanged,
       hasError,
       error,
       application: updatedApplication,
     } = await this.applicationActionService.changeState(
-      mergedApplication,
+      existingApplication.toJSON() as BaseApplication,
       template,
       DefaultEvents.ASSIGN,
       user,
       locale,
+      { assignees },
     )
 
     if (hasError) {
@@ -786,32 +782,7 @@ export class ApplicationController {
         existingApplication as BaseApplication,
       )
       const intl = await this.intlService.useIntl(namespaces, locale)
-
-      const permittedAnswers =
-        await this.validationService.validateIncomingAnswers(
-          existingApplication as BaseApplication,
-          newAnswers,
-          user.nationalId,
-          false,
-          intl.formatMessage,
-        )
-
-      await this.validationService.validateApplicationSchema(
-        existingApplication as BaseApplication,
-        permittedAnswers,
-        intl.formatMessage,
-        user,
-      )
-
-      const mergedAnswers = mergeAnswers(
-        existingApplication.answers,
-        permittedAnswers,
-      )
-
-      const mergedApplication: BaseApplication = {
-        ...(existingApplication.toJSON() as BaseApplication),
-        answers: mergedAnswers,
-      }
+      let permittedAnswerFields = Object.keys(newAnswers)
 
       const {
         hasChanged,
@@ -819,11 +790,32 @@ export class ApplicationController {
         error,
         application: updatedApplication,
       } = await this.applicationActionService.changeState(
-        mergedApplication,
+        existingApplication.toJSON() as BaseApplication,
         template,
         updateApplicationStateDto.event,
         user,
         locale,
+        async (currentApplication) => {
+          const permittedAnswers =
+            await this.validationService.validateIncomingAnswers(
+              currentApplication,
+              newAnswers,
+              user.nationalId,
+              false,
+              intl.formatMessage,
+            )
+
+          await this.validationService.validateApplicationSchema(
+            currentApplication,
+            permittedAnswers,
+            intl.formatMessage,
+            user,
+          )
+
+          permittedAnswerFields = Object.keys(permittedAnswers)
+
+          return { answers: permittedAnswers }
+        },
       )
 
       this.auditService.audit({
@@ -834,7 +826,7 @@ export class ApplicationController {
           event: updateApplicationStateDto.event,
           before: existingApplication.state,
           after: updatedApplication.state,
-          fields: Object.keys(permittedAnswers),
+          fields: permittedAnswerFields,
         },
       })
 

--- a/apps/application-system/api/src/app/modules/application/application.controller.ts
+++ b/apps/application-system/api/src/app/modules/application/application.controller.ts
@@ -849,7 +849,7 @@ export class ApplicationController {
         return updatedApplication
       }
 
-      return existingApplication
+      return updatedApplication
     })
   }
 

--- a/apps/application-system/api/src/app/modules/application/tools/templateApiActionRunner.service.spec.ts
+++ b/apps/application-system/api/src/app/modules/application/tools/templateApiActionRunner.service.spec.ts
@@ -224,7 +224,12 @@ describe('TemplateApi Action runner', () => {
 
     expect(result).toEqual(application)
     expect(result.externalData).toHaveProperty('testAction')
-    expect(applicationServiceSpy).toHaveBeenCalledWith(application.id, {}, {})
+    expect(applicationServiceSpy).toHaveBeenCalledWith(
+      application.id,
+      {},
+      {},
+      undefined,
+    )
   })
 
   it('should run actions in correct order', async () => {

--- a/apps/application-system/api/src/app/modules/application/tools/templateApiActionRunner.service.ts
+++ b/apps/application-system/api/src/app/modules/application/tools/templateApiActionRunner.service.ts
@@ -15,6 +15,7 @@ import {
   isTranslationObject,
 } from '@island.is/application/core'
 import type { Locale } from '@island.is/shared/types'
+import { Transaction } from 'sequelize'
 
 @Injectable()
 export class TemplateApiActionRunner {
@@ -42,6 +43,7 @@ export class TemplateApiActionRunner {
     auth: User,
     currentUserLocale: Locale,
     formatMessage: FormatMessage,
+    transaction?: Transaction,
   ): Promise<ApplicationWithAttachments> {
     const oldExternalData = application.externalData
 
@@ -64,6 +66,7 @@ export class TemplateApiActionRunner {
       application.id,
       oldExternalData,
       newExternalData,
+      transaction,
     )
     return application
   }
@@ -238,6 +241,7 @@ export class TemplateApiActionRunner {
     applicationId: string,
     oldExternalData: ExternalData,
     newExternalData: { data: ExternalData },
+    transaction?: Transaction,
   ): Promise<void> {
     api.map((api) => {
       if (api.shouldPersistToExternalData === false) {
@@ -249,6 +253,7 @@ export class TemplateApiActionRunner {
       applicationId,
       oldExternalData,
       newExternalData.data,
+      transaction,
     )
   }
 }

--- a/apps/application-system/api/src/app/modules/application/utils/application.ts
+++ b/apps/application-system/api/src/app/modules/application/utils/application.ts
@@ -26,6 +26,7 @@ import { expandFieldKeys } from '../lifecycle/application-lifecycle.utils'
 import { IdentityClientService } from '@island.is/clients/identity'
 import { ApplicationTemplateHelper } from '@island.is/application/core'
 import { ApplicationService } from '@island.is/application/api/core'
+import { Transaction } from 'sequelize'
 
 export const getApplicationLifecycle = (
   application: Application,
@@ -364,9 +365,13 @@ export const handleScheduledNotifications = async (
   application: ApplicationWithAttachments,
   template: Unwrap<typeof getApplicationTemplateByTypeId>,
   newState: string,
+  transaction?: Transaction,
 ) => {
   // 1. Clean up any existing scheduled notifications
-  await applicationService.cancelScheduledNotifications(application.id)
+  await applicationService.cancelScheduledNotifications(
+    application.id,
+    transaction,
+  )
 
   // 2. Fetch the metadata for the incoming state
   const newStateMeta = new ApplicationTemplateHelper(
@@ -442,6 +447,7 @@ export const handleScheduledNotifications = async (
       application.id,
       newState,
       notificationsToSchedule,
+      transaction,
     )
   }
 }

--- a/libs/application/api/core/src/lib/application/application.service.ts
+++ b/libs/application/api/core/src/lib/application/application.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, NotFoundException } from '@nestjs/common'
 import { InjectModel } from '@nestjs/sequelize'
-import { Op, QueryTypes, WhereOptions } from 'sequelize'
+import { Op, QueryTypes, Transaction, WhereOptions } from 'sequelize'
 import { Sequelize } from 'sequelize-typescript'
 import {
   ApplicationLifecycle,
@@ -67,6 +67,30 @@ export class ApplicationService {
   ): Promise<Application | null> {
     return this.applicationModel.findOne({
       where: applicationByNationalId(id, nationalId),
+    })
+  }
+
+  async withApplicationLock<T>(
+    id: string,
+    callback: (
+      application: Application,
+      transaction: Transaction,
+    ) => Promise<T>,
+  ): Promise<T> {
+    return this.sequelize.transaction(async (transaction) => {
+      const application = await this.applicationModel.findOne({
+        where: { id },
+        transaction,
+        lock: transaction.LOCK.UPDATE,
+      })
+
+      if (!application) {
+        throw new NotFoundException(
+          `An application with the id ${id} does not exist`,
+        )
+      }
+
+      return callback(application, transaction)
     })
   }
 
@@ -530,13 +554,13 @@ export class ApplicationService {
     return { numberOfAffectedRows, updatedApplication }
   }
 
-  async clearNonces(id: string) {
+  async clearNonces(id: string, transaction?: Transaction) {
     const [numberOfAffectedRows, [updatedApplication]] =
       await this.applicationModel.update(
         {
           assignNonces: [],
         },
-        { where: { id: id }, returning: true },
+        { where: { id: id }, returning: true, transaction },
       )
     return { numberOfAffectedRows, updatedApplication }
   }
@@ -552,7 +576,10 @@ export class ApplicationService {
     return { numberOfAffectedRows, updatedApplication }
   }
 
-  async cancelScheduledNotifications(applicationId: string) {
+  async cancelScheduledNotifications(
+    applicationId: string,
+    transaction?: Transaction,
+  ) {
     return this.scheduledNotificationModel.update(
       { schedule_status: NotificationStatus.CANCELED },
       {
@@ -560,6 +587,7 @@ export class ApplicationService {
           application_id: applicationId,
           schedule_status: NotificationStatus.PENDING,
         },
+        transaction,
       },
     )
   }
@@ -603,6 +631,7 @@ export class ApplicationService {
       schedule_time: Date
       args?: Record<string, unknown>
     }[],
+    transaction?: Transaction,
   ) {
     if (!notifications.length) return
     const records = notifications.map((n) => ({
@@ -612,7 +641,7 @@ export class ApplicationService {
       schedule_time: n.schedule_time,
       args: n.args,
     }))
-    return this.scheduledNotificationModel.bulkCreate(records)
+    return this.scheduledNotificationModel.bulkCreate(records, { transaction })
   }
 
   async updateApplicationState(
@@ -622,6 +651,7 @@ export class ApplicationService {
     assignees: string[],
     status: ApplicationStatus,
     lifecycle: ApplicationLifecycle,
+    transaction?: Transaction,
   ) {
     const [numberOfAffectedRows, [updatedApplication]] =
       await this.applicationModel.update(
@@ -629,6 +659,7 @@ export class ApplicationService {
         {
           where: { id },
           returning: true,
+          transaction,
         },
       )
 
@@ -639,13 +670,14 @@ export class ApplicationService {
     id: string,
     oldExternalData: ExternalData,
     externalData: ExternalData,
+    transaction?: Transaction,
   ) {
     const [numberOfAffectedRows, [updatedApplication]] =
       await this.applicationModel.update(
         {
           externalData: { ...oldExternalData, ...externalData },
         },
-        { where: { id }, returning: true },
+        { where: { id }, returning: true, transaction },
       )
 
     return { numberOfAffectedRows, updatedApplication }

--- a/libs/application/api/history/src/lib/history.service.ts
+++ b/libs/application/api/history/src/lib/history.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common'
 import { InjectModel } from '@nestjs/sequelize'
+import { Transaction } from 'sequelize'
 import { History } from './history.model'
 import type { User } from '@island.is/auth-nest-tools'
 
@@ -10,11 +11,15 @@ export class HistoryService {
     private historyModel: typeof History,
   ) {}
 
-  async getStateHistory(applicationIds: string[]): Promise<History[]> {
+  async getStateHistory(
+    applicationIds: string[],
+    transaction?: Transaction,
+  ): Promise<History[]> {
     return this.historyModel.findAll({
       where: {
         application_id: applicationIds,
       },
+      transaction,
     })
   }
 
@@ -23,15 +28,16 @@ export class HistoryService {
     newStateKey: string,
     auth: User,
     exitEvent?: string,
+    transaction?: Transaction,
   ): Promise<History> {
     //Do we have a current state to move from. Look for a state that has not been exited.
-    const lastState = (await this.getStateHistory([applicationId])).find(
-      (x) => x.exitTimestamp === null,
-    )
+    const lastState = (
+      await this.getStateHistory([applicationId], transaction)
+    ).find((x) => x.exitTimestamp === null)
 
     if (lastState) {
       //update with a new exit timestamp.
-      this.historyModel.update(
+      await this.historyModel.update(
         {
           ...lastState,
           exitTimestamp: new Date(),
@@ -41,16 +47,19 @@ export class HistoryService {
             ? auth.actor.nationalId
             : auth.nationalId,
         },
-        { where: { id: lastState.id } },
+        { where: { id: lastState.id }, transaction },
       )
     }
 
-    return this.historyModel.create({
-      application_id: applicationId,
-      stateKey: newStateKey,
-      entryTimestamp: new Date(),
-      previousState: lastState ? lastState.id : null,
-    })
+    return this.historyModel.create(
+      {
+        application_id: applicationId,
+        stateKey: newStateKey,
+        entryTimestamp: new Date(),
+        previousState: lastState ? lastState.id : null,
+      },
+      { transaction },
+    )
   }
 
   async postPruneHistoryByApplicationId(applicationId: string): Promise<void> {

--- a/libs/application/ui-components/src/components/PaymentPending/PaymentPending.tsx
+++ b/libs/application/ui-components/src/components/PaymentPending/PaymentPending.tsx
@@ -80,7 +80,10 @@ const reserveSubmission = (key: string, force = false): boolean => {
   }
 
   try {
-    if (!force && isActiveSubmissionReservation(getSubmissionReservation(key))) {
+    if (
+      !force &&
+      isActiveSubmissionReservation(getSubmissionReservation(key))
+    ) {
       return false
     }
 

--- a/libs/application/ui-components/src/components/PaymentPending/PaymentPending.tsx
+++ b/libs/application/ui-components/src/components/PaymentPending/PaymentPending.tsx
@@ -17,6 +17,48 @@ import { useSubmitApplication, usePaymentStatus, useMsg } from './hooks'
 import { getRedirectStatus, isComingFromRedirect } from './util'
 import { useSearchParams } from 'react-router-dom'
 
+const SUBMISSION_RESERVATION_TTL = 15 * 60 * 1000
+
+const getSubmissionReservationKey = (
+  applicationId: string,
+  event: DefaultEvents,
+) => `application-payment-pending-submit:${applicationId}:${event}`
+
+const reserveSubmission = (key: string): boolean => {
+  if (typeof window === 'undefined') {
+    return true
+  }
+
+  try {
+    const reservedAt = Number(window.localStorage.getItem(key))
+
+    if (
+      reservedAt &&
+      Number.isFinite(reservedAt) &&
+      Date.now() - reservedAt < SUBMISSION_RESERVATION_TTL
+    ) {
+      return false
+    }
+
+    window.localStorage.setItem(key, String(Date.now()))
+    return true
+  } catch {
+    return true
+  }
+}
+
+const clearSubmissionReservation = (key: string) => {
+  if (typeof window === 'undefined') {
+    return
+  }
+
+  try {
+    window.localStorage.removeItem(key)
+  } catch {
+    // Ignore browsers that disallow storage access.
+  }
+}
+
 export interface PaymentPendingProps {
   application: Application
   targetEvent: DefaultEvents
@@ -30,7 +72,7 @@ export const PaymentPending: FC<
   const { paymentStatus, stopPolling, pollingError } = usePaymentStatus(
     application.id,
   )
-  const [searchParams, setSearchParams] = useSearchParams()
+  const [, setSearchParams] = useSearchParams()
   const isInvoice = getRedirectStatus() === 'invoice'
 
   const shouldRedirect = !isComingFromRedirect() && paymentStatus.paymentUrl
@@ -41,12 +83,11 @@ export const PaymentPending: FC<
     event: targetEvent,
   })
 
-  const [submitCancelApplication, { error: submitCancelError }] =
-    useSubmitApplication({
-      application,
-      refetch,
-      event: DefaultEvents.ABORT,
-    })
+  const [submitCancelApplication] = useSubmitApplication({
+    application,
+    refetch,
+    event: DefaultEvents.ABORT,
+  })
   const hasSubmitted = useRef(false)
   // automatically go to done state if payment has been fulfilled
   useEffect(() => {
@@ -59,12 +100,33 @@ export const PaymentPending: FC<
 
     if (hasSubmitted.current) return
     if (getRedirectStatus() === 'cancelled') {
+      const reservationKey = getSubmissionReservationKey(
+        application.id,
+        DefaultEvents.ABORT,
+      )
+
+      if (!reserveSubmission(reservationKey)) {
+        refetch?.()
+        return
+      }
+
       stopPolling()
-      submitCancelApplication().then(() => {
-        removeCancelledFromURL()
-      })
       hasSubmitted.current = true
+      submitCancelApplication()
+        .then(() => {
+          removeCancelledFromURL()
+        })
+        .catch(() => {
+          hasSubmitted.current = false
+          clearSubmissionReservation(reservationKey)
+        })
+      return
     }
+
+    const reservationKey = getSubmissionReservationKey(
+      application.id,
+      targetEvent,
+    )
 
     if (!paymentStatus.fulfilled) {
       if (shouldRedirect) {
@@ -72,10 +134,22 @@ export const PaymentPending: FC<
       }
       return
     }
+
+    if (!reserveSubmission(reservationKey)) {
+      refetch?.()
+      return
+    }
+
     stopPolling()
-    submitApplication()
     hasSubmitted.current = true
+    submitApplication().catch(() => {
+      hasSubmitted.current = false
+      clearSubmissionReservation(reservationKey)
+    })
   }, [
+    application.id,
+    targetEvent,
+    refetch,
     submitCancelApplication,
     submitApplication,
     paymentStatus,

--- a/libs/application/ui-components/src/components/PaymentPending/PaymentPending.tsx
+++ b/libs/application/ui-components/src/components/PaymentPending/PaymentPending.tsx
@@ -24,27 +24,101 @@ const getSubmissionReservationKey = (
   event: DefaultEvents,
 ) => `application-payment-pending-submit:${applicationId}:${event}`
 
-const reserveSubmission = (key: string): boolean => {
+type SubmissionReservation = {
+  ts: number
+  token: string
+}
+
+const getSubmissionReservation = (
+  key: string,
+): SubmissionReservation | undefined => {
+  if (typeof window === 'undefined') {
+    return
+  }
+
+  try {
+    const reservation = window.localStorage.getItem(key)
+
+    if (!reservation) {
+      return
+    }
+
+    const reservedAt = Number(reservation)
+
+    if (Number.isFinite(reservedAt)) {
+      return { ts: reservedAt, token: '' }
+    }
+
+    const parsedReservation = JSON.parse(reservation) as SubmissionReservation
+
+    if (
+      !Number.isFinite(parsedReservation.ts) ||
+      typeof parsedReservation.token !== 'string'
+    ) {
+      return
+    }
+
+    return parsedReservation
+  } catch {
+    return
+  }
+}
+
+const isActiveSubmissionReservation = (
+  reservation?: SubmissionReservation,
+): boolean =>
+  !!reservation &&
+  Number.isFinite(reservation.ts) &&
+  Number(Date.now()) - reservation.ts < SUBMISSION_RESERVATION_TTL
+
+const createSubmissionReservationToken = () =>
+  `${Number(Date.now())}-${Math.random().toString(36).slice(2)}`
+
+const reserveSubmission = (key: string, force = false): boolean => {
   if (typeof window === 'undefined') {
     return true
   }
 
   try {
-    const reservedAt = Number(window.localStorage.getItem(key))
-
-    if (
-      reservedAt &&
-      Number.isFinite(reservedAt) &&
-      Date.now() - reservedAt < SUBMISSION_RESERVATION_TTL
-    ) {
+    if (!force && isActiveSubmissionReservation(getSubmissionReservation(key))) {
       return false
     }
 
-    window.localStorage.setItem(key, String(Date.now()))
-    return true
+    const reservation = {
+      ts: Number(Date.now()),
+      token: createSubmissionReservationToken(),
+    }
+
+    window.localStorage.setItem(key, JSON.stringify(reservation))
+
+    const storedReservation = getSubmissionReservation(key)
+
+    return (
+      storedReservation?.token === reservation.token &&
+      isActiveSubmissionReservation(storedReservation)
+    )
   } catch {
     return true
   }
+}
+
+const claimSubmissionReservation = (
+  key: string,
+  refetch: FieldBaseProps['refetch'],
+): boolean => {
+  if (reserveSubmission(key)) {
+    return true
+  }
+
+  if (
+    !isActiveSubmissionReservation(getSubmissionReservation(key)) &&
+    reserveSubmission(key, true)
+  ) {
+    return true
+  }
+
+  refetch?.()
+  return false
 }
 
 const clearSubmissionReservation = (key: string) => {
@@ -105,8 +179,7 @@ export const PaymentPending: FC<
         DefaultEvents.ABORT,
       )
 
-      if (!reserveSubmission(reservationKey)) {
-        refetch?.()
+      if (!claimSubmissionReservation(reservationKey, refetch)) {
         return
       }
 
@@ -135,8 +208,7 @@ export const PaymentPending: FC<
       return
     }
 
-    if (!reserveSubmission(reservationKey)) {
-      refetch?.()
+    if (!claimSubmissionReservation(reservationKey, refetch)) {
       return
     }
 


### PR DESCRIPTION
# Prevent duplicate application submissions after payment

[Attach a link to issue if relevant](https://app.asana.com/1/23849317865981/project/1204431115744096/task/1214479544496924?focus=true&erp=Yu4HuwEdR6pUQvJrAFVibA%3D%3D)

## What

Adds backend idempotency around application state transitions by locking the application row before processing a state change. If another request has already advanced the application state, the later request returns the current application without running transition hooks, external API calls, history writes, or state writes.

Also adds a frontend localStorage-backed reservation in `PaymentPending` so payment completion submit/cancel actions are not fired repeatedly across remounts or multiple tabs.

## Why

Operating license applications could be submitted twice to Sýslumenn after a single successful payment when two near-simultaneous `SUBMIT` requests processed the same stale `payment` state. The backend fix prevents duplicate external side effects regardless of frontend behavior, and the frontend guard reduces duplicate requests from the payment polling UI.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Client-side 15-minute submission reservation to prevent duplicate payment/cancel submissions.
  * State-change operations now run under a locking transaction to make multi-step updates atomic.

* **Bug Fixes**
  * Endpoints now return the updated application consistently.
  * Side-effect operations (notifications, external-data, history) participate in the same transaction to reduce inconsistent updates.

* **Tests**
  * Expanded tests for locked-application flows, merged transition updates, and no-op state transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->