### PR TITLE
fix(driving-license): narrow BE health-certificate trigger to medical remark codes

### DIFF
--- a/libs/application/templates/driving-license/src/fields/HealthRemarks.tsx
+++ b/libs/application/templates/driving-license/src/fields/HealthRemarks.tsx
@@ -5,18 +5,23 @@ import { FieldBaseProps } from '@island.is/application/types'
 import { m } from '../lib/messages'
 import { useLocale } from '@island.is/localization'
 import { useFormContext } from 'react-hook-form'
-import { DrivingLicense, Remark } from '../lib/types'
+import { DrivingLicense } from '../lib/types'
 import { DrivingLicenseFakeData } from '../lib/constants'
+import { getHealthCertificateRemarks } from '../lib/utils/formUtils'
 
 const HealthRemarks: FC<React.PropsWithChildren<FieldBaseProps>> = ({
   application,
 }) => {
   const { formatMessage } = useLocale()
-  const remarks: Remark[] =
-    getValueViaPath<DrivingLicense>(
-      application.externalData,
-      'currentLicense.data',
-    )?.remarks || []
+  const rawRemarks = getValueViaPath<DrivingLicense>(
+    application.externalData,
+    'currentLicense.data',
+  )?.remarks
+  const remarks = getHealthCertificateRemarks(rawRemarks)
+  // Stable scalar dep for the effect below — `remarks` is a freshly filtered
+  // array on every render, so depending on it directly would re-fire the
+  // setValue call each render and risk a render loop in react-hook-form.
+  const hasFilteredRemarks = remarks.length > 0
 
   const fakeData = getValueViaPath<DrivingLicenseFakeData>(
     application.answers,
@@ -30,11 +35,11 @@ const HealthRemarks: FC<React.PropsWithChildren<FieldBaseProps>> = ({
   useEffect(() => {
     setValue(
       'hasHealthRemarks',
-      !fakeRemarksOff && remarks.length > 0 ? YES : NO,
+      !fakeRemarksOff && hasFilteredRemarks ? YES : NO,
     )
-  }, [remarks, fakeRemarksOff, setValue])
+  }, [hasFilteredRemarks, fakeRemarksOff, setValue])
 
-  if (fakeRemarksOff) {
+  if (fakeRemarksOff || !hasFilteredRemarks) {
     return null
   }
 
@@ -46,7 +51,7 @@ const HealthRemarks: FC<React.PropsWithChildren<FieldBaseProps>> = ({
         message={
           formatMessage(m.healthRemarksDescription) +
             ' ' +
-            remarks?.map((r) => r.description).join(', ') || ''
+            remarks.map((r) => r.description).join(', ') || ''
         }
       />
     </Box>

--- a/libs/application/templates/driving-license/src/lib/constants.ts
+++ b/libs/application/templates/driving-license/src/lib/constants.ts
@@ -153,7 +153,22 @@ export const CHARGE_ITEM_CODES: Record<string, string> = {
 }
 
 export const otherLicenseCategories = ['C', 'C1', 'CE', 'D', 'D1', 'DE']
-export const codesRequiringHealthCertificate = ['400', '01.06']
+// Remark codes that trigger the BE health-certificate upload. Mirrors EU
+// Directive 2006/126/EC Annex I §5 (vision / hearing / prosthesis), per
+// Samgöngustofa regulation. Administrative codes (e.g. `71` samrit) must
+// not be in this list.
+export const codesRequiringHealthCertificate = [
+  '01',
+  '01.01',
+  '01.02',
+  '01.05',
+  '01.06',
+  '01.07',
+  '02',
+  '03',
+  '03.01',
+  '03.02',
+]
 export const codesExtendedLicenseCategories = [
   'C1',
   'C1E',

--- a/libs/application/templates/driving-license/src/lib/utils/formUtils.spec.ts
+++ b/libs/application/templates/driving-license/src/lib/utils/formUtils.spec.ts
@@ -6,8 +6,11 @@ import {
   allowFakeCondition,
   hasCompletedPrerequisitesStep,
   hasUsableRlsQualityPhoto,
+  hasHealthRemarks,
+  getHealthCertificateRemarks,
 } from './formUtils'
 import { NO, YES } from '@island.is/application/core'
+import { Remark } from '../types'
 
 describe('isVisible', () => {
   it('returns true when all functions return true', () => {
@@ -186,5 +189,93 @@ describe('hasUsableRlsQualityPhoto', () => {
 
   it('returns false when data is null', () => {
     expect(hasUsableRlsQualityPhoto(wrap(null))).toBe(false)
+  })
+})
+
+describe('hasHealthRemarks', () => {
+  const wrap = (remarks: Remark[] | undefined) =>
+    ({
+      currentLicense: {
+        data: { remarks },
+        date: new Date(),
+        status: 'success' as const,
+      },
+    } as any)
+
+  it('returns false when remarks is empty', () => {
+    expect(hasHealthRemarks(wrap([]))).toBe(false)
+  })
+
+  // Regression: code 71 ("samrit" / duplicate license) is administrative,
+  // not medical. Reported prod shape from a real applicant — the BE form
+  // previously opened the health-certificate upload for this user.
+  it('returns false for administrative code 71 (samrit)', () => {
+    expect(
+      hasHealthRemarks(
+        wrap([
+          {
+            code: '71',
+            description:
+              'Samrit ökuskírteinis nr. (auðkennisstafir ESB/SÞ fyrir þriðju lönd, t.d.„71.987654321.HR").',
+          },
+        ]),
+      ),
+    ).toBe(false)
+  })
+
+  it('returns true for vision subcode 01.06', () => {
+    expect(
+      hasHealthRemarks(
+        wrap([{ code: '01.06', description: 'Gleraugu eða snertilinsur' }]),
+      ),
+    ).toBe(true)
+  })
+
+  it('returns true for parent code 01', () => {
+    expect(
+      hasHealthRemarks(
+        wrap([{ code: '01', description: 'Leiðrétting sjónar og/eða vörn.' }]),
+      ),
+    ).toBe(true)
+  })
+
+  it('returns true when a medical remark is mixed with an administrative one', () => {
+    expect(
+      hasHealthRemarks(
+        wrap([
+          { code: '71', description: 'Samrit' },
+          { code: '02', description: 'Heyrnartæki/samskiptastoð.' },
+        ]),
+      ),
+    ).toBe(true)
+  })
+
+  it('returns false when currentLicense.data is missing', () => {
+    expect(hasHealthRemarks({})).toBe(false)
+  })
+})
+
+describe('getHealthCertificateRemarks', () => {
+  it('returns only allowlisted remarks from a mixed input', () => {
+    const result = getHealthCertificateRemarks([
+      { code: '71', description: 'Samrit' },
+      { code: '01.06', description: 'Gleraugu eða snertilinsur' },
+      { code: '400', description: 'Other restriction' },
+      { code: '03.01', description: 'Stoðtæki fyrir hönd' },
+    ])
+    expect(result.map((r) => r.code)).toEqual(['01.06', '03.01'])
+  })
+
+  it('returns an empty array for undefined input', () => {
+    expect(getHealthCertificateRemarks(undefined)).toEqual([])
+  })
+
+  it('returns an empty array when nothing matches', () => {
+    expect(
+      getHealthCertificateRemarks([
+        { code: '71', description: 'Samrit' },
+        { code: '400', description: 'Other' },
+      ]),
+    ).toEqual([])
   })
 })

--- a/libs/application/templates/driving-license/src/lib/utils/formUtils.ts
+++ b/libs/application/templates/driving-license/src/lib/utils/formUtils.ts
@@ -7,11 +7,12 @@ import {
   Application,
 } from '@island.is/application/types'
 import { m } from '../messages'
-import { ConditionFn, DrivingLicense } from '../types'
+import { ConditionFn, DrivingLicense, Remark } from '../types'
 import {
   B_FULL,
   B_TEMP,
   CHARGE_ITEM_CODES,
+  codesRequiringHealthCertificate,
   DELIVERY_FEE,
   DrivingLicenseApplicationFor,
   Pickup,
@@ -79,14 +80,23 @@ export const hasCompletedPrerequisitesStep =
     return requirementsMet === value
   }
 
-export const hasHealthRemarks = (externalData: ExternalData) => {
-  return (
-    (
-      getValueViaPath<DrivingLicense>(externalData, 'currentLicense.data')
-        ?.remarks || []
-    ).length > 0
+// Returns only the remarks whose code is on the BE health-certificate
+// allowlist (vision / hearing / prosthesis). Used both to decide whether the
+// `HealthRemarks` alert renders and to filter what is shown inside it, so
+// administrative remarks (e.g. `71` samrit) never appear in a "health"
+// warning.
+export const getHealthCertificateRemarks = (
+  remarks: Remark[] | undefined,
+): Remark[] =>
+  (remarks ?? []).filter((r) =>
+    codesRequiringHealthCertificate.includes(r.code),
   )
-}
+
+export const hasHealthRemarks = (externalData: ExternalData) =>
+  getHealthCertificateRemarks(
+    getValueViaPath<DrivingLicense>(externalData, 'currentLicense.data')
+      ?.remarks,
+  ).length > 0
 
 // RLS exposes the photo binary (`pohto`) inconsistently — some legacy records
 // return metadata + signature but a null photo blob. Submission resolves the


### PR DESCRIPTION
## Summary

- Narrows the BE health-certificate upload trigger from "any remark on file" to the regulation allowlist (vision `01.xx`, hearing `02`, prosthesis `03.xx`). Administrative codes such as `71` (*samrit* / duplicate license) no longer open the upload.
- Centralizes the filter in a new `getHealthCertificateRemarks` helper used by both `hasHealthRemarks` (external predicate) and the `HealthRemarks` field (hidden form value + alert text), so administrative remarks also stop appearing inside the "health" warning alert.
- Repurposes the previously dead `codesRequiringHealthCertificate` constant as the regulation allowlist (no external importers — grep-verified).
- Keys the `HealthRemarks` `useEffect` on a stable boolean to avoid per-render `setValue` churn.

## Context

Reported by Samgöngustofa: a BE applicant with remark code `71` on a previous (duplicate) license was prompted for a health certificate, uploaded a blank page, and submitted successfully. Per Samgöngustofa regulation (mirroring EU Directive 2006/126/EC Annex I §5), only the medical remark codes above should require a certificate. The blank-PDF acceptance is a separate content-validation gap (not addressed here — worth a follow-up ticket).

`remarksCannotRenew65` (`['400', '450', '95']`) is intentionally untouched — those codes drive 65+ renewal blocking, a separate concern from the BE cert trigger.

## Test plan

- [x] `yarn nx test application-templates-driving-license --testFile=libs/application/templates/driving-license/src/lib/utils/formUtils.spec.ts` — 25/25 pass (9 new)
- [x] `yarn lint application-templates-driving-license` — 0 errors
- [x] `yarn nx format:write` on touched files
- [ ] Manual UI smoke (positive path): set fakeData `currentLicense=full` + `remarks=yes`, temporarily change the fake remark code to `'01.06'` in `drivingLicenseFakeData.ts`, choose BE — confirm the alert renders and the cert upload appears.
- [ ] Manual UI smoke (negative path): non-deterministic — `glassesCheck` is not fakeable and can independently force the upload on for testers whose real RLS data has `glassesCheck.data === true`. Predicate negative path is covered by unit tests instead.

## Regression coverage

New `describe('hasHealthRemarks', ...)` and `describe('getHealthCertificateRemarks', ...)` in `formUtils.spec.ts`:

- `71` (samrit) → no trigger (uses the reported prod payload shape)
- `01.06` / `01` / mixed `[71, 02]` → trigger
- empty remarks / missing `currentLicense.data` → no trigger
- helper-level: filters mixed input down to allowlisted codes only

## Follow-ups (out of scope here)

- Ask Magnús/Tinna what `400` / `450` / `95` represent (currently in `remarksCannotRenew65`; want to confirm none should be in the BE cert allowlist).
- File a separate ticket on the blank-PDF acceptance — the schema only validates that a file exists, not that it contains a meaningful certificate.
- The fake-data layer doesn't honor `currentLicense='full'` for categories (`drivingLicenseFakeData.ts:17-31`); BE selection currently works because `sectionApplicationFor.ts` synthesizes categories independently. Worth aligning these.
- `glassesCheck` not being fakeable makes the BE flow hard to UI-smoke deterministically.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved health certificate requirement detection by expanding the list of recognized health-related remark codes and filtering out administrative remarks that don't require certification.
  * Fixed an issue causing unnecessary re-renders when processing health remarks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/island-is/island.is/pull/22557)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->