### PR TITLE
feat(application-system): use args array in pruneMessage

### DIFF
--- a/apps/application-system/api/src/app/modules/application/lifecycle/application-lifecycle.service.ts
+++ b/apps/application-system/api/src/app/modules/application/lifecycle/application-lifecycle.service.ts
@@ -356,16 +356,7 @@ export class ApplicationLifeCycleService {
                   nationalId: application.applicant,
                 },
                 templateId: pruneMessage.notificationTemplateId,
-                args: [
-                  {
-                    key: 'externalBody',
-                    value: pruneMessage.externalBody || '',
-                  },
-                  {
-                    key: 'internalBody',
-                    value: pruneMessage.internalBody || '',
-                  },
-                ],
+                args: pruneMessage.args ?? [],
               }
               notificationArray.push(notification)
             })
@@ -373,16 +364,7 @@ export class ApplicationLifeCycleService {
             const notification = {
               recipient: application.applicant,
               templateId: pruneMessage.notificationTemplateId,
-              args: [
-                {
-                  key: 'externalBody',
-                  value: pruneMessage.externalBody || '',
-                },
-                {
-                  key: 'internalBody',
-                  value: pruneMessage.internalBody || '',
-                },
-              ],
+              args: pruneMessage.args ?? [],
             }
             notificationArray.push(notification)
           }

