### PR TITLE
fix: Notifications UI in mobile and handle empty links

### DIFF
--- a/apps/portals/my-pages/src/screens/Dashboard/Dashboard.css.ts
+++ b/apps/portals/my-pages/src/screens/Dashboard/Dashboard.css.ts
@@ -44,10 +44,28 @@ globalStyle(`${svgOutline} svg path`, {
   stroke: theme.color.blue400,
 })
 
-export const featuredCardImage = style({
-  height: 110,
-  width: 'auto',
-  display: 'block',
+export const featuredCardImageWrapper = style({
+  alignSelf: 'stretch',
+  flexShrink: 0,
+  width: 132,
+  marginTop: -theme.spacing[3],
+  marginBottom: -theme.spacing[3],
+  marginRight: -theme.spacing[3],
+  borderTopRightRadius: 8,
+  borderBottomRightRadius: 8,
+  overflow: 'hidden',
+  ...themeUtils.responsiveStyle({
+    xl: {
+      marginRight: -theme.spacing[4],
+    },
+  }),
+})
+
+
+export const featuredCardWithImage = style({})
+
+globalStyle(`${featuredCardWithImage} > *`, {
+  overflow: 'hidden',
 })
 
 export const featuredCardNoText = style({})

--- a/apps/portals/my-pages/src/screens/Dashboard/Dashboard.css.ts
+++ b/apps/portals/my-pages/src/screens/Dashboard/Dashboard.css.ts
@@ -67,7 +67,6 @@ export const featuredCardImage = style({
   objectFit: 'contain',
 })
 
-
 export const featuredCardWithImage = style({})
 
 globalStyle(`${featuredCardWithImage} > *`, {

--- a/apps/portals/my-pages/src/screens/Dashboard/Dashboard.css.ts
+++ b/apps/portals/my-pages/src/screens/Dashboard/Dashboard.css.ts
@@ -61,6 +61,12 @@ export const featuredCardImageWrapper = style({
   }),
 })
 
+export const featuredCardImage = style({
+  width: '100%',
+  height: '100%',
+  objectFit: 'contain',
+})
+
 
 export const featuredCardWithImage = style({})
 

--- a/apps/portals/my-pages/src/screens/Dashboard/DashboardV2/DashboardFeatured.tsx
+++ b/apps/portals/my-pages/src/screens/Dashboard/DashboardV2/DashboardFeatured.tsx
@@ -59,6 +59,7 @@ export const DashboardFeatured = ({ items, isMobile }: Props) => {
         // TODO: Update to use the featuredImage when it is available
         const image =
           item.path === '/heilsa' ? './assets/images/jobs.svg' : undefined
+        const showImage = !!image && !isMobile
 
         const icon = item.icon
         const iconEl = icon ? (
@@ -93,6 +94,7 @@ export const DashboardFeatured = ({ items, isMobile }: Props) => {
             // Remove when category card supports no text
             className={cn(styles.svgOutline, {
               [styles.featuredCardNoText]: i >= 2,
+              [styles.featuredCardWithImage]: showImage,
             })}
           >
             {isDisabled && (
@@ -124,12 +126,18 @@ export const DashboardFeatured = ({ items, isMobile }: Props) => {
               text={description ?? title}
               icon={iconEl}
               customImage={
-                image && !isMobile ? (
-                  <img
-                    src={image}
-                    alt=""
-                    className={styles.featuredCardImage}
-                  />
+                showImage ? (
+                  <div className={styles.featuredCardImageWrapper}>
+                    <img
+                      src={image}
+                      alt=""
+                      style={{
+                        width: '100%',
+                        height: '100%',
+                        objectFit: 'contain',
+                      }}
+                    />
+                  </div>
                 ) : undefined
               }
               tags={[]}

--- a/apps/portals/my-pages/src/screens/Dashboard/DashboardV2/DashboardFeatured.tsx
+++ b/apps/portals/my-pages/src/screens/Dashboard/DashboardV2/DashboardFeatured.tsx
@@ -128,7 +128,11 @@ export const DashboardFeatured = ({ items, isMobile }: Props) => {
               customImage={
                 showImage ? (
                   <div className={styles.featuredCardImageWrapper}>
-                    <img src={image} alt="" className={styles.featuredCardImage} />
+                    <img
+                      src={image}
+                      alt=""
+                      className={styles.featuredCardImage}
+                    />
                   </div>
                 ) : undefined
               }

--- a/apps/portals/my-pages/src/screens/Dashboard/DashboardV2/DashboardFeatured.tsx
+++ b/apps/portals/my-pages/src/screens/Dashboard/DashboardV2/DashboardFeatured.tsx
@@ -128,15 +128,7 @@ export const DashboardFeatured = ({ items, isMobile }: Props) => {
               customImage={
                 showImage ? (
                   <div className={styles.featuredCardImageWrapper}>
-                    <img
-                      src={image}
-                      alt=""
-                      style={{
-                        width: '100%',
-                        height: '100%',
-                        objectFit: 'contain',
-                      }}
-                    />
+                    <img src={image} alt="" className={styles.featuredCardImage} />
                   </div>
                 ) : undefined
               }

--- a/apps/portals/my-pages/src/screens/Dashboard/DashboardV2/DashboardNotifications.css.ts
+++ b/apps/portals/my-pages/src/screens/Dashboard/DashboardV2/DashboardNotifications.css.ts
@@ -37,3 +37,11 @@ export const notificationSenderLogoImage = style({
   height: 24,
   objectFit: 'contain',
 })
+export const notificationRowMobileFull = style({
+  '@media': {
+    [`screen and (max-width: ${theme.breakpoints.md - 1}px)`]: {
+      marginLeft: -theme.spacing[4],
+      marginRight: -theme.spacing[4],
+    },
+  },
+})

--- a/apps/portals/my-pages/src/screens/Dashboard/DashboardV2/DashboardNotifications.tsx
+++ b/apps/portals/my-pages/src/screens/Dashboard/DashboardV2/DashboardNotifications.tsx
@@ -11,7 +11,6 @@ import {
 import { useUserInfo } from '@island.is/react-spa/bff'
 import { Problem } from '@island.is/react-spa/shared'
 import { hasNotificationScopes } from '@island.is/auth/scopes'
-import { Link } from 'react-router-dom'
 import { lock } from '../Dashboard.css'
 import * as styles from './DashboardNotifications.css'
 
@@ -145,7 +144,6 @@ export const DashboardNotifications = ({ limit }: { limit: number }) => {
         notifications.map((item) => {
           const href =
             resolveLink(item.message.link) || InformationPaths.Notifications
-          const isExternal = href.startsWith('http')
 
           const unread = !item.metadata.read
           const content = (
@@ -202,33 +200,15 @@ export const DashboardNotifications = ({ limit }: { limit: number }) => {
             </Box>
           )
 
-          if (isExternal) {
-            return (
-              <a
-                key={item.notificationId}
-                href={href}
-                target="_blank"
-                rel="noopener noreferrer"
-                aria-label={`${item.message.title} - ${formatMessage(
-                  m.notificationOpensInNewTab,
-                )}`}
-                className={styles.notificationLink}
-                onClick={() => handleNotificationClick(item.id)}
-              >
-                {content}
-              </a>
-            )
-          }
-
           return (
-            <Link
+            <LinkResolver
               key={item.notificationId}
-              to={href}
+              href={href}
               className={styles.notificationLink}
-              onClick={() => handleNotificationClick(item.id)}
+              callback={() => handleNotificationClick(item.id)}
             >
               {content}
-            </Link>
+            </LinkResolver>
           )
         })}
     </Box>

--- a/apps/portals/my-pages/src/screens/Dashboard/DashboardV2/DashboardNotifications.tsx
+++ b/apps/portals/my-pages/src/screens/Dashboard/DashboardV2/DashboardNotifications.tsx
@@ -43,7 +43,7 @@ export const DashboardNotifications = ({ limit }: { limit: number }) => {
       borderWidth="standard"
       borderColor="blue200"
       paddingY={3}
-      paddingX={4}
+      paddingX={[0, 0, 4]}
     >
       {!loading && !hasDelegationAccess && (
         <span className={lock} aria-hidden="true">
@@ -56,6 +56,7 @@ export const DashboardNotifications = ({ limit }: { limit: number }) => {
         justifyContent="spaceBetween"
         alignItems="center"
         marginBottom={2}
+        paddingX={[4, 4, 0]}
       >
         <LinkResolver href={InformationPaths.Notifications}>
           <Box
@@ -91,7 +92,7 @@ export const DashboardNotifications = ({ limit }: { limit: number }) => {
       </Box>
 
       {loading && (
-        <Box marginTop={4}>
+        <Box marginTop={4} paddingX={[4, 4, 0]}>
           <SkeletonLoader
             space={2}
             repeat={4}
@@ -109,6 +110,7 @@ export const DashboardNotifications = ({ limit }: { limit: number }) => {
           alignItems="center"
           paddingTop={2}
           rowGap={2}
+          paddingX={[4, 4, 0]}
         >
           <Text variant="h4" textAlign="center">
             {formatMessage(m.accessNeeded)}
@@ -141,7 +143,8 @@ export const DashboardNotifications = ({ limit }: { limit: number }) => {
         hasDelegationAccess &&
         !error &&
         notifications.map((item) => {
-          const href = resolveLink(item.message.link)
+          const href =
+            resolveLink(item.message.link) || InformationPaths.Notifications
           const isExternal = href.startsWith('http')
 
           const unread = !item.metadata.read
@@ -151,7 +154,7 @@ export const DashboardNotifications = ({ limit }: { limit: number }) => {
               alignItems="center"
               columnGap={2}
               paddingY={2}
-              paddingX={2}
+              paddingX={[4, 4, 2]}
               borderTopWidth="standard"
               borderColor="blue200"
               className={unread ? styles.unreadRow : undefined}
@@ -198,8 +201,6 @@ export const DashboardNotifications = ({ limit }: { limit: number }) => {
               </Box>
             </Box>
           )
-
-          if (!href) return <Box key={item.notificationId}>{content}</Box>
 
           if (isExternal) {
             return (

--- a/apps/portals/my-pages/src/screens/Dashboard/DashboardV2/DashboardV2.css.ts
+++ b/apps/portals/my-pages/src/screens/Dashboard/DashboardV2/DashboardV2.css.ts
@@ -6,7 +6,7 @@ globalStyle('body.my-pages-hero-bg', {
 
 globalStyle('body.my-pages-hero-bg main', {
   vars: {
-    '--my-pages-hero-blue-height': '300px',
+    '--my-pages-hero-blue-height': '298px',
   },
   backgroundColor: 'white',
   backgroundImage:
@@ -14,10 +14,10 @@ globalStyle('body.my-pages-hero-bg main', {
   backgroundRepeat: 'no-repeat',
   '@media': {
     [`screen and (min-width: ${theme.breakpoints.md}px)`]: {
-      vars: { '--my-pages-hero-blue-height': '320px' },
+      vars: { '--my-pages-hero-blue-height': '319px' },
     },
     [`screen and (min-width: ${theme.breakpoints.lg}px)`]: {
-      vars: { '--my-pages-hero-blue-height': '345px' },
+      vars: { '--my-pages-hero-blue-height': '344px' },
     },
   },
 })


### PR DESCRIPTION
## What

- If notification has no link, go to notifications page, also use LinkResolver
- Full width notification lines in mobile

## Why

UX and UI, we want notifications to be clickable and people can also see the full text on the notifications page if it's a longer notification. 

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Notification links reliably fall back to the Notifications page and consistently mark items read when opened.

* **UI Improvements**
  * Notifications padding and layout made more responsive, including full-width mobile rows.
  * Featured cards improved image handling and display on larger screens.
  * Minor hero background height tweaks for smoother visual alignment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->