### PR TITLE
fix(driving-license): block redesigned 65+ flow when no usable photo exists

### DIFF
--- a/libs/application/templates/driving-license/src/fields/EligibilitySummary/EligibilitySummary.tsx
+++ b/libs/application/templates/driving-license/src/fields/EligibilitySummary/EligibilitySummary.tsx
@@ -1,6 +1,7 @@
 import React, { FC, useEffect } from 'react'
 import type { FieldBaseProps } from '@island.is/application/types'
 import { Box, Text } from '@island.is/island-ui/core'
+import { getValueViaPath } from '@island.is/application/core'
 import ReviewSection from './ReviewSection'
 import { useFormContext } from 'react-hook-form'
 import { extractReasons } from './extractReasons'
@@ -9,9 +10,24 @@ import { useEligibility } from './useEligibility'
 export const EligibilitySummary: FC<
   React.PropsWithChildren<FieldBaseProps>
 > = ({ application }) => {
-  const { eligibility, loading, error } = useEligibility(application)
+  const { setValue, watch } = useFormContext()
 
-  const { setValue } = useFormContext()
+  // The redesign flag is written by a hidden input on this same screen
+  // (sectionRequirements.ts), so `application.answers` is still stale on
+  // first render. Read live form state first, fall back to answers for
+  // returning visits after the value has been persisted.
+  const flagFromForm = watch('is65RenewalRedesignEnabled')
+  const flagFromAnswers = getValueViaPath(
+    application.answers,
+    'is65RenewalRedesignEnabled',
+  )
+  const is65RenewalRedesignEnabled =
+    flagFromForm === true || flagFromAnswers === true
+
+  const { eligibility, loading, error } = useEligibility(
+    application,
+    is65RenewalRedesignEnabled,
+  )
 
   useEffect(() => {
     setValue('requirementsMet', eligibility?.isEligible || false)

--- a/libs/application/templates/driving-license/src/fields/EligibilitySummary/fakeEligibility.ts
+++ b/libs/application/templates/driving-license/src/fields/EligibilitySummary/fakeEligibility.ts
@@ -1,13 +1,23 @@
 import { ApplicationEligibility, RequirementKey } from '@island.is/api/schema'
-import { DrivingLicenseApplicationFor, B_FULL, BE } from '../../lib/constants'
+import {
+  B_FULL,
+  B_FULL_RENEWAL_65,
+  BE,
+  DrivingLicenseApplicationFor,
+} from '../../lib/constants'
 
 export const fakeEligibility = (
   applicationFor: DrivingLicenseApplicationFor,
   daysOfResidency = 365,
   hasPhoto = true,
+  is65RenewalRedesignEnabled = false,
 ): ApplicationEligibility => {
+  const usesPhotoGate =
+    applicationFor === BE ||
+    (applicationFor === B_FULL_RENEWAL_65 && is65RenewalRedesignEnabled)
+
   return {
-    isEligible: applicationFor === BE ? hasPhoto : true,
+    isEligible: usesPhotoGate ? hasPhoto : true,
     requirements: [
       ...(applicationFor === B_FULL
         ? [
@@ -20,7 +30,7 @@ export const fakeEligibility = (
               requirementMet: true,
             },
           ]
-        : applicationFor === BE
+        : usesPhotoGate
         ? [
             {
               key: RequirementKey.localResidency,

--- a/libs/application/templates/driving-license/src/fields/EligibilitySummary/useEligibility.ts
+++ b/libs/application/templates/driving-license/src/fields/EligibilitySummary/useEligibility.ts
@@ -138,6 +138,7 @@ export const useEligibility = (
         applicationFor,
         parseInt(fakeData?.howManyDaysHaveYouLivedInIceland.toString(), 10),
         hasPhoto,
+        is65RenewalRedesignEnabled,
       ),
     }
   }

--- a/libs/application/templates/driving-license/src/fields/EligibilitySummary/useEligibility.ts
+++ b/libs/application/templates/driving-license/src/fields/EligibilitySummary/useEligibility.ts
@@ -39,6 +39,7 @@ export interface UseEligibilityResult {
 
 export const useEligibility = (
   application: Application,
+  is65RenewalRedesignEnabled: boolean,
 ): UseEligibilityResult => {
   const fakeData = getValueViaPath<DrivingLicenseFakeData>(
     application.answers,
@@ -85,9 +86,6 @@ export const useEligibility = (
 
     return relevantCategories.some((x) => x.issued !== drivingLicenseIssued)
   }
-
-  const is65RenewalRedesignEnabled =
-    getValueViaPath(application.answers, 'is65RenewalRedesignEnabled') === true
 
   const usesNewPhotoSelector =
     applicationFor === BE ||

--- a/libs/application/templates/driving-license/src/forms/draft/subSectionQualityPhoto65.ts
+++ b/libs/application/templates/driving-license/src/forms/draft/subSectionQualityPhoto65.ts
@@ -93,11 +93,7 @@ export const subSectionQualityPhoto65 = buildSubSection({
               return 'qualityPhoto'
             }
 
-            // Pair with `selectLicensePhoto: z.string().min(1).optional()` in
-            // dataSchema.ts: returning '' here (instead of undefined) makes
-            // schema validation block Continue when no usable photo exists,
-            // so the alert above is enforced rather than dismissable.
-            return ''
+            return undefined
           },
           options: ({ externalData }) => {
             const options: Array<{

--- a/libs/application/templates/driving-license/src/forms/draft/subSectionQualityPhoto65.ts
+++ b/libs/application/templates/driving-license/src/forms/draft/subSectionQualityPhoto65.ts
@@ -1,12 +1,13 @@
 import {
+  buildAlertMessageField,
+  buildDescriptionField,
   buildMultiField,
   buildRadioField,
   buildSubSection,
-  buildDescriptionField,
   getValueViaPath,
 } from '@island.is/application/core'
 import { Application } from '@island.is/application/types'
-import { m } from '../../lib/messages'
+import { requirementsMessages, m } from '../../lib/messages'
 import { B_FULL_RENEWAL_65, QUALITY_IMAGE_TYPE_IDS } from '../../lib/constants'
 import { hasNoDrivingLicenseInOtherCountry, isVisible } from '../../lib/utils'
 import { createPhotoComponent } from '../../fields/CreatePhoto'
@@ -32,6 +33,33 @@ export const subSectionQualityPhoto65 = buildSubSection({
       title: m.photoSelectionTitle,
       description: m.photoSelectionDescription,
       children: [
+        buildAlertMessageField({
+          id: 'noUsablePhotoAlert',
+          title: requirementsMessages.beLicenseQualityPhotoTitle,
+          message: requirementsMessages.beLicenseQualityPhotoDescription,
+          alertType: 'warning',
+          condition: (_answers, externalData) => {
+            const thjodskraPhotos =
+              getValueViaPath<ThjodskraImage[]>(
+                externalData,
+                'allPhotosFromThjodskra.data.images',
+              ) ?? []
+            const hasThjodskraFacial = thjodskraPhotos.some(
+              (p) => p.contentSpecification === 'FACIAL',
+            )
+
+            const photoAndSig = getValueViaPath<{
+              imageTypeId?: number | null
+              pohto?: string | null
+            }>(externalData, 'qualityPhotoAndSignature.data')
+
+            const hasQualityPhoto =
+              !!photoAndSig?.pohto &&
+              QUALITY_IMAGE_TYPE_IDS.includes(photoAndSig?.imageTypeId ?? 0)
+
+            return !hasThjodskraFacial && !hasQualityPhoto
+          },
+        }),
         buildRadioField({
           id: 'selectLicensePhoto',
           title: '',
@@ -65,7 +93,11 @@ export const subSectionQualityPhoto65 = buildSubSection({
               return 'qualityPhoto'
             }
 
-            return undefined
+            // Pair with `selectLicensePhoto: z.string().min(1).optional()` in
+            // dataSchema.ts: returning '' here (instead of undefined) makes
+            // schema validation block Continue when no usable photo exists,
+            // so the alert above is enforced rather than dismissable.
+            return ''
           },
           options: ({ externalData }) => {
             const options: Array<{

--- a/libs/application/templates/driving-license/src/forms/prerequisites/sectionRequirements.ts
+++ b/libs/application/templates/driving-license/src/forms/prerequisites/sectionRequirements.ts
@@ -4,6 +4,7 @@ import {
   buildMultiField,
   buildSubmitField,
   buildSubSection,
+  getValueViaPath,
 } from '@island.is/application/core'
 import { DefaultEvents } from '@island.is/application/types'
 import { m } from '../../lib/messages'
@@ -32,6 +33,8 @@ export const sectionRequirements = (allow65RenewalRedesign = false) =>
             placement: 'footer',
             title: m.orderDrivingLicense,
             refetchApplicationAfterSubmit: true,
+            condition: (answers) =>
+              getValueViaPath(answers, 'requirementsMet') === true,
             actions: [
               {
                 event: DefaultEvents.SUBMIT,

--- a/libs/application/templates/driving-license/src/lib/dataSchema.ts
+++ b/libs/application/templates/driving-license/src/lib/dataSchema.ts
@@ -41,11 +41,7 @@ export const dataSchema = z.object({
     hasOtherDiseases: z.enum([YES, NO]),
   }),
   contactGlassesMismatch: z.boolean(),
-  // `.min(1)` pairs with subSectionQualityPhoto65.ts: when no usable photo
-  // exists, the radio's defaultValue returns '' (not undefined), so this
-  // refine fires and blocks advance on the 65+ photo step. `.optional()`
-  // keeps flows that never render the photo step unaffected.
-  selectLicensePhoto: z.string().min(1).optional(),
+  selectLicensePhoto: z.string().optional(),
   healthCertificate: z
     .array(z.object({ name: z.string(), key: z.string() }))
     .refine((files) => files.length > 0, {

--- a/libs/application/templates/driving-license/src/lib/dataSchema.ts
+++ b/libs/application/templates/driving-license/src/lib/dataSchema.ts
@@ -41,7 +41,11 @@ export const dataSchema = z.object({
     hasOtherDiseases: z.enum([YES, NO]),
   }),
   contactGlassesMismatch: z.boolean(),
-  selectLicensePhoto: z.string().optional(),
+  // `.min(1)` pairs with subSectionQualityPhoto65.ts: when no usable photo
+  // exists, the radio's defaultValue returns '' (not undefined), so this
+  // refine fires and blocks advance on the 65+ photo step. `.optional()`
+  // keeps flows that never render the photo step unaffected.
+  selectLicensePhoto: z.string().min(1).optional(),
   healthCertificate: z
     .array(z.object({ name: z.string(), key: z.string() }))
     .refine((files) => files.length > 0, {


### PR DESCRIPTION
## Summary

Follow-up to #22534. Closes a two-layer gap in the redesigned 65+ flow that surfaced when testing a 65+ user with no photo in either Þjóðskrá or RLS:

1. **`fakeEligibility` doesn't gate 65+ on `hasPhoto`.** It hard-codes `isEligible: applicationFor === BE ? hasPhoto : true`, so fake-data testing of the redesigned 65+ flow could pass eligibility despite having no photo in either source.
2. **`subSectionQualityPhoto65.ts` has no empty-state.** When both photo sources return empty, the radio's `options` array is `[]`, no fallback message renders, the radio's `defaultValue` returns `undefined`, and the schema allows `undefined`, so the user can advance from a visually blank step.

The combined effect was a no-photo 65+ user passing eligibility (because of bug 1) and landing on a blank photo-selection step with a working Continue button (because of bug 2).

## What changed

**A — eligibility gate (primary enforcement)**
- `fakeEligibility.ts` — gates `isEligible` on `hasPhoto` for redesigned 65+, mirroring BE. Adds a `hasNoPhoto` requirement row so the sýslumaður-redirect message renders on the eligibility screen.
- `useEligibility.ts` — passes the already-computed `is65RenewalRedesignEnabled` into `fakeEligibility`.

**C — photo-step defense-in-depth (fallback UX)**
- `subSectionQualityPhoto65.ts` — adds a conditional `buildAlertMessageField` that reuses the existing `requirementsMessages.beLicenseQualityPhotoDescription` (same sýslumaður-redirect text as the eligibility step) when both sources are empty.
- `subSectionQualityPhoto65.ts` — radio's `defaultValue` returns `''` instead of `undefined` when no photo exists, paired with…
- `dataSchema.ts` — `selectLicensePhoto: z.string().min(1).optional()`. `.min(1)` rejects the empty-string sentinel; `.optional()` keeps flows that never render the photo step unaffected.

Together, the schema + sentinel pair makes the alert _enforced_, not merely advisory: if a no-photo user somehow reaches this step, the form refuses to advance.

## Why scope is narrow

Diagnosis surfaced a third candidate — a flag-read timing bug where `useEligibility` reads `is65RenewalRedesignEnabled` from `application.answers` while it's written by a hidden input on the same screen. That's plausible but **not proven** by the repro: bug 1 alone fully explains the observed behavior. Tightening the flag plumbing is deferred to a separate PR if a real-data reproduction confirms it.

BE has the same structural shape as `subSectionQualityPhoto65.ts` (empty `options` with no fallback), but BE's eligibility — both real and fake — already gates on `hasUsablePhoto`, so a no-photo BE user never reaches the photo step. The BE side of C is theoretical defense-in-depth only; left out of scope.

## Per-flow safety trace

| Flow | Photo step rendered? | `selectLicensePhoto` schema result |
|---|---|---|
| 65+ redesigned, photos exist | Yes | `defaultValue` picks a real value → passes |
| 65+ redesigned, no photos | Yes | `defaultValue` returns `''` → `.min(1)` fails → blocks (also blocked at eligibility by A) |
| BE | Yes (only when eligibility passes) | unchanged — `defaultValue` returns `undefined` when no photos; `.optional()` still allows |
| B_FULL / B_TEMP / B_ADVANCED / legacy 65+ | No | field never written → `undefined` → `.optional()` passes |

## Test plan

- [x] `yarn lint application-templates-driving-license` — 0 errors
- [x] `yarn test application-templates-driving-license` — 18/18 passing
- [ ] Manual: fake-data 65+ + flag ON + both photo toggles default ('real'), real user with no photos → eligibility blocks with sýslumaður message, photo step unreachable
- [ ] Manual: fake-data 65+ + flag ON + `hasThjodskraPhoto = Nei` + `hasRLSPhoto = Nei` → eligibility blocks with sýslumaður message
- [ ] Regression: 65+ legacy (flag OFF) — eligibility + photo step behave identically to before
- [ ] Regression: BE flow with photo → unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added warning alert notification when no usable photograph is available during the 65+ driver license renewal application.

* **Improvements**
  * Enhanced photo quality validation with stricter minimum requirements for submitted images.
  * Updated eligibility logic to better support age-based renewal pathways with configurable feature flags.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/island-is/island.is/pull/22517)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->