### PR TITLE
feat(ids): add FakePersons2 secret to identity-server infra

### DIFF
--- a/apps/services/auth/ids-api/infra/identity-server.ts
+++ b/apps/services/auth/ids-api/infra/identity-server.ts
@@ -107,6 +107,7 @@ export const serviceSetup = (services: {
       AudkenniSettings__ClientSecret:
         '/k8s/identity-server/AudkenniClientSecret',
       IdentityServer__FakePersons: '/k8s/identity-server/FakePersons',
+      IdentityServer__FakePersons2: '/k8s/identity-server/FakePersons2',
       IdentityServer__SigningCertificate__Passphrase:
         '/k8s/identity-server/SigningCertificatePassphrase',
       PersistenceSettings__AccessTokenManagementSettings__ClientSecret:

--- a/charts/identity-server-services/identity-server/values.dev.yaml
+++ b/charts/identity-server-services/identity-server/values.dev.yaml
@@ -138,6 +138,7 @@ secrets:
   Datadog__ClientLogs__Token: '/k8s/identity-server/DD_LOGS_CLIENT_TOKEN'
   FeatureFlags__ConfigCatSdkKey: '/k8s/configcat/CONFIGCAT_SDK_KEY'
   IdentityServer__FakePersons: '/k8s/identity-server/FakePersons'
+  IdentityServer__FakePersons2: '/k8s/identity-server/FakePersons2'
   IdentityServer__LicenseKey: '/k8s/identity-server/LicenseKey'
   IdentityServer__SigningCertificate__Passphrase: '/k8s/identity-server/SigningCertificatePassphrase'
   PersistenceSettings__AccessTokenManagementSettings__ClientSecret: '/k8s/identity-server/ClientSecret'

--- a/charts/identity-server-services/identity-server/values.prod.yaml
+++ b/charts/identity-server-services/identity-server/values.prod.yaml
@@ -137,6 +137,7 @@ secrets:
   Datadog__ClientLogs__Token: '/k8s/identity-server/DD_LOGS_CLIENT_TOKEN'
   FeatureFlags__ConfigCatSdkKey: '/k8s/configcat/CONFIGCAT_SDK_KEY'
   IdentityServer__FakePersons: '/k8s/identity-server/FakePersons'
+  IdentityServer__FakePersons2: '/k8s/identity-server/FakePersons2'
   IdentityServer__LicenseKey: '/k8s/identity-server/LicenseKey'
   IdentityServer__SigningCertificate__Passphrase: '/k8s/identity-server/SigningCertificatePassphrase'
   PersistenceSettings__AccessTokenManagementSettings__ClientSecret: '/k8s/identity-server/ClientSecret'

--- a/charts/identity-server-services/identity-server/values.staging.yaml
+++ b/charts/identity-server-services/identity-server/values.staging.yaml
@@ -138,6 +138,7 @@ secrets:
   Datadog__ClientLogs__Token: '/k8s/identity-server/DD_LOGS_CLIENT_TOKEN'
   FeatureFlags__ConfigCatSdkKey: '/k8s/configcat/CONFIGCAT_SDK_KEY'
   IdentityServer__FakePersons: '/k8s/identity-server/FakePersons'
+  IdentityServer__FakePersons2: '/k8s/identity-server/FakePersons2'
   IdentityServer__LicenseKey: '/k8s/identity-server/LicenseKey'
   IdentityServer__SigningCertificate__Passphrase: '/k8s/identity-server/SigningCertificatePassphrase'
   PersistenceSettings__AccessTokenManagementSettings__ClientSecret: '/k8s/identity-server/ClientSecret'

--- a/charts/identity-server/values.dev.yaml
+++ b/charts/identity-server/values.dev.yaml
@@ -229,6 +229,7 @@ identity-server:
     Datadog__ClientLogs__Token: '/k8s/identity-server/DD_LOGS_CLIENT_TOKEN'
     FeatureFlags__ConfigCatSdkKey: '/k8s/configcat/CONFIGCAT_SDK_KEY'
     IdentityServer__FakePersons: '/k8s/identity-server/FakePersons'
+    IdentityServer__FakePersons2: '/k8s/identity-server/FakePersons2'
     IdentityServer__LicenseKey: '/k8s/identity-server/LicenseKey'
     IdentityServer__SigningCertificate__Passphrase: '/k8s/identity-server/SigningCertificatePassphrase'
     PersistenceSettings__AccessTokenManagementSettings__ClientSecret: '/k8s/identity-server/ClientSecret'

--- a/charts/identity-server/values.prod.yaml
+++ b/charts/identity-server/values.prod.yaml
@@ -226,6 +226,7 @@ identity-server:
     Datadog__ClientLogs__Token: '/k8s/identity-server/DD_LOGS_CLIENT_TOKEN'
     FeatureFlags__ConfigCatSdkKey: '/k8s/configcat/CONFIGCAT_SDK_KEY'
     IdentityServer__FakePersons: '/k8s/identity-server/FakePersons'
+    IdentityServer__FakePersons2: '/k8s/identity-server/FakePersons2'
     IdentityServer__LicenseKey: '/k8s/identity-server/LicenseKey'
     IdentityServer__SigningCertificate__Passphrase: '/k8s/identity-server/SigningCertificatePassphrase'
     PersistenceSettings__AccessTokenManagementSettings__ClientSecret: '/k8s/identity-server/ClientSecret'

--- a/charts/identity-server/values.staging.yaml
+++ b/charts/identity-server/values.staging.yaml
@@ -229,6 +229,7 @@ identity-server:
     Datadog__ClientLogs__Token: '/k8s/identity-server/DD_LOGS_CLIENT_TOKEN'
     FeatureFlags__ConfigCatSdkKey: '/k8s/configcat/CONFIGCAT_SDK_KEY'
     IdentityServer__FakePersons: '/k8s/identity-server/FakePersons'
+    IdentityServer__FakePersons2: '/k8s/identity-server/FakePersons2'
     IdentityServer__LicenseKey: '/k8s/identity-server/LicenseKey'
     IdentityServer__SigningCertificate__Passphrase: '/k8s/identity-server/SigningCertificatePassphrase'
     PersistenceSettings__AccessTokenManagementSettings__ClientSecret: '/k8s/identity-server/ClientSecret'


### PR DESCRIPTION
Add `IdentityServer__FakePersons2` secret mapping to the identity-server infrastructure configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated identity service configuration to include an additional security credential.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/island-is/island.is/pull/22546)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->