### PR TITLE
feat(ids-admin): partial failure handling for permissions

### DIFF
--- a/libs/api/domains/auth-admin/src/lib/client/clients.resolver.ts
+++ b/libs/api/domains/auth-admin/src/lib/client/clients.resolver.ts
@@ -27,6 +27,7 @@ import { RotateSecretInput } from './dto/rotate-secret.input'
 import { ClientSecret } from './models/client-secret.model'
 import { DeleteClientInput } from './dto/delete-client.input'
 import { RestoreClientInput } from './dto/restore-client.input'
+import { PatchClientResponse } from './models/patch-client-response.model'
 
 @UseGuards(IdsUserGuard)
 @Resolver(() => Client)
@@ -76,13 +77,13 @@ export class ClientsResolver {
     return this.clientsService.publishClient(user, input)
   }
 
-  @Mutation(() => [ClientEnvironment], {
+  @Mutation(() => PatchClientResponse, {
     name: 'patchAuthAdminClient',
   })
   patchClient(
     @CurrentUser() user: User,
     @Args('input', { type: () => PatchClientInput }) input: PatchClientInput,
-  ) {
+  ): Promise<PatchClientResponse> {
     return this.clientsService.patchClient(user, input)
   }
 

--- a/libs/api/domains/auth-admin/src/lib/client/clients.service.spec.ts
+++ b/libs/api/domains/auth-admin/src/lib/client/clients.service.spec.ts
@@ -318,39 +318,41 @@ describe('ClientsService', () => {
         1,
       )
       expect(mockAdminProdApi.meClientsControllerUpdateRaw).toBeCalledTimes(1)
-      expect(response).toEqual([
-        {
-          environment: Environment.Development,
-          ...baseResponse,
-          id: `${
-            baseResponse.clientId
-          }#${Environment.Development.toLowerCase()}`,
-          postLogoutRedirectUris: [
-            'https://test.island.is',
-            'https://test2.island.is',
-          ],
-        },
-        {
-          environment: Environment.Staging,
-          ...baseResponse,
-          id: `${baseResponse.clientId}#${Environment.Staging.toLowerCase()}`,
-          postLogoutRedirectUris: [
-            'https://test.island.is',
-            'https://test2.island.is',
-          ],
-        },
-        {
-          environment: Environment.Production,
-          ...baseResponse,
-          id: `${
-            baseResponse.clientId
-          }#${Environment.Production.toLowerCase()}`,
-          postLogoutRedirectUris: [
-            'https://test.island.is',
-            'https://test2.island.is',
-          ],
-        },
-      ])
+      expect(response).toEqual({
+        environments: [
+          {
+            environment: Environment.Development,
+            ...baseResponse,
+            id: `${
+              baseResponse.clientId
+            }#${Environment.Development.toLowerCase()}`,
+            postLogoutRedirectUris: [
+              'https://test.island.is',
+              'https://test2.island.is',
+            ],
+          },
+          {
+            environment: Environment.Staging,
+            ...baseResponse,
+            id: `${baseResponse.clientId}#${Environment.Staging.toLowerCase()}`,
+            postLogoutRedirectUris: [
+              'https://test.island.is',
+              'https://test2.island.is',
+            ],
+          },
+          {
+            environment: Environment.Production,
+            ...baseResponse,
+            id: `${
+              baseResponse.clientId
+            }#${Environment.Production.toLowerCase()}`,
+            postLogoutRedirectUris: [
+              'https://test.island.is',
+              'https://test2.island.is',
+            ],
+          },
+        ],
+      })
     })
 
     it('should update the postLogoutRedirectUris for all Development only', async () => {
@@ -374,19 +376,21 @@ describe('ClientsService', () => {
         0,
       )
       expect(mockAdminProdApi.meClientsControllerUpdateRaw).toBeCalledTimes(0)
-      expect(response).toEqual([
-        {
-          environment: Environment.Development,
-          ...baseResponse,
-          id: `${
-            baseResponse.clientId
-          }#${Environment.Development.toLowerCase()}`,
-          postLogoutRedirectUris: [
-            'https://test.island.is',
-            'https://test2.island.is',
-          ],
-        },
-      ])
+      expect(response).toEqual({
+        environments: [
+          {
+            environment: Environment.Development,
+            ...baseResponse,
+            id: `${
+              baseResponse.clientId
+            }#${Environment.Development.toLowerCase()}`,
+            postLogoutRedirectUris: [
+              'https://test.island.is',
+              'https://test2.island.is',
+            ],
+          },
+        ],
+      })
     })
 
     it('should only rotate secret in a single target environment', async () => {

--- a/libs/api/domains/auth-admin/src/lib/client/clients.service.ts
+++ b/libs/api/domains/auth-admin/src/lib/client/clients.service.ts
@@ -28,6 +28,7 @@ import { DeleteClientInput } from './dto/delete-client.input'
 import { RestoreClientInput } from './dto/restore-client.input'
 import { ClientsPayload } from './dto/clients.payload'
 import { RevokeSecretsInput } from './dto/revoke-secrets.input'
+import { PatchClientResponse } from './models/patch-client-response.model'
 
 @Injectable()
 export class ClientsService extends MultiEnvironmentService {
@@ -167,7 +168,7 @@ export class ClientsService extends MultiEnvironmentService {
       environments,
       ...adminPatchClientDto
     }: PatchClientInput,
-  ): Promise<ClientEnvironment[]> {
+  ): Promise<PatchClientResponse> {
     if (Object.keys(adminPatchClientDto).length === 0) {
       throw new Error('Nothing provided to update')
     }
@@ -184,14 +185,23 @@ export class ClientsService extends MultiEnvironmentService {
       ),
     )
 
-    return this.handleSettledPromises(updated, {
-      mapper: (client, index) => ({
-        ...client,
-        id: this.formatClientId(client.clientId, environments[index]),
-        environment: environments[index],
-      }),
-      prefixErrorMessage: `Failed to update application ${clientId}`,
-    })
+    const { values, failures } = this.handleSettledPromisesWithFailures(
+      updated,
+      environments,
+      {
+        mapper: (client, index): ClientEnvironment => ({
+          ...client,
+          id: this.formatClientId(client.clientId, environments[index]),
+          environment: environments[index],
+        }),
+        prefixErrorMessage: `Failed to update application ${clientId}`,
+      },
+    )
+
+    return {
+      environments: values,
+      ...(failures.length > 0 && { failedEnvironments: failures }),
+    }
   }
 
   async getClientSecrets(

--- a/libs/api/domains/auth-admin/src/lib/client/models/patch-client-response.model.ts
+++ b/libs/api/domains/auth-admin/src/lib/client/models/patch-client-response.model.ts
@@ -1,0 +1,13 @@
+import { Field, ObjectType } from '@nestjs/graphql'
+
+import { EnvironmentFailure } from '../../shared/models/multi-environment-result.model'
+import { ClientEnvironment } from './client-environment.model'
+
+@ObjectType('AuthAdminPatchClientResponse')
+export class PatchClientResponse {
+  @Field(() => [ClientEnvironment])
+  environments!: ClientEnvironment[]
+
+  @Field(() => [EnvironmentFailure], { nullable: true })
+  failedEnvironments?: EnvironmentFailure[]
+}

--- a/libs/api/domains/auth-admin/src/lib/scope/models/patch-scope-response.model.ts
+++ b/libs/api/domains/auth-admin/src/lib/scope/models/patch-scope-response.model.ts
@@ -1,0 +1,13 @@
+import { Field, ObjectType } from '@nestjs/graphql'
+
+import { EnvironmentFailure } from '../../shared/models/multi-environment-result.model'
+import { ScopeEnvironment } from './scope-environment.model'
+
+@ObjectType('AuthAdminPatchScopeResponse')
+export class PatchScopeResponse {
+  @Field(() => [ScopeEnvironment])
+  environments!: ScopeEnvironment[]
+
+  @Field(() => [EnvironmentFailure], { nullable: true })
+  failedEnvironments?: EnvironmentFailure[]
+}

--- a/libs/api/domains/auth-admin/src/lib/scope/models/update-scope-users-response.model.ts
+++ b/libs/api/domains/auth-admin/src/lib/scope/models/update-scope-users-response.model.ts
@@ -1,0 +1,12 @@
+import { Field, ObjectType } from '@nestjs/graphql'
+
+import { EnvironmentFailure } from '../../shared/models/multi-environment-result.model'
+
+@ObjectType('AuthAdminUpdateScopeUsersResponse')
+export class UpdateScopeUsersResponse {
+  @Field(() => Boolean)
+  success!: boolean
+
+  @Field(() => [EnvironmentFailure], { nullable: true })
+  failedEnvironments?: EnvironmentFailure[]
+}

--- a/libs/api/domains/auth-admin/src/lib/scope/models/update-scope-users-response.model.ts
+++ b/libs/api/domains/auth-admin/src/lib/scope/models/update-scope-users-response.model.ts
@@ -1,11 +1,13 @@
 import { Field, ObjectType } from '@nestjs/graphql'
 
+import { Environment } from '@island.is/shared/types'
+
 import { EnvironmentFailure } from '../../shared/models/multi-environment-result.model'
 
 @ObjectType('AuthAdminUpdateScopeUsersResponse')
 export class UpdateScopeUsersResponse {
-  @Field(() => Boolean)
-  success!: boolean
+  @Field(() => [Environment], { nullable: true })
+  environments?: Environment[]
 
   @Field(() => [EnvironmentFailure], { nullable: true })
   failedEnvironments?: EnvironmentFailure[]

--- a/libs/api/domains/auth-admin/src/lib/scope/scope.resolver.ts
+++ b/libs/api/domains/auth-admin/src/lib/scope/scope.resolver.ts
@@ -32,6 +32,8 @@ import { AdminPatchScopeInput } from './dto/patch-scope.input'
 import { PublishScopeInput } from './dto/publish-scope.input'
 import { ScopeCategory } from './models/scope-category.model'
 import { ScopeTag } from './models/scope-tag.model'
+import { PatchScopeResponse } from './models/patch-scope-response.model'
+import { UpdateScopeUsersResponse } from './models/update-scope-users-response.model'
 
 @UseGuards(IdsUserGuard)
 @Resolver(() => Scope)
@@ -52,14 +54,14 @@ export class ScopeResolver {
     return this.scopeService.createScope(user, input)
   }
 
-  @Mutation(() => [ScopeEnvironment], {
+  @Mutation(() => PatchScopeResponse, {
     name: 'patchAuthAdminScope',
   })
   patchScope(
     @CurrentUser() user: User,
     @Args('input', { type: () => AdminPatchScopeInput })
     input: AdminPatchScopeInput,
-  ): Promise<ScopeEnvironment[]> {
+  ): Promise<PatchScopeResponse> {
     return this.scopeService.updateScope({ user, input })
   }
 
@@ -195,14 +197,14 @@ export class ScopeResolver {
     return this.scopeService.createScopeUser(user, input)
   }
 
-  @Mutation(() => Boolean, {
+  @Mutation(() => UpdateScopeUsersResponse, {
     name: 'updateAuthAdminScopeUsers',
   })
   updateScopeUsers(
     @CurrentUser() user: User,
     @Args('input', { type: () => UpdateScopeUsersInput })
     input: UpdateScopeUsersInput,
-  ): Promise<boolean> {
+  ): Promise<UpdateScopeUsersResponse> {
     return this.scopeService.updateScopeUsers(user, input)
   }
 }

--- a/libs/api/domains/auth-admin/src/lib/scope/scope.service.ts
+++ b/libs/api/domains/auth-admin/src/lib/scope/scope.service.ts
@@ -69,8 +69,7 @@ export class ScopeService extends MultiEnvironmentService {
    * Updates a scope for a specific tenant for the given environments.
    *
    * Per-environment failures are collected and returned alongside the
-   * successful results so the caller can surface partial failures to the user
-   * instead of silently dropping them.
+   * successful results
    */
   async updateScope({
     user,
@@ -340,8 +339,8 @@ export class ScopeService extends MultiEnvironmentService {
   /**
    * Updates the user access list for a scope by adding/removing users.
    *
-   * Per-environment failures are collected and returned so the caller can
-   * surface partial failures to the user.
+   * Per-environment failures are collected and returned and
+   * surfaced to the user.
    */
   async updateScopeUsers(
     user: User,
@@ -368,13 +367,13 @@ export class ScopeService extends MultiEnvironmentService {
       settledPromises,
       targetEnvironments,
       {
-        mapper: () => true as const,
+        mapper: (_value, index) => targetEnvironments[index],
         prefixErrorMessage: `Failed to update scope users for ${input.scopeName}`,
       },
     )
 
     return {
-      success: values.length > 0,
+      ...(values.length > 0 && { environments: values }),
       ...(failures.length > 0 && { failedEnvironments: failures }),
     }
   }

--- a/libs/api/domains/auth-admin/src/lib/scope/scope.service.ts
+++ b/libs/api/domains/auth-admin/src/lib/scope/scope.service.ts
@@ -19,6 +19,8 @@ import { ScopeEnvironment } from './models/scope-environment.model'
 import { environments } from '../shared/constants/environments'
 import { AdminPatchScopeInput } from './dto/patch-scope.input'
 import { PublishScopeInput } from './dto/publish-scope.input'
+import { PatchScopeResponse } from './models/patch-scope-response.model'
+import { UpdateScopeUsersResponse } from './models/update-scope-users-response.model'
 
 @Injectable()
 export class ScopeService extends MultiEnvironmentService {
@@ -64,7 +66,11 @@ export class ScopeService extends MultiEnvironmentService {
   }
 
   /**
-   * Updates a scope for a specific tenant for the given environments
+   * Updates a scope for a specific tenant for the given environments.
+   *
+   * Per-environment failures are collected and returned alongside the
+   * successful results so the caller can surface partial failures to the user
+   * instead of silently dropping them.
    */
   async updateScope({
     user,
@@ -72,7 +78,7 @@ export class ScopeService extends MultiEnvironmentService {
   }: {
     user: User
     input: AdminPatchScopeInput
-  }): Promise<ScopeEnvironment[]> {
+  }): Promise<PatchScopeResponse> {
     if (Object.keys(adminPatchScopeDto).length === 0) {
       throw new Error('Nothing provided to update')
     }
@@ -89,16 +95,24 @@ export class ScopeService extends MultiEnvironmentService {
       }),
     )
 
-    return this.handleSettledPromises(updatedSettledPromises, {
-      mapper: (scope, index) => ({
-        ...scope,
-        scopeName: scope.name,
-        environment: environments[index],
-        categoryIds: scope.categoryIds ?? [],
-        tagIds: scope.tagIds ?? [],
-      }),
-      prefixErrorMessage: `Failed to update scope ${scopeName}`,
-    })
+    const { values, failures } = this.handleSettledPromisesWithFailures(
+      updatedSettledPromises,
+      environments,
+      {
+        mapper: (scope, index): ScopeEnvironment => ({
+          ...scope,
+          environment: environments[index],
+          categoryIds: scope.categoryIds ?? [],
+          tagIds: scope.tagIds ?? [],
+        }),
+        prefixErrorMessage: `Failed to update scope ${scopeName}`,
+      },
+    )
+
+    return {
+      environments: values,
+      ...(failures.length > 0 && { failedEnvironments: failures }),
+    }
   }
 
   /**
@@ -324,18 +338,20 @@ export class ScopeService extends MultiEnvironmentService {
   }
 
   /**
-   * Updates the user access list for a scope by adding/removing users
+   * Updates the user access list for a scope by adding/removing users.
+   *
+   * Per-environment failures are collected and returned so the caller can
+   * surface partial failures to the user.
    */
   async updateScopeUsers(
     user: User,
     input: UpdateScopeUsersInput,
-  ): Promise<boolean> {
+  ): Promise<UpdateScopeUsersResponse> {
     const targetEnvironments = input.environments
-    let anySuccess = false
 
-    for (const environment of targetEnvironments) {
-      try {
-        await this.makeRequest(user, environment, (api) =>
+    const settledPromises = await Promise.allSettled(
+      targetEnvironments.map((environment) =>
+        this.makeRequest(user, environment, (api) =>
           api.meScopeUsersControllerUpdateScopeUsersRaw({
             tenantId: input.tenantId,
             scopeName: input.scopeName,
@@ -344,16 +360,22 @@ export class ScopeService extends MultiEnvironmentService {
               removedNationalIds: input.removedNationalIds,
             },
           }),
-        )
-        anySuccess = true
-      } catch (error) {
-        this.logger.error(
-          `Failed to update scope users in ${environment}`,
-          error as Error,
-        )
-      }
-    }
+        ),
+      ),
+    )
 
-    return anySuccess
+    const { values, failures } = this.handleSettledPromisesWithFailures(
+      settledPromises,
+      targetEnvironments,
+      {
+        mapper: () => true as const,
+        prefixErrorMessage: `Failed to update scope users for ${input.scopeName}`,
+      },
+    )
+
+    return {
+      success: values.length > 0,
+      ...(failures.length > 0 && { failedEnvironments: failures }),
+    }
   }
 }

--- a/libs/api/domains/auth-admin/src/lib/shared/services/multi-environment.service.ts
+++ b/libs/api/domains/auth-admin/src/lib/shared/services/multi-environment.service.ts
@@ -131,12 +131,7 @@ export abstract class MultiEnvironmentService {
 
   /**
    * Like {@link handleSettledPromises} but also collects per-environment
-   * failures so callers can surface them to the user. Use for write paths
-   * where silently dropping a failed env would mislead the caller.
-   *
-   * `requestedEnvs` must be the same array (or aligned) as the one used to
-   * build the settled promises — index `i` of `settledPromises` corresponds to
-   * `requestedEnvs[i]`.
+   * failures and returns them alongside the successful results
    */
   public handleSettledPromisesWithFailures<T, K>(
     settledPromises: PromiseSettledResult<T | undefined | null>[],
@@ -156,7 +151,16 @@ export abstract class MultiEnvironmentService {
       const environment = requestedEnvs[index]
       if (resp.status === 'fulfilled' && resp.value) {
         values.push(mapper(resp.value, index))
-      } else if (resp.status === 'rejected') {
+      } else if (resp.status === 'fulfilled') {
+        // makeRequest resolves to null/undefined when the env's API client
+        // is not configured, or when the upstream returned an empty body.
+        // Surface this as a failure rather than silently dropping it.
+        const message = `${
+          prefixErrorMessage ?? 'Error'
+        } in environment ${environment}: no response (environment not configured or empty response)`
+        this.logger.error(message)
+        failures.push({ environment, message })
+      } else {
         const message =
           resp.reason instanceof Error
             ? resp.reason.message

--- a/libs/api/domains/auth-admin/src/lib/shared/services/multi-environment.service.ts
+++ b/libs/api/domains/auth-admin/src/lib/shared/services/multi-environment.service.ts
@@ -13,6 +13,7 @@ import { Environment } from '@island.is/shared/types'
 import { isDefined } from '@island.is/shared/utils'
 
 import { environments } from '../constants/environments'
+import { EnvironmentFailure } from '../models/multi-environment-result.model'
 
 @Injectable()
 export abstract class MultiEnvironmentService {
@@ -126,5 +127,48 @@ export abstract class MultiEnvironmentService {
         }
       })
       .filter(isDefined)
+  }
+
+  /**
+   * Like {@link handleSettledPromises} but also collects per-environment
+   * failures so callers can surface them to the user. Use for write paths
+   * where silently dropping a failed env would mislead the caller.
+   *
+   * `requestedEnvs` must be the same array (or aligned) as the one used to
+   * build the settled promises — index `i` of `settledPromises` corresponds to
+   * `requestedEnvs[i]`.
+   */
+  public handleSettledPromisesWithFailures<T, K>(
+    settledPromises: PromiseSettledResult<T | undefined | null>[],
+    requestedEnvs: Environment[],
+    {
+      mapper,
+      prefixErrorMessage,
+    }: {
+      mapper: (value: PromiseFulfilledResult<T>['value'], index: number) => K
+      prefixErrorMessage?: string
+    },
+  ): { values: K[]; failures: EnvironmentFailure[] } {
+    const values: K[] = []
+    const failures: EnvironmentFailure[] = []
+
+    settledPromises.forEach((resp, index) => {
+      const environment = requestedEnvs[index]
+      if (resp.status === 'fulfilled' && resp.value) {
+        values.push(mapper(resp.value, index))
+      } else if (resp.status === 'rejected') {
+        const message =
+          resp.reason instanceof Error
+            ? resp.reason.message
+            : String(resp.reason ?? 'Unknown error')
+        this.logger.error(
+          `${prefixErrorMessage ?? 'Error'} in environment ${environment}`,
+          resp.reason,
+        )
+        failures.push({ environment, message })
+      }
+    })
+
+    return { values, failures }
   }
 }

--- a/libs/portals/admin/ids-admin/src/components/FormCard/FormCard.tsx
+++ b/libs/portals/admin/ids-admin/src/components/FormCard/FormCard.tsx
@@ -12,6 +12,7 @@ import {
 import { useLocale } from '@island.is/localization'
 import { useSubmitting } from '@island.is/react-spa/shared'
 import { RouterActionResponse } from '@island.is/portals/core'
+import { AuthAdminEnvironmentFailure } from '@island.is/api/schema'
 
 import { m } from '../../lib/messages'
 import { DropdownSync } from '../DropdownSync/DropdownSync'
@@ -87,11 +88,18 @@ export const FormCard = <Intent extends string>({
   const { availableEnvironments, selectedEnvironment } = useEnvironment()
   const { isLoading, isSubmitting, formData } = useSubmitting()
   const { loading } = useIntent(intent)
-  const actionData = useActionData() as RouterActionResponse<
-    unknown, // We don't know the type of the data or the error since it can be permission or client.
-    unknown,
-    Intent
-  >
+  const actionData = useActionData() as
+    | (RouterActionResponse<
+        unknown, // We don't know the type of the data or the error since it can be permission or client.
+        unknown,
+        Intent
+      > & {
+        failedEnvironments?: Pick<
+          AuthAdminEnvironmentFailure,
+          'environment' | 'message'
+        >[]
+      })
+    | undefined
 
   /**
    * On form change check if form is dirty and set dirty state accordingly.
@@ -140,9 +148,7 @@ export const FormCard = <Intent extends string>({
 
         onFormChange()
 
-        const failedEnvironments = (
-          actionData as { failedEnvironments?: { environment: string }[] }
-        )?.failedEnvironments
+        const failedEnvironments = actionData?.failedEnvironments
 
         if (failedEnvironments && failedEnvironments.length > 0) {
           const envs = failedEnvironments.map((f) => f.environment).join(', ')

--- a/libs/portals/admin/ids-admin/src/components/FormCard/FormCard.tsx
+++ b/libs/portals/admin/ids-admin/src/components/FormCard/FormCard.tsx
@@ -139,7 +139,17 @@ export const FormCard = <Intent extends string>({
         }
 
         onFormChange()
-        toast.success(formatMessage(m.successfullySaved))
+
+        const failedEnvironments = (
+          actionData as { failedEnvironments?: { environment: string }[] }
+        )?.failedEnvironments
+
+        if (failedEnvironments && failedEnvironments.length > 0) {
+          const envs = failedEnvironments.map((f) => f.environment).join(', ')
+          toast.warning(formatMessage(m.partiallySaved, { envs }))
+        } else {
+          toast.success(formatMessage(m.successfullySaved))
+        }
       } else if (actionData?.globalError) {
         toast.error(formatMessage(m.globalErrorMessage))
       }

--- a/libs/portals/admin/ids-admin/src/lib/messages.ts
+++ b/libs/portals/admin/ids-admin/src/lib/messages.ts
@@ -692,6 +692,10 @@ export const m = defineMessages({
     id: 'ap.ids-admin:successfully-saved',
     defaultMessage: 'Successfully saved',
   },
+  partiallySaved: {
+    id: 'ap.ids-admin:partially-saved',
+    defaultMessage: 'Saved in some environments. Operation failed on: {envs}',
+  },
   globalErrorMessage: {
     id: 'ap.ids-admin:global-error-message',
     defaultMessage: 'An error occurred',

--- a/libs/portals/admin/ids-admin/src/screens/Client/EditClient.action.ts
+++ b/libs/portals/admin/ids-admin/src/screens/Client/EditClient.action.ts
@@ -3,7 +3,10 @@ import {
   validateFormData,
   ValidateFormDataResult,
 } from '@island.is/react-spa/shared'
-import { AuthAdminEnvironment } from '@island.is/api/schema'
+import {
+  AuthAdminEnvironment,
+  AuthAdminEnvironmentFailure,
+} from '@island.is/api/schema'
 
 import {
   UpdateClientDocument,
@@ -19,10 +22,15 @@ import {
 } from './EditClient.schema'
 
 export type EditClientResult = RouterActionResponse<
-  UpdateClientMutation['patchAuthAdminClient'],
+  UpdateClientMutation['patchAuthAdminClient']['environments'],
   ValidateFormDataResult<MergedFormDataSchema>['errors'],
   keyof typeof ClientFormTypes
->
+> & {
+  failedEnvironments?: Pick<
+    AuthAdminEnvironmentFailure,
+    'environment' | 'message'
+  >[]
+}
 
 export const editClientAction: WrappedActionFn =
   ({ client }) =>
@@ -95,9 +103,13 @@ export const editClientAction: WrappedActionFn =
         return globalErrorResponse
       }
 
+      const failedEnvironments =
+        response.data?.patchAuthAdminClient.failedEnvironments ?? []
+
       return {
-        data: response.data?.patchAuthAdminClient ?? null,
+        data: response.data?.patchAuthAdminClient.environments ?? null,
         intent,
+        ...(failedEnvironments.length > 0 && { failedEnvironments }),
       }
     } catch (error) {
       return globalErrorResponse

--- a/libs/portals/admin/ids-admin/src/screens/Client/EditClient.graphql
+++ b/libs/portals/admin/ids-admin/src/screens/Client/EditClient.graphql
@@ -1,33 +1,39 @@
 mutation UpdateClient($input: AuthAdminPatchClientInput!) {
   patchAuthAdminClient(input: $input) {
-    environment
-    clientId
-    displayName {
-      locale
-      value
+    environments {
+      environment
+      clientId
+      displayName {
+        locale
+        value
+      }
+      redirectUris
+      postLogoutRedirectUris
+      absoluteRefreshTokenLifetime
+      slidingRefreshTokenLifetime
+      refreshTokenExpiration
+      supportsCustomDelegation
+      supportsPersonalRepresentatives
+      supportsLegalGuardians
+      supportsProcuringHolders
+      supportTokenExchange
+      promptDelegations
+      requireApiScopes
+      requireConsent
+      requirePkce
+      singleSession
+      accessTokenLifetime
+      allowOfflineAccess
+      sso
+      customClaims {
+        type
+        value
+      }
+      allowedCorsOrigins
     }
-    redirectUris
-    postLogoutRedirectUris
-    absoluteRefreshTokenLifetime
-    slidingRefreshTokenLifetime
-    refreshTokenExpiration
-    supportsCustomDelegation
-    supportsPersonalRepresentatives
-    supportsLegalGuardians
-    supportsProcuringHolders
-    supportTokenExchange
-    promptDelegations
-    requireApiScopes
-    requireConsent
-    requirePkce
-    singleSession
-    accessTokenLifetime
-    allowOfflineAccess
-    sso
-    customClaims {
-      type
-      value
+    failedEnvironments {
+      environment
+      message
     }
-    allowedCorsOrigins
   }
 }

--- a/libs/portals/admin/ids-admin/src/screens/Permission/EditPermission.action.ts
+++ b/libs/portals/admin/ids-admin/src/screens/Permission/EditPermission.action.ts
@@ -117,7 +117,10 @@ export const editPermissionAction: WrappedActionFn =
 
       const failedEnvironments: NonNullable<
         EditPermissionResult['failedEnvironments']
-      > = [...(patchScopeResult.data?.patchAuthAdminScope.failedEnvironments ?? [])]
+      > = [
+        ...(patchScopeResult.data?.patchAuthAdminScope.failedEnvironments ??
+          []),
+      ]
 
       // Update scope users if there are changes
       const hasUserChanges =
@@ -142,13 +145,21 @@ export const editPermissionAction: WrappedActionFn =
         })
 
         if (updateUsersResult.errors?.length) {
-          return globalErrorResponse
+          const transportMessage = updateUsersResult.errors
+            .map((e) => e.message)
+            .join('; ')
+          for (const env of environments) {
+            failedEnvironments.push({
+              environment: env,
+              message: `Updating scope users failed: ${transportMessage}`,
+            })
+          }
+        } else {
+          const userFailures =
+            updateUsersResult.data?.updateAuthAdminScopeUsers
+              .failedEnvironments ?? []
+          failedEnvironments.push(...userFailures)
         }
-
-        const userFailures =
-          updateUsersResult.data?.updateAuthAdminScopeUsers
-            .failedEnvironments ?? []
-        failedEnvironments.push(...userFailures)
       }
 
       return {

--- a/libs/portals/admin/ids-admin/src/screens/Permission/EditPermission.action.ts
+++ b/libs/portals/admin/ids-admin/src/screens/Permission/EditPermission.action.ts
@@ -3,7 +3,10 @@ import {
   validateFormData,
   ValidateFormDataResult,
 } from '@island.is/react-spa/shared'
-import { AuthAdminEnvironment } from '@island.is/api/schema'
+import {
+  AuthAdminEnvironment,
+  AuthAdminEnvironmentFailure,
+} from '@island.is/api/schema'
 
 import {
   PatchAuthAdminScopeDocument,
@@ -24,10 +27,15 @@ import {
 } from './EditPermission.schema'
 
 export type EditPermissionResult = RouterActionResponse<
-  PatchAuthAdminScopeMutation['patchAuthAdminScope'],
+  PatchAuthAdminScopeMutation['patchAuthAdminScope']['environments'],
   ValidateFormDataResult<MergedFormDataSchema>['errors'],
   keyof typeof PermissionFormTypes
->
+> & {
+  failedEnvironments?: Pick<
+    AuthAdminEnvironmentFailure,
+    'environment' | 'message'
+  >[]
+}
 
 export const editPermissionAction: WrappedActionFn =
   ({ client }) =>
@@ -107,13 +115,17 @@ export const editPermissionAction: WrappedActionFn =
         return globalErrorResponse
       }
 
+      const failedEnvironments: NonNullable<
+        EditPermissionResult['failedEnvironments']
+      > = [...(patchScopeResult.data?.patchAuthAdminScope.failedEnvironments ?? [])]
+
       // Update scope users if there are changes
       const hasUserChanges =
         (addedScopeUserNationalIds && addedScopeUserNationalIds.length > 0) ||
         (removedScopeUserNationalIds && removedScopeUserNationalIds.length > 0)
 
       if (intent === PermissionFormTypes.ACCESS_CONTROL && hasUserChanges) {
-        await client.mutate<
+        const updateUsersResult = await client.mutate<
           UpdateScopeUsersMutation,
           UpdateScopeUsersMutationVariables
         >({
@@ -128,11 +140,21 @@ export const editPermissionAction: WrappedActionFn =
             },
           },
         })
+
+        if (updateUsersResult.errors?.length) {
+          return globalErrorResponse
+        }
+
+        const userFailures =
+          updateUsersResult.data?.updateAuthAdminScopeUsers
+            .failedEnvironments ?? []
+        failedEnvironments.push(...userFailures)
       }
 
       return {
-        data: patchScopeResult.data?.patchAuthAdminScope ?? null,
+        data: patchScopeResult.data?.patchAuthAdminScope.environments ?? null,
         intent,
+        ...(failedEnvironments.length > 0 && { failedEnvironments }),
       }
     } catch (e) {
       return globalErrorResponse

--- a/libs/portals/admin/ids-admin/src/screens/Permission/EditPermission.action.ts
+++ b/libs/portals/admin/ids-admin/src/screens/Permission/EditPermission.action.ts
@@ -117,7 +117,10 @@ export const editPermissionAction: WrappedActionFn =
 
       const failedEnvironments: NonNullable<
         EditPermissionResult['failedEnvironments']
-      > = [...(patchScopeResult.data?.patchAuthAdminScope.failedEnvironments ?? [])]
+      > = [
+        ...(patchScopeResult.data?.patchAuthAdminScope.failedEnvironments ??
+          []),
+      ]
 
       // Update scope users if there are changes
       const hasUserChanges =

--- a/libs/portals/admin/ids-admin/src/screens/Permission/EditPermission.graphql
+++ b/libs/portals/admin/ids-admin/src/screens/Permission/EditPermission.graphql
@@ -1,5 +1,11 @@
 mutation PatchAuthAdminScope($input: AuthAdminPatchScopeInput!) {
   patchAuthAdminScope(input: $input) {
-    ...AuthAdminScopeEnvironmentFragment
+    environments {
+      ...AuthAdminScopeEnvironmentFragment
+    }
+    failedEnvironments {
+      environment
+      message
+    }
   }
 }

--- a/libs/portals/admin/ids-admin/src/screens/Permission/components/PermissionAccessControl.graphql
+++ b/libs/portals/admin/ids-admin/src/screens/Permission/components/PermissionAccessControl.graphql
@@ -18,5 +18,11 @@ query GetAllApiScopeUsersForSelect($input: AuthAdminApiScopeUsersInput!) {
 }
 
 mutation UpdateScopeUsers($input: UpdateAuthAdminScopeUsersInput!) {
-  updateAuthAdminScopeUsers(input: $input)
+  updateAuthAdminScopeUsers(input: $input) {
+    success
+    failedEnvironments {
+      environment
+      message
+    }
+  }
 }

--- a/libs/portals/admin/ids-admin/src/screens/Permission/components/PermissionAccessControl.graphql
+++ b/libs/portals/admin/ids-admin/src/screens/Permission/components/PermissionAccessControl.graphql
@@ -19,7 +19,7 @@ query GetAllApiScopeUsersForSelect($input: AuthAdminApiScopeUsersInput!) {
 
 mutation UpdateScopeUsers($input: UpdateAuthAdminScopeUsersInput!) {
   updateAuthAdminScopeUsers(input: $input) {
-    success
+    environments
     failedEnvironments {
       environment
       message


### PR DESCRIPTION
## What

Implement partial failure handling for permissions/scopes
- Updated `patchAuthAdminClient` and `patchAuthAdminScope` mutations to return structured responses including successful environments and any failures encountered during the operation.
- Introduced `PatchClientResponse` and `PatchScopeResponse` models to encapsulate the results of patch operations.
- Enhanced error handling in the client and scope services to provide feedback on partial failures.
- Updated GraphQL schemas and frontend actions to accommodate the new response structure, ensuring users are informed of any issues during updates.

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced multi-environment update operations to provide detailed failure information, allowing users to identify which specific environments encountered issues.
  * Added warning notifications when partial updates succeed—some environments update successfully while others fail.

* **Improvements**
  * Updated response handling across client and permission operations to distinguish between complete and partial success scenarios.
  * Improved user feedback with environment-specific error details during bulk operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->