### PR TITLE
fix(pension): forward button not working after backing out of employers screen

### DIFF
--- a/libs/application/templates/social-insurance-administration/old-age-pension/src/fields/EmployersOverview/index.tsx
+++ b/libs/application/templates/social-insurance-administration/old-age-pension/src/fields/EmployersOverview/index.tsx
@@ -120,7 +120,7 @@ const EmployersOverview: FC<RepeaterProps> = ({
           </Button>
         </Inline>
       </Box>
-      {!!error && (
+      {typeof error === 'string' && !!error && (
         <Box marginTop={3}>
           <ContentBlock>
             <AlertMessage type="error" title={error} />

--- a/libs/application/templates/social-insurance-administration/old-age-pension/src/fields/EmployersOverview/index.tsx
+++ b/libs/application/templates/social-insurance-administration/old-age-pension/src/fields/EmployersOverview/index.tsx
@@ -57,8 +57,25 @@ const EmployersOverview: FC<RepeaterProps> = ({
     ) {
       markEmployersOverviewAutoExpanded(application.id)
       expandRepeater()
+      return
     }
-  }, [application.id, expandRepeater, employers, rawEmployers])
+
+    // expandRepeater appends an empty {} to the employers array. If the user
+    // backs out of the addEmployers form without entering anything, that empty
+    // entry stays in state and fails dataSchema validation, silently blocking
+    // submission on earlier screens (e.g. employmentStatusSubSection).
+    const nonEmptyEmployers = rawEmployers.filter(
+      (e) =>
+        !!e?.email ||
+        !!e?.phoneNumber ||
+        !!e?.ratioType ||
+        !!e?.ratioYearly ||
+        !!e?.ratioMonthlyAvg,
+    )
+    if (nonEmptyEmployers.length !== rawEmployers.length) {
+      setRepeaterItems(nonEmptyEmployers)
+    }
+  }, [application.id, expandRepeater, employers, rawEmployers, setRepeaterItems])
 
   setBeforeSubmitCallback?.(async () => {
     if (

--- a/libs/application/templates/social-insurance-administration/old-age-pension/src/fields/EmployersOverview/index.tsx
+++ b/libs/application/templates/social-insurance-administration/old-age-pension/src/fields/EmployersOverview/index.tsx
@@ -75,7 +75,13 @@ const EmployersOverview: FC<RepeaterProps> = ({
     if (nonEmptyEmployers.length !== rawEmployers.length) {
       setRepeaterItems(nonEmptyEmployers)
     }
-  }, [application.id, expandRepeater, employers, rawEmployers, setRepeaterItems])
+  }, [
+    application.id,
+    expandRepeater,
+    employers,
+    rawEmployers,
+    setRepeaterItems,
+  ])
 
   setBeforeSubmitCallback?.(async () => {
     if (


### PR DESCRIPTION
Batman mál 465526

## What

Fix an issue where the forward button in the Pension application would cease working if the user pressed back from the employers screen 

## Why

the forward button has to work 

## Screenshots / Gifs

n/a

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented redundant state updates after the auto-expansion path to avoid unintended side effects.
  * Filtered out empty employer entries so empty records no longer persist, fixing form validation failures and data inconsistencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->