### PR TITLE
fix(my-pages): Use AvatarImage for notification logo

### DIFF
--- a/apps/portals/my-pages/src/screens/Dashboard/DashboardV2/DashboardNotifications.css.ts
+++ b/apps/portals/my-pages/src/screens/Dashboard/DashboardV2/DashboardNotifications.css.ts
@@ -16,15 +16,12 @@ export const accessDeniedImage = style({
   height: 180,
 })
 
-export const notificationSenderLogoWrapper = style({
-  width: 40,
-  height: 40,
-  flexShrink: 0,
-  borderRadius: '50%',
-  backgroundColor: theme.color.blue100,
+export const notificationSenderLogoImage = style({
+  height: 'auto',
+  width: 'auto',
   display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center',
+  maxHeight: 28,
+  maxWidth: 28,
 })
 
 export const notificationLink = style({
@@ -32,11 +29,6 @@ export const notificationLink = style({
   textDecoration: 'none',
 })
 
-export const notificationSenderLogoImage = style({
-  width: 24,
-  height: 24,
-  objectFit: 'contain',
-})
 export const notificationRowMobileFull = style({
   '@media': {
     [`screen and (max-width: ${theme.breakpoints.md - 1}px)`]: {

--- a/apps/portals/my-pages/src/screens/Dashboard/DashboardV2/DashboardNotifications.css.ts
+++ b/apps/portals/my-pages/src/screens/Dashboard/DashboardV2/DashboardNotifications.css.ts
@@ -19,7 +19,6 @@ export const accessDeniedImage = style({
 export const notificationSenderLogoImage = style({
   height: 'auto',
   width: 'auto',
-  display: 'flex',
   maxHeight: 28,
   maxWidth: 28,
 })

--- a/apps/portals/my-pages/src/screens/Dashboard/DashboardV2/DashboardNotifications.tsx
+++ b/apps/portals/my-pages/src/screens/Dashboard/DashboardV2/DashboardNotifications.tsx
@@ -42,7 +42,8 @@ export const DashboardNotifications = ({ limit }: { limit: number }) => {
       borderRadius="large"
       borderWidth="standard"
       borderColor="blue200"
-      paddingY={3}
+      paddingTop={3}
+      paddingBottom={1}
       paddingX={[0, 0, 4]}
     >
       {!loading && !hasDelegationAccess && (

--- a/apps/portals/my-pages/src/screens/Dashboard/DashboardV2/DashboardNotifications.tsx
+++ b/apps/portals/my-pages/src/screens/Dashboard/DashboardV2/DashboardNotifications.tsx
@@ -1,6 +1,7 @@
 import { Box, Icon, SkeletonLoader, Text } from '@island.is/island-ui/core'
 import { useLocale } from '@island.is/localization'
 import { LinkResolver, m } from '@island.is/portals/my-pages/core'
+import { AvatarImage } from '@island.is/portals/my-pages/documents'
 import {
   COAT_OF_ARMS,
   InformationPaths,
@@ -157,13 +158,11 @@ export const DashboardNotifications = ({ limit }: { limit: number }) => {
               borderColor="blue200"
               className={unread ? styles.unreadRow : undefined}
             >
-              <Box className={styles.notificationSenderLogoWrapper}>
-                <img
-                  src={item.sender?.logoUrl ?? COAT_OF_ARMS}
-                  alt=""
-                  className={styles.notificationSenderLogoImage}
-                />
-              </Box>
+              <AvatarImage
+                img={item.sender?.logoUrl ?? COAT_OF_ARMS}
+                background={unread ? 'white' : 'blue100'}
+                imageClass={styles.notificationSenderLogoImage}
+              />
               <Box flexGrow={1} overflow="hidden">
                 <Box
                   display="flex"


### PR DESCRIPTION
## What

Use AvatarImage for notification logo

## Why

DRY

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the visual presentation of notification sender logos in the dashboard with enhanced layout flexibility and sizing constraints for better consistency.

* **Refactor**
  * Modernized the notification sender logo rendering component to provide improved maintainability while preserving visual appearance and all existing functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/island-is/island.is/pull/22540)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->