### PR TITLE
fix(j-s): Civil claim files - add role rules 

### DIFF
--- a/apps/judicial-system/backend/src/app/modules/file/file.controller.ts
+++ b/apps/judicial-system/backend/src/app/modules/file/file.controller.ts
@@ -198,7 +198,11 @@ export class FileController {
     CivilClaimantExistsGuard,
     CreateCivilClaimantCaseFileGuard,
   )
-  @RolesRules() // This endpoint is not used by any role at the moment
+  @RolesRules(
+    publicProsecutorStaffRule,
+    prosecutorRule,
+    prosecutorRepresentativeRule,
+  )
   @Post('civilClaimant/:civilClaimantId/file')
   @ApiCreatedResponse({
     type: CaseFile,

--- a/apps/judicial-system/backend/src/app/modules/file/test/fileController/createCivilClaimantCaseFileRolesRules.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/file/test/fileController/createCivilClaimantCaseFileRolesRules.spec.ts
@@ -1,6 +1,15 @@
+import {
+  prosecutorRepresentativeRule,
+  prosecutorRule,
+  publicProsecutorStaffRule,
+} from '../../../../guards'
 import { verifyRolesRules } from '../../../../test'
 import { FileController } from '../../file.controller'
 
-describe('FileController - Create defendant case file rules', () => {
-  verifyRolesRules(FileController, 'createCivilClaimantCaseFile', [])
+describe('FileController - Create civil claimant case file rules', () => {
+  verifyRolesRules(FileController, 'createCivilClaimantCaseFile', [
+    publicProsecutorStaffRule,
+    prosecutorRule,
+    prosecutorRepresentativeRule,
+  ])
 })

--- a/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Processing/Processing.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Processing/Processing.tsx
@@ -333,11 +333,7 @@ const Processing: FC = () => {
         </Box>
         {workingCase.hasCivilClaims && (
           <Box component="section" marginBottom={10}>
-            <Accordion
-              dividerOnTop={false}
-              dividerOnBottom={false}
-              dividers={false}
-            >
+            <Accordion dividerOnTop={false}>
               {workingCase.civilClaimants?.map((civilClaimant, index) => (
                 <AccordionItem
                   key={civilClaimant.id}


### PR DESCRIPTION
[Asana](https://app.asana.com/1/203394141643832/project/1212657017130395/task/1209299067840752?focus=true)

## What

Add prosecution users to the civil claimant file upload endpoint roles

Add separator on the bottom of the civil claimant accordions

## Why

So we don't get forbidden on the civil claim file upload

## Screenshots / Gifs

<img width="828" height="429" alt="image" src="https://github.com/user-attachments/assets/d4b77a8c-3c27-4b0a-9937-f71d88a7bb81" />

<img width="896" height="400" alt="image" src="https://github.com/user-attachments/assets/e719afae-687d-442d-af6b-5e43e1f986a6" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated access control permissions for file operations to allow specific user roles.

* **Style**
  * Refined accordion styling in the civil claims section by adjusting divider configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/island-is/island.is/pull/22579?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->