--- a/apps/application-system/api/src/app/modules/application/lifecycle/test/application-lifecycle-notification.spec.ts
+++ b/apps/application-system/api/src/app/modules/application/lifecycle/test/application-lifecycle-notification.spec.ts
@@ -81,8 +81,10 @@ describe('ApplicationLifeCycleService', () => {
                 lifecycle: {
                   shouldBePruned: true,
                   pruneMessage: {
-                    externalBody: 'external message',
-                    internalBody: 'internal message',
+                    args: [
+                      { key: 'externalBody', value: 'external message' },
+                      { key: 'internalBody', value: 'internal message' },
+                    ],
                     notificationTemplateId: 'template123',
                   },
                 },
@@ -136,8 +138,10 @@ describe('ApplicationLifeCycleService', () => {
                 lifecycle: {
                   shouldBePruned: true,
                   pruneMessage: {
-                    externalBody: 'external message',
-                    internalBody: 'internal message',
+                    args: [
+                      { key: 'externalBody', value: 'external message' },
+                      { key: 'internalBody', value: 'internal message' },
+                    ],
                     notificationTemplateId: 'template123',
                   },
                 },
@@ -211,8 +215,16 @@ describe('ApplicationLifeCycleService', () => {
                 lifecycle: {
                   shouldBePruned: true,
                   pruneMessage: (app: PruningApplication) => ({
-                    externalBody: `external message for ${app.id}`,
-                    internalBody: `internal message for ${app.id}`,
+                    args: [
+                      {
+                        key: 'externalBody',
+                        value: `external message for ${app.id}`,
+                      },
+                      {
+                        key: 'internalBody',
+                        value: `internal message for ${app.id}`,
+                      },
+                    ],
                     notificationTemplateId: 'template123',
                   }),
                 },

--- a/libs/application/templates/aosh/transfer-of-machine-ownership/src/lib/TransferOfMachineOwnershipTemplate.ts
+++ b/libs/application/templates/aosh/transfer-of-machine-ownership/src/lib/TransferOfMachineOwnershipTemplate.ts
@@ -266,7 +266,7 @@ const template: ApplicationTemplate<
                   NotificationConfig[
                     NotificationType.TransferOfMachineOwnershipPruned
                   ].templateId,
-                internalBody: regNumber ?? '',
+                args: [{ key: 'internalBody', value: regNumber ?? '' }],
               }
             },
           },

--- a/libs/application/templates/family-matters/children-residence-change-v2/src/lib/ChildrenResidenceChangeTemplate.ts
+++ b/libs/application/templates/family-matters/children-residence-change-v2/src/lib/ChildrenResidenceChangeTemplate.ts
@@ -216,7 +216,9 @@ const ChildrenResidenceChangeTemplate: ApplicationTemplate<
                 NotificationConfig[
                   NotificationType.ChildrenResidenceChangePruned
                 ].templateId,
-              ...(internalBody && { internalBody }),
+              ...(internalBody && {
+                args: [{ key: 'internalBody', value: internalBody }],
+              }),
             }
           }),
           onEntry: defineTemplateApi({

--- a/libs/application/templates/hms/rental-agreement/src/lib/RentalAgreementTemplate.ts
+++ b/libs/application/templates/hms/rental-agreement/src/lib/RentalAgreementTemplate.ts
@@ -202,8 +202,10 @@ const RentalAgreementTemplate: ApplicationTemplate<
               .join(', ')
             const args: Array<{ key: string; value: string }> = []
             if (address) args.push({ key: 'address', value: address })
-            if (landlordNames) args.push({ key: 'landlordNames', value: landlordNames })
-            if (tenantNames) args.push({ key: 'tenantNames', value: tenantNames })
+            if (landlordNames)
+              args.push({ key: 'landlordNames', value: landlordNames })
+            if (tenantNames)
+              args.push({ key: 'tenantNames', value: tenantNames })
             return {
               notificationTemplateId:
                 NotificationConfig[NotificationType.RentalAgreementPruned]
@@ -299,8 +301,10 @@ const RentalAgreementTemplate: ApplicationTemplate<
               .join(', ')
             const args: Array<{ key: string; value: string }> = []
             if (address) args.push({ key: 'address', value: address })
-            if (landlordNames) args.push({ key: 'landlordNames', value: landlordNames })
-            if (tenantNames) args.push({ key: 'tenantNames', value: tenantNames })
+            if (landlordNames)
+              args.push({ key: 'landlordNames', value: landlordNames })
+            if (tenantNames)
+              args.push({ key: 'tenantNames', value: tenantNames })
             return {
               notificationTemplateId:
                 NotificationConfig[NotificationType.RentalAgreementPruned]

--- a/libs/application/templates/hms/rental-agreement/src/lib/RentalAgreementTemplate.ts
+++ b/libs/application/templates/hms/rental-agreement/src/lib/RentalAgreementTemplate.ts
@@ -291,16 +291,16 @@ const RentalAgreementTemplate: ApplicationTemplate<
               application.answers,
               'parties.tenantInfo.table',
             )
-            const landlordName = landlords
+            const landlordNames = landlords
               ?.map((l) => l.nationalIdWithName.name)
               .join(', ')
-            const tenantName = tenants
+            const tenantNames = tenants
               ?.map((t) => t.nationalIdWithName.name)
               .join(', ')
             const args: Array<{ key: string; value: string }> = []
             if (address) args.push({ key: 'address', value: address })
-            if (landlordName) args.push({ key: 'landlordName', value: landlordName })
-            if (tenantName) args.push({ key: 'tenantName', value: tenantName })
+            if (landlordNames) args.push({ key: 'landlordNames', value: landlordNames })
+            if (tenantNames) args.push({ key: 'tenantNames', value: tenantNames })
             return {
               notificationTemplateId:
                 NotificationConfig[NotificationType.RentalAgreementPruned]

--- a/libs/application/templates/hms/rental-agreement/src/lib/RentalAgreementTemplate.ts
+++ b/libs/application/templates/hms/rental-agreement/src/lib/RentalAgreementTemplate.ts
@@ -31,6 +31,7 @@ import {
   NationalRegistryV3UserApi,
   NationalRegistryV3SpouseApi,
 } from '../dataProviders'
+import { ApplicantsInfo } from '../shared'
 import { dataSchema } from './dataSchema'
 import { application } from './messages'
 import { ApiScope, HmsScope } from '@island.is/auth/scopes'
@@ -185,11 +186,29 @@ const RentalAgreementTemplate: ApplicationTemplate<
               application.answers,
               'registerProperty.searchresults.address',
             )
+            const landlords = getValueViaPath<Array<ApplicantsInfo>>(
+              application.answers,
+              'parties.landlordInfo.table',
+            )
+            const tenants = getValueViaPath<Array<ApplicantsInfo>>(
+              application.answers,
+              'parties.tenantInfo.table',
+            )
+            const landlordNames = landlords
+              ?.map((l) => l.nationalIdWithName.name)
+              .join(', ')
+            const tenantNames = tenants
+              ?.map((t) => t.nationalIdWithName.name)
+              .join(', ')
+            const args: Array<{ key: string; value: string }> = []
+            if (address) args.push({ key: 'address', value: address })
+            if (landlordNames) args.push({ key: 'landlordNames', value: landlordNames })
+            if (tenantNames) args.push({ key: 'tenantNames', value: tenantNames })
             return {
               notificationTemplateId:
                 NotificationConfig[NotificationType.RentalAgreementPruned]
                   .templateId,
-              ...(address && { internalBody: address }),
+              ...(args.length > 0 && { args }),
             }
           }),
           onEntry: defineTemplateApi({
@@ -264,11 +283,29 @@ const RentalAgreementTemplate: ApplicationTemplate<
               application.answers,
               'registerProperty.searchresults.address',
             )
+            const landlords = getValueViaPath<Array<ApplicantsInfo>>(
+              application.answers,
+              'parties.landlordInfo.table',
+            )
+            const tenants = getValueViaPath<Array<ApplicantsInfo>>(
+              application.answers,
+              'parties.tenantInfo.table',
+            )
+            const landlordName = landlords
+              ?.map((l) => l.nationalIdWithName.name)
+              .join(', ')
+            const tenantName = tenants
+              ?.map((t) => t.nationalIdWithName.name)
+              .join(', ')
+            const args: Array<{ key: string; value: string }> = []
+            if (address) args.push({ key: 'address', value: address })
+            if (landlordName) args.push({ key: 'landlordName', value: landlordName })
+            if (tenantName) args.push({ key: 'tenantName', value: tenantName })
             return {
               notificationTemplateId:
                 NotificationConfig[NotificationType.RentalAgreementPruned]
                   .templateId,
-              ...(address && { internalBody: address }),
+              ...(args.length > 0 && { args }),
             }
           }),
           onEntry: defineTemplateApi({

--- a/libs/application/templates/iceland-health/accident-notification/src/lib/AccidentNotificationTemplate.ts
+++ b/libs/application/templates/iceland-health/accident-notification/src/lib/AccidentNotificationTemplate.ts
@@ -355,7 +355,9 @@ const AccidentNotificationTemplate: ApplicationTemplate<
               notificationTemplateId:
                 NotificationConfig[NotificationType.AccidentNotificationPruned]
                   .templateId,
-              ...(nationalId && { internalBody: nationalId }),
+              ...(nationalId && {
+                args: [{ key: 'internalBody', value: nationalId }],
+              }),
             }
           }),
           onEntry: defineTemplateApi({

--- a/libs/application/templates/id-card/src/lib/IdCardTemplate.ts
+++ b/libs/application/templates/id-card/src/lib/IdCardTemplate.ts
@@ -179,7 +179,9 @@ const IdCardTemplate: ApplicationTemplate<
             return {
               notificationTemplateId:
                 NotificationConfig[NotificationType.IdCardPruned].templateId,
-              ...(nationalId && { internalBody: nationalId }),
+              ...(nationalId && {
+                args: [{ key: 'internalBody', value: nationalId }],
+              }),
             }
           }),
           onEntry: defineTemplateApi({

--- a/libs/application/templates/new-primary-school/src/lib/NewPrimarySchoolTemplate.ts
+++ b/libs/application/templates/new-primary-school/src/lib/NewPrimarySchoolTemplate.ts
@@ -264,7 +264,9 @@ const NewPrimarySchoolTemplate: ApplicationTemplate<
               notificationTemplateId:
                 NotificationConfig[NotificationType.NewPrimarySchoolPruned]
                   .templateId,
-              ...(nationalId && { internalBody: nationalId }),
+              ...(nationalId && {
+                args: [{ key: 'internalBody', value: nationalId }],
+              }),
             }
           }),
           actionCard: {
@@ -391,7 +393,9 @@ const NewPrimarySchoolTemplate: ApplicationTemplate<
               notificationTemplateId:
                 NotificationConfig[NotificationType.NewPrimarySchoolPruned]
                   .templateId,
-              ...(nationalId && { internalBody: nationalId }),
+              ...(nationalId && {
+                args: [{ key: 'internalBody', value: nationalId }],
+              }),
             }
           }),
           actionCard: {

--- a/libs/application/templates/passport/src/lib/PassportTemplate.ts
+++ b/libs/application/templates/passport/src/lib/PassportTemplate.ts
@@ -167,7 +167,9 @@ const PassportTemplate: ApplicationTemplate<
                 notificationTemplateId:
                   NotificationConfig[NotificationType.PassportPruned]
                     .templateId,
-                ...(nationalId && { internalBody: nationalId }),
+                ...(nationalId && {
+                  args: [{ key: 'internalBody', value: nationalId }],
+                }),
               }
             },
           },

