### PR TITLE
feat(j-s): Send SMS to prosecution when court of appeals completes restriction cases

### DIFF
--- a/apps/judicial-system/backend/src/app/messages/notifications.ts
+++ b/apps/judicial-system/backend/src/app/messages/notifications.ts
@@ -731,6 +731,13 @@ export const notifications = {
         'Landsréttur hefur úrskurðað í máli {appealCaseNumber} (héraðsdómsmál nr. {courtCaseNumber}). Niðurstaða Landsréttar: {appealRulingDecision}. {userHasAccessToRVG, select, true {Hægt er að nálgast gögn málsins á {linkStart}yfirlitssíðu málsins í Réttarvörslugátt{linkEnd}} other {Hægt er að nálgast gögn málsins hjá {court} ef þau hafa ekki þegar verið afhent}}.',
       description: 'Texti í pósti til aðila máls þegar kæru er lokið',
     },
+    text: {
+      id: 'judicial.system.backend:notifications.case_appeal_completed.text',
+      defaultMessage:
+        'Landsréttur hefur úrskurðað í máli {appealCaseNumber} (héraðsdómsmál nr. {courtCaseNumber}). Niðurstaða Landsréttar: {appealRulingDecision}. Sjá nánar á rettarvorslugatt.island.is',
+      description:
+        'Texti í SMS til sækjanda þegar Landsréttur hefur úrskurðað í kærumáli',
+    },
   }),
   caseAppealResent: defineMessages({
     subject: {

--- a/apps/judicial-system/backend/src/app/modules/notification/services/caseNotification/caseNotification.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/services/caseNotification/caseNotification.service.ts
@@ -3615,6 +3615,20 @@ export class CaseNotificationService extends BaseNotificationService {
       )
     }
 
+    if (!isReopened) {
+      const smsText = this.formatMessage(
+        notifications.caseAppealCompleted.text,
+        {
+          courtCaseNumber: theCase.courtCaseNumber,
+          appealCaseNumber: theCase.appealCase?.appealCaseNumber,
+          appealRulingDecision: getAppealResultTextByValue(
+            theCase.appealCase?.appealRulingDecision,
+          ),
+        },
+      )
+      promises.push(this.sendSms(smsText, theCase.prosecutor?.mobileNumber))
+    }
+
     return Promise.all(promises)
   }
 

--- a/apps/judicial-system/backend/src/app/modules/notification/test/internalNotificationController/sendAppealCompletedNotifications.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/test/internalNotificationController/sendAppealCompletedNotifications.spec.ts
@@ -2,6 +2,7 @@ import { v4 as uuid } from 'uuid'
 
 import { EmailService } from '@island.is/email-service'
 import { ConfigType } from '@island.is/nest/config'
+import { SmsService } from '@island.is/nova-sms'
 
 import {
   AppealCaseNotificationType,
@@ -30,6 +31,7 @@ interface Then {
 type GivenWhenThen = (
   defenderNationalId?: string,
   appealRulingDecision?: AppealCaseRulingDecision,
+  notifications?: { type: CaseNotificationType }[],
 ) => Promise<Then>
 
 describe('InternalNotificationController - Send appeal completed notifications', () => {
@@ -46,21 +48,28 @@ describe('InternalNotificationController - Send appeal completed notifications',
   const courtId = uuid()
 
   let mockEmailService: EmailService
+  let mockSmsService: SmsService
   let mockConfig: ConfigType<typeof notificationModuleConfig>
   let givenWhenThen: GivenWhenThen
 
   beforeEach(async () => {
     process.env.COURTS_EMAILS = `{"4676f08b-aab4-4b4f-a366-697540788088":"${courtOfAppeals.email}"}`
 
-    const { emailService, notificationConfig, internalNotificationController } =
-      await createTestingNotificationModule()
+    const {
+      emailService,
+      smsService,
+      notificationConfig,
+      internalNotificationController,
+    } = await createTestingNotificationModule()
 
     mockEmailService = emailService
+    mockSmsService = smsService
     mockConfig = notificationConfig
 
     givenWhenThen = async (
       defenderNationalId?: string,
       appealRulingDecision?: AppealCaseRulingDecision,
+      notifications?: { type: CaseNotificationType }[],
     ) => {
       const then = {} as Then
 
@@ -72,7 +81,11 @@ describe('InternalNotificationController - Send appeal completed notifications',
             type: CaseType.CUSTODY,
             state: CaseState.ACCEPTED,
             decision: CaseDecision.ACCEPTING,
-            prosecutor: { name: prosecutor.name, email: prosecutor.email },
+            prosecutor: {
+              name: prosecutor.name,
+              email: prosecutor.email,
+              mobileNumber: prosecutor.mobile,
+            },
             judge: { name: judge.name, email: judge.email },
             court: { name: 'Héraðsdómur Reykjavíkur' },
             defenderNationalId,
@@ -80,6 +93,7 @@ describe('InternalNotificationController - Send appeal completed notifications',
             defenderEmail: defender.email,
             courtCaseNumber,
             courtId: courtId,
+            notifications,
             appealCase: {
               appealCaseNumber,
               appealRulingDecision:
@@ -150,6 +164,48 @@ describe('InternalNotificationController - Send appeal completed notifications',
           html: `Landsréttur hefur úrskurðað í máli ${appealCaseNumber} (héraðsdómsmál nr. ${courtCaseNumber}). Niðurstaða Landsréttar: Staðfest. Hægt er að nálgast gögn málsins á <a href="http://localhost:4200/verjandi/krafa/${caseId}">yfirlitssíðu málsins í Réttarvörslugátt</a>.`,
         }),
       )
+      expect(mockSmsService.sendSms).toHaveBeenCalledWith(
+        [prosecutor.mobile],
+        `Landsréttur hefur úrskurðað í máli ${appealCaseNumber} (héraðsdómsmál nr. ${courtCaseNumber}). Niðurstaða Landsréttar: Staðfest. Sjá nánar á rettarvorslugatt.island.is`,
+      )
+      expect(then.result).toEqual({ delivered: true })
+    })
+  })
+
+  describe('notification sent with repealed ruling', () => {
+    let then: Then
+
+    beforeEach(async () => {
+      then = await givenWhenThen(uuid(), AppealCaseRulingDecision.REPEAL)
+    })
+
+    it('should send sms with repealed ruling decision', () => {
+      expect(mockSmsService.sendSms).toHaveBeenCalledWith(
+        [prosecutor.mobile],
+        `Landsréttur hefur úrskurðað í máli ${appealCaseNumber} (héraðsdómsmál nr. ${courtCaseNumber}). Niðurstaða Landsréttar: Fellt úr gildi. Sjá nánar á rettarvorslugatt.island.is`,
+      )
+      expect(then.result).toEqual({ delivered: true })
+    })
+  })
+
+  describe('notification sent for corrected ruling', () => {
+    let then: Then
+
+    beforeEach(async () => {
+      then = await givenWhenThen(uuid(), AppealCaseRulingDecision.CHANGED, [
+        { type: CaseNotificationType.APPEAL_COMPLETED },
+      ])
+    })
+
+    it('should send resent email but not sms to prosecutor', () => {
+      expect(mockEmailService.sendEmail).toHaveBeenCalledWith(
+        expect.objectContaining({
+          to: [{ name: prosecutor.name, address: prosecutor.email }],
+          subject: `Leiðréttur úrskurður í landsréttarmáli ${appealCaseNumber} (${courtCaseNumber})`,
+          html: `Landsréttur hefur leiðrétt úrskurð í máli ${appealCaseNumber} (héraðsdómsmál nr. ${courtCaseNumber}). Hægt er að nálgast gögn málsins á <a href="http://localhost:4200/krafa/yfirlit/${caseId}">yfirlitssíðu málsins í Réttarvörslugátt</a>.`,
+        }),
+      )
+      expect(mockSmsService.sendSms).not.toHaveBeenCalled()
       expect(then.result).toEqual({ delivered: true })
     })
   })
@@ -195,6 +251,7 @@ describe('InternalNotificationController - Send appeal completed notifications',
           html: `Landsréttur hefur móttekið afturköllun á kæru í máli ${courtCaseNumber}. Landsréttarmálið ${appealCaseNumber} hefur verið fellt niður.`,
         }),
       )
+      expect(mockSmsService.sendSms).not.toHaveBeenCalled()
       expect(then.result).toEqual({ delivered: true })
     })
   })

