### PR TITLE
feat(web): Claude-powered AI search summary

### DIFF
--- a/apps/web/components/AISummaryCard/AISummaryCard.tsx
+++ b/apps/web/components/AISummaryCard/AISummaryCard.tsx
@@ -1,0 +1,143 @@
+import React, { useEffect, useRef, useState } from 'react'
+
+import {
+  Box,
+  Inline,
+  SkeletonLoader,
+  Stack,
+  Text,
+} from '@island.is/island-ui/core'
+
+interface AISummaryCardProps {
+  query: string
+  locale: 'is' | 'en'
+}
+
+type FetchState =
+  | { kind: 'idle' }
+  | { kind: 'loading' }
+  | { kind: 'success'; summary: string }
+  | { kind: 'error' }
+
+const COPY = {
+  is: {
+    title: 'Svar frá Claude',
+    badge: 'Gervigreind',
+    error: 'Tókst ekki að sækja samantekt.',
+    disclaimer:
+      'Sjálfvirkt myndað svar. Getur verið ónákvæmt — staðfestu á opinberum þjónustusíðum.',
+  },
+  en: {
+    title: 'Claude’s response',
+    badge: 'AI',
+    error: 'Could not fetch summary.',
+    disclaimer:
+      'Automatically generated. May be inaccurate — verify on the official service pages.',
+  },
+} as const
+
+export const AISummaryCard: React.FC<AISummaryCardProps> = ({
+  query,
+  locale,
+}) => {
+  const [state, setState] = useState<FetchState>({ kind: 'idle' })
+  // Guard against duplicate fetches when React StrictMode double-invokes effects.
+  const lastFetchedRef = useRef<string | null>(null)
+
+  useEffect(() => {
+    const q = (query ?? '').trim()
+    if (!q) {
+      setState({ kind: 'idle' })
+      return
+    }
+    const key = `${locale}::${q}`
+    if (lastFetchedRef.current === key) return
+    lastFetchedRef.current = key
+
+    const controller = new AbortController()
+    setState({ kind: 'loading' })
+
+    fetch('/api/ai-search', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ q, locale }),
+      signal: controller.signal,
+    })
+      .then(async (res) => {
+        if (!res.ok) throw new Error(`HTTP ${res.status}`)
+        return (await res.json()) as { summary: string }
+      })
+      .then((data) => setState({ kind: 'success', summary: data.summary }))
+      .catch((err) => {
+        if (controller.signal.aborted) return
+        // eslint-disable-next-line no-console
+        console.warn('[AISummaryCard] fetch failed', err)
+        setState({ kind: 'error' })
+      })
+
+    return () => controller.abort()
+  }, [query, locale])
+
+  if (state.kind === 'idle') return null
+
+  const copy = COPY[locale]
+  const paragraphs =
+    state.kind === 'success'
+      ? state.summary
+          .split(/\n{2,}/)
+          .map((p) => p.trim())
+          .filter(Boolean)
+      : []
+
+  return (
+    <Box
+      background="blue100"
+      padding={[3, 3, 4]}
+      borderRadius="large"
+      dataTestId="ai-summary-card"
+    >
+      <Stack space={2}>
+        <Inline space={2} alignY="center">
+          <Text variant="eyebrow" color="blue400">
+            {copy.title}
+          </Text>
+          <Box
+            background="blue200"
+            paddingX={1}
+            borderRadius="standard"
+            display="inlineBlock"
+          >
+            <Text variant="eyebrow" color="blue600">
+              {copy.badge}
+            </Text>
+          </Box>
+        </Inline>
+
+        {state.kind === 'loading' && (
+          <SkeletonLoader repeat={3} height={18} space={1} />
+        )}
+
+        {state.kind === 'success' && (
+          <Stack space={2}>
+            {paragraphs.map((p, i) => (
+              <Text key={i} variant="default">
+                {p}
+              </Text>
+            ))}
+            <Text variant="small" color="dark300">
+              {copy.disclaimer}
+            </Text>
+          </Stack>
+        )}
+
+        {state.kind === 'error' && (
+          <Text variant="default" color="red600">
+            {copy.error}
+          </Text>
+        )}
+      </Stack>
+    </Box>
+  )
+}
+
+export default AISummaryCard

