### PR TITLE
fix(web): Query slug field when fetching organization page footer items

### DIFF
--- a/libs/cms/src/lib/cms.contentful.service.ts
+++ b/libs/cms/src/lib/cms.contentful.service.ts
@@ -1920,7 +1920,7 @@ export class CmsContentfulService {
       .getLocalizedEntries<types.IOrganizationPageFields>(lang, {
         content_type: 'organizationPage',
         'fields.organization.sys.id': organizationId,
-        select: 'fields.footerItems,fields.footerConfig',
+        select: 'fields.footerItems,fields.footerConfig,fields.slug',
         limit: 1,
       })
       .catch((error) => {


### PR DESCRIPTION
# Query slug field when fetching organization page footer items


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved organization footer data retrieval to ensure complete information is fetched correctly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/island-is/island.is/pull/22585?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->