### PR TITLE
fix(auth): include uncategorized scopes, exclude admin scopes, and gate capabilities card

### DIFF
--- a/libs/auth-api-lib/src/lib/resources/scope.service.ts
+++ b/libs/auth-api-lib/src/lib/resources/scope.service.ts
@@ -193,9 +193,7 @@ export class ScopeService {
         },
       ],
     })
-    const scopes = allScopes.filter(
-      (s) => s.domainName !== '@admin.island.is',
-    )
+    const scopes = allScopes.filter((s) => s.domainName !== '@admin.island.is')
 
     // Group scopes by category. Scopes with no category go into a
     // special __none__ bucket so they surface in the uncategorized group.

--- a/libs/auth-api-lib/src/lib/resources/scope.service.ts
+++ b/libs/auth-api-lib/src/lib/resources/scope.service.ts
@@ -170,8 +170,9 @@ export class ScopeService {
       lang,
     )
 
-    // Fetch all scopes with their category associations
-    const scopes = await this.delegationResourcesService.findScopesInternal({
+    // Fetch all scopes with their category associations, excluding
+    // admin scopes which are not relevant.
+    const allScopes = await this.delegationResourcesService.findScopesInternal({
       user,
       language: lang,
       direction,
@@ -192,6 +193,9 @@ export class ScopeService {
         },
       ],
     })
+    const scopes = allScopes.filter(
+      (s) => s.domainName !== '@admin.island.is',
+    )
 
     // Group scopes by category. Scopes with no category go into a
     // special __none__ bucket so they surface in the uncategorized group.
@@ -257,16 +261,6 @@ export class ScopeService {
       }
     }
 
-    if (orphanedScopes.size > 0) {
-      result.push({
-        id: '__uncategorized__',
-        title: lang === 'is' ? 'Annað' : 'Other',
-        description: '',
-        slug: 'uncategorized-category',
-        scopes: Array.from(orphanedScopes.values()),
-      })
-    }
-
     // Virtual "Þjónusta ísland.is" category — scopes assigned to this
     // category ID in the DB won't match a CMS category, so build it here.
     const islandIsScopes = categoryMap.get(ISLAND_IS_CATEGORY.id)
@@ -278,6 +272,17 @@ export class ScopeService {
           ISLAND_IS_CATEGORY.description[lang === 'en' ? 'en' : 'is'],
         slug: ISLAND_IS_CATEGORY.slug,
         scopes: islandIsScopes,
+      })
+    }
+
+    // Uncategorized always last
+    if (orphanedScopes.size > 0) {
+      result.push({
+        id: '__uncategorized__',
+        title: lang === 'is' ? 'Annað' : 'Other',
+        description: '',
+        slug: 'uncategorized',
+        scopes: Array.from(orphanedScopes.values()),
       })
     }
 
@@ -362,17 +367,6 @@ export class ScopeService {
       }
     }
 
-    if (orphanedScopes.size > 0) {
-      result.push({
-        id: '__uncategorized__',
-        title: lang === 'is' ? 'Annað' : 'Other',
-        description: '',
-        slug: 'uncategorized-tag',
-        showAsCard: true,
-        scopes: Array.from(orphanedScopes.values()),
-      })
-    }
-
     // If the "Sveitarfélag" tag exists with scopes, look up the user's
     // municipality and extract matching scopes into a virtual tag.
     // Scopes remain in their original tag as well.
@@ -405,6 +399,18 @@ export class ScopeService {
           ]
         }
       }
+    }
+
+    // Uncategorized always last
+    if (orphanedScopes.size > 0) {
+      result.push({
+        id: '__uncategorized__',
+        title: lang === 'is' ? 'Annað' : 'Other',
+        description: '',
+        slug: 'uncategorized',
+        showAsCard: true,
+        scopes: Array.from(orphanedScopes.values()),
+      })
     }
 
     return result

--- a/libs/auth-api-lib/src/lib/resources/scope.service.ts
+++ b/libs/auth-api-lib/src/lib/resources/scope.service.ts
@@ -188,29 +188,40 @@ export class ScopeService {
           model: ApiScopeCategory,
           as: 'categories',
           attributes: ['categoryId'],
-          required: true,
+          required: false,
         },
       ],
     })
 