--- a/apps/web/components/AISummaryCard/index.ts
+++ b/apps/web/components/AISummaryCard/index.ts
@@ -1,0 +1,1 @@
+export { AISummaryCard } from './AISummaryCard'

--- a/apps/web/components/real.ts
+++ b/apps/web/components/real.ts
@@ -11,6 +11,7 @@
  * `libs/shared/babel/README.md` for more details.
  */
 
+export * from './AISummaryCard/AISummaryCard'
 export * from './Card/Card'
 export * from './Header/Header'
 export * from './SearchInput/SearchInput'

--- a/apps/web/pages/api/ai-search.ts
+++ b/apps/web/pages/api/ai-search.ts
@@ -1,0 +1,130 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import Anthropic from '@anthropic-ai/sdk'
+
+// Claude model. Haiku 4.5 is the fastest and cheapest Claude 4.x model —
+// well-suited to short search-summary responses.
+const MODEL = 'claude-haiku-4-5'
+
+// Cap output. A 2–4 short-paragraph summary fits in <600 tokens easily.
+const MAX_TOKENS = 600
+
+// Reject pathologically long queries up front.
+const MAX_QUERY_LENGTH = 200
+
+type SuccessResponse = { summary: string }
+type ErrorResponse = { error: string }
+
+const buildSystemPrompt = (locale: 'is' | 'en'): string => {
+  const respondIn = locale === 'is' ? 'Icelandic' : 'English'
+  return `You are an assistant integrated into Ísland.is — Iceland's official portal for digital public services. Users search the site for help with government procedures: ID documents, driving licences, residence permits, taxes, social benefits, healthcare, family matters, education, courts, business registration, and similar civic affairs.
+
+Your job: given the user's search query, write a short, useful orientation summary that helps them understand what the site likely offers on the topic and what to look for in the results below. Treat keyword-style queries as questions.
+
+Response rules:
+- Respond in ${respondIn}. The user is reading the site in this language.
+- Length: 2 to 4 short paragraphs separated by blank lines. Plain text only. No markdown, no headings, no bullets, no asterisks.
+- Be concrete and helpful. Never invent specific URLs, phone numbers, opening hours, fees, deadlines, or office addresses. When precise figures matter, say so generically and direct the user to check the official service page for current details.
+- If the query is ambiguous, briefly note the most likely interpretations.
+- If the topic is clearly outside the scope of public services (weather, opinion, entertainment), say so politely in one short paragraph rather than guessing.
+- Do not include greetings, sign-offs, or meta-commentary about being an AI. Do not start with "Here is a summary" or "Based on your query" — start with the substance.`
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<SuccessResponse | ErrorResponse>,
+): Promise<void> {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST')
+    res.status(405).json({ error: 'Method not allowed' })
+    return
+  }
+
+  const body = (req.body ?? {}) as { q?: unknown; locale?: unknown }
+  const q = typeof body.q === 'string' ? body.q.trim() : ''
+  if (!q) {
+    res.status(400).json({ error: 'Missing or empty `q`.' })
+    return
+  }
+  if (q.length > MAX_QUERY_LENGTH) {
+    res
+      .status(400)
+      .json({ error: `Query is too long (max ${MAX_QUERY_LENGTH} chars).` })
+    return
+  }
+  const locale: 'is' | 'en' = body.locale === 'en' ? 'en' : 'is'
+
+  if (!process.env.ANTHROPIC_API_KEY) {
+    res.status(503).json({ error: 'AI search is not configured on this server.' })
+    return
+  }
+
+  const client = new Anthropic()
+
+  try {
+    const message = await client.messages.create({
+      model: MODEL,
+      max_tokens: MAX_TOKENS,
+      // Mark the system prompt for ephemeral prompt caching. The cache key is
+      // a prefix match; since the system prompt is identical across requests
+      // (only the per-request user message varies), every request after the
+      // first becomes a cache read at ~0.1× input cost.
+      //
+      // Caveat: Haiku 4.5's minimum cacheable prefix is 4096 tokens. The
+      // current system prompt is well below that, so the marker is silently
+      // a no-op today (response.usage.cache_read_input_tokens stays 0). The
+      // marker is placed correctly so caching activates automatically once
+      // the prompt is expanded above the threshold.
+      system: [
+        {
+          type: 'text',
+          text: buildSystemPrompt(locale),
+          cache_control: { type: 'ephemeral' },
+        },
+      ],
+      messages: [{ role: 'user', content: q }],
+    })
+
+    const summary = message.content
+      .filter((block): block is Anthropic.TextBlock => block.type === 'text')
+      .map((block) => block.text)
+      .join('\n\n')
+      .trim()
+
+    if (!summary) {
+      res.status(502).json({ error: 'Empty response from model.' })
+      return
+    }
+
+    if (process.env.NODE_ENV !== 'production') {
+      // Surface usage + cache activity in dev logs so we can see when caching kicks in.
+      // eslint-disable-next-line no-console
+      console.log('[ai-search] usage', {
+        q,
+        locale,
+        input_tokens: message.usage.input_tokens,
+        output_tokens: message.usage.output_tokens,
+        cache_creation_input_tokens: message.usage.cache_creation_input_tokens,
+        cache_read_input_tokens: message.usage.cache_read_input_tokens,
+      })
+    }
+
+    // Cheap browser-side cache: same (q, locale) within 60s reuses the response.
+    res.setHeader('Cache-Control', 'private, max-age=60')
+    res.status(200).json({ summary })
+  } catch (err) {
+    if (err instanceof Anthropic.RateLimitError) {
+      res.setHeader('Retry-After', '30')
+      res.status(429).json({ error: 'Rate limited. Try again shortly.' })
+      return
+    }
+    if (err instanceof Anthropic.APIError) {
+      res
+        .status(err.status ?? 502)
+        .json({ error: err.message ?? 'Upstream model error.' })
+      return
+    }
+    // eslint-disable-next-line no-console
+    console.error('[ai-search] unexpected error', err)
+    res.status(500).json({ error: 'Internal error.' })
+  }
+}

