### PR TITLE
fix(j-s): Fix auto populate of first indictment count

### DIFF
--- a/apps/judicial-system/backend/src/app/modules/indictment-count/indictmentCount.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/indictment-count/indictmentCount.service.ts
@@ -54,16 +54,6 @@ export class IndictmentCountService {
     return indictmentCount
   }
 
-  async findByCaseId(
-    caseId: string,
-    transaction?: Transaction,
-  ): Promise<IndictmentCount[]> {
-    return this.indictmentCountModel.findAll({
-      where: { caseId },
-      ...(transaction ? { transaction } : {}),
-    })
-  }
-
   async create(caseId: string): Promise<IndictmentCount> {
     return this.indictmentCountModel.create({ caseId })
   }

--- a/apps/judicial-system/backend/src/app/modules/indictment-count/indictmentCount.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/indictment-count/indictmentCount.service.ts
@@ -54,6 +54,16 @@ export class IndictmentCountService {
     return indictmentCount
   }
 
+  async findByCaseId(
+    caseId: string,
+    transaction?: Transaction,
+  ): Promise<IndictmentCount[]> {
+    return this.indictmentCountModel.findAll({
+      where: { caseId },
+      ...(transaction ? { transaction } : {}),
+    })
+  }
+
   async create(caseId: string): Promise<IndictmentCount> {
     return this.indictmentCountModel.create({ caseId })
   }

--- a/apps/judicial-system/backend/src/app/modules/police/police.controller.ts
+++ b/apps/judicial-system/backend/src/app/modules/police/police.controller.ts
@@ -137,7 +137,6 @@ export class PoliceController {
       theCase.defendants?.flatMap((d) =>
         d.nationalId ? [{ id: d.id, nationalId: d.nationalId }] : [],
       ),
-      theCase.type,
     )
   }
 

