### PR TITLE
fix(web): Remove hearing time from héraðsdómstólar agendas

### DIFF
--- a/libs/clients/verdicts/src/lib/verdicts-client.service.ts
+++ b/libs/clients/verdicts/src/lib/verdicts-client.service.ts
@@ -656,7 +656,9 @@ export class VerdictsClientService {
           type: agenda.bookingType ?? '',
           title: agenda.caseTitle?.raw ? agenda.caseTitle.raw : '',
           caseSubType: agenda.caseSubType ?? '',
-          hearingTime: sanitizeHtml(agenda.length ?? ''),
+          hearingTime: !agenda.court?.code?.startsWith('hd')
+            ? sanitizeHtml(agenda.length ?? '')
+            : undefined,
         })
       }
     } else {


### PR DESCRIPTION
# Remove hearing time from héraðsdómstólar agendas


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed hearing time display in court agendas to be conditionally shown based on court type, rather than displayed for all courts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/island-is/island.is/pull/22569?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->