--- a/apps/web/proxy.config.json
+++ b/apps/web/proxy.config.json
@@ -1,5 +1,5 @@
 {
-  "/api": {
+  "/api/graphql": {
     "target": "http://localhost:4444",
     "secure": false
   }

--- a/apps/web/screens/Search/Search.tsx
+++ b/apps/web/screens/Search/Search.tsx
@@ -32,6 +32,7 @@ import {
 import { theme } from '@island.is/island-ui/theme'
 import { useMatomoTrackSearch } from '@island.is/matomo'
 import {
+  AISummaryCard,
   Card,
   CardTagsProps,
   FilterTag,
@@ -825,6 +826,7 @@ const Search: Screen<CategoryProps> = ({
                   </Text>
                 </Box>
               )}
+              <AISummaryCard query={q} locale={activeLocale} />
             </Stack>
             <ColorSchemeContext.Provider value={{ colorScheme: 'blue' }}>
               <Stack space={2}>

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
   "dependencies": {
     "@actions/core": "1.11.1",
     "@actions/github": "6.0.0",
+    "@anthropic-ai/sdk": "0.96.0",
     "@apollo/client": "3.7.15",
     "@apollo/gateway": "2.1.1",
     "@apollo/subgraph": "2.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -128,6 +128,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@anthropic-ai/sdk@npm:0.96.0":
+  version: 0.96.0
+  resolution: "@anthropic-ai/sdk@npm:0.96.0"
+  dependencies:
+    json-schema-to-ts: "npm:^3.1.1"
+    standardwebhooks: "npm:^1.0.0"
+  peerDependencies:
+    zod: ^3.25.0 || ^4.0.0
+  peerDependenciesMeta:
+    zod:
+      optional: true
+  bin:
+    anthropic-ai-sdk: bin/cli
+  checksum: 10/07d74a5c9df0162bec91b3682a11745114b7d676f17eba3746ee0c7e353b0cd8d05aec964331502976fbb089c7045ce67f1e01bdd9ee0b1ed5f8111a22b8a82e
+  languageName: node
+  linkType: hard
+
 "@apidevtools/json-schema-ref-parser@npm:9.0.6":
   version: 9.0.6
   resolution: "@apidevtools/json-schema-ref-parser@npm:9.0.6"
@@ -16767,6 +16784,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@stablelib/base64@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "@stablelib/base64@npm:1.0.1"
+  checksum: 10/93f3edb05d5a828a775d23ebde49884abeb456b8946942acbe6a0815630e769c59c06c7275983031c8707bdcefc1c62917aaa99522ff1ec5f457704c83b686da
+  languageName: node
+  linkType: hard
+
 "@standard-schema/utils@npm:^0.3.0":
   version: 0.3.0
   resolution: "@standard-schema/utils@npm:0.3.0"
@@ -30711,6 +30735,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fast-sha256@npm:^1.3.0":
+  version: 1.3.0
+  resolution: "fast-sha256@npm:1.3.0"
+  checksum: 10/3bef0491f10a254348ec11dcddb26e4d951cfd3b4c0662ea5843ad1be3fe184ed74d640df68565fcc60f6437548cddf49e3ac886f88a69e05b5142e862840bf9
+  languageName: node
+  linkType: hard
+
 "fast-shallow-equal@npm:^1.0.0":
   version: 1.0.0
   resolution: "fast-shallow-equal@npm:1.0.0"
@@ -35134,6 +35165,7 @@ __metadata:
     "@actions/github": "npm:6.0.0"
     "@anatine/esbuild-decorators": "npm:0.2.4"
     "@anev/ts-mountebank": "npm:^1.6.0"
+    "@anthropic-ai/sdk": "npm:0.96.0"
     "@apollo/client": "npm:3.7.15"
     "@apollo/gateway": "npm:2.1.1"
     "@apollo/subgraph": "npm:2.1.1"
@@ -36865,6 +36897,16 @@ __metadata:
   dependencies:
     foreach: "npm:^2.0.4"
   checksum: 10/1d8fc507008cf28815ad398baa7a6d62a73cce2d5ca7859097bb56043b3b6889e393bf5285db9674ddcdb8bc10551146cf8048d3d6430d55ce922105813661e2
+  languageName: node
+  linkType: hard
+
+"json-schema-to-ts@npm:^3.1.1":
+  version: 3.1.1
+  resolution: "json-schema-to-ts@npm:3.1.1"
+  dependencies:
+    "@babel/runtime": "npm:^7.18.3"
+    ts-algebra: "npm:^2.0.0"
+  checksum: 10/9fd0490279d36ff8b4604cc10632df05e4e5f5ee1d0a77841c927623fc1e636c47eb4ace488018c4e9a2e7e5dde5520d0870e06dfc84b930d9c98c6eacd0f041
   languageName: node
   linkType: hard
 
@@ -49051,6 +49093,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"standardwebhooks@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "standardwebhooks@npm:1.0.0"
+  dependencies:
+    "@stablelib/base64": "npm:^1.0.0"
+    fast-sha256: "npm:^1.3.0"
+  checksum: 10/02b74a3e4cd131affe8bf18945360747a5a0bf81c1d62a7bbbea3d40976b4fef4bb37de71a35cdc0fdc4d6f0d951a3b6031052e78bd086dc9b09b629b82d3919
+  languageName: node
+  linkType: hard
+
 "static-eval@npm:2.0.2":
   version: 2.0.2
   resolution: "static-eval@npm:2.0.2"
@@ -50721,6 +50773,13 @@ __metadata:
   version: 1.0.1
   resolution: "tryer@npm:1.0.1"
   checksum: 10/4d869d187bd715136903b349f39d1cc3e5c19f742689a348190aff92408ee8dd3d7d9adc26dc9265c35d722731184c979ed316109b6c1239249a8707bb92cc49
+  languageName: node
+  linkType: hard
+
+"ts-algebra@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "ts-algebra@npm:2.0.0"
+  checksum: 10/b970eef64ca9594a77337e03b9c1732c1b7a0d2c4d316638b654e921a47b40c4cc42f41821445e9e54408d5dfdf4ecca27ffa59554373033b9c92dee8b52066d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Adds an AI-generated orientation summary at the top of the search results page (`/leit` and `/search`). When a user submits a search, the existing GraphQL search query and a new Claude-powered summary request fire in parallel; results render immediately via SSR while the summary appears in a card a few seconds later, replacing a skeleton loader.

The summary helps users orient to what Ísland.is likely offers on their topic and what to look for in the result list below — useful especially for ambiguous queries or topics where the user isn't sure which service applies.

## What's in this PR

Two commits:

1. **`fix(web): narrow dev proxy context to /api/graphql`** — bugfix. The dev-mode proxy in `apps/web/proxy.config.json` was matching `/api` and forwarding everything under it to the local API server, silently swallowing every Next.js API route under `apps/web/pages/api/*` (RSS feeds, etc.) in dev. Narrowed to `/api/graphql`, which is the only path the web app actually forwards. Production is unaffected (the proxy only runs in dev).

2. **`feat(web): Claude-powered AI search summary`** — the feature itself.

## Implementation

- **New Next.js API route** [`apps/web/pages/api/ai-search.ts`](apps/web/pages/api/ai-search.ts). Accepts `POST { q, locale }`, calls `claude-haiku-4-5` via [`@anthropic-ai/sdk`](https://www.npmjs.com/package/@anthropic-ai/sdk), returns `{ summary }`. Small island.is-specific system prompt grounds the model in the public-services context, instructs plain-text output in the user's language, and forbids invented URLs, fees, deadlines, and contact details. Caps query length at 200 chars, output at 600 tokens.
- **Prompt caching marker** (`cache_control: { type: 'ephemeral' }`) is set on the system prompt. Today it's a silent no-op because the prompt is below Haiku 4.5's 4096-token cache minimum; the marker is placed correctly so caching activates automatically once the prompt grows.
- **New `AISummaryCard` component** ([`apps/web/components/AISummaryCard/`](apps/web/components/AISummaryCard/AISummaryCard.tsx)) using `Box`, `Stack`, `Text`, `Inline`, `SkeletonLoader` from `@island.is/island-ui/core`. States: idle / loading (skeleton) / success (paragraph-split prose + small disclaimer) / error. Bilingual copy keyed off `locale`. Aborts in-flight fetches when the query changes.
- **Rendered in [`apps/web/screens/Search/Search.tsx`](apps/web/screens/Search/Search.tsx)** inside the existing outer `<Stack space={[3, 3, 4]}>` so it slots between the result count and the result list and reuses the stack's spacing.

## Configuration

Set `ANTHROPIC_API_KEY` in the server environment of any deployment that should serve summaries. With the var unset the route returns `503` and the card surfaces an error state, so the rest of the search page is unaffected. A new `.env.local` template is **not** committed — `ANTHROPIC_API_KEY` should be wired in via the existing secrets pipeline.

## Cost

`claude-haiku-4-5` at $1/M input, $5/M output. A typical query (~300 input tokens for system + user, ~200 output tokens) costs well under $0.001 per request and will drop further once prompt caching activates.

## Failure modes — graceful

| Condition | Behavior |
|---|---|
| `ANTHROPIC_API_KEY` unset | API returns 503, card shows error message; search results unaffected |
| Anthropic API rate-limited | API returns 429 with `Retry-After`, card shows error message |
| Upstream API error | API forwards upstream status + sanitized message, card shows error message |
| Empty / oversized query | API returns 400 |
| User abandons page mid-fetch | Fetch is aborted via `AbortController` |

## How to test locally

1. Add `ANTHROPIC_API_KEY=<your key>` to a server-only env file (`apps/web/.env.local` is git-ignored).
2. `yarn install` at repo root (adds `@anthropic-ai/sdk`).
3. `yarn start web` and open http://localhost:4200/leit?q=vegabr%C3%A9f (Icelandic) or http://localhost:4200/search?q=passport+renewal (English).
4. You should see the result list render immediately, then the AI summary card appear at the top of the list a few seconds later.

The card respects locale and only fires for non-empty queries; it does not block the search results.

## Notes / follow-ups

- **No streaming.** The user sees a skeleton for a few seconds (~2–4s) before the full summary renders. Streaming would improve perceived latency but requires harness work (`text/event-stream` is unprecedented in this repo); deferred.
- **System prompt is intentionally compact.** Expanding it with a fuller catalogue of common Ísland.is service categories would both improve answer quality and push the prompt above Haiku's 4096-token cache minimum, making the existing `cache_control` marker active. Happy to do that as a follow-up.
- **No request-rate limiting on the route itself** — relies on the Anthropic account's per-key quotas. Worth adding a simple per-IP cap if this ships to production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
