### PR TITLE
feat(web): Accordion slice with just 1 item no longer starts expanded

### DIFF
--- a/apps/web/components/Organization/Slice/AccordionSlice/AccordionSlice.tsx
+++ b/apps/web/components/Organization/Slice/AccordionSlice/AccordionSlice.tsx
@@ -52,7 +52,6 @@ export const AccordionSlice: React.FC<React.PropsWithChildren<SliceProps>> = ({
                 id={item.id}
                 label={item.title}
                 labelUse={childHeading}
-                startExpanded={slice.accordionItems?.length === 1}
               >
                 <Box>{webRichText(item.content ?? [])}</Box>
               </AccordionCard>
@@ -67,7 +66,6 @@ export const AccordionSlice: React.FC<React.PropsWithChildren<SliceProps>> = ({
                   id={item.id}
                   label={item.title}
                   labelUse={childHeading}
-                  startExpanded={slice.accordionItems?.length === 1}
                 >
                   <Text>{webRichText(item.content as SliceType[])}</Text>
                 </AccordionItem>


### PR DESCRIPTION
# Accordion slice with just 1 item no longer starts expanded


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Accordions no longer automatically expand when they contain a single item. This change applies to both standard and minimal accordion variants, providing consistent user control over accordion state across the application.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/island-is/island.is/pull/22520)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->