### PR TITLE
feat(web): Verdict details - Render docx file in case web service does not return pdf

### DIFF
--- a/apps/web/screens/Verdicts/VerdictDetails.css.ts
+++ b/apps/web/screens/Verdicts/VerdictDetails.css.ts
@@ -8,6 +8,11 @@ globalStyle(`${pdfContainer} .react-pdf__Page`, {
   marginBottom: '32px',
 })
 
+globalStyle(`${pdfContainer} .docx-wrapper`, {
+  backgroundColor: theme.color.blue100,
+  padding: 0,
+})
+
 export const hiddenOnScreen = style({
   '@media': {
     screen: {

--- a/apps/web/screens/Verdicts/VerdictDetails.css.ts
+++ b/apps/web/screens/Verdicts/VerdictDetails.css.ts
@@ -24,6 +24,15 @@ export const hiddenOnScreen = style({
   },
 })
 
+export const docxScaleWrapper = style({
+  zoom: 'var(--docx-scale)',
+  '@media': {
+    print: {
+      zoom: '1',
+    },
+  },
+})
+
 export const textMaxWidth = style({
   maxWidth: '876px',
 })

--- a/apps/web/screens/Verdicts/VerdictDetails.tsx
+++ b/apps/web/screens/Verdicts/VerdictDetails.tsx
@@ -305,7 +305,10 @@ const PdfView = ({ item }: VerdictDetailsProps) => {
               boxShadow="subtle"
             >
               <Box className="rs_read">
-                <div style={{ zoom: docxScale }}>
+                <div
+                  className={styles.docxScaleWrapper}
+                  style={{ ['--docx-scale' as string]: docxScale }}
+                >
                   <div ref={docxContainerRef} />
                 </div>
               </Box>

--- a/apps/web/screens/Verdicts/VerdictDetails.tsx
+++ b/apps/web/screens/Verdicts/VerdictDetails.tsx
@@ -1,7 +1,8 @@
-import type { ReactNode } from 'react'
+import { type ReactNode, useEffect, useRef, useState } from 'react'
 import { useIntl } from 'react-intl'
 import { useWindowSize } from 'react-use'
 import cn from 'classnames'
+import { renderAsync } from 'docx-preview'
 import capitalize from 'lodash/capitalize'
 import { BLOCKS } from '@contentful/rich-text-types'
 
@@ -45,6 +46,13 @@ const calculatePdfScale = (width: number) => {
   return 0.63
 }
 
+const docxPageWidth = 816
+const calculateDocxScale = (width: number): number => {
+  const padding = 48
+  if (width >= docxPageWidth + padding) return 1
+  return Math.max(0.45, (width - padding) / docxPageWidth)
+}
+
 const getPdfBlob = (base64String: string) => {
   // Convert Base64 to binary data
   const byteCharacters = atob(base64String)
@@ -57,6 +65,17 @@ const getPdfBlob = (base64String: string) => {
   const byteArray = new Uint8Array(byteNumbers)
 
   return new Blob([byteArray], { type: 'application/pdf' })
+}
+
+const base64ToUint8Array = (base64String: string) => {
+  const byteCharacters = atob(base64String)
+  const byteNumbers = new Array(byteCharacters.length)
+
+  for (let i = 0; i < byteCharacters.length; i++) {
+    byteNumbers[i] = byteCharacters.charCodeAt(i)
+  }
+
+  return new Uint8Array(byteNumbers)
 }
 
 const downloadPdf = (base64String: string, filename = 'download.pdf') => {
@@ -114,6 +133,59 @@ const PdfView = ({ item }: VerdictDetailsProps) => {
   const { width } = useWindowSize()
   const { formatMessage } = useIntl()
 
+  const [pdfBase64, setPdfBase64] = useState<string | null>(null)
+  const [docxRenderFailed, setDocxRenderFailed] = useState(false)
+  const isDocxSource = Boolean(item.pdfString?.startsWith('UEsDB'))
+  const docxContainerRef = useRef<HTMLDivElement | null>(null)
+  const docxScale = isDocxSource ? calculateDocxScale(width) : 1
+
+  useEffect(() => {
+    const docxContainer = docxContainerRef.current
+
+    const renderDocx = async () => {
+      if (!item.pdfString) return
+
+      if (!isDocxSource) {
+        setPdfBase64(item.pdfString)
+        setDocxRenderFailed(false)
+        return
+      }
+
+      setPdfBase64(null)
+
+      if (!docxContainer) return
+
+      docxContainer.innerHTML = ''
+
+      try {
+        await renderAsync(
+          base64ToUint8Array(item.pdfString).buffer,
+          docxContainer,
+          undefined,
+          {
+            className: 'docx',
+            inWrapper: true,
+            breakPages: true,
+            useBase64URL: true,
+          },
+        )
+        setDocxRenderFailed(false)
+      } catch (error) {
+        console.error('Failed to render DOCX in browser', error)
+        setDocxRenderFailed(true)
+      }
+    }
+
+    if (isDocxSource) renderDocx()
+    else
+      setPdfBase64(
+        item.pdfString ?? 'test', // Fallback to 'test' since that'll render an error message in the PDF viewer
+      )
+
+    return () => {
+      docxContainer?.replaceChildren()
+    }
+  }, [isDocxSource, item.pdfString])
   return (
     <>
       <HeadWithSocialSharing title="Dómur" />
@@ -145,7 +217,7 @@ const PdfView = ({ item }: VerdictDetailsProps) => {
               )}
               <Inline alignY="center" justifyContent="spaceBetween" space={3}>
                 <Webreader readClass="rs_read" marginBottom={0} marginTop={2} />
-                {Boolean(item.pdfString) && (
+                {Boolean(pdfBase64) && (
                   <Hidden print={true}>
                     <Inline alignY="center" space={2}>
                       <Button
@@ -153,7 +225,7 @@ const PdfView = ({ item }: VerdictDetailsProps) => {
                         iconType="outline"
                         size="small"
                         onClick={() => {
-                          downloadPdf(item.pdfString as string)
+                          downloadPdf(pdfBase64 as string)
                         }}
                       >
                         PDF
@@ -163,7 +235,23 @@ const PdfView = ({ item }: VerdictDetailsProps) => {
                         iconType="outline"
                         size="small"
                         onClick={() => {
-                          printPdf(item.pdfString as string)
+                          printPdf(pdfBase64 as string)
+                        }}
+                      >
+                        {formatMessage(m.verdictPage.print)}
+                      </Button>
+                    </Inline>
+                  </Hidden>
+                )}
+                {isDocxSource && !docxRenderFailed && (
+                  <Hidden print={true}>
+                    <Inline alignY="center" space={2}>
+                      <Button
+                        icon="print"
+                        iconType="outline"
+                        size="small"
+                        onClick={() => {
+                          window.print()
                         }}
                       >
                         {formatMessage(m.verdictPage.print)}
@@ -176,7 +264,7 @@ const PdfView = ({ item }: VerdictDetailsProps) => {
           </GridRow>
         </GridContainer>
       </Box>
-      {Boolean(item.pdfString) && (
+      {Boolean(pdfBase64) && (
         <Box paddingY={5} background="overlayDefault">
           <GridContainer>
             <Box
@@ -189,17 +277,37 @@ const PdfView = ({ item }: VerdictDetailsProps) => {
             >
               <Box printHidden={true} className="rs_read">
                 <PdfViewer
-                  file={`data:application/pdf;base64,${item.pdfString}`}
+                  file={`data:application/pdf;base64,${pdfBase64}`}
                   showAllPages={true}
                   scale={calculatePdfScale(width)}
                 />
               </Box>
               <Box className={styles.hiddenOnScreen}>
                 <PdfViewer
-                  file={`data:application/pdf;base64,${item.pdfString}`}
+                  file={`data:application/pdf;base64,${pdfBase64}`}
                   showAllPages={true}
                   scale={1}
                 />
+              </Box>
+            </Box>
+          </GridContainer>
+        </Box>
+      )}
+      {isDocxSource && !docxRenderFailed && (
+        <Box paddingY={5} background="overlayDefault">
+          <GridContainer>
+            <Box
+              display="flex"
+              justifyContent="center"
+              className={styles.pdfContainer}
+              height="full"
+              overflow="auto"
+              boxShadow="subtle"
+            >
+              <Box className="rs_read">
+                <div style={{ zoom: docxScale }}>
+                  <div ref={docxContainerRef} />
+                </div>
               </Box>
             </Box>
           </GridContainer>

--- a/apps/web/screens/Verdicts/VerdictDetails.tsx
+++ b/apps/web/screens/Verdicts/VerdictDetails.tsx
@@ -8,6 +8,7 @@ import { BLOCKS } from '@contentful/rich-text-types'
 
 import type { SliceType } from '@island.is/island-ui/contentful'
 import {
+  AlertMessage,
   Box,
   Button,
   GridColumn,
@@ -311,6 +312,32 @@ const PdfView = ({ item }: VerdictDetailsProps) => {
                 >
                   <div ref={docxContainerRef} />
                 </div>
+              </Box>
+            </Box>
+          </GridContainer>
+        </Box>
+      )}
+      {isDocxSource && docxRenderFailed && Boolean(item.pdfString) && (
+        <Box paddingY={5} background="overlayDefault">
+          <GridContainer>
+            <Box
+              display="flex"
+              justifyContent="center"
+              className={cn(styles.pdfContainer, 'rs_read')}
+              height="full"
+              overflow="auto"
+              boxShadow="subtle"
+            >
+              <Box width="full" padding={4}>
+                <AlertMessage
+                  type="warning"
+                  title={formatMessage(
+                    m.verdictPage.docxPreviewUnavailableTitle,
+                  )}
+                  message={formatMessage(
+                    m.verdictPage.docxPreviewUnavailableDescription,
+                  )}
+                />
               </Box>
             </Box>
           </GridContainer>

--- a/apps/web/screens/Verdicts/translations.strings.ts
+++ b/apps/web/screens/Verdicts/translations.strings.ts
@@ -237,6 +237,17 @@ export const m = {
     },
   }),
   verdictPage: defineMessages({
+    docxPreviewUnavailableTitle: {
+      id: 'web.verdicts:verdictPage.docxPreviewUnavailableTitle',
+      defaultMessage: 'Ekki tókst að birta .docx skjal í vafra',
+      description: 'Titill á síðu dóms sem ekki er til staðar í vafra',
+    },
+    docxPreviewUnavailableDescription: {
+      id: 'web.verdicts:verdictPage.docxPreviewUnavailableDescription',
+      defaultMessage:
+        'Villa kom upp þegar það var reynt að birta .docx skjal í vafra',
+      description: 'Lýsing á síðu dóms sem ekki er til staðar í vafra',
+    },
     resolutionLink: {
       id: 'web.verdicts:verdictPage.resolutionLink',
       defaultMessage: 'Úrlausn Landsréttar / Héraðsdóms',

--- a/package.json
+++ b/package.json
@@ -188,6 +188,7 @@
     "datebook": "7.0.8",
     "dd-trace": "5.14.1",
     "deepmerge": "4.2.2",
+    "docx-preview": "0.3.7",
     "downshift": "5.4.3",
     "entropy-string": "4.2.0",
     "escape-html": "1.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -27840,6 +27840,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"docx-preview@npm:0.3.7":
+  version: 0.3.7
+  resolution: "docx-preview@npm:0.3.7"
+  dependencies:
+    jszip: "npm:>=3.0.0"
+  checksum: 10/f642f4c6d8232517795fa8441e12ad63a9b418c51459eac6065970446769a729d44ff26e38aaf3359914529217aa1bd63e6d6dcc586ba4dc90a667071ee90f50
+  languageName: node
+  linkType: hard
+
 "dogapi@npm:2.8.4":
   version: 2.8.4
   resolution: "dogapi@npm:2.8.4"
@@ -35368,6 +35377,7 @@ __metadata:
     datebook: "npm:7.0.8"
     dd-trace: "npm:5.14.1"
     deepmerge: "npm:4.2.2"
+    docx-preview: "npm:0.3.7"
     dotenv: "npm:16.3.1"
     downshift: "npm:5.4.3"
     entropy-string: "npm:4.2.0"
@@ -37095,7 +37105,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jszip@npm:^3.10.1, jszip@npm:^3.7.1":
+"jszip@npm:>=3.0.0, jszip@npm:^3.10.1, jszip@npm:^3.7.1":
   version: 3.10.1
   resolution: "jszip@npm:3.10.1"
   dependencies:


### PR DESCRIPTION
# Verdict details - Render docx file in case web service does not return pdf

All of the sudden the verdict api is returning base64 encoded docx strings for some verdicts. Previously there were only base64 encoded pdf strings being returned.

To handle this new use case I added the docx-preview npm package that we're now using in the browser to display the contents of the docx file

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive support for previewing and rendering DOCX documents in the Verdicts details view, complementing the existing PDF viewer functionality.
  * Enhanced document display with improved rendering management and error handling across different file formats.

* **Style**
  * Updated document container styling for better visual presentation, background color, and layout consistency across document types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->