### PR TITLE
feat(my-pages): Add plausible tracking of header button usage

### DIFF
--- a/apps/portals/my-pages/src/components/Header/Header.tsx
+++ b/apps/portals/my-pages/src/components/Header/Header.tsx
@@ -16,10 +16,20 @@ import { hasNotificationScopes } from '@island.is/auth/scopes'
 import {
   LinkResolver,
   ServicePortalPaths,
+  formatPlausiblePathToParams,
   m,
   useScrollPosition,
 } from '@island.is/portals/my-pages/core'
 import { DocumentsPaths } from '@island.is/portals/my-pages/documents'
+import {
+  myPagesHeaderDocumentsClick,
+  myPagesHeaderLanguageSwitchClick,
+  myPagesHeaderNotificationsClick,
+  myPagesHeaderOverviewClick,
+  myPagesHeaderSearchIconClick,
+  myPagesHeaderSearchInputInitialized,
+  myPagesHeaderUserMenuClick,
+} from '@island.is/plausible'
 import { useUserInfo } from '@island.is/react-spa/bff'
 import {
   DelegationBanner,
@@ -196,6 +206,16 @@ export const Header = ({
                             whiteMenuBackground
                             hideInput={isMobile}
                             box={{ marginLeft: 'auto' }}
+                            onButtonClick={() =>
+                              myPagesHeaderSearchIconClick(
+                                formatPlausiblePathToParams(location.pathname),
+                              )
+                            }
+                            onInputInitialized={() =>
+                              myPagesHeaderSearchInputInitialized(
+                                formatPlausiblePathToParams(location.pathname),
+                              )
+                            }
                           />
                         </Box>
                       )}
@@ -203,6 +223,11 @@ export const Header = ({
                         <Box marginRight={[1, 1, 2]} position="relative">
                           <LinkResolver
                             href={DocumentsPaths.ElectronicDocumentsRoot}
+                            callback={() =>
+                              myPagesHeaderDocumentsClick(
+                                formatPlausiblePathToParams(location.pathname),
+                              )
+                            }
                           >
                             <Button
                               icon="mail"
@@ -225,9 +250,22 @@ export const Header = ({
                         setMenuState={(val: MenuTypes) => setMenuOpen(val)}
                         showMenu={menuOpen === 'notifications'}
                         disabled={!hasNotificationsDelegationAccess}
+                        onButtonClick={() =>
+                          myPagesHeaderNotificationsClick(
+                            formatPlausiblePathToParams(location.pathname),
+                          )
+                        }
                       />
 
-                      {user && <UserLanguageSwitcher />}
+                      {user && (
+                        <UserLanguageSwitcher
+                          onButtonClick={() =>
+                            myPagesHeaderLanguageSwitchClick(
+                              formatPlausiblePathToParams(location.pathname),
+                            )
+                          }
+                        />
+                      )}
 
                       <Box className={styles.overview} marginRight={[1, 1, 2]}>
                         <Button
@@ -237,6 +275,9 @@ export const Header = ({
                             menuOpen === 'side' && isMobile ? 'close' : 'dots'
                           }
                           onClick={() => {
+                            myPagesHeaderOverviewClick(
+                              formatPlausiblePathToParams(location.pathname),
+                            )
                             menuOpen === 'side' && isMobile
                               ? setMenuOpen(undefined)
                               : setMenuOpen('side')
@@ -273,6 +314,11 @@ export const Header = ({
                         iconOnlyMobile
                         showLanguageSwitcher={false}
                         userMenuOpen={menuOpen === 'user'}
+                        onButtonClick={() =>
+                          myPagesHeaderUserMenuClick(
+                            formatPlausiblePathToParams(location.pathname),
+                          )
+                        }
                       />
                     </Box>
                   </Box>

--- a/apps/portals/my-pages/src/components/Notifications/NotificationButton.tsx
+++ b/apps/portals/my-pages/src/components/Notifications/NotificationButton.tsx
@@ -17,12 +17,14 @@ interface Props {
   setMenuState: (val: MenuTypes) => void
   showMenu?: boolean
   disabled?: boolean
+  onButtonClick?: () => void
 }
 
 const NotificationButton = ({
   setMenuState,
   showMenu = false,
   disabled,
+  onButtonClick,
 }: Props) => {
   const { formatMessage, lang } = useLocale()
   const [hasMarkedLocally, setHasMarkedLocally] = useState(false)
@@ -67,6 +69,7 @@ const NotificationButton = ({
         icon={showMenu && isTablet ? 'close' : 'notifications'}
         iconType="outline"
         onClick={() => {
+          onButtonClick?.()
           showMenu && isTablet
             ? setMenuState(undefined)
             : setMenuState('notifications')

--- a/apps/portals/my-pages/src/components/SearchInput/SearchInput.tsx
+++ b/apps/portals/my-pages/src/components/SearchInput/SearchInput.tsx
@@ -24,6 +24,8 @@ interface Props {
   buttonAriaLabel?: string
   hideInput?: boolean
   whiteMenuBackground?: boolean
+  onButtonClick?: () => void
+  onInputInitialized?: () => void
 }
 
 export const SearchInput = ({
@@ -34,6 +36,8 @@ export const SearchInput = ({
   buttonAriaLabel,
   hideInput,
   whiteMenuBackground,
+  onButtonClick,
+  onInputInitialized,
 }: Props) => {
   const [query, setQuery] = useState<string>()
   const search = usePortalModulesSearch()
@@ -41,6 +45,7 @@ export const SearchInput = ({
   const navigate = useNavigate()
 
   const ref = useRef<HTMLInputElement>(null)
+  const inputInitializedRef = useRef(false)
   const [searchParams] = useSearchParams()
 
   const searchQuery = searchParams.get('query')
@@ -114,7 +119,7 @@ export const SearchInput = ({
   if (hideInput) {
     return (
       <Box className={styles.wrapper} {...box}>
-        <LinkResolver href={SearchPaths.Search} className={styles.searchButton}>
+        <LinkResolver href={SearchPaths.Search} className={styles.searchButton} callback={onButtonClick}>
           <Button
             aria-label={buttonAriaLabel}
             icon="search"
@@ -163,6 +168,10 @@ export const SearchInput = ({
           onInputValueChange={(value) => {
             if (value !== query) {
               setQuery(value)
+            }
+            if (!inputInitializedRef.current && value) {
+              onInputInitialized?.()
+              inputInitializedRef.current = true
             }
           }}
           onChange={(value) => {

--- a/apps/portals/my-pages/src/components/SearchInput/SearchInput.tsx
+++ b/apps/portals/my-pages/src/components/SearchInput/SearchInput.tsx
@@ -119,7 +119,11 @@ export const SearchInput = ({
   if (hideInput) {
     return (
       <Box className={styles.wrapper} {...box}>
-        <LinkResolver href={SearchPaths.Search} className={styles.searchButton} callback={onButtonClick}>
+        <LinkResolver
+          href={SearchPaths.Search}
+          className={styles.searchButton}
+          callback={onButtonClick}
+        >
           <Button
             aria-label={buttonAriaLabel}
             icon="search"

--- a/libs/plausible/src/lib/servicePortalEvents.ts
+++ b/libs/plausible/src/lib/servicePortalEvents.ts
@@ -19,6 +19,24 @@ type OutboundTypes = {
   outboundUrl?: string
 }
 
+const myPagesHeaderEvent =
+  (eventName: string) =>
+  (params: Pick<ParamType, 'url' | 'location'>) =>
+    plausibleCustomEvent({
+      eventName,
+      featureName: 'My Pages Header',
+      params: { location: params.location },
+      url: params.url,
+    })
+
+export const myPagesHeaderDocumentsClick = myPagesHeaderEvent('Documents Click')
+export const myPagesHeaderNotificationsClick = myPagesHeaderEvent('Notifications Click')
+export const myPagesHeaderLanguageSwitchClick = myPagesHeaderEvent('Language Switch Click')
+export const myPagesHeaderOverviewClick = myPagesHeaderEvent('Overview Click')
+export const myPagesHeaderUserMenuClick = myPagesHeaderEvent('User Menu Click')
+export const myPagesHeaderSearchIconClick = myPagesHeaderEvent('Search Icon Click')
+export const myPagesHeaderSearchInputInitialized = myPagesHeaderEvent('Search Input Initialized')
+
 // Event sent when the search feature of documents is interacted with by the user
 export const documentsSearchDocumentsInitialized = (params: ParamType) => {
   const event: BaseEvent = {

--- a/libs/plausible/src/lib/servicePortalEvents.ts
+++ b/libs/plausible/src/lib/servicePortalEvents.ts
@@ -20,8 +20,7 @@ type OutboundTypes = {
 }
 
 const myPagesHeaderEvent =
-  (eventName: string) =>
-  (params: Pick<ParamType, 'url' | 'location'>) =>
+  (eventName: string) => (params: Pick<ParamType, 'url' | 'location'>) =>
     plausibleCustomEvent({
       eventName,
       featureName: 'My Pages Header',
@@ -30,12 +29,19 @@ const myPagesHeaderEvent =
     })
 
 export const myPagesHeaderDocumentsClick = myPagesHeaderEvent('Documents Click')
-export const myPagesHeaderNotificationsClick = myPagesHeaderEvent('Notifications Click')
-export const myPagesHeaderLanguageSwitchClick = myPagesHeaderEvent('Language Switch Click')
+export const myPagesHeaderNotificationsClick = myPagesHeaderEvent(
+  'Notifications Click',
+)
+export const myPagesHeaderLanguageSwitchClick = myPagesHeaderEvent(
+  'Language Switch Click',
+)
 export const myPagesHeaderOverviewClick = myPagesHeaderEvent('Overview Click')
 export const myPagesHeaderUserMenuClick = myPagesHeaderEvent('User Menu Click')
-export const myPagesHeaderSearchIconClick = myPagesHeaderEvent('Search Icon Click')
-export const myPagesHeaderSearchInputInitialized = myPagesHeaderEvent('Search Input Initialized')
+export const myPagesHeaderSearchIconClick =
+  myPagesHeaderEvent('Search Icon Click')
+export const myPagesHeaderSearchInputInitialized = myPagesHeaderEvent(
+  'Search Input Initialized',
+)
 
 // Event sent when the search feature of documents is interacted with by the user
 export const documentsSearchDocumentsInitialized = (params: ParamType) => {

--- a/libs/shared/components/src/auth/UserMenu/UserLanguageSwitcher.tsx
+++ b/libs/shared/components/src/auth/UserMenu/UserLanguageSwitcher.tsx
@@ -8,14 +8,17 @@ import { useUpdateUserProfileMutation } from '../../../gen/schema'
 
 export const UserLanguageSwitcher = ({
   dropdown = false,
+  onButtonClick,
 }: {
   dropdown?: boolean
+  onButtonClick?: () => void
 }) => {
   const user = useUserInfo()
   const { lang, formatMessage, changeLanguage } = useLocale()
   const [updateUserProfileMutation] = useUpdateUserProfileMutation()
 
   const handleLanguageChange = async () => {
+    if (!dropdown) onButtonClick?.()
     const locale = lang === 'en' ? 'is' : 'en'
     const isDelegation = checkDelegation(user)
 

--- a/libs/shared/components/src/auth/UserMenu/UserMenu.tsx
+++ b/libs/shared/components/src/auth/UserMenu/UserMenu.tsx
@@ -14,6 +14,7 @@ type UserMenuProps = {
   iconOnlyMobile?: boolean
   showLanguageSwitcher?: boolean
   showActorButton?: boolean
+  onButtonClick?: () => void
 }
 
 export const UserMenu = ({
@@ -25,6 +26,7 @@ export const UserMenu = ({
   showLanguageSwitcher = true,
   showActorButton = true,
   iconOnlyMobile = false,
+  onButtonClick,
 }: UserMenuProps) => {
   const [dropdownState, setDropdownState] = useState<'closed' | 'open'>(
     'closed',
@@ -32,6 +34,7 @@ export const UserMenu = ({
   const { signOut, switchUser, userInfo: user } = useAuth()
 
   const handleClick = () => {
+    if (dropdownState === 'closed') onButtonClick?.()
     setDropdownState(dropdownState === 'open' ? 'closed' : 'open')
   }
   useEffect(() => {


### PR DESCRIPTION
## What

* Custom event tracking on each button/input in the my pages header.

## Why

* Need to measure usage of UI elements in the header.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Integrated analytics tracking for header interactions (search, documents, language switcher, notifications, overview, user menu).
  * Added optional callback hooks to header controls to support event dispatching and search-input initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->