### PR TITLE
fix(driving-license): gate BE/65+ photo eligibility on imageId, not photo binary (cherry-pick of #22548)

### DIFF
--- a/libs/application/template-api-modules/src/lib/modules/shared/api/driving-license/driving-license.service.spec.ts
+++ b/libs/application/template-api-modules/src/lib/modules/shared/api/driving-license/driving-license.service.spec.ts
@@ -11,6 +11,12 @@ import { DrivingLicenseProviderService } from './driving-license.service'
 describe('DrivingLicenseProviderService — fakeData photo modes', () => {
   let drivingLicenseService: any
   let drivingLicenseBookService: any
+  let logger: {
+    info: jest.Mock
+    warn: jest.Mock
+    error: jest.Mock
+    log: jest.Mock
+  }
   let service: DrivingLicenseProviderService
 
   beforeEach(() => {
@@ -32,9 +38,16 @@ describe('DrivingLicenseProviderService — fakeData photo modes', () => {
       })),
     }
     drivingLicenseBookService = {}
+    logger = {
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      log: jest.fn(),
+    }
     service = new DrivingLicenseProviderService(
       drivingLicenseService,
       drivingLicenseBookService,
+      logger as any,
     )
   })
 
@@ -87,6 +100,28 @@ describe('DrivingLicenseProviderService — fakeData photo modes', () => {
         drivingLicenseService.getQualityPhotoAndSignature,
       ).toHaveBeenCalledTimes(1)
       expect(result).toMatchObject({ imageTypeName: 'Real photo' })
+    })
+
+    it('logs when RLS returns metadata but no photo binary', async () => {
+      drivingLicenseService.getQualityPhotoAndSignature = jest.fn(async () => ({
+        imageId: 1390033,
+        imageTypeId: 1,
+        imageTypeName: 'Passamynd',
+        imageDate: new Date('2015-04-17T13:02:16.390Z'),
+        pohto: null,
+        signature: 'sigbase64',
+      }))
+      const result = await service.qualityPhotoAndSignature(buildProps())
+      expect(result).toMatchObject({ imageId: 1390033, pohto: null })
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.stringContaining('without binary'),
+        expect.objectContaining({ imageTypeId: 1 }),
+      )
+    })
+
+    it('does not log when RLS returns the full record with binary', async () => {
+      await service.qualityPhotoAndSignature(buildProps())
+      expect(logger.info).not.toHaveBeenCalled()
     })
   })
 

--- a/libs/application/template-api-modules/src/lib/modules/shared/api/driving-license/driving-license.service.ts
+++ b/libs/application/template-api-modules/src/lib/modules/shared/api/driving-license/driving-license.service.ts
@@ -1,7 +1,9 @@
-import { Injectable } from '@nestjs/common'
+import { Inject, Injectable } from '@nestjs/common'
 import { TemplateApiError } from '@island.is/nest/problem'
 import { BaseTemplateApiService } from '../../../base-template-api.service'
 import { coreErrorMessages } from '@island.is/application/core'
+import type { Logger } from '@island.is/logging'
+import { LOGGER_PROVIDER } from '@island.is/logging'
 
 import { StudentAssessment, DrivingLicense, HasQualitySignature } from './types'
 import {
@@ -31,6 +33,7 @@ export class DrivingLicenseProviderService extends BaseTemplateApiService {
   constructor(
     private readonly drivingLicenseService: DrivingLicenseApi,
     private readonly drivingLicenseBookService: DrivingLicenseBookService,
+    @Inject(LOGGER_PROVIDER) private logger: Logger,
   ) {
     super('DrivingLicenseShared')
   }
@@ -254,9 +257,24 @@ export class DrivingLicenseProviderService extends BaseTemplateApiService {
     }
 
     try {
-      return await this.drivingLicenseService.getQualityPhotoAndSignature({
-        token: auth.authorization,
-      })
+      const result =
+        await this.drivingLicenseService.getQualityPhotoAndSignature({
+          token: auth.authorization,
+        })
+      // Some legacy RLS records return metadata + signature but no photo
+      // binary. Submission still resolves the photo by imageId, but log the
+      // case so we can spot patterns (image type, date range, frequency).
+      if (result && result.imageId != null && !result.pohto) {
+        this.logger.info(
+          '[driving-license] quality photo metadata returned without binary',
+          {
+            imageTypeId: result.imageTypeId,
+            imageTypeName: result.imageTypeName,
+            imageDate: result.imageDate,
+          },
+        )
+      }
+      return result
     } catch {
       return null
     }

--- a/libs/application/template-api-modules/src/lib/modules/shared/api/driving-license/drivingLicenseFakeData.spec.ts
+++ b/libs/application/template-api-modules/src/lib/modules/shared/api/driving-license/drivingLicenseFakeData.spec.ts
@@ -46,6 +46,19 @@ describe('drivingLicenseFakeData builders', () => {
       })
       expect(result).toBeNull()
     })
