### PR TITLE
chore(j-s): prepend evidenceType & fullName to digital case file name

### DIFF
--- a/apps/judicial-system/backend/src/app/modules/police/police.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/police/police.service.ts
@@ -508,9 +508,7 @@ export class PoliceService {
       const response: z.infer<typeof this.digitalCaseFilesStructure> =
         await res.json()
 
-      const parsed = this.digitalCaseFilesStructure.parse(response)
-
-      return parsed
+      return this.digitalCaseFilesStructure.parse(response)
     } catch (reason) {
       if (reason instanceof NotFoundException) {
         throw reason

--- a/apps/judicial-system/backend/src/app/modules/police/police.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/police/police.service.ts
@@ -168,6 +168,8 @@ export class PoliceService {
   private policeDigitalCaseFileStructure = z.object({
     id: z.string(),
     rvMalID: z.number(),
+    evidenceType: z.string().nullish(),
+    fullName: z.string().nullish(),
     externalVendorFileName: z.string(),
     externalVendorID: z.string(),
     registeredAt: z.string().nullish(),
@@ -204,6 +206,18 @@ export class PoliceService {
       gogn: z.optional(z.array(this.policeDigitalCaseFileStructure)),
     }),
   )
+
+  private buildDigitalCaseFileName(
+    file: z.infer<typeof this.policeDigitalCaseFileStructure>,
+  ): string {
+    return [
+      file.evidenceType?.trim(),
+      file.fullName?.trim(),
+      file.externalVendorFileName.trim(),
+    ]
+      .filter((part): part is string => Boolean(part))
+      .join(', ')
+  }
 
   private subpoenaStructure = z.object({
     acknowledged: z.boolean().nullish(),
@@ -492,6 +506,12 @@ export class PoliceService {
       const response: z.infer<typeof this.digitalCaseFilesStructure> =
         await res.json()
 
+      this.logger.info('Raw GetRVRafraengogn response', {
+        caseId,
+        source,
+        response,
+      })
+
       this.digitalCaseFilesStructure.parse(response)
 
       return response
@@ -667,7 +687,7 @@ export class PoliceService {
       filesPerCaseNumber.gogn?.forEach((file) => {
         files.push({
           id: file.id.toString(),
-          name: file.externalVendorFileName,
+          name: this.buildDigitalCaseFileName(file),
           policeCaseNumber: filesPerCaseNumber.malsnumer,
           policeExternalVendorId: file.externalVendorID,
           displayDate: file.registeredAt

--- a/apps/judicial-system/backend/src/app/modules/police/police.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/police/police.service.ts
@@ -209,8 +209,10 @@ export class PoliceService {
 
   private buildDigitalCaseFileName(
     file: z.infer<typeof this.policeDigitalCaseFileStructure>,
+    policeCaseNumber: string,
   ): string {
     return [
+      policeCaseNumber.trim(),
       file.evidenceType?.trim(),
       file.fullName?.trim(),
       file.externalVendorFileName.trim(),
@@ -506,9 +508,9 @@ export class PoliceService {
       const response: z.infer<typeof this.digitalCaseFilesStructure> =
         await res.json()
 
-      this.digitalCaseFilesStructure.parse(response)
+      const parsed = this.digitalCaseFilesStructure.parse(response)
 
-      return response
+      return parsed
     } catch (reason) {
       if (reason instanceof NotFoundException) {
         throw reason
@@ -681,7 +683,10 @@ export class PoliceService {
       filesPerCaseNumber.gogn?.forEach((file) => {
         files.push({
           id: file.id.toString(),
-          name: this.buildDigitalCaseFileName(file),
+          name: this.buildDigitalCaseFileName(
+            file,
+            filesPerCaseNumber.malsnumer,
+          ),
           policeCaseNumber: filesPerCaseNumber.malsnumer,
           policeExternalVendorId: file.externalVendorID,
           displayDate: file.registeredAt

--- a/apps/judicial-system/backend/src/app/modules/police/police.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/police/police.service.ts
@@ -506,12 +506,6 @@ export class PoliceService {
       const response: z.infer<typeof this.digitalCaseFilesStructure> =
         await res.json()
 
-      this.logger.info('Raw GetRVRafraengogn response', {
-        caseId,
-        source,
-        response,
-      })
-
       this.digitalCaseFilesStructure.parse(response)
 
       return response

--- a/apps/judicial-system/backend/src/app/modules/police/test/getDigitalCaseFiles.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/police/test/getDigitalCaseFiles.spec.ts
@@ -32,7 +32,7 @@ describe('PoliceController - Get digital case files', () => {
       user: User,
       theCase: Case,
     ): Promise<Then> => {
-      const then = {} as Then
+      const then: Then = { result: [] }
 
       await policeController
         .getDigitalCaseFiles(caseId, user, theCase)
@@ -77,7 +77,7 @@ describe('PoliceController - Get digital case files', () => {
       expect(then.result).toEqual([
         {
           id: '1723e662-6514-4aab-9b03-6b7778939a47',
-          name: 'Video, John Doe, Recording 1',
+          name: '007-2026-000007, Video, John Doe, Recording 1',
           policeCaseNumber: '007-2026-000007',
           policeExternalVendorId: '2359',
           displayDate: new Date('2026-04-17T12:19:21.537'),
@@ -127,14 +127,14 @@ describe('PoliceController - Get digital case files', () => {
       expect(then.result).toEqual([
         {
           id: '6cab5177-bfa7-4998-8c09-b4884fca0ae6',
-          name: 'Recording 2',
+          name: '007-2026-000007, Recording 2',
           policeCaseNumber: '007-2026-000007',
           policeExternalVendorId: '2360',
           displayDate: new Date('2026-04-17T12:19:22.130'),
         },
         {
           id: 'ea4ccb3d-9670-4e3c-81f8-b63fb69c51e6',
-          name: 'Recording 3',
+          name: '007-2026-000007, Recording 3',
           policeCaseNumber: '007-2026-000007',
           policeExternalVendorId: '2361',
           displayDate: undefined,
@@ -177,10 +177,53 @@ describe('PoliceController - Get digital case files', () => {
       expect(then.result).toEqual([
         {
           id: '4bdc60ee-8d39-49b1-a0bc-dad2feb4c490',
-          name: 'Recording 4',
+          name: '007-2026-000007, Recording 4',
           policeCaseNumber: '007-2026-000007',
           policeExternalVendorId: '2362',
           displayDate: new Date('2026-04-17T12:19:20.787'),
+        },
+      ])
+    })
+  })
+
+  describe('when police case number contains surrounding whitespace', () => {
+    const theUser = {} as User
+    const theCase = {} as Case
+    let then: Then
+
+    beforeEach(async () => {
+      const mockFetch = fetch as jest.Mock
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => [
+          {
+            malsnumer: ' 007-2026-000007 ',
+            gogn: [
+              {
+                id: '6fd92208-b460-4f60-ae5c-d8d6f9d4f42d',
+                rvMalID: 766,
+                evidenceType: null,
+                fullName: null,
+                externalVendorFileName: 'Recording 5',
+                externalVendorID: '2363',
+                registeredAt: null,
+              },
+            ],
+          },
+        ],
+      })
+
+      then = await givenWhenThen(uuid(), theUser, theCase)
+    })
+
+    it('should trim and prepend the police case number without extra separators', () => {
+      expect(then.result).toEqual([
+        {
+          id: '6fd92208-b460-4f60-ae5c-d8d6f9d4f42d',
+          name: '007-2026-000007, Recording 5',
+          policeCaseNumber: ' 007-2026-000007 ',
+          policeExternalVendorId: '2363',
+          displayDate: undefined,
         },
       ])
     })

--- a/apps/judicial-system/backend/src/app/modules/police/test/getDigitalCaseFiles.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/police/test/getDigitalCaseFiles.spec.ts
@@ -1,0 +1,188 @@
+import fetch from 'isomorphic-fetch'
+import { v4 as uuid } from 'uuid'
+
+import { User } from '@island.is/judicial-system/types'
+
+import { createTestingPoliceModule } from './createTestingPoliceModule'
+
+import { Case } from '../../repository'
+import { PoliceSystemDigitalCaseFile } from '../models/PoliceSystemDigitalCaseFile.model'
+
+jest.mock('isomorphic-fetch')
+
+interface Then {
+  result: PoliceSystemDigitalCaseFile[]
+  error?: Error
+}
+
+type GivenWhenThen = (
+  caseId: string,
+  user: User,
+  theCase: Case,
+) => Promise<Then>
+
+describe('PoliceController - Get digital case files', () => {
+  let givenWhenThen: GivenWhenThen
+
+  beforeEach(async () => {
+    const { policeController } = await createTestingPoliceModule()
+
+    givenWhenThen = async (
+      caseId: string,
+      user: User,
+      theCase: Case,
+    ): Promise<Then> => {
+      const then = {} as Then
+
+      await policeController
+        .getDigitalCaseFiles(caseId, user, theCase)
+        .then((result) => (then.result = result))
+        .catch((error) => (then.error = error))
+
+      return then
+    }
+  })
+
+  describe('when all metadata fields are present', () => {
+    const theUser = {} as User
+    const theCase = {} as Case
+    let then: Then
+
+    beforeEach(async () => {
+      const mockFetch = fetch as jest.Mock
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => [
+          {
+            malsnumer: '007-2026-000007',
+            gogn: [
+              {
+                id: '1723e662-6514-4aab-9b03-6b7778939a47',
+                rvMalID: 766,
+                evidenceType: 'Video',
+                fullName: 'John Doe',
+                externalVendorFileName: 'Recording 1',
+                externalVendorID: '2359',
+                registeredAt: '2026-04-17T12:19:21.537',
+              },
+            ],
+          },
+        ],
+      })
+
+      then = await givenWhenThen(uuid(), theUser, theCase)
+    })
+
+    it('should prepend all available metadata to the filename', () => {
+      expect(then.result).toEqual([
+        {
+          id: '1723e662-6514-4aab-9b03-6b7778939a47',
+          name: '766, Video, John Doe, Recording 1',
+          policeCaseNumber: '007-2026-000007',
+          policeExternalVendorId: '2359',
+          displayDate: new Date('2026-04-17T12:19:21.537'),
+        },
+      ])
+    })
+  })
+
+  describe('when optional metadata fields are missing', () => {
+    const theUser = {} as User
+    const theCase = {} as Case
+    let then: Then
+
+    beforeEach(async () => {
+      const mockFetch = fetch as jest.Mock
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => [
+          {
+            malsnumer: '007-2026-000007',
+            gogn: [
+              {
+                id: '6cab5177-bfa7-4998-8c09-b4884fca0ae6',
+                rvMalID: 766,
+                evidenceType: null,
+                fullName: null,
+                externalVendorFileName: 'Recording 2',
+                externalVendorID: '2360',
+                registeredAt: '2026-04-17T12:19:22.130',
+              },
+              {
+                id: 'ea4ccb3d-9670-4e3c-81f8-b63fb69c51e6',
+                rvMalID: 766,
+                externalVendorFileName: 'Recording 3',
+                externalVendorID: '2361',
+                registeredAt: null,
+              },
+            ],
+          },
+        ],
+      })
+
+      then = await givenWhenThen(uuid(), theUser, theCase)
+    })
+
+    it('should omit missing fields and avoid extra separators', () => {
+      expect(then.result).toEqual([
+        {
+          id: '6cab5177-bfa7-4998-8c09-b4884fca0ae6',
+          name: '766, Recording 2',
+          policeCaseNumber: '007-2026-000007',
+          policeExternalVendorId: '2360',
+          displayDate: new Date('2026-04-17T12:19:22.130'),
+        },
+        {
+          id: 'ea4ccb3d-9670-4e3c-81f8-b63fb69c51e6',
+          name: '766, Recording 3',
+          policeCaseNumber: '007-2026-000007',
+          policeExternalVendorId: '2361',
+          displayDate: undefined,
+        },
+      ])
+    })
+  })
+
+  describe('when optional metadata fields only contain whitespace', () => {
+    const theUser = {} as User
+    const theCase = {} as Case
+    let then: Then
+
+    beforeEach(async () => {
+      const mockFetch = fetch as jest.Mock
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => [
+          {
+            malsnumer: '007-2026-000007',
+            gogn: [
+              {
+                id: '4bdc60ee-8d39-49b1-a0bc-dad2feb4c490',
+                rvMalID: 766,
+                evidenceType: '   ',
+                fullName: '\t',
+                externalVendorFileName: '  Recording 4  ',
+                externalVendorID: '2362',
+                registeredAt: '2026-04-17T12:19:20.787',
+              },
+            ],
+          },
+        ],
+      })
+
+      then = await givenWhenThen(uuid(), theUser, theCase)
+    })
+
+    it('should trim values and skip whitespace-only metadata fields', () => {
+      expect(then.result).toEqual([
+        {
+          id: '4bdc60ee-8d39-49b1-a0bc-dad2feb4c490',
+          name: '766, Recording 4',
+          policeCaseNumber: '007-2026-000007',
+          policeExternalVendorId: '2362',
+          displayDate: new Date('2026-04-17T12:19:20.787'),
+        },
+      ])
+    })
+  })
+})

--- a/apps/judicial-system/backend/src/app/modules/police/test/getDigitalCaseFiles.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/police/test/getDigitalCaseFiles.spec.ts
@@ -73,11 +73,11 @@ describe('PoliceController - Get digital case files', () => {
       then = await givenWhenThen(uuid(), theUser, theCase)
     })
 
-    it('should prepend all available metadata to the filename', () => {
+    it('should prepend all supported metadata to the filename', () => {
       expect(then.result).toEqual([
         {
           id: '1723e662-6514-4aab-9b03-6b7778939a47',
-          name: '766, Video, John Doe, Recording 1',
+          name: 'Video, John Doe, Recording 1',
           policeCaseNumber: '007-2026-000007',
           policeExternalVendorId: '2359',
           displayDate: new Date('2026-04-17T12:19:21.537'),
@@ -127,14 +127,14 @@ describe('PoliceController - Get digital case files', () => {
       expect(then.result).toEqual([
         {
           id: '6cab5177-bfa7-4998-8c09-b4884fca0ae6',
-          name: '766, Recording 2',
+          name: 'Recording 2',
           policeCaseNumber: '007-2026-000007',
           policeExternalVendorId: '2360',
           displayDate: new Date('2026-04-17T12:19:22.130'),
         },
         {
           id: 'ea4ccb3d-9670-4e3c-81f8-b63fb69c51e6',
-          name: '766, Recording 3',
+          name: 'Recording 3',
           policeCaseNumber: '007-2026-000007',
           policeExternalVendorId: '2361',
           displayDate: undefined,
@@ -177,7 +177,7 @@ describe('PoliceController - Get digital case files', () => {
       expect(then.result).toEqual([
         {
           id: '4bdc60ee-8d39-49b1-a0bc-dad2feb4c490',
-          name: '766, Recording 4',
+          name: 'Recording 4',
           policeCaseNumber: '007-2026-000007',
           policeExternalVendorId: '2362',
           displayDate: new Date('2026-04-17T12:19:20.787'),


### PR DESCRIPTION
[Asana](https://app.asana.com/1/203394141643832/project/1212657017130395/task/1214378780479016?focus=true)

## What

Prepend evidenceType and fullName fields to the name before saving digital case files to our DB.

## Why

So the names are more descriptive.


here we get the police case number prepended before the filename:
<img width="841" height="652" alt="image" src="https://github.com/user-attachments/assets/07845639-d47c-4022-8840-0d9c437f60c7" />





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced digital case file display: names now include evidence type and full name when available, trim whitespace, and omit empty parts for cleaner labels.
  * Improved validation of external responses so displayed files reflect parsed and validated metadata.

* **Tests**
  * Added tests covering digital case file retrieval and transformation, including missing, null, and whitespace-only metadata scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->