--- a/apps/judicial-system/backend/src/app/modules/notification/test/internalNotificationController/sendAppealCompletedNotifications.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/test/internalNotificationController/sendAppealCompletedNotifications.spec.ts
@@ -31,7 +31,7 @@ interface Then {
 type GivenWhenThen = (
   defenderNationalId?: string,
   appealRulingDecision?: AppealCaseRulingDecision,
-  notifications?: { type: CaseNotificationType }[],
+  notifications?: { type: TrackedNotificationType }[],
 ) => Promise<Then>
 
 describe('InternalNotificationController - Send appeal completed notifications', () => {
@@ -69,7 +69,7 @@ describe('InternalNotificationController - Send appeal completed notifications',
     givenWhenThen = async (
       defenderNationalId?: string,
       appealRulingDecision?: AppealCaseRulingDecision,
-      notifications?: { type: CaseNotificationType }[],
+      notifications?: { type: TrackedNotificationType }[],
     ) => {
       const then = {} as Then
 
@@ -193,7 +193,7 @@ describe('InternalNotificationController - Send appeal completed notifications',
 
     beforeEach(async () => {
       then = await givenWhenThen(uuid(), AppealCaseRulingDecision.CHANGED, [
-        { type: CaseNotificationType.APPEAL_COMPLETED },
+        { type: TrackedNotificationType.APPEAL_COMPLETED },
       ])
     })
 

--- a/apps/judicial-system/backend/src/app/modules/notification/test/internalNotificationController/sendAppealCompletedNotifications.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/test/internalNotificationController/sendAppealCompletedNotifications.spec.ts
@@ -31,7 +31,7 @@ interface Then {
 type GivenWhenThen = (
   defenderNationalId?: string,
   appealRulingDecision?: AppealCaseRulingDecision,
-  notifications?: { type: TrackedNotificationType }[],
+  notifications?: { type: AppealCaseNotificationType }[],
 ) => Promise<Then>
 
 describe('InternalNotificationController - Send appeal completed notifications', () => {
@@ -69,7 +69,7 @@ describe('InternalNotificationController - Send appeal completed notifications',
     givenWhenThen = async (
       defenderNationalId?: string,
       appealRulingDecision?: AppealCaseRulingDecision,
-      notifications?: { type: TrackedNotificationType }[],
+      notifications?: { type: AppealCaseNotificationType }[],
     ) => {
       const then = {} as Then
 
@@ -193,7 +193,7 @@ describe('InternalNotificationController - Send appeal completed notifications',
 
     beforeEach(async () => {
       then = await givenWhenThen(uuid(), AppealCaseRulingDecision.CHANGED, [
-        { type: TrackedNotificationType.APPEAL_COMPLETED },
+        { type: AppealCaseNotificationType.APPEAL_COMPLETED },
       ])
     })
 


### PR DESCRIPTION
[Asana](https://app.asana.com/1/203394141643832/project/1212657017130395/task/1214085141586897?focus=true)

## What

Send an SMS when court of appeals completes a restriction case

## Why

These are often time-sensitive cases and prosecutors have said this would benefit them



## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Cursor


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SMS notifications added for case appeal completion, sent to prosecutors with case numbers, ruling outcome, and a reference link.

* **Improvements**
  * SMS sending is conditional (not sent for reopened appeals) and varies by ruling outcome.

* **Tests**
  * Automated tests expanded to verify SMS delivery and content across ruling scenarios, corrections, repeals, and discontinued appeals.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/island-is/island.is/pull/22583?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->