### PR TITLE
fix(ids-admin): allow clearing level field in IDP provider modal

### DIFF
--- a/libs/portals/admin/ids-admin/src/lib/messages.ts
+++ b/libs/portals/admin/ids-admin/src/lib/messages.ts
@@ -1501,6 +1501,10 @@ export const m = defineMessages({
     id: 'ap.ids-admin:idp-providers-error-helptext-required',
     defaultMessage: 'Help text is required',
   },
+  idpProvidersErrorLevelRequired: {
+    id: 'ap.ids-admin:idp-providers-error-level-required',
+    defaultMessage: 'Level is required',
+  },
   idpProvidersErrorLevelRange: {
     id: 'ap.ids-admin:idp-providers-error-level-range',
     defaultMessage: 'Level must be between 1 and 4',

--- a/libs/portals/admin/ids-admin/src/screens/AdminControls/IdpProviders/IdpProviders.types.ts
+++ b/libs/portals/admin/ids-admin/src/screens/AdminControls/IdpProviders/IdpProviders.types.ts
@@ -12,7 +12,7 @@ export interface IdpProviderFormData {
   name: string
   description: string
   helptext: string
-  level: number
+  level: number | ''
 }
 
 export const emptyForm: IdpProviderFormData = {

--- a/libs/portals/admin/ids-admin/src/screens/AdminControls/IdpProviders/IdpProviders.utils.ts
+++ b/libs/portals/admin/ids-admin/src/screens/AdminControls/IdpProviders/IdpProviders.utils.ts
@@ -41,7 +41,9 @@ export const validateIdpProviderForm = ({
     errors.helptext = formatMessage(m.idpProvidersErrorHelptextRequired)
   }
 
-  if (formData.level < 1 || formData.level > 4) {
+  if (formData.level === '') {
+    errors.level = formatMessage(m.idpProvidersErrorLevelRequired)
+  } else if (formData.level < 1 || formData.level > 4) {
     errors.level = formatMessage(m.idpProvidersErrorLevelRange)
   }
 

--- a/libs/portals/admin/ids-admin/src/screens/AdminControls/IdpProviders/components/IdpProviderModal.tsx
+++ b/libs/portals/admin/ids-admin/src/screens/AdminControls/IdpProviders/components/IdpProviderModal.tsx
@@ -132,9 +132,18 @@ export const IdpProviderModal = ({ modal }: IdpProviderModalProps) => {
                 <Input
                   name="level"
                   label={formatMessage(m.idpProvidersLevel)}
-                  value={String(modal.formData.level)}
+                  value={
+                    modal.formData.level === ''
+                      ? ''
+                      : String(modal.formData.level)
+                  }
                   onChange={(e) => {
-                    const val = parseInt(e.target.value, 10)
+                    const raw = e.target.value
+                    if (raw === '') {
+                      modal.setFormField('level', '')
+                      return
+                    }
+                    const val = parseInt(raw, 10)
                     if (!isNaN(val)) {
                       modal.setFormField('level', val)
                     }

--- a/libs/portals/admin/ids-admin/src/screens/AdminControls/IdpProviders/hooks/useIdpProviderModal.ts
+++ b/libs/portals/admin/ids-admin/src/screens/AdminControls/IdpProviders/hooks/useIdpProviderModal.ts
@@ -225,6 +225,7 @@ export const useIdpProviderModal = ({
   }
 
   const handlePublish = async (targetEnvironment: AuthAdminEnvironment) => {
+    if (formData.level === '') return
     try {
       await publishToEnvironment({
         variables: {


### PR DESCRIPTION
## What

The level input's onChange used a parseInt + !isNaN guard, so clearing the field produced NaN and skipped the state update — leaving the controlled value stuck at its previous number. Widen the form type to allow an empty string, accept empty in onChange, and surface a "Level is required" error if the field is submitted empty.


## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Identity Provider level field validation. The level field is now required, and users will see an error message if they attempt to save without specifying a level.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/island-is/island.is/pull/22532)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->