### PR TITLE
fix(ids-admin): placement of last-modified

### DIFF
--- a/libs/portals/admin/ids-admin/src/components/EnvironmentHeader/EnvironmentHeader.tsx
+++ b/libs/portals/admin/ids-admin/src/components/EnvironmentHeader/EnvironmentHeader.tsx
@@ -19,6 +19,7 @@ interface EnvironmentHeaderProps {
   availableEnvironments: AuthAdminEnvironment[]
   onChange(value: AuthAdminEnvironment): void
   preHeader?: ReactNode
+  postHeader?: ReactNode
 }
 
 const formatOption = (
@@ -35,6 +36,7 @@ export const EnvironmentHeader = ({
   availableEnvironments,
   onChange,
   preHeader,
+  postHeader,
 }: EnvironmentHeaderProps) => {
   const { formatMessage } = useLocale()
   const tenant = useRouteLoaderData(tenantLoaderId) as TenantLoaderResult
@@ -66,6 +68,7 @@ export const EnvironmentHeader = ({
         <Text as="h1" variant="h2">
           {title}
         </Text>
+        {postHeader}
       </Box>
       <div className={styles.selectWrapper}>
         <Select

--- a/libs/portals/admin/ids-admin/src/screens/Client/Client.css.ts
+++ b/libs/portals/admin/ids-admin/src/screens/Client/Client.css.ts
@@ -10,9 +10,3 @@ export const tagHide = style({
   opacity: 0,
   height: 0,
 })
-
-export const editHeaderContainer = style({
-  display: 'flex',
-  flexDirection: 'column',
-  gap: spacing[1],
-})

--- a/libs/portals/admin/ids-admin/src/screens/Client/EditClient.tsx
+++ b/libs/portals/admin/ids-admin/src/screens/Client/EditClient.tsx
@@ -61,37 +61,34 @@ export const EditClient = () => {
     >
       <StickyLayout
         header={(isSticky) => (
-          <div className={styles.editHeaderContainer}>
-            <EnvironmentHeader
-              title={getTranslatedValue(
-                selectedEnvironment.displayName,
-                locale,
-              )}
-              selectedEnvironment={selectedEnvironment.environment}
-              availableEnvironments={client.availableEnvironments}
-              onChange={onEnvironmentChange}
-              preHeader={
-                <div
-                  className={classNames(
-                    styles.tagWrapper,
-                    isSticky && styles.tagHide,
-                  )}
-                >
-                  <ClientType client={client} />
-                </div>
-              }
-            />
-            {selectedEnvironment.modified && (
-              <Text variant="small">
-                {formatMessage(m.modified, {
-                  date: format(
-                    new Date(selectedEnvironment.modified),
-                    'dd.MM.yyyy HH:mm',
-                  ),
-                })}
-              </Text>
-            )}
-          </div>
+          <EnvironmentHeader
+            title={getTranslatedValue(selectedEnvironment.displayName, locale)}
+            selectedEnvironment={selectedEnvironment.environment}
+            availableEnvironments={client.availableEnvironments}
+            onChange={onEnvironmentChange}
+            preHeader={
+              <div
+                className={classNames(
+                  styles.tagWrapper,
+                  isSticky && styles.tagHide,
+                )}
+              >
+                <ClientType client={client} />
+              </div>
+            }
+            postHeader={
+              selectedEnvironment.modified && (
+                <Text variant="small">
+                  {formatMessage(m.modified, {
+                    date: format(
+                      new Date(selectedEnvironment.modified),
+                      'dd.MM.yyyy HH:mm',
+                    ),
+                  })}
+                </Text>
+              )
+            }
+          />
         )}
       >
         <Stack space={3}>

--- a/libs/portals/admin/ids-admin/src/screens/Permission/components/PermissionHeader.tsx
+++ b/libs/portals/admin/ids-admin/src/screens/Permission/components/PermissionHeader.tsx
@@ -20,17 +20,19 @@ export const PermissionHeader = () => {
         selectedEnvironment={selectedPermission.environment}
         availableEnvironments={permission.availableEnvironments}
         onChange={onEnvironmentChange}
+        postHeader={
+          selectedPermission.modified && (
+            <Text variant="small">
+              {formatMessage(m.modified, {
+                date: format(
+                  new Date(selectedPermission.modified),
+                  'dd.MM.yyyy HH:mm',
+                ),
+              })}
+            </Text>
+          )
+        }
       />
-      {selectedPermission.modified && (
-        <Text variant="small">
-          {formatMessage(m.modified, {
-            date: format(
-              new Date(selectedPermission.modified),
-              'dd.MM.yyyy HH:mm',
-            ),
-          })}
-        </Text>
-      )}
     </div>
   )
 }


### PR DESCRIPTION

## What
Small UI fix because the sticky header for applications and clients had gotten too big after adding the "last modified" info. By adding a postHeader prop and placing the text in there, instead of below the Environment header, it stays the same size when scrolling as it was before this was added

- Introduced a new `postHeader` prop in the `EnvironmentHeader` component to allow rendering additional content below the header title.
- Updated the `EditClient` and `PermissionHeader` components to utilize the new `postHeader` prop for displaying modification timestamps.
- Removed unused CSS styles

## Why

Specify why you need to achieve this

## Screenshots / Gifs

before: 
<img width="1451" height="494" alt="image" src="https://github.com/user-attachments/assets/73b2d378-fea5-4bf1-a873-4cfd75d31bd2" />

after:
<img width="1333" height="678" alt="image" src="https://github.com/user-attachments/assets/af617de0-f020-4bf0-8dff-4db083c7f239" />


## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured the admin interface environment header component to provide more flexible content positioning for metadata like modification timestamps.
  * Enhanced header layout logic across multiple admin screens to improve consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->