--- a/apps/judicial-system/backend/src/app/modules/police/police.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/police/police.service.ts
@@ -1073,21 +1073,31 @@ export class PoliceService {
 
   private buildAutoFillUpdates(
     cases: PoliceCaseInfo[],
-    newPoliceCaseNumbers: string[],
+    policeCaseNumbers: string[],
+    existingCrimeScenes?: CrimeSceneMap,
+    existingSubtypes?: IndictmentSubtypeMap,
   ): { crimeScenes: CrimeSceneMap; indictmentSubtypes: IndictmentSubtypeMap } {
     const lookup = new Map(cases.map((c) => [c.policeCaseNumber, c]))
     const crimeScenes: CrimeSceneMap = {}
     const indictmentSubtypes: IndictmentSubtypeMap = {}
 
-    for (const policeCaseNumber of newPoliceCaseNumbers) {
+    for (const policeCaseNumber of policeCaseNumbers) {
       const info = lookup.get(policeCaseNumber)
       if (!info) {
         continue
       }
 
-      crimeScenes[policeCaseNumber] = { place: info.place, date: info.date }
+      const scene = existingCrimeScenes?.[policeCaseNumber]
+      if (!scene?.place && !scene?.date) {
+        crimeScenes[policeCaseNumber] = { place: info.place, date: info.date }
+      }
 
-      if (info.subtypes && info.subtypes.length > 0) {
+      const subTypes = existingSubtypes?.[policeCaseNumber]
+      if (
+        (!subTypes || subTypes.length === 0) &&
+        info.subtypes &&
+        info.subtypes.length > 0
+      ) {
         indictmentSubtypes[policeCaseNumber] =
           info.subtypes as IndictmentSubtypeEnum[]
       }
@@ -1128,19 +1138,35 @@ export class PoliceService {
 
       if (defendantPoliceCaseNumberLinks.length > 0) {
         await this.sequelize.transaction(async (transaction: Transaction) => {
-          const newPoliceCaseNumbers =
-            await this.caseDefendantPoliceCaseNumberRepositoryService.assignDefendantPoliceCaseNumbers(
-              caseId,
-              defendantPoliceCaseNumberLinks,
-              { transaction },
+          await this.caseDefendantPoliceCaseNumberRepositoryService.assignDefendantPoliceCaseNumbers(
+            caseId,
+            defendantPoliceCaseNumberLinks,
+            { transaction },
+          )
+
+          if (caseType && isIndictmentCase(caseType)) {
+            const allLinkedPoliceCaseNumbers = [
+              ...new Set(
+                defendantPoliceCaseNumberLinks.map((l) => l.policeCaseNumber),
+              ),
+            ]
+
+            const existingCounts =
+              await this.indictmentCountService.findByCaseId(
+                caseId,
+                transaction,
+              )
+            const coveredPoliceCaseNumbers = new Set(
+              existingCounts
+                .map((c) => c.policeCaseNumber)
+                .filter((pcn): pcn is string => !!pcn),
             )
 
-          if (
-            newPoliceCaseNumbers.length > 0 &&
-            caseType &&
-            isIndictmentCase(caseType)
-          ) {
-            for (const policeCaseNumber of newPoliceCaseNumbers) {
+            const missingPoliceCaseNumbers = allLinkedPoliceCaseNumbers.filter(
+              (pcn) => !coveredPoliceCaseNumbers.has(pcn),
+            )
+
+            for (const policeCaseNumber of missingPoliceCaseNumbers) {
               await this.indictmentCountService.createWithPoliceCaseNumber(
                 caseId,
                 policeCaseNumber,
@@ -1148,31 +1174,34 @@ export class PoliceService {
               )
             }
 
-            const newFills = this.buildAutoFillUpdates(
-              cases,
-              newPoliceCaseNumbers,
-            )
-
             const theCase = await this.caseRepositoryService.findById(caseId, {
               transaction,
             })
+
             if (theCase) {
+              const fills = this.buildAutoFillUpdates(
+                cases,
+                allLinkedPoliceCaseNumbers,
+                theCase.crimeScenes,
+                theCase.indictmentSubtypes,
+              )
+
               const updates: {
                 crimeScenes?: CrimeSceneMap
                 indictmentSubtypes?: IndictmentSubtypeMap
               } = {}
 
-              if (Object.keys(newFills.crimeScenes).length > 0) {
+              if (Object.keys(fills.crimeScenes).length > 0) {
                 updates.crimeScenes = {
                   ...theCase.crimeScenes,
-                  ...newFills.crimeScenes,
+                  ...fills.crimeScenes,
                 }
               }
 
-              if (Object.keys(newFills.indictmentSubtypes).length > 0) {
+              if (Object.keys(fills.indictmentSubtypes).length > 0) {
                 updates.indictmentSubtypes = {
                   ...theCase.indictmentSubtypes,
-                  ...newFills.indictmentSubtypes,
+                  ...fills.indictmentSubtypes,
                 }
               }
 

--- a/apps/judicial-system/backend/src/app/modules/police/police.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/police/police.service.ts
@@ -28,12 +28,8 @@ import { normalizeAndFormatNationalId } from '@island.is/judicial-system/formatt
 import {
   CaseState,
   CaseType,
-  type CrimeSceneMap,
   getServiceDateFromSupplements,
   IndictmentCaseSubtypes,
-  IndictmentSubtype as IndictmentSubtypeEnum,
-  type IndictmentSubtypeMap,
-  isIndictmentCase,
   mapPoliceVerdictDeliveryStatus,
   PoliceFileTypeCode,
   ServiceStatus,
@@ -1071,46 +1067,10 @@ export class PoliceService {
     return links
   }
 
-  private buildAutoFillUpdates(
-    cases: PoliceCaseInfo[],
-    policeCaseNumbers: string[],
-    existingCrimeScenes?: CrimeSceneMap,
-    existingSubtypes?: IndictmentSubtypeMap,
-  ): { crimeScenes: CrimeSceneMap; indictmentSubtypes: IndictmentSubtypeMap } {
-    const lookup = new Map(cases.map((c) => [c.policeCaseNumber, c]))
-    const crimeScenes: CrimeSceneMap = {}
-    const indictmentSubtypes: IndictmentSubtypeMap = {}
-
-    for (const policeCaseNumber of policeCaseNumbers) {
-      const info = lookup.get(policeCaseNumber)
-      if (!info) {
-        continue
-      }
-
-      const scene = existingCrimeScenes?.[policeCaseNumber]
-      if (!scene?.place && !scene?.date) {
-        crimeScenes[policeCaseNumber] = { place: info.place, date: info.date }
-      }
-
-      const subTypes = existingSubtypes?.[policeCaseNumber]
-      if (
-        (!subTypes || subTypes.length === 0) &&
-        info.subtypes &&
-        info.subtypes.length > 0
-      ) {
-        indictmentSubtypes[policeCaseNumber] =
-          info.subtypes as IndictmentSubtypeEnum[]
-      }
-    }
-
-    return { crimeScenes, indictmentSubtypes }
-  }
-
   async getPoliceCaseInfo(
     caseId: string,
     user: User,
     defendants: { id: string; nationalId: string }[] = [],
-    caseType?: CaseType,
   ): Promise<PoliceCaseInfo[]> {
     try {
       const nationalIdsToUse =
@@ -1138,79 +1098,25 @@ export class PoliceService {
 
       if (defendantPoliceCaseNumberLinks.length > 0) {
         await this.sequelize.transaction(async (transaction: Transaction) => {
-          await this.caseDefendantPoliceCaseNumberRepositoryService.assignDefendantPoliceCaseNumbers(
-            caseId,
-            defendantPoliceCaseNumberLinks,
-            { transaction },
+          const existingPcnMap =
+            await this.caseDefendantPoliceCaseNumberRepositoryService.findDistinctPoliceCaseNumbersByCaseIds(
+              [caseId],
+              { transaction },
+            )
+          const existingPoliceCaseNumbers = new Set(
+            existingPcnMap.get(caseId) ?? [],
           )
 
-          if (caseType && isIndictmentCase(caseType)) {
-            const allLinkedPoliceCaseNumbers = [
-              ...new Set(
-                defendantPoliceCaseNumberLinks.map((l) => l.policeCaseNumber),
-              ),
-            ]
+          const linksForExistingNumbers = defendantPoliceCaseNumberLinks.filter(
+            (link) => existingPoliceCaseNumbers.has(link.policeCaseNumber),
+          )
 
-            const existingCounts =
-              await this.indictmentCountService.findByCaseId(
-                caseId,
-                transaction,
-              )
-            const coveredPoliceCaseNumbers = new Set(
-              existingCounts
-                .map((c) => c.policeCaseNumber)
-                .filter((pcn): pcn is string => !!pcn),
+          if (linksForExistingNumbers.length > 0) {
+            await this.caseDefendantPoliceCaseNumberRepositoryService.assignDefendantPoliceCaseNumbers(
+              caseId,
+              linksForExistingNumbers,
+              { transaction },
             )
-
-            const missingPoliceCaseNumbers = allLinkedPoliceCaseNumbers.filter(
-              (pcn) => !coveredPoliceCaseNumbers.has(pcn),
-            )
-
-            for (const policeCaseNumber of missingPoliceCaseNumbers) {
-              await this.indictmentCountService.createWithPoliceCaseNumber(
-                caseId,
-                policeCaseNumber,
-                transaction,
-              )
-            }
-
-            const theCase = await this.caseRepositoryService.findById(caseId, {
-              transaction,
-            })
-
-            if (theCase) {
-              const fills = this.buildAutoFillUpdates(
-                cases,
-                allLinkedPoliceCaseNumbers,
-                theCase.crimeScenes,
-                theCase.indictmentSubtypes,
-              )
-
-              const updates: {
-                crimeScenes?: CrimeSceneMap
-                indictmentSubtypes?: IndictmentSubtypeMap
-              } = {}
-
-              if (Object.keys(fills.crimeScenes).length > 0) {
-                updates.crimeScenes = {
-                  ...theCase.crimeScenes,
-                  ...fills.crimeScenes,
-                }
-              }
-
-              if (Object.keys(fills.indictmentSubtypes).length > 0) {
-                updates.indictmentSubtypes = {
-                  ...theCase.indictmentSubtypes,
-                  ...fills.indictmentSubtypes,
-                }
-              }
-
-              if (updates.crimeScenes || updates.indictmentSubtypes) {
-                await this.caseRepositoryService.update(caseId, updates, {
-                  transaction,
-                })
-              }
-            }
           }
         })
       }

--- a/apps/judicial-system/backend/src/app/modules/police/test/createTestingPoliceModule.ts
+++ b/apps/judicial-system/backend/src/app/modules/police/test/createTestingPoliceModule.ts
@@ -83,6 +83,7 @@ export const createTestingPoliceModule = async () => {
       {
         provide: IndictmentCountService,
         useValue: {
+          findByCaseId: jest.fn().mockResolvedValue([]),
           createWithPoliceCaseNumber: jest.fn().mockResolvedValue({}),
         },
       },

--- a/apps/judicial-system/backend/src/app/modules/police/test/createTestingPoliceModule.ts
+++ b/apps/judicial-system/backend/src/app/modules/police/test/createTestingPoliceModule.ts
@@ -78,6 +78,9 @@ export const createTestingPoliceModule = async () => {
         provide: CaseDefendantPoliceCaseNumberRepositoryService,
         useValue: {
           assignDefendantPoliceCaseNumbers: jest.fn().mockResolvedValue([]),
+          findDistinctPoliceCaseNumbersByCaseIds: jest
+            .fn()
+            .mockResolvedValue(new Map()),
         },
       },
       {

--- a/apps/judicial-system/backend/src/app/modules/police/test/getPoliceCaseInfo.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/police/test/getPoliceCaseInfo.spec.ts
@@ -32,10 +32,8 @@ describe('PoliceController - Get police case info', () => {
   beforeEach(async () => {
     ;(fetch as jest.Mock).mockReset()
 
-    const {
-      policeController,
-      caseDefendantPoliceCaseNumberRepositoryService,
-    } = await createTestingPoliceModule()
+    const { policeController, caseDefendantPoliceCaseNumberRepositoryService } =
+      await createTestingPoliceModule()
 
     assignDefendantPoliceCaseNumbers =
       caseDefendantPoliceCaseNumberRepositoryService.assignDefendantPoliceCaseNumbers as jest.Mock
@@ -227,14 +225,12 @@ describe('PoliceController - Get police case info', () => {
           expect.objectContaining({ transaction: expect.any(Object) }),
         )
 
-        const passedLinks =
-          assignDefendantPoliceCaseNumbers.mock.calls[0][1] as Array<{
-            policeCaseNumber: string
-          }>
+        const passedLinks = assignDefendantPoliceCaseNumbers.mock
+          .calls[0][1] as Array<{
+          policeCaseNumber: string
+        }>
         expect(
-          passedLinks.some(
-            (l) => l.policeCaseNumber === '007-2020-000057',
-          ),
+          passedLinks.some((l) => l.policeCaseNumber === '007-2020-000057'),
         ).toBe(false)
       })
 

--- a/apps/judicial-system/backend/src/app/modules/police/test/getPoliceCaseInfo.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/police/test/getPoliceCaseInfo.spec.ts
@@ -176,7 +176,7 @@ describe('PoliceController - Get police case info', () => {
     })
   })
 
-  describe('indictment counts created for new police case numbers', () => {
+  describe('indictment counts and auto-fill for indictment cases', () => {
     const theUser = {} as User
     const caseId = uuid()
     const theCase = {
@@ -190,85 +190,187 @@ describe('PoliceController - Get police case info', () => {
         },
       ],
     } as Case
-    let then: Then
 
-    beforeEach(async () => {
-      assignDefendantPoliceCaseNumbers.mockResolvedValueOnce([
-        '007-2020-000103',
-        '007-2020-000057',
-      ])
+    const policeResponse = [
+      {
+        upprunalegtMalsnumer: '007-2021-000001',
+        brotFra: '2021-02-23T13:17:00',
+        gotuHeiti: 'Testgata',
+        gotuNumer: '3',
+        sveitafelag: 'Testbær',
+        artalNrGreinLidur: null,
+      },
+      {
+        upprunalegtMalsnumer: '007-2020-000103',
+        brotFra: '2021-02-23T13:17:00',
+        gotuHeiti: null,
+        gotuNumer: null,
+        sveitafelag: null,
+        artalNrGreinLidur: null,
+      },
+      {
+        upprunalegtMalsnumer: '007-2020-000057',
+        brotFra: '2021-02-23T13:17:00',
+        gotuHeiti: null,
+        gotuNumer: null,
+        sveitafelag: null,
+        artalNrGreinLidur: null,
+      },
+    ]
 
-      const mockFetch = fetch as jest.Mock
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: async () => [
-          {
-            upprunalegtMalsnumer: '007-2021-000001',
-            brotFra: '2021-02-23T13:17:00',
-            gotuHeiti: 'Testgata',
-            gotuNumer: '3',
-            sveitafelag: 'Testbær',
-            artalNrGreinLidur: null,
-          },
-          {
-            upprunalegtMalsnumer: '007-2020-000103',
-            brotFra: '2021-02-23T13:17:00',
-            gotuHeiti: null,
-            gotuNumer: null,
-            sveitafelag: null,
-            artalNrGreinLidur: null,
-          },
-          {
-            upprunalegtMalsnumer: '007-2020-000057',
-            brotFra: '2021-02-23T13:17:00',
-            gotuHeiti: null,
-            gotuNumer: null,
-            sveitafelag: null,
-            artalNrGreinLidur: null,
-          },
-        ],
+    describe('when some police case numbers are new and none have indictment counts', () => {
+      let then: Then
+
+      beforeEach(async () => {
+        assignDefendantPoliceCaseNumbers.mockResolvedValueOnce([
+          '007-2020-000103',
+          '007-2020-000057',
+        ])
+
+        const mockFetch = fetch as jest.Mock
+        mockFetch.mockResolvedValueOnce({
+          ok: true,
+          json: async () => policeResponse,
+        })
+
+        then = await givenWhenThen(caseId, theUser, theCase)
       })
 
-      then = await givenWhenThen(caseId, theUser, theCase)
+      it('should create indictment counts for all police case numbers missing them', () => {
+        expect(
+          mockIndictmentCountService.createWithPoliceCaseNumber,
+        ).toHaveBeenCalledTimes(3)
+        expect(
+          mockIndictmentCountService.createWithPoliceCaseNumber,
+        ).toHaveBeenCalledWith(caseId, '007-2021-000001', expect.any(Object))
+        expect(
+          mockIndictmentCountService.createWithPoliceCaseNumber,
+        ).toHaveBeenCalledWith(caseId, '007-2020-000103', expect.any(Object))
+        expect(
+          mockIndictmentCountService.createWithPoliceCaseNumber,
+        ).toHaveBeenCalledWith(caseId, '007-2020-000057', expect.any(Object))
+      })
+
+      it('should auto-fill crime scenes for all linked police case numbers', () => {
+        expect(mockCaseRepositoryService.update).toHaveBeenCalledWith(
+          caseId,
+          expect.objectContaining({
+            crimeScenes: expect.objectContaining({
+              '007-2021-000001': {
+                place: 'Testgata 3, Testbær',
+                date: new Date('2021-02-23T13:17:00'),
+              },
+              '007-2020-000103': {
+                place: '',
+                date: new Date('2021-02-23T13:17:00'),
+              },
+              '007-2020-000057': {
+                place: '',
+                date: new Date('2021-02-23T13:17:00'),
+              },
+            }),
+          }),
+          expect.objectContaining({ transaction: expect.any(Object) }),
+        )
+      })
+
+      it('should still return police case info', () => {
+        expect(then.result).toHaveLength(3)
+      })
     })
 
-    it('should create indictment counts for newly discovered police case numbers', () => {
-      expect(
-        mockIndictmentCountService.createWithPoliceCaseNumber,
-      ).toHaveBeenCalledTimes(2)
-      expect(
-        mockIndictmentCountService.createWithPoliceCaseNumber,
-      ).toHaveBeenCalledWith(caseId, '007-2020-000103', expect.any(Object))
-      expect(
-        mockIndictmentCountService.createWithPoliceCaseNumber,
-      ).toHaveBeenCalledWith(caseId, '007-2020-000057', expect.any(Object))
+    describe('when all police case numbers already have indictment counts', () => {
+      beforeEach(async () => {
+        assignDefendantPoliceCaseNumbers.mockResolvedValueOnce([])
+        ;(mockIndictmentCountService.findByCaseId as jest.Mock).mockResolvedValueOnce([
+          { policeCaseNumber: '007-2021-000001' },
+          { policeCaseNumber: '007-2020-000103' },
+          { policeCaseNumber: '007-2020-000057' },
+        ])
+
+        const mockFetch = fetch as jest.Mock
+        mockFetch.mockResolvedValueOnce({
+          ok: true,
+          json: async () => policeResponse,
+        })
+
+        await givenWhenThen(caseId, theUser, theCase)
+      })
+
+      it('should not create any indictment counts', () => {
+        expect(
+          mockIndictmentCountService.createWithPoliceCaseNumber,
+        ).not.toHaveBeenCalled()
+      })
     })
 
-    it('should auto-fill missing inferred crime scenes and subtypes', () => {
-      expect(mockCaseRepositoryService.findById).toHaveBeenCalledWith(
-        caseId,
-        expect.objectContaining({ transaction: expect.any(Object) }),
-      )
-      expect(mockCaseRepositoryService.update).toHaveBeenCalledWith(
-        caseId,
-        expect.objectContaining({
-          crimeScenes: expect.objectContaining({
+    describe('when existing police case numbers are missing indictment counts', () => {
+      beforeEach(async () => {
+        assignDefendantPoliceCaseNumbers.mockResolvedValueOnce([])
+        ;(mockIndictmentCountService.findByCaseId as jest.Mock).mockResolvedValueOnce([
+          { policeCaseNumber: '007-2021-000001' },
+        ])
+
+        const mockFetch = fetch as jest.Mock
+        mockFetch.mockResolvedValueOnce({
+          ok: true,
+          json: async () => policeResponse,
+        })
+
+        await givenWhenThen(caseId, theUser, theCase)
+      })
+
+      it('should backfill the missing indictment counts', () => {
+        expect(
+          mockIndictmentCountService.createWithPoliceCaseNumber,
+        ).toHaveBeenCalledTimes(2)
+        expect(
+          mockIndictmentCountService.createWithPoliceCaseNumber,
+        ).toHaveBeenCalledWith(caseId, '007-2020-000103', expect.any(Object))
+        expect(
+          mockIndictmentCountService.createWithPoliceCaseNumber,
+        ).toHaveBeenCalledWith(caseId, '007-2020-000057', expect.any(Object))
+      })
+    })
+
+    describe('when crime scene data already exists', () => {
+      beforeEach(async () => {
+        assignDefendantPoliceCaseNumbers.mockResolvedValueOnce([])
+        ;(mockIndictmentCountService.findByCaseId as jest.Mock).mockResolvedValueOnce([
+          { policeCaseNumber: '007-2021-000001' },
+          { policeCaseNumber: '007-2020-000103' },
+          { policeCaseNumber: '007-2020-000057' },
+        ])
+        ;(mockCaseRepositoryService.findById as jest.Mock).mockResolvedValueOnce({
+          crimeScenes: {
+            '007-2021-000001': {
+              place: 'User-entered place',
+              date: new Date('2024-01-01'),
+            },
             '007-2020-000103': {
-              place: '',
-              date: new Date('2021-02-23T13:17:00'),
+              place: 'Another place',
+              date: new Date('2024-02-01'),
             },
             '007-2020-000057': {
-              place: '',
-              date: new Date('2021-02-23T13:17:00'),
+              place: 'Third place',
+              date: new Date('2024-03-01'),
             },
-          }),
-        }),
-        expect.objectContaining({ transaction: expect.any(Object) }),
-      )
-    })
+          },
+          indictmentSubtypes: {},
+        })
 
-    it('should still return police case info', () => {
-      expect(then.result).toHaveLength(3)
+        const mockFetch = fetch as jest.Mock
+        mockFetch.mockResolvedValueOnce({
+          ok: true,
+          json: async () => policeResponse,
+        })
+
+        await givenWhenThen(caseId, theUser, theCase)
+      })
+
+      it('should not overwrite existing crime scene data', () => {
+        expect(mockCaseRepositoryService.update).not.toHaveBeenCalled()
+      })
     })
   })
 

--- a/apps/judicial-system/backend/src/app/modules/police/test/getPoliceCaseInfo.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/police/test/getPoliceCaseInfo.spec.ts
@@ -3,12 +3,12 @@ import { v4 as uuid } from 'uuid'
 
 import { NotFoundException } from '@nestjs/common'
 
-import { CaseType, User } from '@island.is/judicial-system/types'
+import { User } from '@island.is/judicial-system/types'
 
 import { createTestingPoliceModule } from './createTestingPoliceModule'
 
-import { IndictmentCountService } from '../../indictment-count/indictmentCount.service'
-import { Case, CaseRepositoryService } from '../../repository'
+import { CaseDefendantPoliceCaseNumberRepositoryService } from '../../repository'
+import { Case } from '../../repository'
 import { PoliceCaseInfo } from '../models/policeCaseInfo.model'
 
 jest.mock('isomorphic-fetch')
@@ -27,8 +27,7 @@ type GivenWhenThen = (
 describe('PoliceController - Get police case info', () => {
   let givenWhenThen: GivenWhenThen
   let assignDefendantPoliceCaseNumbers: jest.Mock
-  let mockIndictmentCountService: IndictmentCountService
-  let mockCaseRepositoryService: CaseRepositoryService
+  let findDistinctPoliceCaseNumbersByCaseIds: jest.Mock
 
   beforeEach(async () => {
     ;(fetch as jest.Mock).mockReset()
@@ -36,14 +35,12 @@ describe('PoliceController - Get police case info', () => {
     const {
       policeController,
       caseDefendantPoliceCaseNumberRepositoryService,
-      indictmentCountService,
-      caseRepositoryService,
     } = await createTestingPoliceModule()
 
     assignDefendantPoliceCaseNumbers =
       caseDefendantPoliceCaseNumberRepositoryService.assignDefendantPoliceCaseNumbers as jest.Mock
-    mockIndictmentCountService = indictmentCountService
-    mockCaseRepositoryService = caseRepositoryService
+    findDistinctPoliceCaseNumbersByCaseIds =
+      caseDefendantPoliceCaseNumberRepositoryService.findDistinctPoliceCaseNumbersByCaseIds as jest.Mock
 
     givenWhenThen = async (
       caseId: string,
@@ -79,7 +76,6 @@ describe('PoliceController - Get police case info', () => {
 
     beforeEach(async () => {
       const mockFetch = fetch as jest.Mock
-      // getCaseUnitsFromPolice (GetRVMalseiningar)
       mockFetch.mockResolvedValueOnce({
         ok: true,
         json: async () => [
@@ -153,35 +149,16 @@ describe('PoliceController - Get police case info', () => {
       ).toBe(false)
     })
 
-    it('should assign defendant-linked police case numbers from police case units', () => {
-      expect(assignDefendantPoliceCaseNumbers).toHaveBeenCalledTimes(1)
-      expect(assignDefendantPoliceCaseNumbers).toHaveBeenCalledWith(
-        caseId,
-        expect.arrayContaining([
-          {
-            defendantId: '11111111-1111-1111-1111-111111111111',
-            policeCaseNumber: '007-2021-000001',
-          },
-          {
-            defendantId: '11111111-1111-1111-1111-111111111111',
-            policeCaseNumber: '007-2020-000103',
-          },
-          {
-            defendantId: '11111111-1111-1111-1111-111111111111',
-            policeCaseNumber: '007-2020-000057',
-          },
-        ]),
-        expect.objectContaining({ transaction: expect.any(Object) }),
-      )
+    it('should not assign defendant links for numbers not already on the case', () => {
+      expect(assignDefendantPoliceCaseNumbers).not.toHaveBeenCalled()
     })
   })
 
-  describe('indictment counts and auto-fill for indictment cases', () => {
+  describe('defendant linking for existing police case numbers', () => {
     const theUser = {} as User
     const caseId = uuid()
     const theCase = {
       id: caseId,
-      type: CaseType.INDICTMENT,
       defendants: [
         {
           id: '11111111-1111-1111-1111-111111111111',
@@ -191,185 +168,107 @@ describe('PoliceController - Get police case info', () => {
       ],
     } as Case
 
-    const policeResponse = [
-      {
-        upprunalegtMalsnumer: '007-2021-000001',
-        brotFra: '2021-02-23T13:17:00',
-        gotuHeiti: 'Testgata',
-        gotuNumer: '3',
-        sveitafelag: 'Testbær',
-        artalNrGreinLidur: null,
-      },
-      {
-        upprunalegtMalsnumer: '007-2020-000103',
-        brotFra: '2021-02-23T13:17:00',
-        gotuHeiti: null,
-        gotuNumer: null,
-        sveitafelag: null,
-        artalNrGreinLidur: null,
-      },
-      {
-        upprunalegtMalsnumer: '007-2020-000057',
-        brotFra: '2021-02-23T13:17:00',
-        gotuHeiti: null,
-        gotuNumer: null,
-        sveitafelag: null,
-        artalNrGreinLidur: null,
-      },
-    ]
-
-    describe('when some police case numbers are new and none have indictment counts', () => {
+    describe('when some police case numbers already exist on the case', () => {
       let then: Then
 
       beforeEach(async () => {
-        assignDefendantPoliceCaseNumbers.mockResolvedValueOnce([
-          '007-2020-000103',
-          '007-2020-000057',
-        ])
+        findDistinctPoliceCaseNumbersByCaseIds.mockResolvedValueOnce(
+          new Map([[caseId, ['007-2021-000001', '007-2020-000103']]]),
+        )
 
         const mockFetch = fetch as jest.Mock
         mockFetch.mockResolvedValueOnce({
           ok: true,
-          json: async () => policeResponse,
+          json: async () => [
+            {
+              upprunalegtMalsnumer: '007-2021-000001',
+              brotFra: '2021-02-23T13:17:00',
+              gotuHeiti: 'Testgata',
+              gotuNumer: '3',
+              sveitafelag: 'Testbær',
+              artalNrGreinLidur: null,
+            },
+            {
+              upprunalegtMalsnumer: '007-2020-000103',
+              brotFra: '2021-02-23T13:17:00',
+              gotuHeiti: null,
+              gotuNumer: null,
+              sveitafelag: null,
+              artalNrGreinLidur: null,
+            },
+            {
+              upprunalegtMalsnumer: '007-2020-000057',
+              brotFra: '2021-02-23T13:17:00',
+              gotuHeiti: null,
+              gotuNumer: null,
+              sveitafelag: null,
+              artalNrGreinLidur: null,
+            },
+          ],
         })
 
         then = await givenWhenThen(caseId, theUser, theCase)
       })
 
-      it('should create indictment counts for all police case numbers missing them', () => {
-        expect(
-          mockIndictmentCountService.createWithPoliceCaseNumber,
-        ).toHaveBeenCalledTimes(3)
-        expect(
-          mockIndictmentCountService.createWithPoliceCaseNumber,
-        ).toHaveBeenCalledWith(caseId, '007-2021-000001', expect.any(Object))
-        expect(
-          mockIndictmentCountService.createWithPoliceCaseNumber,
-        ).toHaveBeenCalledWith(caseId, '007-2020-000103', expect.any(Object))
-        expect(
-          mockIndictmentCountService.createWithPoliceCaseNumber,
-        ).toHaveBeenCalledWith(caseId, '007-2020-000057', expect.any(Object))
-      })
-
-      it('should auto-fill crime scenes for all linked police case numbers', () => {
-        expect(mockCaseRepositoryService.update).toHaveBeenCalledWith(
+      it('should only assign defendant links for police case numbers already on the case', () => {
+        expect(assignDefendantPoliceCaseNumbers).toHaveBeenCalledTimes(1)
+        expect(assignDefendantPoliceCaseNumbers).toHaveBeenCalledWith(
           caseId,
-          expect.objectContaining({
-            crimeScenes: expect.objectContaining({
-              '007-2021-000001': {
-                place: 'Testgata 3, Testbær',
-                date: new Date('2021-02-23T13:17:00'),
-              },
-              '007-2020-000103': {
-                place: '',
-                date: new Date('2021-02-23T13:17:00'),
-              },
-              '007-2020-000057': {
-                place: '',
-                date: new Date('2021-02-23T13:17:00'),
-              },
-            }),
-          }),
+          expect.arrayContaining([
+            {
+              defendantId: '11111111-1111-1111-1111-111111111111',
+              policeCaseNumber: '007-2021-000001',
+            },
+            {
+              defendantId: '11111111-1111-1111-1111-111111111111',
+              policeCaseNumber: '007-2020-000103',
+            },
+          ]),
           expect.objectContaining({ transaction: expect.any(Object) }),
         )
+
+        const passedLinks =
+          assignDefendantPoliceCaseNumbers.mock.calls[0][1] as Array<{
+            policeCaseNumber: string
+          }>
+        expect(
+          passedLinks.some(
+            (l) => l.policeCaseNumber === '007-2020-000057',
+          ),
+        ).toBe(false)
       })
 
-      it('should still return police case info', () => {
+      it('should still return all police case info', () => {
         expect(then.result).toHaveLength(3)
       })
     })
 
-    describe('when all police case numbers already have indictment counts', () => {
+    describe('when no police case numbers exist on the case yet', () => {
       beforeEach(async () => {
-        assignDefendantPoliceCaseNumbers.mockResolvedValueOnce([])
-        ;(mockIndictmentCountService.findByCaseId as jest.Mock).mockResolvedValueOnce([
-          { policeCaseNumber: '007-2021-000001' },
-          { policeCaseNumber: '007-2020-000103' },
-          { policeCaseNumber: '007-2020-000057' },
-        ])
+        findDistinctPoliceCaseNumbersByCaseIds.mockResolvedValueOnce(
+          new Map([[caseId, []]]),
+        )
 
         const mockFetch = fetch as jest.Mock
         mockFetch.mockResolvedValueOnce({
           ok: true,
-          json: async () => policeResponse,
+          json: async () => [
+            {
+              upprunalegtMalsnumer: '007-2021-000001',
+              brotFra: '2021-02-23T13:17:00',
+              gotuHeiti: 'Testgata',
+              gotuNumer: '3',
+              sveitafelag: 'Testbær',
+              artalNrGreinLidur: null,
+            },
+          ],
         })
 
         await givenWhenThen(caseId, theUser, theCase)
       })
 
-      it('should not create any indictment counts', () => {
-        expect(
-          mockIndictmentCountService.createWithPoliceCaseNumber,
-        ).not.toHaveBeenCalled()
-      })
-    })
-
-    describe('when existing police case numbers are missing indictment counts', () => {
-      beforeEach(async () => {
-        assignDefendantPoliceCaseNumbers.mockResolvedValueOnce([])
-        ;(mockIndictmentCountService.findByCaseId as jest.Mock).mockResolvedValueOnce([
-          { policeCaseNumber: '007-2021-000001' },
-        ])
-
-        const mockFetch = fetch as jest.Mock
-        mockFetch.mockResolvedValueOnce({
-          ok: true,
-          json: async () => policeResponse,
-        })
-
-        await givenWhenThen(caseId, theUser, theCase)
-      })
-
-      it('should backfill the missing indictment counts', () => {
-        expect(
-          mockIndictmentCountService.createWithPoliceCaseNumber,
-        ).toHaveBeenCalledTimes(2)
-        expect(
-          mockIndictmentCountService.createWithPoliceCaseNumber,
-        ).toHaveBeenCalledWith(caseId, '007-2020-000103', expect.any(Object))
-        expect(
-          mockIndictmentCountService.createWithPoliceCaseNumber,
-        ).toHaveBeenCalledWith(caseId, '007-2020-000057', expect.any(Object))
-      })
-    })
-
-    describe('when crime scene data already exists', () => {
-      beforeEach(async () => {
-        assignDefendantPoliceCaseNumbers.mockResolvedValueOnce([])
-        ;(mockIndictmentCountService.findByCaseId as jest.Mock).mockResolvedValueOnce([
-          { policeCaseNumber: '007-2021-000001' },
-          { policeCaseNumber: '007-2020-000103' },
-          { policeCaseNumber: '007-2020-000057' },
-        ])
-        ;(mockCaseRepositoryService.findById as jest.Mock).mockResolvedValueOnce({
-          crimeScenes: {
-            '007-2021-000001': {
-              place: 'User-entered place',
-              date: new Date('2024-01-01'),
-            },
-            '007-2020-000103': {
-              place: 'Another place',
-              date: new Date('2024-02-01'),
-            },
-            '007-2020-000057': {
-              place: 'Third place',
-              date: new Date('2024-03-01'),
-            },
-          },
-          indictmentSubtypes: {},
-        })
-
-        const mockFetch = fetch as jest.Mock
-        mockFetch.mockResolvedValueOnce({
-          ok: true,
-          json: async () => policeResponse,
-        })
-
-        await givenWhenThen(caseId, theUser, theCase)
-      })
-
-      it('should not overwrite existing crime scene data', () => {
-        expect(mockCaseRepositoryService.update).not.toHaveBeenCalled()
+      it('should not assign any defendant links', () => {
+        expect(assignDefendantPoliceCaseNumbers).not.toHaveBeenCalled()
       })
     })
   })
@@ -385,7 +284,6 @@ describe('PoliceController - Get police case info', () => {
 
     beforeEach(async () => {
       const mockFetch = fetch as jest.Mock
-      // getDefendantsFromPolice
       mockFetch.mockResolvedValueOnce({
         ok: true,
         json: async () => [
@@ -396,7 +294,6 @@ describe('PoliceController - Get police case info', () => {
         ],
       })
 
-      // getCaseUnitsFromPolice (GetRVMalseiningar)
       mockFetch.mockResolvedValueOnce({
         ok: true,
         json: async () => [
@@ -445,7 +342,6 @@ describe('PoliceController - Get police case info', () => {
 
     beforeEach(async () => {
       const mockFetch = fetch as jest.Mock
-      // getDefendantsFromPolice
       mockFetch.mockResolvedValueOnce({
         ok: false,
         text: () => 'Some error for getDefendantsFromPolice',

--- a/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Defendant/PoliceCaseList/PoliceCaseInfo/PoliceCaseInfo.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Defendant/PoliceCaseList/PoliceCaseInfo/PoliceCaseInfo.tsx
@@ -1,4 +1,4 @@
-import { FC, useContext, useMemo, useRef } from 'react'
+import { FC, useContext, useMemo } from 'react'
 import { useIntl } from 'react-intl'
 
 import { Box } from '@island.is/island-ui/core'
@@ -25,8 +25,7 @@ export const PoliceCaseInfo: FC<Props> = ({
   onAddPoliceCaseInfo,
 }) => {
   const { formatMessage } = useIntl()
-  const { workingCase, refreshCase } = useContext(FormContext)
-  const hasRefreshedRef = useRef(false)
+  const { workingCase } = useContext(FormContext)
 
   const { data, loading, error } = usePoliceCaseInfoQuery({
     variables: { input: { caseId: workingCase.id } },
@@ -36,11 +35,6 @@ export const PoliceCaseInfo: FC<Props> = ({
     onCompleted: (data) => {
       if (!data.policeCaseInfo) {
         return
-      }
-
-      if (!hasRefreshedRef.current) {
-        hasRefreshedRef.current = true
-        refreshCase()
       }
 
       onPoliceCaseInfoLoaded(data.policeCaseInfo)
@@ -71,6 +65,8 @@ export const PoliceCaseInfo: FC<Props> = ({
 
     return sorted
   }, [data])
+
+  console.log({ policeCaseInfo })
 
   const availablePoliceCases = useMemo(() => {
     return policeCaseInfo.filter(

--- a/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Defendant/PoliceCaseList/PoliceCaseInfo/PoliceCaseInfo.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Defendant/PoliceCaseList/PoliceCaseInfo/PoliceCaseInfo.tsx
@@ -66,7 +66,6 @@ export const PoliceCaseInfo: FC<Props> = ({
     return sorted
   }, [data])
 
-
   const availablePoliceCases = useMemo(() => {
     return policeCaseInfo.filter(
       (caseInfo) =>

--- a/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Defendant/PoliceCaseList/PoliceCaseInfo/PoliceCaseInfo.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Defendant/PoliceCaseList/PoliceCaseInfo/PoliceCaseInfo.tsx
@@ -66,7 +66,6 @@ export const PoliceCaseInfo: FC<Props> = ({
     return sorted
   }, [data])
 
-  console.log({ policeCaseInfo })
 
   const availablePoliceCases = useMemo(() => {
     return policeCaseInfo.filter(

--- a/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Defendant/PoliceCaseList/PoliceCaseList.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Defendant/PoliceCaseList/PoliceCaseList.tsx
@@ -54,7 +54,7 @@ interface Checkpoint {
 
 export const PoliceCaseList = () => {
   const { formatMessage } = useIntl()
-  const { workingCase, setWorkingCase } = useContext(FormContext)
+  const { workingCase, setWorkingCase, refreshCase } = useContext(FormContext)
   const { setAndSendCaseToServer } = useCase()
   const { updateIndictmentCount } = useIndictmentCounts()
 
@@ -300,7 +300,9 @@ export const PoliceCaseList = () => {
     checkpoint.current.update = update
   }
 
-  const handleUpdatePoliceCase = (updates: IndexedPoliceCaseUpdate[] = []) => {
+  const handleUpdatePoliceCase = async (
+    updates: IndexedPoliceCaseUpdate[] = [],
+  ) => {
     const { policeCaseNumbers, indictmentSubtypes, crimeScenes } =
       getWorkingCaseUpdates(policeCases, updates)
 
@@ -346,7 +348,7 @@ export const PoliceCaseList = () => {
       return
     }
 
-    setAndSendCaseToServer(
+    await setAndSendCaseToServer(
       [{ policeCaseNumbers, indictmentSubtypes, crimeScenes, force: true }],
       workingCase,
       setWorkingCase,
@@ -357,6 +359,8 @@ export const PoliceCaseList = () => {
       { policeCaseNumbers, indictmentSubtypes, crimeScenes },
       unsavedUpdates,
     )
+
+    refreshCase()
   }
 
   const handleDeletePoliceCase = async (index: number) => {
@@ -420,9 +424,18 @@ export const PoliceCaseList = () => {
       ) {
         subtypes = policeCaseInfo.subtypes
       }
+
+      console.log('place date subtypes', {
+        policeCaseNumber: policeCaseInfo.policeCaseNumber,
+        place,
+        date,
+        subtypes,
+      })
       if (!place && !date && !subtypes) {
         continue
       }
+
+      console.log('place date subtypes', { place, date, subtypes })
 
       updates.push({
         index: idx,

--- a/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Defendant/PoliceCaseList/PoliceCaseList.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Defendant/PoliceCaseList/PoliceCaseList.tsx
@@ -435,7 +435,6 @@ export const PoliceCaseList = () => {
         continue
       }
 
-      console.log('place date subtypes', { place, date, subtypes })
 
       updates.push({
         index: idx,

--- a/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Defendant/PoliceCaseList/PoliceCaseList.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Defendant/PoliceCaseList/PoliceCaseList.tsx
@@ -425,16 +425,9 @@ export const PoliceCaseList = () => {
         subtypes = policeCaseInfo.subtypes
       }
 
-      console.log('place date subtypes', {
-        policeCaseNumber: policeCaseInfo.policeCaseNumber,
-        place,
-        date,
-        subtypes,
-      })
       if (!place && !date && !subtypes) {
         continue
       }
-
 
       updates.push({
         index: idx,


### PR DESCRIPTION
## What

The first indictment count was created with missing data (Sakarefni and vettvangur)

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Fetch indictment counts for a specific case.

* **Bug Fixes**
  * Only create missing indictment count records; avoid overwriting existing crime scene and subtype data.
  * Auto-fill now merges with existing case data, updating only absent fields.
  * UI now awaits server updates and refreshes case data after successful updates.

* **Tests**
  * Reorganized and expanded tests covering indictment-count and auto-fill scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/island-is/island.is/pull/22568?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->