### PR TITLE
fix(j-s): Resolve police case numbers for merged cases as well.

### DIFF
--- a/apps/judicial-system/backend/src/app/modules/repository/services/caseRepository.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/repository/services/caseRepository.service.ts
@@ -131,6 +131,32 @@ export class CaseRepositoryService {
     return !attributes.exclude?.includes('policeCaseNumbers')
   }
 
+  private async resolvePoliceCaseNumbersForCaseGraph(
+    cases: Case[],
+    options?: { transaction?: Transaction },
+  ): Promise<void> {
+    const byId = new Map<string, Case>()
+
+    // Add merged cases so we resolve their police case numbers too
+    for (const c of cases) {
+      if (c.id) {
+        byId.set(c.id, c)
+      }
+      c.mergedCases?.forEach((mergedCase) => {
+        if (mergedCase.id) {
+          byId.set(mergedCase.id, mergedCase)
+        }
+      })
+    }
+
+    const toResolve = [...byId.values()]
+
+    await this.caseDefendantPoliceCaseNumberRepositoryService.resolvePoliceCaseNumbersForCases(
+      toResolve,
+      { transaction: options?.transaction },
+    )
+  }
+
   async findById(id: string, options?: FindByIdOptions): Promise<Case | null> {
     try {
       this.logger.debug(`Finding case by ID ${id}`)
@@ -150,10 +176,9 @@ export class CaseRepositoryService {
       this.logger.debug(`Case ${id} ${result ? 'found' : 'not found'}`)
 
       if (result) {
-        await this.caseDefendantPoliceCaseNumberRepositoryService.resolvePoliceCaseNumbersForCases(
-          [result],
-          { transaction: options?.transaction },
-        )
+        await this.resolvePoliceCaseNumbersForCaseGraph([result], {
+          transaction: options?.transaction,
+        })
       }
 
       return result
@@ -197,10 +222,9 @@ export class CaseRepositoryService {
       this.logger.debug(`Case ${result ? 'found' : 'not found'}`)
 
       if (result && this.shouldResolvePoliceCaseNumbers(options?.attributes)) {
-        await this.caseDefendantPoliceCaseNumberRepositoryService.resolvePoliceCaseNumbersForCases(
-          [result],
-          { transaction: options?.transaction },
-        )
+        await this.resolvePoliceCaseNumbersForCaseGraph([result], {
+          transaction: options?.transaction,
+        })
       }
 
       return result
@@ -266,10 +290,9 @@ export class CaseRepositoryService {
         results.length > 0 &&
         this.shouldResolvePoliceCaseNumbers(options?.attributes)
       ) {
-        await this.caseDefendantPoliceCaseNumberRepositoryService.resolvePoliceCaseNumbersForCases(
-          results,
-          { transaction: options?.transaction },
-        )
+        await this.resolvePoliceCaseNumbersForCaseGraph(results, {
+          transaction: options?.transaction,
+        })
       }
 
       return results
@@ -341,10 +364,9 @@ export class CaseRepositoryService {
         !options?.raw &&
         this.shouldResolvePoliceCaseNumbers(options?.attributes)
       ) {
-        await this.caseDefendantPoliceCaseNumberRepositoryService.resolvePoliceCaseNumbersForCases(
-          results.rows,
-          { transaction: options?.transaction },
-        )
+        await this.resolvePoliceCaseNumbersForCaseGraph(results.rows, {
+          transaction: options?.transaction,
+        })
       }
 
       return results

--- a/apps/judicial-system/backend/src/app/modules/repository/test/caseRepository.policeCaseNumbersSync.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/repository/test/caseRepository.policeCaseNumbersSync.spec.ts
@@ -216,6 +216,33 @@ describe('CaseRepositoryService — police case number junction sync', () => {
       expect(findDistinctPoliceCaseNumbersByCaseIds).not.toHaveBeenCalled()
       expect(built.policeCaseNumbers).toEqual(['x'])
     })
+
+    it('resolves policeCaseNumbers for included merged cases', async () => {
+      const mergedCase = stubCase('merged-case-id', ['legacy-merged'])
+      const rootCase = stubCase('root-case-id', ['legacy-root'])
+      Object.assign(rootCase, {
+        mergedCases: [mergedCase],
+      })
+
+      caseModel.findOne.mockResolvedValue(rootCase)
+      findDistinctPoliceCaseNumbersByCaseIds.mockResolvedValue(
+        new Map([
+          ['root-case-id', ['007-2024-root']],
+          ['merged-case-id', ['007-2024-merged']],
+        ]),
+      )
+
+      await caseRepositoryService.findOne({
+        where: { id: 'root-case-id' },
+      })
+
+      expect(resolvePoliceCaseNumbersForCases).toHaveBeenCalledWith(
+        expect.arrayContaining([rootCase, mergedCase]),
+        { transaction: undefined },
+      )
+      expect(rootCase.policeCaseNumbers).toEqual(['007-2024-root'])
+      expect(mergedCase.policeCaseNumbers).toEqual(['007-2024-merged'])
+    })
   })
 
   describe('create', () => {


### PR DESCRIPTION
[Asana](https://app.asana.com/1/203394141643832/project/1212657017130395/task/1214607723263386?focus=true)

## What

When cases are merged, we show the police case numbers from the merged case in the UI. Since we now have police case numbers stored in a junction table (caseDefendantPoliceCaseNumbers), we need to resolve them for the merged cases as well, not just the case itself.

## Why

So we get the data in the client 

## Screenshots / Gifs

Before (no police case numbers visible in "Sameinað úr"):
<img width="1174" height="2118" alt="image" src="https://github.com/user-attachments/assets/d616ad66-7416-4ead-be34-9c6a25be1c32" />

After (police case numbers correctly set and rendered):
<img width="814" height="1000" alt="image" src="https://github.com/user-attachments/assets/a505d53a-715c-4bbd-a6bd-556b34843219" />