--- a/libs/application/templates/transport-authority/change-co-owner-of-vehicle/src/lib/ChangeCoOwnerOfVehicleTemplate.ts
+++ b/libs/application/templates/transport-authority/change-co-owner-of-vehicle/src/lib/ChangeCoOwnerOfVehicleTemplate.ts
@@ -246,7 +246,7 @@ const template: ApplicationTemplate<
                   NotificationConfig[
                     NotificationType.ChangeCoOwnerOfVehiclePruned
                   ].templateId,
-                internalBody: plate ?? '',
+                args: [{ key: 'internalBody', value: plate ?? '' }],
               }
             },
           },

--- a/libs/application/templates/transport-authority/change-operator-of-vehicle/src/lib/ChangeOperatorOfVehicleTemplate.ts
+++ b/libs/application/templates/transport-authority/change-operator-of-vehicle/src/lib/ChangeOperatorOfVehicleTemplate.ts
@@ -249,7 +249,7 @@ const template: ApplicationTemplate<
                   NotificationConfig[
                     NotificationType.ChangeOperatorOfVehiclePruned
                   ].templateId,
-                internalBody: plate ?? '',
+                args: [{ key: 'internalBody', value: plate ?? '' }],
               }
             },
           },

--- a/libs/application/templates/transport-authority/transfer-of-vehicle-ownership/src/lib/TransferOfVehicleOwnershipTemplate.ts
+++ b/libs/application/templates/transport-authority/transfer-of-vehicle-ownership/src/lib/TransferOfVehicleOwnershipTemplate.ts
@@ -259,7 +259,7 @@ const template: ApplicationTemplate<
                   NotificationConfig[
                     NotificationType.TransferOfVehicleOwnershipPruned
                   ].templateId,
-                internalBody: plate ?? '',
+                args: [{ key: 'internalBody', value: plate ?? '' }],
               }
             },
           },

--- a/libs/application/types/src/lib/ApplicationLifecycle.ts
+++ b/libs/application/types/src/lib/ApplicationLifecycle.ts
@@ -18,7 +18,6 @@ export type PruningApplication = Pick<
 >
 
 export type PruningNotification = {
-  externalBody?: string
-  internalBody?: string
+  args?: Array<{ key: string; value: string }>
   notificationTemplateId: string
 }


### PR DESCRIPTION
Instead of defining explicit internal and external bodies in pruneMessage this PR defines an args array of key-value pairs that can be used for substitution in contentful strings.

I kept keys unchanged where possible so there should be no need to update contentful strings

# ...

Attach a link to issue if relevant

## What

Specify what you're trying to achieve

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized pruning notifications to use flexible key-value argument arrays across many application templates and core lifecycle handling.
* **Tests**
  * Updated tests to reflect the new prune message shape and ensure error handling for malformed messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->