### PR TITLE
chore(j-s): Use new endpoint when updating cases created via the new method

### DIFF
--- a/apps/judicial-system/backend/src/app/modules/police/police.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/police/police.service.ts
@@ -1174,30 +1174,36 @@ export class PoliceService {
     caseConclusion: string,
     courtDocuments: PoliceDocument[],
   ): Promise<boolean> {
-    return this.fetchPoliceCaseApi(
-      `${this.xRoadPath}/V2/UpdateRVCase/${caseId}`,
-      {
-        method: 'PUT',
-        headers: {
-          accept: '*/*',
-          'Content-Type': 'application/json',
-          'X-Road-Client': this.config.clientId,
-          'X-API-KEY': this.config.policeApiKey,
-        },
-        agent: this.agent,
-        body: JSON.stringify({
-          rvMal_ID: caseId,
-          caseNumber: policeCaseNumber,
-          courtCaseNumber,
-          ssn: defendantNationalId,
-          type: caseType,
-          courtVerdict: caseState,
-          expiringDate: validToDate?.toISOString(),
-          courtVerdictString: caseConclusion,
-          courtDocuments,
-        }),
-      } as RequestInit,
-    )
+    const usesLegacyPoliceCaseUpdate = Boolean(defendantNationalId)
+    const url = usesLegacyPoliceCaseUpdate
+      ? `${this.xRoadPath}/V2/UpdateRVCase/${caseId}`
+      : `${this.xRoadPath}/V4/case/${caseId}`
+
+    const body = {
+      rvMal_ID: caseId,
+      caseNumber: policeCaseNumber,
+      courtCaseNumber,
+      ...(usesLegacyPoliceCaseUpdate
+        ? { ssn: defendantNationalId }
+        : undefined),
+      type: caseType,
+      courtVerdict: caseState,
+      expiringDate: validToDate?.toISOString(),
+      courtVerdictString: caseConclusion,
+      courtDocuments,
+    }
+
+    return this.fetchPoliceCaseApi(url, {
+      method: 'PUT',
+      headers: {
+        accept: '*/*',
+        'Content-Type': 'application/json',
+        'X-Road-Client': this.config.clientId,
+        'X-API-KEY': this.config.policeApiKey,
+      },
+      agent: this.agent,
+      body: JSON.stringify(body),
+    } as RequestInit)
       .then(async (res) => {
         if (res.ok) {
           return true

--- a/apps/judicial-system/backend/src/app/modules/police/test/updatePoliceCase.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/police/test/updatePoliceCase.spec.ts
@@ -84,14 +84,14 @@ describe('PoliceController - Update Police Case', () => {
     }
   })
 
-  describe('update police case', () => {
+  describe('update police case with defendant national id', () => {
     let then: Then
 
     beforeEach(async () => {
       then = await givenWhenThen()
     })
 
-    it('should update the police case', async () => {
+    it('should update the police case using the v2 endpoint', async () => {
       expect(fetch).toHaveBeenCalledWith(
         `${xRoadPath}/V2/UpdateRVCase/${caseId}`,
         {
@@ -108,6 +108,63 @@ describe('PoliceController - Update Police Case', () => {
             caseNumber: policeCaseNumber,
             courtCaseNumber,
             ssn: defendantNationalId,
+            type: caseType,
+            courtVerdict: caseState,
+            expiringDate: validToDate,
+            courtVerdictString: caseConclusion,
+            courtDocuments,
+          }),
+        },
+      )
+      expect(then.result).toBe(true)
+    })
+  })
+
+  describe('update police case without defendant national id', () => {
+    let then: Then
+
+    beforeEach(async () => {
+      const mockFetch = fetch as unknown as jest.Mock
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValueOnce({ ok: true }),
+      })
+
+      const { policeService } = await createTestingPoliceModule()
+
+      then = await policeService
+        .updatePoliceCase(
+          user,
+          caseId,
+          caseType,
+          caseState,
+          policeCaseNumber,
+          courtCaseNumber,
+          '',
+          validToDate,
+          caseConclusion,
+          courtDocuments,
+        )
+        .then((result) => ({ result } as Then))
+        .catch((error) => ({ error } as Then))
+    })
+
+    it('should update the police case using the v4 endpoint without ssn', async () => {
+      expect(fetch).toHaveBeenCalledWith(
+        `${xRoadPath}/V4/case/${caseId}`,
+        {
+          method: 'PUT',
+          headers: {
+            accept: '*/*',
+            'Content-Type': 'application/json',
+            'X-Road-Client': mockConfig.clientId,
+            'X-API-KEY': mockConfig.policeApiKey,
+          },
+          agent: expect.any(Agent),
+          body: JSON.stringify({
+            rvMal_ID: caseId,
+            caseNumber: policeCaseNumber,
+            courtCaseNumber,
             type: caseType,
             courtVerdict: caseState,
             expiringDate: validToDate,

--- a/apps/judicial-system/backend/src/app/modules/police/test/updatePoliceCase.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/police/test/updatePoliceCase.spec.ts
@@ -150,29 +150,26 @@ describe('PoliceController - Update Police Case', () => {
     })
 
     it('should update the police case using the v4 endpoint without ssn', async () => {
-      expect(fetch).toHaveBeenCalledWith(
-        `${xRoadPath}/V4/case/${caseId}`,
-        {
-          method: 'PUT',
-          headers: {
-            accept: '*/*',
-            'Content-Type': 'application/json',
-            'X-Road-Client': mockConfig.clientId,
-            'X-API-KEY': mockConfig.policeApiKey,
-          },
-          agent: expect.any(Agent),
-          body: JSON.stringify({
-            rvMal_ID: caseId,
-            caseNumber: policeCaseNumber,
-            courtCaseNumber,
-            type: caseType,
-            courtVerdict: caseState,
-            expiringDate: validToDate,
-            courtVerdictString: caseConclusion,
-            courtDocuments,
-          }),
+      expect(fetch).toHaveBeenCalledWith(`${xRoadPath}/V4/case/${caseId}`, {
+        method: 'PUT',
+        headers: {
+          accept: '*/*',
+          'Content-Type': 'application/json',
+          'X-Road-Client': mockConfig.clientId,
+          'X-API-KEY': mockConfig.policeApiKey,
         },
-      )
+        agent: expect.any(Agent),
+        body: JSON.stringify({
+          rvMal_ID: caseId,
+          caseNumber: policeCaseNumber,
+          courtCaseNumber,
+          type: caseType,
+          courtVerdict: caseState,
+          expiringDate: validToDate,
+          courtVerdictString: caseConclusion,
+          courtDocuments,
+        }),
+      })
       expect(then.result).toBe(true)
     })
   })


### PR DESCRIPTION
[Asana](https://app.asana.com/1/203394141643832/project/1199153462262248/task/1214924882576483?focus=true)

## What

Use new endpoint to update cases that were created using the new LOKE 3.0 window.
Cases created with the legacy window still use the old one.

## Why

With the new method we don't have a dedidcated accused SSN to send to LOKE. The old endpoint rejects updates if they don't have a valid SSN.

The new endpoint drops the SSN field so we can safely update cases.



## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved police case update to route to the appropriate backend endpoint depending on whether defendant identification is provided, ensuring correct data is sent for both legacy and current case flows.

* **Tests**
  * Expanded test coverage to verify police case updates with and without defendant identification, increasing confidence across both scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/island-is/island.is/pull/22594?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->