### PR TITLE
style(web): show ellipsis for too long tags in life events page

### DIFF
--- a/apps/web/components/CardWithFeaturedItems/CardWithFeaturedItems.tsx
+++ b/apps/web/components/CardWithFeaturedItems/CardWithFeaturedItems.tsx
@@ -50,7 +50,7 @@ export const CardWithFeaturedItems = ({
         <Box height="full">
           {limitedFeaturedItems.length > 0 && (
             <Hidden below="sm">
-              <FeaturedItemTags featuredItems={limitedFeaturedItems} />
+              <FeaturedItemTags featuredItems={limitedFeaturedItems} truncate />
             </Hidden>
           )}
         </Box>

--- a/apps/web/components/CardWithFeaturedItems/FeaturedItemTags.css.ts
+++ b/apps/web/components/CardWithFeaturedItems/FeaturedItemTags.css.ts
@@ -8,12 +8,3 @@ globalStyle(`${purpleTags} a:hover, ${purpleTags} button:hover`, {
   backgroundColor: theme.color.purple400,
   color: theme.color.white,
 })
-
-export const truncatedTags = style({})
-
-globalStyle(`${truncatedTags} a, ${truncatedTags} button`, {
-  maxWidth: '100%',
-  overflow: 'hidden',
-  textOverflow: 'ellipsis',
-  whiteSpace: 'nowrap',
-})

--- a/apps/web/components/CardWithFeaturedItems/FeaturedItemTags.tsx
+++ b/apps/web/components/CardWithFeaturedItems/FeaturedItemTags.tsx
@@ -21,12 +21,7 @@ export const FeaturedItemTags = ({
   const items = featuredItems.slice(0, maxItems)
 
   return (
-    <Box
-      marginY={2}
-      className={`${styles.purpleTags}${
-        truncate ? ` ${styles.truncatedTags}` : ''
-      }`}
-    >
+    <Box marginY={2} className={styles.purpleTags}>
       {items.map((item: Featured) => {
         const { thing } = item
         if (!thing?.type || !thing?.slug) {
@@ -35,7 +30,7 @@ export const FeaturedItemTags = ({
         const cardUrl = linkResolver(thing.type as LinkType, [thing.slug])
         return (
           <Box marginBottom={1} key={thing.slug}>
-            <FeaturedTag item={item} cardUrl={cardUrl} />
+            <FeaturedTag item={item} cardUrl={cardUrl} truncate={truncate} />
           </Box>
         )
       })}
@@ -46,9 +41,11 @@ export const FeaturedItemTags = ({
 const FeaturedTag = ({
   item,
   cardUrl,
+  truncate,
 }: {
   item: Featured
   cardUrl: { href: string; as?: string }
+  truncate?: boolean
 }) => {
   const CustomLink = useMemo(
     () =>
@@ -71,6 +68,7 @@ const FeaturedTag = ({
         ? { CustomLink }
         : { href: cardUrl.href })}
       variant="purple"
+      truncate={truncate}
     >
       {item.title}
     </Tag>


### PR DESCRIPTION
<img width="459" height="292" alt="image" src="https://github.com/user-attachments/assets/a5867102-d760-4337-89bd-0f86a8b01746" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated featured item tags hover appearance with purple background and white text styling.

* **Features**
  * Made text truncation for featured item tags configurable per component usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->