### PR TITLE
fix(ids-admin): adjust partial failure handling

### DIFF
--- a/libs/api/domains/auth-admin/src/lib/scope/dto/patch-scope.input.ts
+++ b/libs/api/domains/auth-admin/src/lib/scope/dto/patch-scope.input.ts
@@ -75,6 +75,27 @@ export class AdminPatchScopeInput {
   @Field(() => [String], { nullable: true })
   removedTagIds?: string[]
 
+  @Field(() => [String], {
+    nullable: true,
+    description:
+      'Absolute set of supported delegation types for the scope. When provided, the backend computes added/removed delegation types per environment based on each environment\'s current state, so the same input can be safely fanned out across environments. Takes precedence over addedDelegationTypes/removedDelegationTypes when supplied.',
+  })
+  supportedDelegationTypes?: string[]
+
+  @Field(() => [String], {
+    nullable: true,
+    description:
+      'Absolute set of category IDs for the scope. When provided, the backend computes added/removed category IDs per environment based on each environment\'s current state, so the same input can be safely fanned out across environments. Takes precedence over addedCategoryIds/removedCategoryIds when supplied.',
+  })
+  categoryIds?: string[]
+
+  @Field(() => [String], {
+    nullable: true,
+    description:
+      'Absolute set of tag IDs for the scope. When provided, the backend computes added/removed tag IDs per environment based on each environment\'s current state, so the same input can be safely fanned out across environments. Takes precedence over addedTagIds/removedTagIds when supplied.',
+  })
+  tagIds?: string[]
+
   @Field(() => Boolean, {
     nullable: true,
     description:

--- a/libs/api/domains/auth-admin/src/lib/scope/dto/patch-scope.input.ts
+++ b/libs/api/domains/auth-admin/src/lib/scope/dto/patch-scope.input.ts
@@ -25,22 +25,19 @@ export class AdminPatchScopeInput {
 
   @Field(() => Boolean, {
     nullable: true,
-    deprecationReason:
-      'Use addedDelegationTypes or removedDelegationTypes instead',
+    deprecationReason: 'Use supportedDelegationTypes instead',
   })
   grantToLegalGuardians?: boolean
 
   @Field(() => Boolean, {
     nullable: true,
-    deprecationReason:
-      'Use addedDelegationTypes or removedDelegationTypes instead',
+    deprecationReason: 'Use supportedDelegationTypes instead',
   })
   grantToProcuringHolders?: boolean
 
   @Field(() => Boolean, {
     nullable: true,
-    deprecationReason:
-      'Use addedDelegationTypes or removedDelegationTypes instead',
+    deprecationReason: 'Use supportedDelegationTypes instead',
   })
   allowExplicitDelegationGrant?: boolean
 
@@ -52,47 +49,28 @@ export class AdminPatchScopeInput {
 
   @Field(() => Boolean, {
     nullable: true,
-    deprecationReason:
-      'Use addedDelegationTypes or removedDelegationTypes instead',
+    deprecationReason: 'Use supportedDelegationTypes instead',
   })
   grantToPersonalRepresentatives?: boolean
-
-  @Field(() => [String], { nullable: true })
-  addedDelegationTypes?: string[]
-
-  @Field(() => [String], { nullable: true })
-  removedDelegationTypes?: string[]
-
-  @Field(() => [String], { nullable: true })
-  addedCategoryIds?: string[]
-
-  @Field(() => [String], { nullable: true })
-  removedCategoryIds?: string[]
-
-  @Field(() => [String], { nullable: true })
-  addedTagIds?: string[]
-
-  @Field(() => [String], { nullable: true })
-  removedTagIds?: string[]
 
   @Field(() => [String], {
     nullable: true,
     description:
-      "Absolute set of supported delegation types for the scope. When provided, the backend computes added/removed delegation types per environment based on each environment's current state, so the same input can be safely fanned out across environments. Takes precedence over addedDelegationTypes/removedDelegationTypes when supplied.",
+      "Absolute set of supported delegation types for the scope. The backend computes added/removed delegation types per environment based on each environment's current state, so the same input can be safely fanned out across environments.",
   })
   supportedDelegationTypes?: string[]
 
   @Field(() => [String], {
     nullable: true,
     description:
-      "Absolute set of category IDs for the scope. When provided, the backend computes added/removed category IDs per environment based on each environment's current state, so the same input can be safely fanned out across environments. Takes precedence over addedCategoryIds/removedCategoryIds when supplied.",
+      "Absolute set of category IDs for the scope. The backend computes added/removed category IDs per environment based on each environment's current state, so the same input can be safely fanned out across environments.",
   })
   categoryIds?: string[]
 
   @Field(() => [String], {
     nullable: true,
     description:
-      "Absolute set of tag IDs for the scope. When provided, the backend computes added/removed tag IDs per environment based on each environment's current state, so the same input can be safely fanned out across environments. Takes precedence over addedTagIds/removedTagIds when supplied.",
+      "Absolute set of tag IDs for the scope. The backend computes added/removed tag IDs per environment based on each environment's current state, so the same input can be safely fanned out across environments.",
   })
   tagIds?: string[]
 

--- a/libs/api/domains/auth-admin/src/lib/scope/dto/patch-scope.input.ts
+++ b/libs/api/domains/auth-admin/src/lib/scope/dto/patch-scope.input.ts
@@ -78,21 +78,21 @@ export class AdminPatchScopeInput {
   @Field(() => [String], {
     nullable: true,
     description:
-      'Absolute set of supported delegation types for the scope. When provided, the backend computes added/removed delegation types per environment based on each environment\'s current state, so the same input can be safely fanned out across environments. Takes precedence over addedDelegationTypes/removedDelegationTypes when supplied.',
+      "Absolute set of supported delegation types for the scope. When provided, the backend computes added/removed delegation types per environment based on each environment's current state, so the same input can be safely fanned out across environments. Takes precedence over addedDelegationTypes/removedDelegationTypes when supplied.",
   })
   supportedDelegationTypes?: string[]
 
   @Field(() => [String], {
     nullable: true,
     description:
-      'Absolute set of category IDs for the scope. When provided, the backend computes added/removed category IDs per environment based on each environment\'s current state, so the same input can be safely fanned out across environments. Takes precedence over addedCategoryIds/removedCategoryIds when supplied.',
+      "Absolute set of category IDs for the scope. When provided, the backend computes added/removed category IDs per environment based on each environment's current state, so the same input can be safely fanned out across environments. Takes precedence over addedCategoryIds/removedCategoryIds when supplied.",
   })
   categoryIds?: string[]
 
   @Field(() => [String], {
     nullable: true,
     description:
-      'Absolute set of tag IDs for the scope. When provided, the backend computes added/removed tag IDs per environment based on each environment\'s current state, so the same input can be safely fanned out across environments. Takes precedence over addedTagIds/removedTagIds when supplied.',
+      "Absolute set of tag IDs for the scope. When provided, the backend computes added/removed tag IDs per environment based on each environment's current state, so the same input can be safely fanned out across environments. Takes precedence over addedTagIds/removedTagIds when supplied.",
   })
   tagIds?: string[]
 

--- a/libs/api/domains/auth-admin/src/lib/scope/scope.service.ts
+++ b/libs/api/domains/auth-admin/src/lib/scope/scope.service.ts
@@ -97,23 +97,16 @@ export class ScopeService extends MultiEnvironmentService {
       throw new Error('Nothing provided to update')
     }
 
-    const baseDto = { ...adminPatchScopeDto }
-    if (hasAbsoluteCategoryIds) {
-      delete baseDto.addedCategoryIds
-      delete baseDto.removedCategoryIds
-    }
-    if (hasAbsoluteTagIds) {
-      delete baseDto.addedTagIds
-      delete baseDto.removedTagIds
-    }
-    if (hasAbsoluteDelegationTypes) {
-      delete baseDto.addedDelegationTypes
-      delete baseDto.removedDelegationTypes
-    }
-
     const updatedSettledPromises = await Promise.allSettled(
       environments.map(async (environment) => {
-        const dtoForEnv = { ...baseDto }
+        const perEnvDeltas: {
+          addedCategoryIds?: string[]
+          removedCategoryIds?: string[]
+          addedTagIds?: string[]
+          removedTagIds?: string[]
+          addedDelegationTypes?: string[]
+          removedDelegationTypes?: string[]
+        } = {}
 
         if (needsPerEnvDeltas) {
           const current = await this.makeRequest(user, environment, (api) =>
@@ -135,16 +128,16 @@ export class ScopeService extends MultiEnvironmentService {
             const removed = currentCategoryIds.filter(
               (id) => !desired.includes(id),
             )
-            if (added.length > 0) dtoForEnv.addedCategoryIds = added
-            if (removed.length > 0) dtoForEnv.removedCategoryIds = removed
+            if (added.length > 0) perEnvDeltas.addedCategoryIds = added
+            if (removed.length > 0) perEnvDeltas.removedCategoryIds = removed
           }
 
           if (hasAbsoluteTagIds) {
             const desired = tagIds ?? []
             const added = desired.filter((id) => !currentTagIds.includes(id))
             const removed = currentTagIds.filter((id) => !desired.includes(id))
-            if (added.length > 0) dtoForEnv.addedTagIds = added
-            if (removed.length > 0) dtoForEnv.removedTagIds = removed
+            if (added.length > 0) perEnvDeltas.addedTagIds = added
+            if (removed.length > 0) perEnvDeltas.removedTagIds = removed
           }
 
           if (hasAbsoluteDelegationTypes) {
@@ -155,10 +148,13 @@ export class ScopeService extends MultiEnvironmentService {
             const removed = currentDelegationTypes.filter(
               (id) => !desired.includes(id),
             )
-            if (added.length > 0) dtoForEnv.addedDelegationTypes = added
-            if (removed.length > 0) dtoForEnv.removedDelegationTypes = removed
+            if (added.length > 0) perEnvDeltas.addedDelegationTypes = added
+            if (removed.length > 0)
+              perEnvDeltas.removedDelegationTypes = removed
           }
         }
+
+        const dtoForEnv = { ...adminPatchScopeDto, ...perEnvDeltas }
 
         if (Object.keys(dtoForEnv).length === 0) {
           return this.makeRequest(user, environment, (api) =>

--- a/libs/api/domains/auth-admin/src/lib/scope/scope.service.ts
+++ b/libs/api/domains/auth-admin/src/lib/scope/scope.service.ts
@@ -69,26 +69,111 @@ export class ScopeService extends MultiEnvironmentService {
    * Updates a scope for a specific tenant for the given environments.
    *
    * Per-environment failures are collected and returned alongside the
-   * successful results
+   * successful results.
+
    */
   async updateScope({
     user,
-    input: { environments, scopeName, tenantId, ...adminPatchScopeDto },
+    input: {
+      environments,
+      scopeName,
+      tenantId,
+      categoryIds,
+      tagIds,
+      supportedDelegationTypes,
+      ...adminPatchScopeDto
+    },
   }: {
     user: User
     input: AdminPatchScopeInput
   }): Promise<PatchScopeResponse> {
-    if (Object.keys(adminPatchScopeDto).length === 0) {
+    const hasAbsoluteCategoryIds = categoryIds !== undefined
+    const hasAbsoluteTagIds = tagIds !== undefined
+    const hasAbsoluteDelegationTypes = supportedDelegationTypes !== undefined
+    const needsPerEnvDeltas =
+      hasAbsoluteCategoryIds || hasAbsoluteTagIds || hasAbsoluteDelegationTypes
+
+    if (Object.keys(adminPatchScopeDto).length === 0 && !needsPerEnvDeltas) {
       throw new Error('Nothing provided to update')
+    }
+
+    const baseDto = { ...adminPatchScopeDto }
+    if (hasAbsoluteCategoryIds) {
+      delete baseDto.addedCategoryIds
+      delete baseDto.removedCategoryIds
+    }
+    if (hasAbsoluteTagIds) {
+      delete baseDto.addedTagIds
+      delete baseDto.removedTagIds
+    }
+    if (hasAbsoluteDelegationTypes) {
+      delete baseDto.addedDelegationTypes
+      delete baseDto.removedDelegationTypes
     }
 
     const updatedSettledPromises = await Promise.allSettled(
       environments.map(async (environment) => {
+        const dtoForEnv = { ...baseDto }
+
+        if (needsPerEnvDeltas) {
+          const current = await this.makeRequest(user, environment, (api) =>
+            api.meScopesControllerFindByTenantIdAndScopeNameRaw({
+              tenantId,
+              scopeName,
+            }),
+          )
+
+          const currentCategoryIds = current?.categoryIds ?? []
+          const currentTagIds = current?.tagIds ?? []
+          const currentDelegationTypes = current?.supportedDelegationTypes ?? []
+
+          if (hasAbsoluteCategoryIds) {
+            const desired = categoryIds ?? []
+            const added = desired.filter(
+              (id) => !currentCategoryIds.includes(id),
+            )
+            const removed = currentCategoryIds.filter(
+              (id) => !desired.includes(id),
+            )
+            if (added.length > 0) dtoForEnv.addedCategoryIds = added
+            if (removed.length > 0) dtoForEnv.removedCategoryIds = removed
+          }
+
+          if (hasAbsoluteTagIds) {
+            const desired = tagIds ?? []
+            const added = desired.filter((id) => !currentTagIds.includes(id))
+            const removed = currentTagIds.filter((id) => !desired.includes(id))
+            if (added.length > 0) dtoForEnv.addedTagIds = added
+            if (removed.length > 0) dtoForEnv.removedTagIds = removed
+          }
+
+          if (hasAbsoluteDelegationTypes) {
+            const desired = supportedDelegationTypes ?? []
+            const added = desired.filter(
+              (id) => !currentDelegationTypes.includes(id),
+            )
+            const removed = currentDelegationTypes.filter(
+              (id) => !desired.includes(id),
+            )
+            if (added.length > 0) dtoForEnv.addedDelegationTypes = added
+            if (removed.length > 0) dtoForEnv.removedDelegationTypes = removed
+          }
+        }
+
+        if (Object.keys(dtoForEnv).length === 0) {
+          return this.makeRequest(user, environment, (api) =>
+            api.meScopesControllerFindByTenantIdAndScopeNameRaw({
+              tenantId,
+              scopeName,
+            }),
+          )
+        }
+
         return this.makeRequest(user, environment, (api) =>
           api.meScopesControllerUpdateRaw({
             tenantId,
             scopeName,
-            adminPatchScopeDto,
+            adminPatchScopeDto: dtoForEnv,
           }),
         )
       }),

--- a/libs/portals/admin/ids-admin/src/screens/Client/EditClient.action.ts
+++ b/libs/portals/admin/ids-admin/src/screens/Client/EditClient.action.ts
@@ -14,7 +14,6 @@ import {
   UpdateClientMutationVariables,
 } from './EditClient.generated'
 import { getIntent } from '../../utils/getIntent'
-import { authAdminEnvironments } from '../../utils/environments'
 import {
   ClientFormTypes,
   MergedFormDataSchema,
@@ -68,9 +67,10 @@ export const editClientAction: WrappedActionFn =
     // then update all environments with the same settings as the current environment intent
     if (sync && syncEnvironments && syncEnvironments.length > 0) {
       environments.push(...syncEnvironments)
-      // If the save in all environments was enabled, then update all environments
+      // If the save in all environments was enabled,
+      // then update every environment the client is configured in
     } else if (saveInAllEnvironments) {
-      environments.push(...authAdminEnvironments)
+      environments.push(environment, ...(syncEnvironments ?? []))
     } else {
       // Otherwise, just update the current environment
       environments.push(environment)

--- a/libs/portals/admin/ids-admin/src/screens/Permission/EditPermission.action.ts
+++ b/libs/portals/admin/ids-admin/src/screens/Permission/EditPermission.action.ts
@@ -18,7 +18,6 @@ import {
   UpdateScopeUsersMutation,
   UpdateScopeUsersMutationVariables,
 } from './components/PermissionAccessControl.generated'
-import { authAdminEnvironments } from '../../utils/environments'
 import { getIntent } from '../../utils/getIntent'
 import {
   MergedFormDataSchema,
@@ -80,9 +79,10 @@ export const editPermissionAction: WrappedActionFn =
     // then update all environments with the same settings as the current environment intent
     if (sync && syncEnvironments && syncEnvironments.length > 0) {
       environments.push(...syncEnvironments)
-      // If the save in all environments was enabled, then update all environments
+      // If the save in all environments was enabled,
+      // then update every environment the scope is configured in.
     } else if (saveInAllEnvironments) {
-      environments.push(...authAdminEnvironments)
+      environments.push(environment, ...(syncEnvironments ?? []))
     } else {
       // Otherwise, just update the current environment
       environments.push(environment)

--- a/libs/portals/admin/ids-admin/src/screens/Permission/EditPermission.schema.ts
+++ b/libs/portals/admin/ids-admin/src/screens/Permission/EditPermission.schema.ts
@@ -3,7 +3,6 @@ import { z } from 'zod'
 import { Languages } from '../../utils/languages'
 import { booleanCheckbox } from '../../utils/forms'
 import { defaultEnvironmentSchema } from '../../utils/schemas'
-import { zfd } from 'zod-form-data'
 
 const safeParseStringArray = (val: string | undefined): string[] => {
   if (!val) return []
@@ -15,6 +14,22 @@ const safeParseStringArray = (val: string | undefined): string[] => {
     return []
   } catch {
     return []
+  }
+}
+
+const safeParseOptionalStringArray = (
+  val: string | undefined,
+): string[] | undefined => {
+  if (val === undefined || val === null) return undefined
+  if (val === '') return []
+  try {
+    const parsed = JSON.parse(val)
+    if (Array.isArray(parsed) && parsed.every((x) => typeof x === 'string')) {
+      return parsed
+    }
+    return undefined
+  } catch {
+    return undefined
   }
 }
 
@@ -48,10 +63,6 @@ const contentSchema = z
     is_description: z.string().nonempty('errorDescription'),
     en_displayName: z.optional(z.string()),
     en_description: z.optional(z.string()),
-    categoryIds: z.string().optional().transform(safeParseStringArray),
-    tagIds: z.string().optional().transform(safeParseStringArray),
-    originalCategoryIds: z.string().optional().transform(safeParseStringArray),
-    originalTagIds: z.string().optional().transform(safeParseStringArray),
   })
   .merge(defaultEnvironmentSchema)
   .transform(
@@ -60,25 +71,8 @@ const contentSchema = z
       en_description: enDescription,
       is_displayName: isDisplayName,
       en_displayName: enDisplayName,
-      categoryIds,
-      tagIds,
-      originalCategoryIds,
-      originalTagIds,
       ...rest
     }) => {
-      const addedCategoryIds = categoryIds.filter(
-        (id: string) => !originalCategoryIds.includes(id),
-      )
-      const removedCategoryIds = originalCategoryIds.filter(
-        (id: string) => !categoryIds.includes(id),
-      )
-      const addedTagIds = tagIds.filter(
-        (id: string) => !originalTagIds.includes(id),
-      )
-      const removedTagIds = originalTagIds.filter(
-        (id: string) => !tagIds.includes(id),
-      )
-
       return {
         ...rest,
         displayName: [
@@ -101,12 +95,6 @@ const contentSchema = z
             value: enDescription ?? '',
           },
         ],
-        addedCategoryIds:
-          addedCategoryIds.length > 0 ? addedCategoryIds : undefined,
-        removedCategoryIds:
-          removedCategoryIds.length > 0 ? removedCategoryIds : undefined,
-        addedTagIds: addedTagIds.length > 0 ? addedTagIds : undefined,
-        removedTagIds: removedTagIds.length > 0 ? removedTagIds : undefined,
       }
     },
   )
@@ -136,12 +124,12 @@ const accessControlSchema = z
 
 const delegationsSchema = z
   .object({
-    removedDelegationTypes: zfd.repeatable(z.optional(z.array(z.string()))),
-    addedDelegationTypes: zfd.repeatable(z.optional(z.array(z.string()))),
-    categoryIds: z.string().optional().transform(safeParseStringArray),
-    tagIds: z.string().optional().transform(safeParseStringArray),
-    originalCategoryIds: z.string().optional().transform(safeParseStringArray),
-    originalTagIds: z.string().optional().transform(safeParseStringArray),
+    supportedDelegationTypes: z
+      .string()
+      .optional()
+      .transform(safeParseOptionalStringArray),
+    categoryIds: z.string().optional().transform(safeParseOptionalStringArray),
+    tagIds: z.string().optional().transform(safeParseOptionalStringArray),
     originUrl: z
       .union([z.literal(''), z.string().url({ message: 'errorInvalidUrl' })])
       .optional(),
@@ -152,27 +140,13 @@ const delegationsSchema = z
   .merge(defaultEnvironmentSchema)
   .transform(
     ({
-      categoryIds = [],
-      tagIds = [],
-      originalCategoryIds = [],
-      originalTagIds = [],
+      supportedDelegationTypes,
+      categoryIds,
+      tagIds,
       originUrl,
       targetLinkUri,
       ...rest
     }) => {
-      const addedCategoryIds = categoryIds.filter(
-        (id: string) => !originalCategoryIds.includes(id),
-      )
-      const removedCategoryIds = originalCategoryIds.filter(
-        (id: string) => !categoryIds.includes(id),
-      )
-      const addedTagIds = tagIds.filter(
-        (id: string) => !originalTagIds.includes(id),
-      )
-      const removedTagIds = originalTagIds.filter(
-        (id: string) => !tagIds.includes(id),
-      )
-
       const thirdPartyLoginUrl =
         originUrl && targetLinkUri
           ? buildThirdPartyLoginUrl(originUrl, targetLinkUri)
@@ -182,12 +156,11 @@ const delegationsSchema = z
 
       return {
         ...rest,
-        addedCategoryIds:
-          addedCategoryIds.length > 0 ? addedCategoryIds : undefined,
-        removedCategoryIds:
-          removedCategoryIds.length > 0 ? removedCategoryIds : undefined,
-        addedTagIds: addedTagIds.length > 0 ? addedTagIds : undefined,
-        removedTagIds: removedTagIds.length > 0 ? removedTagIds : undefined,
+        ...(supportedDelegationTypes !== undefined && {
+          supportedDelegationTypes,
+        }),
+        ...(categoryIds !== undefined && { categoryIds }),
+        ...(tagIds !== undefined && { tagIds }),
         ...(thirdPartyLoginUrl !== undefined && { thirdPartyLoginUrl }),
       }
     },
@@ -195,38 +168,17 @@ const delegationsSchema = z
 
 const categoriesAndTagsSchema = z
   .object({
-    categoryIds: z.string().optional().transform(safeParseStringArray),
-    tagIds: z.string().optional().transform(safeParseStringArray),
-    originalCategoryIds: z.string().optional().transform(safeParseStringArray),
-    originalTagIds: z.string().optional().transform(safeParseStringArray),
+    categoryIds: z.string().optional().transform(safeParseOptionalStringArray),
+    tagIds: z.string().optional().transform(safeParseOptionalStringArray),
   })
   .merge(defaultEnvironmentSchema)
-  .transform(
-    ({ categoryIds, tagIds, originalCategoryIds, originalTagIds, ...rest }) => {
-      const addedCategoryIds = categoryIds.filter(
-        (id: string) => !originalCategoryIds.includes(id),
-      )
-      const removedCategoryIds = originalCategoryIds.filter(
-        (id: string) => !categoryIds.includes(id),
-      )
-      const addedTagIds = tagIds.filter(
-        (id: string) => !originalTagIds.includes(id),
-      )
-      const removedTagIds = originalTagIds.filter(
-        (id: string) => !tagIds.includes(id),
-      )
-
-      return {
-        ...rest,
-        addedCategoryIds:
-          addedCategoryIds.length > 0 ? addedCategoryIds : undefined,
-        removedCategoryIds:
-          removedCategoryIds.length > 0 ? removedCategoryIds : undefined,
-        addedTagIds: addedTagIds.length > 0 ? addedTagIds : undefined,
-        removedTagIds: removedTagIds.length > 0 ? removedTagIds : undefined,
-      }
-    },
-  )
+  .transform(({ categoryIds, tagIds, ...rest }) => {
+    return {
+      ...rest,
+      ...(categoryIds !== undefined && { categoryIds }),
+      ...(tagIds !== undefined && { tagIds }),
+    }
+  })
 
 export const schema = {
   [PermissionFormTypes.CONTENT]: contentSchema,

--- a/libs/portals/admin/ids-admin/src/screens/Permission/components/PermissionDelegations.tsx
+++ b/libs/portals/admin/ids-admin/src/screens/Permission/components/PermissionDelegations.tsx
@@ -92,16 +92,12 @@ export const PermissionDelegations = ({
     isAccessControlled: boolean
     grantToAuthenticatedUser: boolean
     supportedDelegationTypes: string[]
-    addedDelegationTypes: string[]
-    removedDelegationTypes: string[]
     originUrl: string
     targetLinkUri: string
   }>({
     isAccessControlled,
     grantToAuthenticatedUser,
     supportedDelegationTypes,
-    addedDelegationTypes: [],
-    removedDelegationTypes: [],
     originUrl: parsedUrl.originUrl,
     targetLinkUri: parsedUrl.targetLinkUri,
   })
@@ -161,14 +157,6 @@ export const PermissionDelegations = ({
   const [categoriesTagsDirty, setCategoriesTagsDirty] =
     useEnvironmentState(false)
 
-  // Baseline IDs only reset on env change, not after saves — keeps sync diffs accurate
-  const [baselineCategoryIds] = useEnvironmentState<string[]>(
-    selectedPermission.categoryIds ?? [],
-  )
-  const [baselineTagIds] = useEnvironmentState<string[]>(
-    selectedPermission.tagIds ?? [],
-  )
-
   useEffect(() => {
     if (!showCategoriesAndTags || categoriesLoading || tagsLoading) return
     setSelectedCategories(
@@ -225,9 +213,15 @@ export const PermissionDelegations = ({
 
   const showUrlErrors = urlFieldBlurred && urlPartiallyFilled
 
+  const delegationTypesDirty = !isEqual(
+    [...(inputValues.supportedDelegationTypes ?? [])].sort(),
+    [...(supportedDelegationTypes ?? [])].sort(),
+  )
+
   const customValidation = useCallback(
     (_newFormData: FormData, _prevFormData: FormData) => {
       if (urlDirty) return true
+      if (delegationTypesDirty) return true
       if (!showCategoriesAndTags) return false
       return categoriesTagsDirty
     },
@@ -238,6 +232,7 @@ export const PermissionDelegations = ({
       selectedCategories,
       selectedTags,
       urlDirty,
+      delegationTypesDirty,
     ],
   )
 
@@ -252,58 +247,24 @@ export const PermissionDelegations = ({
   const toggleDelegationType = (field: string, checked: boolean) => {
     const type = field.split('-')[1]
 
-    if (checked) {
-      const newInputValues = { ...inputValues }
-      // should not be in removed delegation types if field is checked
-      if (inputValues.removedDelegationTypes.includes(type)) {
-        newInputValues.removedDelegationTypes =
-          inputValues.removedDelegationTypes.filter((t) => t !== type)
+    setInputValues((prev) => {
+      const isPresent = prev.supportedDelegationTypes.includes(type)
+      if (checked && !isPresent) {
+        return {
+          ...prev,
+          supportedDelegationTypes: [...prev.supportedDelegationTypes, type],
+        }
       }
-
-      // if not in supported delegation types, user is adding it for the first time
-      if (!supportedDelegationTypes.includes(type)) {
-        newInputValues.addedDelegationTypes = [
-          ...inputValues.addedDelegationTypes,
-          type,
-        ]
-        newInputValues.supportedDelegationTypes = [
-          ...inputValues.supportedDelegationTypes,
-          type,
-        ]
+      if (!checked && isPresent) {
+        return {
+          ...prev,
+          supportedDelegationTypes: prev.supportedDelegationTypes.filter(
+            (t) => t !== type,
+          ),
+        }
       }
-
-      // if already in supported delegation types, user is re-adding it
-      if (supportedDelegationTypes.includes(type)) {
-        newInputValues.supportedDelegationTypes = [
-          ...inputValues.supportedDelegationTypes,
-          type,
-        ]
-      }
-
-      setInputValues(newInputValues)
-    } else {
-      const newInputValues = { ...inputValues }
-      // should not be in added delegation types if field is not checked
-      if (inputValues.addedDelegationTypes.includes(type)) {
-        newInputValues.addedDelegationTypes =
-          inputValues.addedDelegationTypes.filter((t) => t !== type)
-      }
-      // should not be in supported delegation types if field is not checked
-      if (inputValues.supportedDelegationTypes.includes(type)) {
-        newInputValues.supportedDelegationTypes =
-          inputValues.supportedDelegationTypes.filter((t) => t !== type)
-      }
-
-      // if not in removed delegation types, user is removing it for the first time
-      if (supportedDelegationTypes.includes(type)) {
-        newInputValues.removedDelegationTypes = [
-          ...inputValues.removedDelegationTypes,
-          type,
-        ]
-      }
-
-      setInputValues(newInputValues)
-    }
+      return prev
+    })
   }
 
   return (
@@ -374,11 +335,6 @@ export const PermissionDelegations = ({
                                       selectedCategories.map((c) => c.value),
                                     )}
                                   />
-                                  <input
-                                    type="hidden"
-                                    name="originalCategoryIds"
-                                    value={JSON.stringify(baselineCategoryIds)}
-                                  />
                                   <Select
                                     value={selectedCategories}
                                     options={categories}
@@ -432,11 +388,6 @@ export const PermissionDelegations = ({
                                     value={JSON.stringify(
                                       selectedTags.map((t) => t.value),
                                     )}
-                                  />
-                                  <input
-                                    type="hidden"
-                                    name="originalTagIds"
-                                    value={JSON.stringify(baselineTagIds)}
                                   />
                                   <Select
                                     value={selectedTags}
@@ -554,16 +505,13 @@ export const PermissionDelegations = ({
             </Stack>
           ),
         )}
-        {inputValues.removedDelegationTypes.map((type) => (
-          <Hidden key={type} print screen>
-            <input type="hidden" name="removedDelegationTypes" value={type} />
-          </Hidden>
-        ))}
-        {inputValues.addedDelegationTypes.map((type) => (
-          <Hidden key={type} print screen>
-            <input type="hidden" name="addedDelegationTypes" value={type} />
-          </Hidden>
-        ))}
+        <Hidden print screen>
+          <input
+            type="hidden"
+            name="supportedDelegationTypes"
+            value={JSON.stringify(inputValues.supportedDelegationTypes ?? [])}
+          />
+        </Hidden>
       </Stack>
     </FormCard>
   )

--- a/libs/portals/admin/ids-admin/src/screens/Permission/components/PermissionDelegations.tsx
+++ b/libs/portals/admin/ids-admin/src/screens/Permission/components/PermissionDelegations.tsx
@@ -248,19 +248,18 @@ export const PermissionDelegations = ({
     const type = field.split('-')[1]
 
     setInputValues((prev) => {
-      const isPresent = prev.supportedDelegationTypes.includes(type)
+      const currentTypes = prev.supportedDelegationTypes ?? []
+      const isPresent = currentTypes.includes(type)
       if (checked && !isPresent) {
         return {
           ...prev,
-          supportedDelegationTypes: [...prev.supportedDelegationTypes, type],
+          supportedDelegationTypes: [...currentTypes, type],
         }
       }
       if (!checked && isPresent) {
         return {
           ...prev,
-          supportedDelegationTypes: prev.supportedDelegationTypes.filter(
-            (t) => t !== type,
-          ),
+          supportedDelegationTypes: currentTypes.filter((t) => t !== type),
         }
       }
       return prev


### PR DESCRIPTION
## What

- Don't show "operation failed on environment xxx" message if the fail was because the scope hasn't been published to said environment
- Fix glitchy environment syncing for delegations

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x]  AI tools were used in preparing this pull request
Tools used: Claude


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Submit absolute sets for delegation types, categories, and tags; these replace incremental add/remove inputs and are used to compute per-environment differences.
  * Forms now send single snapshot fields for delegation/category/tag selections.

* **Refactor**
  * "Save in all environments" respects current selection plus synced entries.
  * Simplified form handling and validation for delegation types, categories, and tags.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/island-is/island.is/pull/22561?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->