-    // Group scopes by category
+    // Group scopes by category. Scopes with no category go into a
+    // special __none__ bucket so they surface in the uncategorized group.
+    const UNCATEGORIZED_KEY = '__none__'
     const categoryMap = new Map<string, ScopeDTO[]>()
 
     for (const scope of scopes) {
       const categoryIds = scope.categories?.map((c) => c.categoryId) ?? []
 
-      for (const categoryId of categoryIds) {
-        if (!categoryMap.has(categoryId)) {
-          categoryMap.set(categoryId, [])
+      const scopeDto = {
+        name: scope.name,
+        displayName: scope.displayName,
+        description: scope.description || '',
+        domainName: scope.domainName,
+        order: scope.order || 0,
+        allowsWrite: scope.allowsWrite ?? false,
+      } as ScopeDTO
+
+      if (categoryIds.length === 0) {
+        if (!categoryMap.has(UNCATEGORIZED_KEY)) {
+          categoryMap.set(UNCATEGORIZED_KEY, [])
         }
-        categoryMap.get(categoryId)!.push({
-          name: scope.name,
-          displayName: scope.displayName,
-          description: scope.description || '',
-          domainName: scope.domainName,
-          order: scope.order || 0,
-          allowsWrite: scope.allowsWrite ?? false,
-        } as ScopeDTO)
+        categoryMap.get(UNCATEGORIZED_KEY)!.push(scopeDto)
+      } else {
+        for (const categoryId of categoryIds) {
+          if (!categoryMap.has(categoryId)) {
+            categoryMap.set(categoryId, [])
+          }
+          categoryMap.get(categoryId)!.push(scopeDto)
+        }
       }
     }
 
@@ -230,14 +241,15 @@ export class ScopeService {
       .filter((category) => category.scopes.length > 0)
       .sort((a, b) => a.title.localeCompare(b.title))
 
-    // Collect orphaned scopes whose categoryId no longer exists in CMS
-    // (excluding virtual categories which are handled separately)
+    // Collect orphaned scopes: either no category at all (__none__) or
+    // a categoryId that no longer exists in CMS (excluding virtual categories)
     const virtualCategoryIds = new Set<string>([ISLAND_IS_CATEGORY.id])
     const orphanedScopes = new Map<string, ScopeDTO>()
     for (const [categoryId, catScopes] of categoryMap.entries()) {
       if (
-        !resolvedCategoryIds.has(categoryId) &&
-        !virtualCategoryIds.has(categoryId)
+        categoryId === UNCATEGORIZED_KEY ||
+        (!resolvedCategoryIds.has(categoryId) &&
+          !virtualCategoryIds.has(categoryId))
       ) {
         for (const scope of catScopes) {
           orphanedScopes.set(scope.name, scope)

--- a/libs/portals/admin/ids-admin/src/screens/Permission/components/PermissionSecurityAndCapabilities.tsx
+++ b/libs/portals/admin/ids-admin/src/screens/Permission/components/PermissionSecurityAndCapabilities.tsx
@@ -24,18 +24,26 @@ export const PermissionSecurityAndCapabilities = () => {
   const { selectedPermission, permission } = usePermission()
   const { allowsWrite, requiresConfirmation } = selectedPermission
   const featureFlagClient: FeatureFlagClient = useFeatureFlagClient()
+  const [isCapabilitiesEnabled, setCapabilitiesEnabled] = useState(false)
   const [isStepUpAuthEnabled, setStepUpAuthEnabled] = useState(false)
 
   useEffect(() => {
-    const checkStepUpAuthEnabled = async () => {
-      const stepUpAuthEnabled = await featureFlagClient.getValue(
-        Features.isIDSAdminStepUpAuthEnabled,
-        false,
-      )
+    const checkFlags = async () => {
+      const [capabilitiesEnabled, stepUpAuthEnabled] = await Promise.all([
+        featureFlagClient.getValue(
+          Features.isNewPermissionsOptionsEnabled,
+          false,
+        ),
+        featureFlagClient.getValue(
+          Features.isIDSAdminStepUpAuthEnabled,
+          false,
+        ),
+      ])
+      setCapabilitiesEnabled(capabilitiesEnabled)
       setStepUpAuthEnabled(stepUpAuthEnabled)
     }
 
-    checkStepUpAuthEnabled()
+    checkFlags()
   }, [featureFlagClient])
 
   const [inputValues, setInputValues] = useEnvironmentState<{
@@ -45,6 +53,10 @@ export const PermissionSecurityAndCapabilities = () => {
     allowsWrite,
     requiresConfirmation,
   })
+
+  if (!isCapabilitiesEnabled) {
+    return null
+  }
 
   return (
     <FormCard

--- a/libs/portals/admin/ids-admin/src/screens/Permission/components/PermissionSecurityAndCapabilities.tsx
+++ b/libs/portals/admin/ids-admin/src/screens/Permission/components/PermissionSecurityAndCapabilities.tsx
@@ -34,10 +34,7 @@ export const PermissionSecurityAndCapabilities = () => {
           Features.isNewPermissionsOptionsEnabled,
           false,
         ),
-        featureFlagClient.getValue(
-          Features.isIDSAdminStepUpAuthEnabled,
-          false,
-        ),
+        featureFlagClient.getValue(Features.isIDSAdminStepUpAuthEnabled, false),
       ])
       setCapabilitiesEnabled(capabilitiesEnabled)
       setStepUpAuthEnabled(stepUpAuthEnabled)


### PR DESCRIPTION
# Include uncategorized scopes, exclude admin scopes, and gate capabilities card

## What

- Include scopes with no category association in the "Annað" / "Other" uncategorized group (changed join from inner to left join)
- Filter out `@admin.island.is` scopes from category and tag listings
- Ensure the uncategorized group is always last in the list
- Hide the "Security and Capabilities" card behind the `isNewPermissionsOptionsEnabled` feature flag

## Why

- Scopes without any category were silently excluded from the UI due to a required inner join
- Admin scopes are not relevant for delegation categories and should not appear
- Uncategorized should always appear at the end for better UX
- The read/write and step-up auth options need to be gated behind a feature flag before broader rollout

## Screenshots / Gifs

N/A

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Capabilities and step-up authentication are now controlled by feature flags for selective rollout.

* **Refactoring**
  * Enhanced scope and tag categorization with improved organization of uncategorized and orphaned items for better consistency across the platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->