### PR TITLE
fix(scripts): Updating contentful string no longer overwrites internal title 

### DIFF
--- a/libs/localization/scripts/extract.ts
+++ b/libs/localization/scripts/extract.ts
@@ -94,10 +94,6 @@ export const updateNamespace = async (
   messages: MessageDict,
   locales: Locales,
 ) => {
-  namespace.fields.internalTitle = {
-    [DEFAULT_LOCALE]: namespace.fields.namespace[DEFAULT_LOCALE],
-  }
-
   namespace.fields.defaults[DEFAULT_LOCALE] = updateDefaultsObject(
     namespace,
     messages,


### PR DESCRIPTION
## What

We recently added Internal Title to the extract strings script so new applications get a default value instead of needing to manually create it. But we dont want to reset the Internal Title to the namespace if someone has edit the title to be more human readable.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized localization extraction script performance by streamlining internal calculation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->