### PR TITLE
fix(native-app): guard against null healthDirectorateAppointments

### DIFF
--- a/apps/native/app/src/app/(auth)/(tabs)/health/index.tsx
+++ b/apps/native/app/src/app/(auth)/(tabs)/health/index.tsx
@@ -334,7 +334,7 @@ export default function HealthOverviewScreen() {
   const organDonationData =
     organDonationRes.data?.healthDirectorateOrganDonation.donor
   const appointments =
-    appointmentsRes.data?.healthDirectorateAppointments.data ?? []
+    appointmentsRes.data?.healthDirectorateAppointments?.data ?? []
 
   const isMedicinePeriodActive =
     medicinePurchaseData?.active ||


### PR DESCRIPTION
## What

- Add an optional chain before `.data` when reading `appointmentsRes.data?.healthDirectorateAppointments.data` in `HealthOverviewScreen`.

## Why

- The `healthDirectorateAppointments` field is nullable (`Maybe<HealthDirectorateAppointments>`). When the appointments query returns no value for a user (e.g. someone with no appointments), the existing chain stopped one step too short and threw `Cannot read property 'data' of null` while rendering the screen.
- On iOS this surfaced as the LogBox render-error overlay; on Android (Fabric) the same throw mid-mount left the native view tree in an inconsistent state and produced `IllegalStateException: The specified child already has a parent`. Fixing the chain resolves both symptoms.

## Screenshots / Gifs

N/A

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of the health appointments display by adding proper handling for cases where appointment data may not be available, preventing potential crashes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/island-is/island.is/pull/22516)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->