### PR TITLE
feat(ids-api): remove organisationLogoKey from domain

### DIFF
--- a/apps/auth-admin-web/components/Admin/form/DomainCreateForm.tsx
+++ b/apps/auth-admin-web/components/Admin/form/DomainCreateForm.tsx
@@ -206,42 +206,6 @@ const DomainCreateForm: React.FC<React.PropsWithChildren<Props>> = (
                   />
                 </div>
 
-                <div className="domain-create-form__container__field">
-                  <label
-                    className="domain-create-form__label"
-                    htmlFor="organisationLogoKey"
-                  >
-                    {localization.fields['organisationLogoKey'].label}
-                  </label>
-                  <input
-                    id="organisationLogoKey"
-                    type="text"
-                    {...register('domain.organisationLogoKey', {
-                      required: true,
-                      validate: ValidationUtils.validateDescription,
-                    })}
-                    defaultValue={props.domain.organisationLogoKey}
-                    className="domain-create-form__input"
-                    title={localization.fields['organisationLogoKey'].helpText}
-                    placeholder={
-                      localization.fields['organisationLogoKey'].placeholder
-                    }
-                  />
-                  <ErrorMessage
-                    as="span"
-                    errors={errors}
-                    name="domain.organisationLogoKey"
-                    message={
-                      localization.fields['organisationLogoKey'].errorMessage
-                    }
-                  />
-                  <HelpBox
-                    helpText={
-                      localization.fields['organisationLogoKey'].helpText
-                    }
-                  />
-                </div>
-
                 {/*Contact email*/}
                 <div className="domain-create-form__container__field">
                   <label

--- a/apps/auth-admin-web/entities/dtos/domain.dto.ts
+++ b/apps/auth-admin-web/entities/dtos/domain.dto.ts
@@ -3,6 +3,5 @@ export class DomainDTO {
   description!: string
   nationalId!: string
   displayName!: string
-  organisationLogoKey!: string
   contactEmail?: string
 }

--- a/apps/auth-admin-web/entities/models/domain.model.ts
+++ b/apps/auth-admin-web/entities/models/domain.model.ts
@@ -5,7 +5,6 @@ export class Domain {
   description!: string
   nationalId!: string
   displayName!: string
-  organisationLogoKey!: string
   created!: Date
   modified?: Date
   groups?: ApiScopeGroup[]

--- a/apps/auth-admin-web/i18n/locales/en.json
+++ b/apps/auth-admin-web/i18n/locales/en.json
@@ -803,12 +803,6 @@
           "helpText": "The display name for this domain",
           "errorMessage": "The display name is required and can not include invalid characters"
         },
-        "organisationLogoKey": {
-          "label": "Logo Key",
-          "placeholder": "Logo key for this domain",
-          "helpText": "The logo key for this domain",
-          "errorMessage": "The logo key is required and can not include invalid characters"
-        },
         "contactEmail": {
           "label": "Contact Email",
           "placeholder": "Contact email for this domain",

--- a/apps/services/auth/admin-api/src/app/v2/tenants/test/me-tenants.spec.ts
+++ b/apps/services/auth/admin-api/src/app/v2/tenants/test/me-tenants.spec.ts
@@ -242,7 +242,6 @@ describe('MeTenantsController', () => {
           nationalId: createNationalId('company'),
           displayName: 'Super new domain',
           description: 'A freshly created tenant',
-          organisationLogoKey: 'stafraent-island',
           contactEmail: 'contact@example.is',
         }
 
@@ -267,7 +266,6 @@ describe('MeTenantsController', () => {
           nationalId: createNationalId('company'),
           displayName: 'dup',
           description: 'dup',
-          organisationLogoKey: 'dup',
         })
 
         expect(res.status).toBe(409)
@@ -279,7 +277,6 @@ describe('MeTenantsController', () => {
           nationalId: createNationalId('company'),
           displayName: 'x',
           description: 'x',
-          organisationLogoKey: 'x',
         })
 
         expect(res.status).toBe(400)
@@ -396,7 +393,6 @@ describe('MeTenantsController', () => {
           nationalId: createNationalId('company'),
           displayName: 'x',
           description: 'x',
-          organisationLogoKey: 'x',
         })
 
         expect(res.status).toBe(403)

--- a/libs/api/domains/auth-admin/src/lib/delegationAdmin/delegation-admin.resolver.ts
+++ b/libs/api/domains/auth-admin/src/lib/delegationAdmin/delegation-admin.resolver.ts
@@ -126,7 +126,6 @@ export class DelegationAdminResolver {
         displayName: '',
         description: '',
         nationalId: '',
-        organisationLogoKey: '',
       }
     }
 

--- a/libs/api/domains/auth-admin/src/lib/tenant/dto/create-tenant.input.ts
+++ b/libs/api/domains/auth-admin/src/lib/tenant/dto/create-tenant.input.ts
@@ -17,9 +17,6 @@ export class CreateTenantInput {
   @Field(() => String)
   description!: string
 
-  @Field(() => String)
-  organisationLogoKey!: string
-
   @Field(() => String, { nullable: true })
   contactEmail?: string
 

--- a/libs/api/domains/auth-admin/src/lib/tenant/dto/update-tenant.input.ts
+++ b/libs/api/domains/auth-admin/src/lib/tenant/dto/update-tenant.input.ts
@@ -20,8 +20,5 @@ export class UpdateTenantInput {
   description?: string
 
   @Field(() => String, { nullable: true })
-  organisationLogoKey?: string
-
-  @Field(() => String, { nullable: true })
   contactEmail?: string
 }

--- a/libs/api/domains/auth-admin/src/lib/tenant/models/tenant-environment.model.ts
+++ b/libs/api/domains/auth-admin/src/lib/tenant/models/tenant-environment.model.ts
@@ -28,8 +28,5 @@ export class TenantEnvironment {
   description?: string
 
   @Field({ nullable: true })
-  organisationLogoKey?: string
-
-  @Field({ nullable: true })
   contactEmail?: string
 }

--- a/libs/api/domains/auth-admin/src/lib/tenant/models/tenant.model.ts
+++ b/libs/api/domains/auth-admin/src/lib/tenant/models/tenant.model.ts
@@ -20,7 +20,4 @@ export class Tenant {
 
   @Field({ nullable: true })
   description?: string
-
-  @Field({ nullable: true })
-  organisationLogoKey?: string
 }

--- a/libs/api/domains/auth-admin/src/lib/tenant/tenants.service.ts
+++ b/libs/api/domains/auth-admin/src/lib/tenant/tenants.service.ts
@@ -120,7 +120,6 @@ export class TenantsService extends MultiEnvironmentService {
           displayName: [{ locale: 'is', value: domain.displayName }],
           nationalId: domain.nationalId,
           description: domain.description,
-          organisationLogoKey: domain.organisationLogoKey,
           contactEmail: domain.contactEmail,
         }),
         prefixErrorMessage: `Failed to fetch admin details for tenant ${id}`,
@@ -139,7 +138,6 @@ export class TenantsService extends MultiEnvironmentService {
       nationalId: primary.nationalId,
       contactEmail: primary.contactEmail,
       description: primary.description,
-      organisationLogoKey: primary.organisationLogoKey,
     }
   }
 
@@ -156,7 +154,6 @@ export class TenantsService extends MultiEnvironmentService {
               nationalId: input.nationalId,
               displayName: input.displayName,
               description: input.description,
-              organisationLogoKey: input.organisationLogoKey,
               ...(input.contactEmail
                 ? { contactEmail: input.contactEmail }
                 : {}),
@@ -207,7 +204,6 @@ export class TenantsService extends MultiEnvironmentService {
         displayName: [{ locale: 'is', value: domain.displayName }],
         nationalId: domain.nationalId,
         description: domain.description,
-        organisationLogoKey: domain.organisationLogoKey,
         contactEmail: domain.contactEmail,
       }),
       prefixErrorMessage: `Failed to update tenant ${tenantId}`,
@@ -247,7 +243,6 @@ export class TenantsService extends MultiEnvironmentService {
             nationalId: source.nationalId,
             displayName: source.displayName,
             description: source.description,
-            organisationLogoKey: source.organisationLogoKey,
             ...(source.contactEmail
               ? { contactEmail: source.contactEmail }
               : {}),
@@ -267,7 +262,6 @@ export class TenantsService extends MultiEnvironmentService {
       displayName: [{ locale: 'is', value: created.displayName }],
       nationalId: created.nationalId,
       description: created.description,
-      organisationLogoKey: created.organisationLogoKey,
       contactEmail: created.contactEmail,
     }
   }

--- a/libs/api/domains/auth/src/lib/models/domain.model.ts
+++ b/libs/api/domains/auth/src/lib/models/domain.model.ts
@@ -14,9 +14,6 @@ export class Domain {
   @Field(() => String)
   nationalId!: string
 
-  @Field(() => String)
-  organisationLogoKey!: string
-
   @Field(() => String, { nullable: true })
   organisationLogoUrl?: string
 }

--- a/libs/api/mocks/src/domains/auth/factories.ts
+++ b/libs/api/mocks/src/domains/auth/factories.ts
@@ -3,7 +3,6 @@ import { factory, faker, title } from '@island.is/shared/mocking'
 import { createNationalId } from '@island.is/testing/fixtures'
 import {
   AuthCustomDelegation,
-  AuthDelegation,
   AuthApiScope,
   AuthDomain,
   AuthDelegationScope,
@@ -14,7 +13,6 @@ export const domain = factory<AuthDomain>({
   description: () => faker.lorem.paragraph(),
   nationalId: () => createNationalId('company'),
   displayName: () => faker.company.companyName(),
-  organisationLogoKey: ({ displayName }) => displayName,
   organisationLogoUrl: () => faker.image.business(16, 16),
 })
 

--- a/libs/auth-api-lib/migrations/20260511103000-drop-domain-organisation-logo-key.js
+++ b/libs/auth-api-lib/migrations/20260511103000-drop-domain-organisation-logo-key.js
@@ -1,0 +1,26 @@
+'use strict'
+
+module.exports = {
+  async up(queryInterface) {
+    return queryInterface.sequelize.transaction(async (transaction) => {
+      await queryInterface.removeColumn('domain', 'organisation_logo_key', {
+        transaction,
+      })
+    })
+  },
+
+  async down(queryInterface, Sequelize) {
+    return queryInterface.sequelize.transaction(async (transaction) => {
+      await queryInterface.addColumn(
+        'domain',
+        'organisation_logo_key',
+        {
+          type: Sequelize.STRING,
+          allowNull: false,
+          defaultValue: 'Stafrænt Ísland',
+        },
+        { transaction },
+      )
+    })
+  },
+}

--- a/libs/auth-api-lib/seeders/local/008-domains_resources.js
+++ b/libs/auth-api-lib/seeders/local/008-domains_resources.js
@@ -5,21 +5,18 @@ const adminDomain = {
   description: '@admin.island.is domain',
   national_id: '5005101370',
   display_name: 'Ísland.is stjórnborð',
-  organisation_logo_key: 'Stafrænt Ísland',
 }
 const arcticDomains = {
   name: '@arctic.island.is',
   description: '@arctic.island.is domain',
   national_id: '5005101370',
   display_name: 'Arctic',
-  organisation_logo_key: 'Stafrænt Ísland',
 }
 const otherDomain = {
   name: '@other.island.is',
   description: '@other.island.is domain',
   national_id: '4703013920',
   display_name: 'Other stjornborð',
-  organisation_logo_key: 'Stafrænt Ísland',
 }
 const domains = [adminDomain, arcticDomains, otherDomain]
 

--- a/libs/auth-api-lib/seeders/local/010-contact-email-domain.js
+++ b/libs/auth-api-lib/seeders/local/010-contact-email-domain.js
@@ -5,7 +5,6 @@ const emailDomain = {
   description: '@email.island.is domain',
   national_id: '5005101370',
   display_name: 'Ísland.is email',
-  organisation_logo_key: 'Stafrænt Ísland',
   contact_email: 'email@island.is',
 }
 

--- a/libs/auth-api-lib/seeders/local/011-local-artic.js
+++ b/libs/auth-api-lib/seeders/local/011-local-artic.js
@@ -5,7 +5,6 @@ const articDomain = {
   description: '64 Artic domain',
   national_id: '5005101370',
   display_name: '64 Artic',
-  organisation_logo_key: 'Stafrænt Ísland',
   contact_email: 'dev-artic@64-artic.is',
 }
 

--- a/libs/auth-api-lib/src/lib/resources/dto/admin-create-tenant.dto.ts
+++ b/libs/auth-api-lib/src/lib/resources/dto/admin-create-tenant.dto.ts
@@ -46,11 +46,6 @@ export class AdminCreateTenantDto {
   @ApiProperty({ example: 'Domain for Island.is' })
   description!: string
 
-  @IsString()
-  @IsNotEmpty()
-  @ApiProperty({ example: 'Stafrænt Ísland' })
-  organisationLogoKey!: string
-
   @IsOptional()
   @IsEmail()
   @ApiPropertyOptional({ example: 'island@example.is' })

--- a/libs/auth-api-lib/src/lib/resources/dto/domain.dto.ts
+++ b/libs/auth-api-lib/src/lib/resources/dto/domain.dto.ts
@@ -31,14 +31,6 @@ export class DomainDTO {
   readonly displayName!: string
 
   @IsString()
-  @IsNotEmpty()
-  @ApiProperty({
-    example: 'Stafrænt Ísland',
-    description: 'This key is used to look up the organisation in Contentful.',
-  })
-  readonly organisationLogoKey!: string
-
-  @IsString()
   @ApiProperty({
     example: 'email@island.is',
   })

--- a/libs/auth-api-lib/src/lib/resources/models/domain.model.ts
+++ b/libs/auth-api-lib/src/lib/resources/models/domain.model.ts
@@ -56,17 +56,6 @@ export class Domain extends Model {
 
   @Column({
     type: DataType.STRING,
-    allowNull: false,
-    defaultValue: 'Stafrænt Ísland',
-  })
-  @ApiProperty({
-    example: 'Stafrænt Ísland',
-    description: 'This key is used to look up the organisation in Contentful.',
-  })
-  organisationLogoKey!: string
-
-  @Column({
-    type: DataType.STRING,
   })
   @ApiProperty({
     example: 'island@example.is',

--- a/libs/portals/admin/delegation-admin/src/screens/DelegationAdminDetails/DelegationAdmin.graphql
+++ b/libs/portals/admin/delegation-admin/src/screens/DelegationAdminDetails/DelegationAdmin.graphql
@@ -8,7 +8,6 @@ query getCustomDelegationsAdmin($nationalId: String!) {
       referenceId
       domain {
         name
-        organisationLogoKey
         organisationLogoUrl
         displayName
         nationalId
@@ -39,7 +38,6 @@ query getCustomDelegationsAdmin($nationalId: String!) {
       referenceId
       domain {
         name
-        organisationLogoKey
         organisationLogoUrl
         displayName
         nationalId

--- a/libs/portals/admin/ids-admin/src/screens/Tenants/CreateTenantModal/CreateTenantModal.tsx
+++ b/libs/portals/admin/ids-admin/src/screens/Tenants/CreateTenantModal/CreateTenantModal.tsx
@@ -124,9 +124,6 @@ const CreateTenantModal = ({
             nationalId: result.data.nationalId,
             displayName: result.data.displayName,
             description: result.data.description,
-            // Backend still requires this field; sending the tenant name as a
-            // placeholder until the column is dropped from the database.
-            organisationLogoKey: result.data.name,
             contactEmail: result.data.contactEmail || undefined,
             environments: result.data.environments,
           },

--- a/libs/portals/shared-modules/delegations/src/components/access/AccessList/AccessListContainer/AccessListContainer.tsx
+++ b/libs/portals/shared-modules/delegations/src/components/access/AccessList/AccessListContainer/AccessListContainer.tsx
@@ -21,7 +21,6 @@ type DelegationScope = Pick<
   domain?: {
     displayName?: string
     organisationLogoUrl?: string | null
-    organisationLogoKey?: string
   } | null
   apiScope?: {
     name?: string

--- a/libs/portals/shared-modules/delegations/src/components/delegations/incoming/DelegationIncoming.graphql
+++ b/libs/portals/shared-modules/delegations/src/components/delegations/incoming/DelegationIncoming.graphql
@@ -9,7 +9,6 @@ fragment AuthCustomDelegation on AuthCustomDelegation {
     domain {
       displayName
       organisationLogoUrl
-      organisationLogoKey
     }
     apiScope(lang: $lang) {
       ...AuthApiScope
@@ -18,7 +17,6 @@ fragment AuthCustomDelegation on AuthCustomDelegation {
   domain {
     name
     displayName
-    organisationLogoKey
     organisationLogoUrl
   }
 }

--- a/libs/portals/shared-modules/delegations/src/components/delegations/incoming/DelegationsGroupedByIdentityIncoming.graphql
+++ b/libs/portals/shared-modules/delegations/src/components/delegations/incoming/DelegationsGroupedByIdentityIncoming.graphql
@@ -23,7 +23,6 @@ query AuthDelegationsGroupedByIdentityIncoming($lang: String) {
       domain(lang: $lang) {
         name
         displayName
-        organisationLogoKey
         organisationLogoUrl
       }
       apiScope(lang: $lang) {

--- a/libs/portals/shared-modules/delegations/src/components/delegations/outgoing/DelegationsGroupedByIdentityOutgoing.graphql
+++ b/libs/portals/shared-modules/delegations/src/components/delegations/outgoing/DelegationsGroupedByIdentityOutgoing.graphql
@@ -23,7 +23,6 @@ query AuthDelegationsGroupedByIdentityOutgoing($lang: String) {
       domain(lang: $lang) {
         name
         displayName
-        organisationLogoKey
         organisationLogoUrl
       }
       apiScope(lang: $lang) {

--- a/libs/portals/shared-modules/delegations/src/components/delegations/outgoing/DelegationsOutgoing.graphql
+++ b/libs/portals/shared-modules/delegations/src/components/delegations/outgoing/DelegationsOutgoing.graphql
@@ -9,7 +9,6 @@ fragment AuthCustomDelegationOutgoing on AuthCustomDelegation {
     domain {
       displayName
       organisationLogoUrl
-      organisationLogoKey
     }
     apiScope(lang: $lang) {
       ...AuthApiScope
@@ -22,7 +21,6 @@ fragment AuthCustomDelegationOutgoing on AuthCustomDelegation {
   domain {
     name
     displayName
-    organisationLogoKey
     organisationLogoUrl
   }
 }

--- a/libs/portals/shared-modules/delegations/src/hooks/useDomains/useDomains.graphql
+++ b/libs/portals/shared-modules/delegations/src/hooks/useDomains/useDomains.graphql
@@ -4,6 +4,5 @@ query AuthDomains($input: AuthDomainsInput!) {
     displayName
     description
     nationalId
-    organisationLogoKey
   }
 }

--- a/libs/services/auth/testing/src/fixtures/domain.fixture.ts
+++ b/libs/services/auth/testing/src/fixtures/domain.fixture.ts
@@ -4,9 +4,7 @@ import { Domain } from '@island.is/auth-api-lib'
 import { CreateApiScope } from './types'
 
 export type CreateDomain = Pick<Domain, 'name'> &
-  Partial<
-    Pick<Domain, 'description' | 'nationalId' | 'organisationLogoKey'>
-  > & {
+  Partial<Pick<Domain, 'description' | 'nationalId'>> & {
     apiScopes?: CreateApiScope[]
   }
 

--- a/libs/services/auth/testing/src/fixtures/fixture-factory.ts
+++ b/libs/services/auth/testing/src/fixtures/fixture-factory.ts
@@ -81,7 +81,6 @@ export class FixtureFactory {
     description,
     nationalId,
     apiScopes = [],
-    organisationLogoKey,
   }: CreateDomain): Promise<Domain> {
     // Create the global identity resources as createDomain is always called first when test data is created.
     await Promise.all(
@@ -94,7 +93,6 @@ export class FixtureFactory {
       name: name ?? faker.random.word(),
       description: description ?? faker.lorem.sentence(),
       nationalId: nationalId ?? createNationalId('company'),
-      organisationLogoKey: organisationLogoKey ?? faker.random.word(),
     })
     domain.scopes = await Promise.all(
       apiScopes.map((apiScope, order) =>


### PR DESCRIPTION
## What

Removing the organisationLogoKey field from the Domain model, DTOs, and various components across the application. The field was deemed unnecessary, leading to updates in the frontend forms, GraphQL queries, and service logic to ensure consistency. Additionally, related localization entries and test cases have been cleaned up to reflect this change.

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
Tools used: Claude


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Simplified domain and tenant creation forms by removing the organisation logo key field for a streamlined user experience.

* **Refactor**
  * Updated logo handling to use URLs instead of key references where applicable, improving data consistency and accessibility.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/island-is/island.is/pull/22523)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->