+
+    it('returns metadata-only shape when hasRLSPhoto is "metadata-only"', () => {
+      const result = buildFakeQualityPhotoAndSignature({
+        ...baseFakeData,
+        hasRLSPhoto: 'metadata-only',
+      })
+      expect(result).toMatchObject({
+        imageId: expect.any(Number),
+        imageTypeId: 1,
+        imageTypeName: 'Passamynd',
+        pohto: null,
+      })
+    })
   })
 
   describe('buildFakeAllPhotosFromThjodskra', () => {

--- a/libs/application/template-api-modules/src/lib/modules/shared/api/driving-license/drivingLicenseFakeData.ts
+++ b/libs/application/template-api-modules/src/lib/modules/shared/api/driving-license/drivingLicenseFakeData.ts
@@ -76,6 +76,23 @@ export const buildFakeQualitySignature = (
   return null
 }
 
+// Prod-observed shape from legacy RLS records (e.g. 2015-era passport photos):
+// metadata is present, the photo binary (`pohto`) is null. All values here are
+// synthetic — no real captured data, just enough fields to reproduce the
+// regression code path that PR #22548 fixes.
+const legacyMetadataOnlyRlsPhoto = {
+  imageId: 1,
+  imageTypeId: 1,
+  imageTypeName: 'Passamynd',
+  imageDate: null,
+  pohto: null,
+  signatureId: null,
+  signatureTypeId: null,
+  signatureTypeName: null,
+  signatureDate: null,
+  signature: null,
+}
+
 export const buildFakeQualityPhotoAndSignature = (
   fakeData: DrivingLicenseFakeData,
 ) => {
@@ -83,6 +100,9 @@ export const buildFakeQualityPhotoAndSignature = (
   // provider call real RLS. Returning undefined is the sentinel for that.
   if (fakeData.hasRLSPhoto === 'real') {
     return undefined
+  }
+  if (fakeData.hasRLSPhoto === 'metadata-only') {
+    return legacyMetadataOnlyRlsPhoto
   }
   if (fakeData.hasRLSPhoto === YES) {
     return {

--- a/libs/application/template-api-modules/src/lib/modules/shared/api/driving-license/types.ts
+++ b/libs/application/template-api-modules/src/lib/modules/shared/api/driving-license/types.ts
@@ -9,8 +9,9 @@ export type HasQualitySignature = {
 
 type FakeCurrentLicense = 'none' | 'temp' | 'B' | 'C' | 'C1' | 'D' | 'D1'
 
-// 'yes' = inject fake photo, 'no' = inject "no photo" fake, 'real' = fall through to real data
-export type FakePhotoMode = 'yes' | 'no' | 'real'
+// 'yes' = inject fake photo, 'no' = inject "no photo" fake, 'real' = fall through to real data,
+// 'metadata-only' = prod-observed legacy shape: RLS metadata returned, photo binary missing
+export type FakePhotoMode = 'yes' | 'no' | 'real' | 'metadata-only'
 
 export interface DrivingLicenseFakeData {
   useFakeData?: YesOrNo

--- a/libs/application/templates/driving-license/src/fields/EligibilitySummary/useEligibility.ts
+++ b/libs/application/templates/driving-license/src/fields/EligibilitySummary/useEligibility.ts
@@ -13,11 +13,11 @@ import {
   codesExtendedLicenseCategories,
   DrivingLicenseApplicationFor,
   DrivingLicenseFakeData,
-  QUALITY_IMAGE_TYPE_IDS,
   remarksCannotRenew65,
 } from '../../lib/constants'
 import { fakeEligibility } from './fakeEligibility'
 import { DrivingLicense } from '../../lib/types'
+import { hasUsableRlsQualityPhoto } from '../../lib/utils'
 
 const QUERY = gql`
   query EligibilityQuery($input: ApplicationEligibilityInput!) {
@@ -94,39 +94,25 @@ export const useEligibility = (
   if (usingFakeData) {
     let hasPhoto: boolean
     if (usesNewPhotoSelector) {
-      // When a photo source is set to 'real', the data provider falls through
-      // to RLS, so externalData reflects whatever the logged-in user actually
-      // has. For 'yes' it's faked into externalData; for 'no' it's empty.
-      // In all three cases, reading externalData via the same logic the real
-      // path uses gives us the correct hasPhoto.
-      const thjodskraOrRLSIsReal =
-        fakeData?.hasThjodskraPhoto === 'real' ||
-        fakeData?.hasRLSPhoto === 'real'
+      // 'real' falls through to RLS/Þjóðskrá and populates externalData with
+      // real data. 'yes' / 'no' / 'metadata-only' all inject their fake shape
+      // into externalData via the data provider. So in every case the right
+      // answer comes from reading externalData through the same predicates
+      // the real path uses.
+      const qualityPhotoConfirmed = hasUsableRlsQualityPhoto(
+        application.externalData,
+      )
 
-      if (thjodskraOrRLSIsReal) {
-        const qualityPhotoAndSignature = getValueViaPath<{
-          imageTypeId?: number | null
-          pohto?: string | null
-        }>(application.externalData, 'qualityPhotoAndSignature.data')
-        const qualityPhotoConfirmed =
-          QUALITY_IMAGE_TYPE_IDS.includes(
-            qualityPhotoAndSignature?.imageTypeId ?? 0,
-          ) && !!qualityPhotoAndSignature?.pohto
+      const thjodskraPhotos =
+        getValueViaPath<{
+          images?: Array<{ contentSpecification?: string }>
+        }>(application.externalData, 'allPhotosFromThjodskra.data')?.images ??
+        []
+      const hasThjodskraFacial = thjodskraPhotos.some(
+        (p) => p.contentSpecification === 'FACIAL',
+      )
 
-        const thjodskraPhotos =
-          getValueViaPath<{
-            images?: Array<{ contentSpecification?: string }>
-          }>(application.externalData, 'allPhotosFromThjodskra.data')?.images ??
-          []
-        const hasThjodskraFacial = thjodskraPhotos.some(
-          (p) => p.contentSpecification === 'FACIAL',
-        )
-
-        hasPhoto = qualityPhotoConfirmed || hasThjodskraFacial
-      } else {
-        hasPhoto =
-          fakeData?.hasThjodskraPhoto === YES || fakeData?.hasRLSPhoto === YES
-      }
+      hasPhoto = qualityPhotoConfirmed || hasThjodskraFacial
     } else {
       hasPhoto = fakeData?.qualityPhoto === YES
     }
@@ -152,18 +138,8 @@ export const useEligibility = (
   const eligibility: ApplicationEligibilityRequirement[] =
     data.drivingLicenseApplicationEligibility?.requirements ?? []
 
-  // BE and redesigned 65+ both use the new photo selector (Thjóðskrá +
-  // RLS quality photo) and gate eligibility on having a usable photo.
   const computeUsablePhoto = () => {
-    const qualityPhotoAndSignature = getValueViaPath<{
-      imageTypeId?: number | null
-      pohto?: string | null
-    }>(application.externalData, 'qualityPhotoAndSignature.data')
-
-    const qualityPhotoConfirmed =
-      QUALITY_IMAGE_TYPE_IDS.includes(
-        qualityPhotoAndSignature?.imageTypeId ?? 0,
-      ) && !!qualityPhotoAndSignature?.pohto
+    if (hasUsableRlsQualityPhoto(application.externalData)) return true
 
     const thjodskraPhotos =
       getValueViaPath<{ images?: Array<{ contentSpecification?: string }> }>(
@@ -171,11 +147,7 @@ export const useEligibility = (
         'allPhotosFromThjodskra.data',
       )?.images ?? []
 
-    const hasThjodskraFacial = thjodskraPhotos.some(
-      (p) => p.contentSpecification === 'FACIAL',
-    )
-
-    return qualityPhotoConfirmed || hasThjodskraFacial
+    return thjodskraPhotos.some((p) => p.contentSpecification === 'FACIAL')
   }
 
   if (application.answers.applicationFor === BE) {

--- a/libs/application/templates/driving-license/src/forms/draft/subSectionQualityPhoto65.ts
+++ b/libs/application/templates/driving-license/src/forms/draft/subSectionQualityPhoto65.ts
@@ -8,8 +8,12 @@ import {
 } from '@island.is/application/core'
 import { Application } from '@island.is/application/types'
 import { requirementsMessages, m } from '../../lib/messages'
-import { B_FULL_RENEWAL_65, QUALITY_IMAGE_TYPE_IDS } from '../../lib/constants'
-import { hasNoDrivingLicenseInOtherCountry, isVisible } from '../../lib/utils'
+import { B_FULL_RENEWAL_65 } from '../../lib/constants'
+import {
+  hasNoDrivingLicenseInOtherCountry,
+  hasUsableRlsQualityPhoto,
+  isVisible,
+} from '../../lib/utils'
 import { createPhotoComponent } from '../../fields/CreatePhoto'
 
 interface ThjodskraImage {
@@ -48,16 +52,9 @@ export const subSectionQualityPhoto65 = buildSubSection({
               (p) => p.contentSpecification === 'FACIAL',
             )
 
-            const photoAndSig = getValueViaPath<{
-              imageTypeId?: number | null
-              pohto?: string | null
-            }>(externalData, 'qualityPhotoAndSignature.data')
-
-            const hasQualityPhoto =
-              !!photoAndSig?.pohto &&
-              QUALITY_IMAGE_TYPE_IDS.includes(photoAndSig?.imageTypeId ?? 0)
-
-            return !hasThjodskraFacial && !hasQualityPhoto
+            return (
+              !hasThjodskraFacial && !hasUsableRlsQualityPhoto(externalData)
+            )
           },
         }),
         buildRadioField({
@@ -81,15 +78,7 @@ export const subSectionQualityPhoto65 = buildSubSection({
               return facialPhotos[0].biometricId
             }
 
-            const photoAndSig = getValueViaPath<{
-              imageTypeId?: number | null
-              pohto?: string | null
-            }>(externalData, 'qualityPhotoAndSignature.data')
-
-            if (
-              photoAndSig?.pohto &&
-              QUALITY_IMAGE_TYPE_IDS.includes(photoAndSig?.imageTypeId ?? 0)
-            ) {
+            if (hasUsableRlsQualityPhoto(externalData)) {
               return 'qualityPhoto'
             }
 
@@ -121,21 +110,20 @@ export const subSectionQualityPhoto65 = buildSubSection({
               })
             }
 
-            // Quality photo from getqualityphotoandsignature
-            const photoAndSig = getValueViaPath<{
-              imageTypeId?: number | null
-              pohto?: string | null
-            }>(externalData, 'qualityPhotoAndSignature.data')
-
-            if (
-              photoAndSig?.pohto &&
-              QUALITY_IMAGE_TYPE_IDS.includes(photoAndSig?.imageTypeId ?? 0)
-            ) {
+            // Quality photo from getqualityphotoandsignature. The binary
+            // (`pohto`) may be null for legacy records — createPhotoComponent
+            // falls back to a placeholder, and submission resolves the photo
+            // by reference, so offer the option whenever a record exists.
+            if (hasUsableRlsQualityPhoto(externalData)) {
+              const photoAndSig = getValueViaPath<{ pohto?: string | null }>(
+                externalData,
+                'qualityPhotoAndSignature.data',
+              )
               options.push({
                 value: 'qualityPhoto',
                 label: m.useDriversLicenseImage,
                 illustration: createPhotoComponent(
-                  photoAndSig.pohto ?? undefined,
+                  photoAndSig?.pohto ?? undefined,
                 ),
               })
             }

--- a/libs/application/templates/driving-license/src/forms/draft/subSectionQualityPhotoBE.ts
+++ b/libs/application/templates/driving-license/src/forms/draft/subSectionQualityPhotoBE.ts
@@ -7,8 +7,12 @@ import {
 } from '@island.is/application/core'
 import { Application } from '@island.is/application/types'
 import { m } from '../../lib/messages'
-import { BE, QUALITY_IMAGE_TYPE_IDS } from '../../lib/constants'
-import { hasNoDrivingLicenseInOtherCountry, isVisible } from '../../lib/utils'
+import { BE } from '../../lib/constants'
+import {
+  hasNoDrivingLicenseInOtherCountry,
+  hasUsableRlsQualityPhoto,
+  isVisible,
+} from '../../lib/utils'
 import { createPhotoComponent } from '../../fields/CreatePhoto'
 
 interface ThjodskraImage {
@@ -51,15 +55,7 @@ export const subSectionQualityPhotoBE = buildSubSection({
               return facialPhotos[0].biometricId
             }
 
-            const photoAndSig = getValueViaPath<{
-              imageTypeId?: number | null
-              pohto?: string | null
-            }>(externalData, 'qualityPhotoAndSignature.data')
-
-            if (
-              photoAndSig?.pohto &&
-              QUALITY_IMAGE_TYPE_IDS.includes(photoAndSig?.imageTypeId ?? 0)
-            ) {
+            if (hasUsableRlsQualityPhoto(externalData)) {
               return 'qualityPhoto'
             }
 
@@ -91,21 +87,20 @@ export const subSectionQualityPhotoBE = buildSubSection({
               })
             }
 
-            // Quality photo from getqualityphotoandsignature
-            const photoAndSig = getValueViaPath<{
-              imageTypeId?: number | null
-              pohto?: string | null
-            }>(externalData, 'qualityPhotoAndSignature.data')
-
-            if (
-              photoAndSig?.pohto &&
-              QUALITY_IMAGE_TYPE_IDS.includes(photoAndSig?.imageTypeId ?? 0)
-            ) {
+            // Quality photo from getqualityphotoandsignature. The binary
+            // (`pohto`) may be null for legacy records — createPhotoComponent
+            // falls back to a placeholder, and submission resolves the photo
+            // by reference, so offer the option whenever a record exists.
+            if (hasUsableRlsQualityPhoto(externalData)) {
+              const photoAndSig = getValueViaPath<{ pohto?: string | null }>(
+                externalData,
+                'qualityPhotoAndSignature.data',
+              )
               options.push({
                 value: 'qualityPhoto',
                 label: m.useDriversLicenseImage,
                 illustration: createPhotoComponent(
-                  photoAndSig.pohto ?? undefined,
+                  photoAndSig?.pohto ?? undefined,
                 ),
               })
             }

--- a/libs/application/templates/driving-license/src/forms/prerequisites/sectionFakeData.ts
+++ b/libs/application/templates/driving-license/src/forms/prerequisites/sectionFakeData.ts
@@ -161,6 +161,10 @@ export const sectionFakeData = buildSubSection({
               label: 'Nei — gervi engin gæðamynd',
             },
             {
+              value: 'metadata-only',
+              label: 'Já — gervi gæðamynd, en pohto-bita vantar (eldri skrá)',
+            },
+            {
               value: 'real',
               label: 'Raunveruleg gögn (sækja í RLS)',
             },

--- a/libs/application/templates/driving-license/src/lib/constants.ts
+++ b/libs/application/templates/driving-license/src/lib/constants.ts
@@ -152,10 +152,6 @@ export const CHARGE_ITEM_CODES: Record<string, string> = {
   [DELIVERY_FEE]: 'AY145',
 }
 
-// RLS image type IDs that indicate a quality-certified photo for BE license
-// 1 = standard quality photo, 11 = quality scanned photo
-export const QUALITY_IMAGE_TYPE_IDS = [1, 11]
-
 export const otherLicenseCategories = ['C', 'C1', 'CE', 'D', 'D1', 'DE']
 export const codesRequiringHealthCertificate = ['400', '01.06']
 export const codesExtendedLicenseCategories = [
@@ -201,10 +197,12 @@ export enum States {
 type FakeCurrentLicense = 'none' | 'temp' | 'full' | 'BE'
 
 // Fake-photo modes for hasThjodskraPhoto / hasRLSPhoto:
-//   'yes'  — inject a fake photo
-//   'no'   — inject "no photo" (fake empty)
-//   'real' — fall through to real RLS / Þjóðskrá data (default)
-export type FakePhotoMode = 'yes' | 'no' | 'real'
+//   'yes'           — inject a fake photo
+//   'no'            — inject "no photo" (fake empty)
+//   'real'          — fall through to real RLS / Þjóðskrá data (default)
+//   'metadata-only' — inject the prod-observed legacy-record shape:
+//                     metadata returned, photo binary missing (RLS only)
+export type FakePhotoMode = 'yes' | 'no' | 'real' | 'metadata-only'
 
 export interface DrivingLicenseFakeData {
   useFakeData?: YesOrNo

--- a/libs/application/templates/driving-license/src/lib/utils/formUtils.spec.ts
+++ b/libs/application/templates/driving-license/src/lib/utils/formUtils.spec.ts
@@ -5,6 +5,7 @@ import {
   needsHealthCertificateCondition,
   allowFakeCondition,
   hasCompletedPrerequisitesStep,
+  hasUsableRlsQualityPhoto,
 } from './formUtils'
 import { NO, YES } from '@island.is/application/core'
 
@@ -136,5 +137,54 @@ describe('hasCompletedPrerequisitesStep', () => {
         }),
       }),
     ).toBe(false)
+  })
+})
+
+describe('hasUsableRlsQualityPhoto', () => {
+  const wrap = (data: unknown) =>
+    ({
+      qualityPhotoAndSignature: {
+        data,
+        date: new Date(),
+        status: 'success' as const,
+      },
+    } as any)
+
+  it('returns true when RLS returns imageId + binary', () => {
+    expect(
+      hasUsableRlsQualityPhoto(
+        wrap({ imageId: 1390033, imageTypeId: 1, pohto: 'base64data' }),
+      ),
+    ).toBe(true)
+  })
+
+  // Regression: legacy RLS records return metadata + signature but no photo
+  // binary. Submission resolves photo by reference (imageId) so the user
+  // should still pass eligibility and see the option.
+  it('returns true when imageId is present but pohto is null', () => {
+    expect(
+      hasUsableRlsQualityPhoto(
+        wrap({
+          imageId: 1390033,
+          imageTypeId: 1,
+          imageTypeName: 'Passamynd',
+          pohto: null,
+        }),
+      ),
+    ).toBe(true)
+  })
+
+  it('returns false when imageId is null', () => {
+    expect(hasUsableRlsQualityPhoto(wrap({ imageId: null, pohto: null }))).toBe(
+      false,
+    )
+  })
+
+  it('returns false when externalData is empty', () => {
+    expect(hasUsableRlsQualityPhoto({})).toBe(false)
+  })
+
+  it('returns false when data is null', () => {
+    expect(hasUsableRlsQualityPhoto(wrap(null))).toBe(false)
   })
 })

--- a/libs/application/templates/driving-license/src/lib/utils/formUtils.ts
+++ b/libs/application/templates/driving-license/src/lib/utils/formUtils.ts
@@ -88,6 +88,16 @@ export const hasHealthRemarks = (externalData: ExternalData) => {
   )
 }
 
+// RLS exposes the photo binary (`pohto`) inconsistently — some legacy records
+// return metadata + signature but a null photo blob. Submission resolves the
+// photo by reference (imageId), so binary presence is irrelevant for whether
+// a usable quality photo exists. Gate on the record, not the blob.
+export const hasUsableRlsQualityPhoto = (externalData: ExternalData): boolean =>
+  getValueViaPath<{ imageId?: number | null }>(
+    externalData,
+    'qualityPhotoAndSignature.data',
+  )?.imageId != null
+
 export const getCodes = (application: Application): BasicChargeItem[] => {
   const applicationFor = getValueViaPath<
     'B-full' | 'B-temp' | 'BE' | 'B-full-renewal-65' | 'B-advanced'


### PR DESCRIPTION

Cherry-pick of #22548 (squashed merge commit `c0b526acd7`) onto `release/43.2.0`.

See #22548 for full context — root cause, fix details, repro steps, and test plan.

## Summary

BE and redesigned 65+ applicants could be blocked at the prerequisites step with a `Krefst aðgerða` card for `Gæðavottuð mynd` even when RLS had a usable quality photo on file, because the eligibility gate required the photo binary (`pohto`) but RLS sometimes returns metadata + signature without the binary for legacy records.

The fix gates eligibility on `imageId != null` instead — aligning with submission, which already resolves the photo by reference and tolerates a missing binary.

## Blast radius

- **Affected:** BE flow, and redesigned 65+ flow (when its feature flag is on).
- **Untouched:** B-temp, B-full, and non-redesigned 65+ all take different code paths.
- **Shared:** the `qualityPhotoAndSignature` data provider runs for everyone; the only change there is one extra `logger.info` line on the metadata-only response shape — no behavioral change.

## Test plan

- [x] `yarn nx test application-templates-driving-license`
- [x] `yarn nx test application-template-api-modules`
- [x] `yarn nx lint` on both projects
- [x] Local walk-through on BE: metadata-only repro → eligibility passes with placeholder option; both `no` → still blocked (verified on `main` before merge)