### PR TITLE
feat(web): Feature flag set up for organization footer items

### DIFF
--- a/libs/cms/src/lib/cms.contentful.service.ts
+++ b/libs/cms/src/lib/cms.contentful.service.ts
@@ -1916,15 +1916,20 @@ export class CmsContentfulService {
   }
 
   async getOrganizationFooter(organizationId: string, lang: string) {
-    const response =
-      await this.contentfulRepository.getLocalizedEntries<types.IOrganizationPageFields>(
-        lang,
-        {
-          content_type: 'organizationPage',
-          'fields.organization.sys.id': organizationId,
-          select: 'fields.footerItems,fields.footerConfig',
-        },
-      )
+    const response = await this.contentfulRepository
+      .getLocalizedEntries<types.IOrganizationPageFields>(lang, {
+        content_type: 'organizationPage',
+        'fields.organization.sys.id': organizationId,
+        select: 'fields.footerItems,fields.footerConfig',
+        limit: 1,
+      })
+      .catch((error) => {
+        logger.error(
+          'cms.contentful.service getOrganizationFooter error',
+          error,
+        )
+        return { items: [] }
+      })
 
     if (!response?.items?.length) return null
 

--- a/libs/cms/src/lib/cms.contentful.service.ts
+++ b/libs/cms/src/lib/cms.contentful.service.ts
@@ -132,6 +132,7 @@ import {
   mapServicePortalPage,
   ServicePortalPage,
 } from './models/servicePortalPage.model'
+import { mapFooterItem } from './models/footerItem.model'
 
 const errorHandler = (name: string) => {
   return (error: Error) => {
@@ -1912,5 +1913,27 @@ export class CmsContentfulService {
 
     return response?.fields?.courseListPage?.fields?.organization?.fields
       ?.kennitala
+  }
+
+  async getOrganizationFooter(organizationId: string, lang: string) {
+    const response =
+      await this.contentfulRepository.getLocalizedEntries<types.IOrganizationPageFields>(
+        lang,
+        {
+          content_type: 'organizationPage',
+          'fields.organization.sys.id': organizationId,
+          select: 'fields.footerItems,fields.footerConfig',
+        },
+      )
+
+    if (!response?.items?.length) return null
+
+    const organizationPage = response.items[0]
+
+    return {
+      footerItems:
+        organizationPage?.fields?.footerItems?.map(mapFooterItem) ?? [],
+      footerConfig: organizationPage?.fields?.footerConfig ?? {},
+    }
   }
 }

--- a/libs/cms/src/lib/cms.module.ts
+++ b/libs/cms/src/lib/cms.module.ts
@@ -2,6 +2,7 @@ import { HttpModule } from '@nestjs/axios'
 import { Module } from '@nestjs/common'
 import { TerminusModule } from '@nestjs/terminus'
 import { ElasticService } from '@island.is/content-search-toolkit'
+import { ConfigModule } from '@island.is/nest/config'
 import {
   CmsResolver,
   ArticleResolver,
@@ -38,13 +39,20 @@ import { OrganizationTitleEnByNationalIdLoader } from './loaders/organizationTit
 import { OrganizationLogoByEntryIdLoader } from './loaders/organizationLogoByEntryId.loader'
 import { OrganizationTitleByEntryIdLoader } from './loaders/organizationTitleByEntryId.loader'
 import { OrganizationPageResolver } from './organizationPage.resolver'
-import { FeatureFlagModule } from '@island.is/nest/feature-flags'
+import {
+  FeatureFlagConfig,
+  FeatureFlagModule,
+} from '@island.is/nest/feature-flags'
 
 @Module({
   imports: [
     HttpModule,
     TerminusModule,
     PowerBiConfig.registerOptional(),
+    ConfigModule.forRoot({
+      isGlobal: true,
+      load: [FeatureFlagConfig],
+    }),
     FeatureFlagModule,
   ],
   providers: [

--- a/libs/cms/src/lib/cms.module.ts
+++ b/libs/cms/src/lib/cms.module.ts
@@ -18,6 +18,7 @@ import {
   IntroLinkImageResolver,
   GenericListResolver,
   FeaturedGenericListItemsResolver,
+  OrganizationResolver,
 } from './cms.resolver'
 import { CmsContentfulService } from './cms.contentful.service'
 import { ContentfulRepository } from './contentful.repository'
@@ -37,9 +38,15 @@ import { OrganizationTitleEnByNationalIdLoader } from './loaders/organizationTit
 import { OrganizationLogoByEntryIdLoader } from './loaders/organizationLogoByEntryId.loader'
 import { OrganizationTitleByEntryIdLoader } from './loaders/organizationTitleByEntryId.loader'
 import { OrganizationPageResolver } from './organizationPage.resolver'
+import { FeatureFlagModule } from '@island.is/nest/feature-flags'
 
 @Module({
-  imports: [HttpModule, TerminusModule, PowerBiConfig.registerOptional()],
+  imports: [
+    HttpModule,
+    TerminusModule,
+    PowerBiConfig.registerOptional(),
+    FeatureFlagModule,
+  ],
   providers: [
     CmsResolver,
     ArticleResolver,
@@ -74,6 +81,7 @@ import { OrganizationPageResolver } from './organizationPage.resolver'
     GenericListResolver,
     FeaturedGenericListItemsResolver,
     OrganizationPageResolver,
+    OrganizationResolver,
   ],
   exports: [
     ContentfulRepository,

--- a/libs/cms/src/lib/cms.resolver.ts
+++ b/libs/cms/src/lib/cms.resolver.ts
@@ -1229,8 +1229,11 @@ export class OrganizationResolver {
 
     if (org[cacheKey]) {
       const time = cacheKey.split(delimiter)[1]
-      const tenMinutesInMilliseconds = 10 * 60 * 1000
-      if (Boolean(time) && Number(time) < Date.now() - tenMinutesInMilliseconds)
+      const fiveMinutesInMilliseconds = 5 * 60 * 1000
+      if (
+        Boolean(time) &&
+        Number(time) < Date.now() - fiveMinutesInMilliseconds
+      )
         delete org[cacheKey]
     }
 

--- a/libs/cms/src/lib/cms.resolver.ts
+++ b/libs/cms/src/lib/cms.resolver.ts
@@ -1,5 +1,6 @@
 import { CacheControl, CacheControlOptions } from '@island.is/nest/graphql'
 import { CACHE_CONTROL_MAX_AGE } from '@island.is/shared/constants'
+import { FeatureFlagService, Features } from '@island.is/nest/feature-flags'
 import {
   Args,
   Query,
@@ -177,6 +178,7 @@ import { GetCourseSelectOptionsInput } from './dto/getCourseSelectOptions.input'
 import { WebChat } from './models/webChat.model'
 import { GetWebChatInput } from './dto/getWebChat.input'
 import { ServicePortalPage } from './models/servicePortalPage.model'
+import { FooterItem } from './models/footerItem.model'
 
 const defaultCache: CacheControlOptions = { maxAge: CACHE_CONTROL_MAX_AGE }
 
@@ -1205,5 +1207,48 @@ export class FeaturedGenericListItemsResolver {
       input,
     )
     return response.items
+  }
+}
+
+@Resolver(() => Organization)
+@CacheControl(defaultCache)
+export class OrganizationResolver {
+  constructor(
+    private readonly cmsContentfulService: CmsContentfulService,
+    private readonly featureFlagService: FeatureFlagService,
+  ) {}
+
+  @ResolveField(() => [FooterItem])
+  async footerItems(@Parent() organization: Organization) {
+    const oldBehaviour = !(await this.featureFlagService.getValue(
+      Features.organizationFooterComesFromOrganizationPage,
+      false,
+    ))
+
+    if (oldBehaviour) return organization.footerItems ?? []
+
+    const footer = await this.cmsContentfulService.getOrganizationFooter(
+      organization.id,
+      organization.lang ?? 'is',
+    )
+
+    return footer?.footerItems ?? []
+  }
+
+  @ResolveField(() => GraphQLJSONObject)
+  async footerConfig(@Parent() organization: Organization) {
+    const oldBehaviour = !(await this.featureFlagService.getValue(
+      Features.organizationFooterComesFromOrganizationPage,
+      false,
+    ))
+
+    if (oldBehaviour) return organization.footerConfig ?? {}
+
+    const footer = await this.cmsContentfulService.getOrganizationFooter(
+      organization.id,
+      organization.lang ?? 'is',
+    )
+
+    return footer?.footerConfig ?? {}
   }
 }

--- a/libs/cms/src/lib/cms.resolver.ts
+++ b/libs/cms/src/lib/cms.resolver.ts
@@ -1218,37 +1218,49 @@ export class OrganizationResolver {
     private readonly featureFlagService: FeatureFlagService,
   ) {}
 
+  private getFooter(organization: Organization) {
+    const delimiter = ';'
+    const cacheKey = `${organization.id}-${
+      organization.lang ?? 'is'
+    }-${Date.now()}`
+    const org = organization as Organization & {
+      [cacheKey]?: ReturnType<CmsContentfulService['getOrganizationFooter']>
+    }
+
+    if (org[cacheKey]) {
+      const time = cacheKey.split(delimiter)[1]
+      const tenMinutesInMilliseconds = 10 * 60 * 1000
+      if (Boolean(time) && Number(time) < Date.now() - tenMinutesInMilliseconds)
+        delete org[cacheKey]
+    }
+
+    if (!org[cacheKey])
+      org[cacheKey] = this.featureFlagService
+        .getValue(Features.organizationFooterComesFromOrganizationPage, false)
+        .then((flag) =>
+          flag
+            ? this.cmsContentfulService.getOrganizationFooter(
+                org.id,
+                org.lang ?? 'is',
+              )
+            : {
+                footerItems: org?.footerItems ?? [],
+                footerConfig: org?.footerConfig ?? {},
+              },
+        )
+
+    return org[cacheKey]
+  }
+
   @ResolveField(() => [FooterItem])
   async footerItems(@Parent() organization: Organization) {
-    const oldBehaviour = !(await this.featureFlagService.getValue(
-      Features.organizationFooterComesFromOrganizationPage,
-      false,
-    ))
-
-    if (oldBehaviour) return organization.footerItems ?? []
-
-    const footer = await this.cmsContentfulService.getOrganizationFooter(
-      organization.id,
-      organization.lang ?? 'is',
-    )
-
+    const footer = await this.getFooter(organization)
     return footer?.footerItems ?? []
   }
 
   @ResolveField(() => GraphQLJSONObject)
   async footerConfig(@Parent() organization: Organization) {
-    const oldBehaviour = !(await this.featureFlagService.getValue(
-      Features.organizationFooterComesFromOrganizationPage,
-      false,
-    ))
-
-    if (oldBehaviour) return organization.footerConfig ?? {}
-
-    const footer = await this.cmsContentfulService.getOrganizationFooter(
-      organization.id,
-      organization.lang ?? 'is',
-    )
-
+    const footer = await this.getFooter(organization)
     return footer?.footerConfig ?? {}
   }
 }

--- a/libs/cms/src/lib/generated/contentfulTypes.d.ts
+++ b/libs/cms/src/lib/generated/contentfulTypes.d.ts
@@ -3663,6 +3663,9 @@ export interface IOrganizationPageFields {
   /** Footer Items */
   footerItems?: IFooterItem[] | undefined
 
+  /** Footer Config */
+  footerConfig?: Record<string, any> | undefined
+
   /** Default Header Image */
   defaultHeaderImage?: Asset | undefined
 

--- a/libs/cms/src/lib/models/organization.model.ts
+++ b/libs/cms/src/lib/models/organization.model.ts
@@ -82,6 +82,9 @@ export class Organization {
 
   @Field(() => Boolean, { nullable: true })
   canPagesBeFoundInSearchResults?: boolean
+
+  @Field(() => String, { nullable: true })
+  lang?: string
 }
 
 export const mapOrganization = ({
@@ -119,5 +122,6 @@ export const mapOrganization = ({
     newsBottomSlices: (fields.newsBottomSlices ?? []).map(mapEmailSignup),
     canPagesBeFoundInSearchResults:
       fields.canPagesBeFoundInSearchResults ?? true,
+    lang: sys.locale === 'is-IS' ? 'is' : sys.locale,
   }
 }

--- a/libs/cms/src/lib/models/organizationPage.model.ts
+++ b/libs/cms/src/lib/models/organizationPage.model.ts
@@ -5,6 +5,7 @@ import { getOrganizationPageUrlPrefix } from '@island.is/shared/utils'
 
 import { IOrganizationPage } from '../generated/contentfulTypes'
 import { mapOrganization, Organization } from './organization.model'
+import { FooterItem, mapFooterItem } from './footerItem.model'
 import { LinkGroup, mapLinkGroup } from './linkGroup.model'
 import { Link, mapLink } from './link.model'
 import { Image, mapImage } from './image.model'
@@ -157,6 +158,9 @@ export class OrganizationPage {
   @CacheField(() => [Link], { nullable: true })
   externalLinks?: Array<Link>
 
+  @CacheField(() => [FooterItem], { nullable: true })
+  footerItems?: Array<FooterItem>
+
   @CacheField(() => AlertBanner, { nullable: true })
   alertBanner?: AlertBanner
 
@@ -237,6 +241,7 @@ export const mapOrganizationPage = ({
       .map(safelyMapSliceUnion)
       .filter(Boolean),
     externalLinks: (fields.externalLinks ?? []).map(mapLink),
+    footerItems: (fields.footerItems ?? []).map(mapFooterItem),
     alertBanner: fields.alertBanner
       ? mapAlertBanner(fields.alertBanner)
       : undefined,

--- a/libs/feature-flags/src/lib/features.ts
+++ b/libs/feature-flags/src/lib/features.ts
@@ -190,6 +190,8 @@ export enum Features {
   servicePortalUniversityMicroCredentialsEnabled = 'isServicePortalUniversityMicroCredentialsPageEnabled',
   // Car recycling
   isNewCarRecyclingBackendEnabled = 'isNewCarRecyclingBackendEnabled',
+
+  organizationFooterComesFromOrganizationPage = 'organizationFooterComesFromOrganizationPage',
 }
 
 export enum ServerSideFeature {


### PR DESCRIPTION
# Feature flag set up for organization footer items

We're moving the footer items from the organization content type to the organizationPage content type.

To do this I'm adding a field resolver to the graphql api and a feature flag for when we make the switch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Organization footers can now surface footer items and footer configuration from the CMS.
  * Runtime choice (via feature flag) to source footer data from organization pages or CMS.
  * Organizations now include language metadata to ensure correct localized footer selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->