### PR TITLE
fix(j-s): remove CaseCompletedGuard from defender limited access route

### DIFF
--- a/apps/judicial-system/backend/src/app/modules/case/limitedAccessCase.controller.ts
+++ b/apps/judicial-system/backend/src/app/modules/case/limitedAccessCase.controller.ts
@@ -476,7 +476,6 @@ export class LimitedAccessCaseController {
       ...indictmentCases,
     ]),
     CaseReadGuard,
-    CaseCompletedGuard,
   )
   @RolesRules(defenderRule)
   @Get('case/:caseId/limitedAccess/all')


### PR DESCRIPTION
## What
Removes `CaseCompletedGuard` from the `GET case/:caseId/limitedAccess/all` endpoint in `LimitedAccessCaseController`.

## Why
Defenders should be able to access case data via the limited access route even after a case has been completed. The `CaseCompletedGuard` was blocking this access unnecessarily.

## Screenshots / Gifs
Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added the ability for defenders to download all related case files as a compressed zip archive through a new endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->