### PR TITLE
feat(web): Zendesk chat launcher now has hover text

### DIFF
--- a/apps/contentful-apps/components/WebChat/ZendeskSection.tsx
+++ b/apps/contentful-apps/components/WebChat/ZendeskSection.tsx
@@ -105,6 +105,27 @@ export const ZendeskSection = ({ sdk, value, updateValue }: SectionProps) => {
                     <Select.Option value="circle">Blue circle</Select.Option>
                   </Select>
                 </Flex>
+                <Flex flexDirection="column">
+                  <FormControl.Label>Chat Bubble Hover Text</FormControl.Label>
+                  <TextInput
+                    value={
+                      value?.[locale]?.[WebChatType.Zendesk]?.chatBubbleTitle ??
+                      ''
+                    }
+                    onChange={(event) => {
+                      updateValue((previousValue) => ({
+                        ...previousValue,
+                        [locale]: {
+                          ...previousValue?.[locale],
+                          [WebChatType.Zendesk]: {
+                            ...previousValue?.[locale]?.[WebChatType.Zendesk],
+                            chatBubbleTitle: event.target.value.trim(),
+                          },
+                        },
+                      }))
+                    }}
+                  />
+                </Flex>
               </Flex>
             </Flex>
           </FormControl>

--- a/apps/contentful-apps/components/WebChat/types.ts
+++ b/apps/contentful-apps/components/WebChat/types.ts
@@ -46,6 +46,7 @@ export type ZendeskConfiguration = {
       snippetUrl?: string
       urlTrackingTicketId?: string
       chatBubbleVariant?: 'default' | 'circle'
+      chatBubbleTitle?: string
     }
   }
 >

--- a/apps/web/components/ChatPanel/ChatBubble/ChatBubble.tsx
+++ b/apps/web/components/ChatPanel/ChatBubble/ChatBubble.tsx
@@ -18,6 +18,7 @@ interface ChatBubbleProps {
   loading?: boolean
   embedDisclaimerProps?: Pick<EmbedDisclaimerProps, 'localStorageKey' | 'texts'>
   variant?: 'default' | 'circle'
+  title?: string
 }
 
 interface DefaultVariantProps {
@@ -26,6 +27,7 @@ interface DefaultVariantProps {
   handleClick: () => void
   loading: boolean
   text: string
+  title?: string
 }
 
 const DefaultVariant = ({
@@ -34,9 +36,13 @@ const DefaultVariant = ({
   handleClick,
   loading,
   text,
+  title,
 }: DefaultVariantProps) => {
   return (
-    <div className={cn(styles.root, { [styles.hidden]: !isVisible })}>
+    <div
+      title={title}
+      className={cn(styles.root, { [styles.hidden]: !isVisible })}
+    >
       <button
         data-testid="chatbot"
         tabIndex={0}
@@ -70,6 +76,7 @@ interface CircleVariantProps {
   handleClick: () => void
   loading: boolean
   text: string
+  title?: string
 }
 
 const CircleVariant = ({
@@ -78,9 +85,11 @@ const CircleVariant = ({
   handleClick,
   loading,
   text,
+  title,
 }: CircleVariantProps) => {
   return (
     <div
+      title={title}
       className={cn(
         styles.circleRoot,
         { [styles.hidden]: !isVisible },
@@ -111,6 +120,7 @@ export const ChatBubble = ({
   loading = false,
   embedDisclaimerProps,
   variant = 'default',
+  title,
 }: ChatBubbleProps) => {
   const [isConfirmModalOpen, setIsConfirmModalOpen] = useState(false)
   const hasButtonBeenClicked = useRef(false)
@@ -158,6 +168,7 @@ export const ChatBubble = ({
           handleClick={handleClick}
           loading={loading}
           text={text}
+          title={title}
         />
       )}
       {variant === 'circle' && (
@@ -167,6 +178,7 @@ export const ChatBubble = ({
           handleClick={handleClick}
           loading={loading}
           text={text}
+          title={title}
         />
       )}
     </>

--- a/apps/web/components/ChatPanel/ZendeskChatPanel/ZendeskChatPanel.tsx
+++ b/apps/web/components/ChatPanel/ZendeskChatPanel/ZendeskChatPanel.tsx
@@ -25,6 +25,7 @@ export const ZendeskChatPanel = ({
   pushUp = false,
   chatBubbleVariant = 'circle',
   urlTrackingTicketId,
+  chatBubbleTitle,
 }: ZendeskChatPanelProps) => {
   const [isLoading, setIsLoading] = useState(false)
   const [isChatOpen, setIsChatOpen] = useState(false)
@@ -105,6 +106,7 @@ export const ZendeskChatPanel = ({
       pushUp={pushUp}
       loading={isLoading}
       isVisible={!isChatOpen}
+      title={chatBubbleTitle}
     />
   )
 }

--- a/apps/web/components/ChatPanel/types.ts
+++ b/apps/web/components/ChatPanel/types.ts
@@ -55,6 +55,7 @@ export interface ZendeskChatPanelProps {
   pushUp?: boolean
   chatBubbleVariant?: 'default' | 'circle'
   urlTrackingTicketId?: string
+  chatBubbleTitle?: string
 }
 
 export type WatsonIntegration =

--- a/apps/web/components/WebChat/WebChat.tsx
+++ b/apps/web/components/WebChat/WebChat.tsx
@@ -20,8 +20,12 @@ const WebChat = ({ webChat, pushUp, renderFallback }: WebChatProps) => {
   const webChatType = webChat.webChatConfiguration?.type
 
   if (webChatType === 'zendesk') {
-    const { snippetUrl, chatBubbleVariant, urlTrackingTicketId } =
-      webChat.webChatConfiguration.zendesk ?? {}
+    const {
+      snippetUrl,
+      chatBubbleVariant,
+      urlTrackingTicketId,
+      chatBubbleTitle,
+    } = webChat.webChatConfiguration.zendesk ?? {}
     if (!snippetUrl) return renderFallback?.() ?? null
     return (
       <ZendeskChatPanel
@@ -29,6 +33,7 @@ const WebChat = ({ webChat, pushUp, renderFallback }: WebChatProps) => {
         pushUp={pushUp}
         chatBubbleVariant={chatBubbleVariant || 'circle'}
         urlTrackingTicketId={urlTrackingTicketId}
+        chatBubbleTitle={chatBubbleTitle}
       />
     )
   }


### PR DESCRIPTION
# Zendesk chat launcher now has hover text

* Hover text is set in CMS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The Zendesk chat bubble widget now supports customizable hover text configuration. Administrators can easily set locale-specific tooltip messages through the chat configuration interface, allowing teams to deliver truly personalized guidance and messaging to users in their preferred language when they hover over or interact with the chat bubble widget.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/island-is/island.is/pull/22514)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->