### PR TITLE
fix(althingi-ombudsman): use submission timestamp for "Kvörtun móttekin" date in pdf

### DIFF
--- a/libs/application/template-api-modules/src/lib/modules/templates/complaints-to-althingi-ombudsman/complaints-to-althingi-ombudsman.service.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/complaints-to-althingi-ombudsman/complaints-to-althingi-ombudsman.service.ts
@@ -39,8 +39,8 @@ export class ComplaintsToAlthingiOmbudsmanTemplateService extends BaseTemplateAp
         ['complainedForInformation.powerOfAttorney'],
         application,
       )
-    const buffer = await generateComplaintPdf(application)
     const now = new Date()
+    const buffer = await generateComplaintPdf(application, now)
     const nowString = now.toISOString().replace(/T.*$/g, '')
     const pdf: DocumentInfo = {
       content: buffer.toString('base64'),

--- a/libs/application/template-api-modules/src/lib/modules/templates/complaints-to-althingi-ombudsman/pdfGenerators/templates/complaint.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/complaints-to-althingi-ombudsman/pdfGenerators/templates/complaint.ts
@@ -10,7 +10,10 @@ import { format as formatNationalId } from 'kennitala'
 import { PdfConstants } from '../constants'
 import { YES } from '@island.is/application/core'
 
-export const generateComplaintPdf = async (application: Application) => {
+export const generateComplaintPdf = async (
+  application: Application,
+  submittedAt: Date,
+) => {
   const answers = application.answers as ComplaintsToAlthingiOmbudsmanAnswers
   const complainedFor =
     answers.complainedFor.decision === ComplainedForTypes.MYSELF
@@ -27,7 +30,7 @@ export const generateComplaintPdf = async (application: Application) => {
 
   addSubheader('Kvörtun móttekin', doc)
   addValue(
-    application.created.toISOString().substring(0, 10),
+    submittedAt.toISOString().substring(0, 10),
     doc,
     PdfConstants.NORMAL_FONT,
     PdfConstants.NORMAL_LINE_GAP,


### PR DESCRIPTION
[Zendesk ticket #496710](https://digitaliceland.zendesk.com/agent/tickets/496710)

## What

Render the "Kvörtun móttekin" date in the complaint PDF using the actual submission timestamp (`new Date()` at the moment `submitApplication` runs), instead of `application.created`.

## Why

The Ombudsman's office (Umboðsmaður Alþingis) reported receiving complaint PDFs with the wrong "Kvörtun móttekin" date, which was configured to be the application's created date which can become wrong if that application has been for long in the pipes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed the submission date displayed in complaint PDFs to accurately reflect when the complaint was submitted, rather than when it was initially created.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/island-is/island.is/pull/22588?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->