### PR TITLE
fix(j-s): Route to overview when opening a case already received by court as a prosecution user

### DIFF
--- a/apps/judicial-system/web/src/utils/hooks/useCaseList/index.tsx
+++ b/apps/judicial-system/web/src/utils/hooks/useCaseList/index.tsx
@@ -16,6 +16,7 @@ import {
   isDistrictCourtUser,
   isInvestigationCase,
   isPrisonSystemUser,
+  isProsecutionUser,
   isPublicProsecutionOfficeUser,
   isRequestCase,
   isRestrictionCase,
@@ -151,6 +152,13 @@ const useCaseList = () => {
             routeTo = isPrisonSystemUser(user)
               ? constants.PRISON_CLOSED_INDICTMENT_OVERVIEW_ROUTE
               : constants.CLOSED_INDICTMENT_OVERVIEW_ROUTE
+          } else if (
+            caseToOpen.state === CaseState.RECEIVED &&
+            isProsecutionUser(user)
+          ) {
+            // Prosecutor cannot edit earlier steps once the court has received
+            // the case — same rule as in useSections.
+            routeTo = constants.INDICTMENTS_OVERVIEW_ROUTE
           } else {
             routeTo = findFirstInvalidStep(
               constants.prosecutorIndictmentRoutes,


### PR DESCRIPTION
# ...

Attach a link to issue if relevant

## What

Specify what you're trying to achieve

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved routing for prosecution users when opening indictments in received state, directing them to the appropriate overview page.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/island-is/island.is/pull/22600?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->