### PR TITLE
feat(driving-license): B-temp photo selection behind feature flag

### DIFF
--- a/libs/api/domains/driving-license/src/lib/drivingLicense.service.ts
+++ b/libs/api/domains/driving-license/src/lib/drivingLicense.service.ts
@@ -497,6 +497,8 @@ export class DrivingLicenseService {
         email: input.email,
         phone: input.phone,
         auth,
+        photoBiometricsId: input.photoBiometricsId,
+        signatureBiometricsId: input.signatureBiometricsId,
       })
 
     return {

--- a/libs/api/domains/driving-license/src/lib/drivingLicense.type.ts
+++ b/libs/api/domains/driving-license/src/lib/drivingLicense.type.ts
@@ -41,6 +41,8 @@ export interface NewTemporaryDrivingLicenseInput {
   email: string
   phone: string
   sendLicenseInMail: boolean
+  photoBiometricsId?: string | null
+  signatureBiometricsId?: string | null
 }
 
 export interface NewBEDrivingLicenseContentItem {

--- a/libs/application/template-api-modules/src/lib/modules/templates/transport-authority/driving-license-submission/driving-license-submission.service.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/transport-authority/driving-license-submission/driving-license-submission.service.ts
@@ -228,13 +228,19 @@ export class DrivingLicenseSubmissionService extends BaseTemplateApiService {
       nationalId: string,
       answers: FormValue,
       auth: User,
+      photoBiometricsId?: string | null,
+      signatureBiometricsId?: string | null,
     ) => {
       await this.drivingLicenseService
         .postHealthDeclaration(
           nationalId,
-          PostTemporaryLicenseWithHealthDeclarationMapper(
-            answers as DrivingLicenseSchema,
-          ),
+          {
+            ...PostTemporaryLicenseWithHealthDeclarationMapper(
+              answers as DrivingLicenseSchema,
+            ),
+            photoBiometricsId,
+            signatureBiometricsId,
+          },
           auth.authorization.split(' ')[1] ?? '',
         )
         .catch((e) => {
@@ -403,8 +409,83 @@ export class DrivingLicenseSubmissionService extends BaseTemplateApiService {
             : DrivingLicenseCategory.BE,
       })
     } else if (applicationFor === 'B-temp') {
+      // Photo selection only applies to the redesigned B-temp flow. Gate on
+      // the *persisted* flag (captured into answers by a hidden input during
+      // prerequisites) — not on the mere presence of `selectLicensePhoto` —
+      // so a draft created while the flag was on does not keep sending
+      // biometric IDs after the flag is turned off. Flag off → both IDs stay
+      // null and the calls are identical to the pre-redesign behaviour.
+      const isBTempRedesignEnabled =
+        getValueViaPath<boolean>(answers, 'isBTempRedesignEnabled') === true
+
+      let photoBiometricsId: string | null = null
+      let signatureBiometricsId: string | null = null
+
+      if (isBTempRedesignEnabled) {
+        const selectedPhoto = getValueViaPath<string>(
+          answers,
+          'selectLicensePhoto',
+        )
+
+        if (selectedPhoto === 'qualityPhoto') {
+          // User selected the RLS quality photo — RLS already has it, so no
+          // biometric IDs are sent. Verify it actually exists for logging.
+          const qualityPhotoData = application.externalData
+            ?.qualityPhotoAndSignature?.data as {
+            pohto?: string | null
+          } | null
+
+          if (!qualityPhotoData?.pohto) {
+            this.log(
+              'error',
+              'User selected qualityPhoto but no quality photo exists in externalData',
+              {},
+            )
+          }
+
+          photoBiometricsId = null
+          signatureBiometricsId = null
+        } else if (selectedPhoto) {
+          // User selected a Thjodskra photo — validate against FACIAL entries.
+          const allThjodskraPhotos =
+            getValueViaPath<
+              Array<{ biometricId: string; contentSpecification: string }>
+            >(application.externalData, 'allPhotosFromThjodskra.data.images') ??
+            []
+
+          const facialPhotos = allThjodskraPhotos.filter(
+            (p) => p.contentSpecification === 'FACIAL',
+          )
+
+          const isValidFacial = facialPhotos.some(
+            (p) => p.biometricId === selectedPhoto,
+          )
+
+          if (!isValidFacial) {
+            this.log(
+              'error',
+              'Selected photo biometricId does not match any FACIAL Thjodskra photo',
+              { selectedPhoto },
+            )
+          }
+
+          photoBiometricsId = isValidFacial ? selectedPhoto : null
+          signatureBiometricsId = isValidFacial
+            ? allThjodskraPhotos.find(
+                (p) => p.contentSpecification === 'SIGNATURE',
+              )?.biometricId ?? null
+            : null
+        }
+      }
+
       if (needsHealthCert) {
-        await postHealthDeclaration(nationalId, answers, auth)
+        await postHealthDeclaration(
+          nationalId,
+          answers,
+          auth,
+          photoBiometricsId,
+          signatureBiometricsId,
+        )
       }
       return this.drivingLicenseService.newTemporaryDrivingLicense(
         nationalId,
@@ -419,6 +500,8 @@ export class DrivingLicenseSubmissionService extends BaseTemplateApiService {
           teacherNationalId: teacher,
           email: email,
           phone: phone,
+          photoBiometricsId,
+          signatureBiometricsId,
         },
       )
     } else if (applicationFor === 'BE') {

--- a/libs/application/template-api-modules/src/lib/modules/templates/transport-authority/driving-license-submission/driving-license-submission.service.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/transport-authority/driving-license-submission/driving-license-submission.service.ts
@@ -414,12 +414,13 @@ export class DrivingLicenseSubmissionService extends BaseTemplateApiService {
       // prerequisites) — not on the mere presence of `selectLicensePhoto` —
       // so a draft created while the flag was on does not keep sending
       // biometric IDs after the flag is turned off. Flag off → both IDs stay
-      // null and the calls are identical to the pre-redesign behaviour.
+      // `undefined`, so the keys are omitted from the RLS request bodies
+      // entirely and the calls are byte-identical to the pre-redesign flow.
       const isBTempRedesignEnabled =
         getValueViaPath<boolean>(answers, 'isBTempRedesignEnabled') === true
 
-      let photoBiometricsId: string | null = null
-      let signatureBiometricsId: string | null = null
+      let photoBiometricsId: string | null | undefined
+      let signatureBiometricsId: string | null | undefined
 
       if (isBTempRedesignEnabled) {
         const selectedPhoto = getValueViaPath<string>(

--- a/libs/application/template-api-modules/src/lib/modules/templates/transport-authority/driving-license-submission/driving-license-submission.spec.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/transport-authority/driving-license-submission/driving-license-submission.spec.ts
@@ -405,4 +405,208 @@ describe('DrivingLicenseSubmissionService', () => {
       expect(applyForRenewal65).toHaveBeenCalledTimes(1)
     })
   })
+
+  describe('B-temp redesign branch', () => {
+    let service: DrivingLicenseSubmissionService
+    let newTemporaryDrivingLicense: jest.Mock
+    let postHealthDeclaration: jest.Mock
+
+    const baseAnswers = {
+      applicationFor: 'B-temp',
+      email: 'mock@email.com',
+      phone: '9999999',
+      delivery: {
+        deliveryMethod: 'post',
+        jurisdiction: '37',
+      },
+    }
+
+    const thjodskraExternalData = {
+      allPhotosFromThjodskra: {
+        data: {
+          images: [
+            { biometricId: 'facial-1', contentSpecification: 'FACIAL' },
+            { biometricId: 'sig-1', contentSpecification: 'SIGNATURE' },
+          ],
+        },
+        status: 'success' as const,
+        date: new Date(),
+      },
+    }
+
+    beforeEach(async () => {
+      newTemporaryDrivingLicense = jest.fn(async () => ({
+        success: true,
+        errorMessage: null,
+      }))
+      postHealthDeclaration = jest.fn(async () => undefined)
+
+      const module = await Test.createTestingModule({
+        imports: [
+          ConfigModule.forRoot({
+            isGlobal: true,
+            load: [emailModuleConfig],
+          }),
+        ],
+        providers: [
+          DrivingLicenseSubmissionService,
+          EmailService,
+          AdapterService,
+          {
+            provide: DrivingLicenseService,
+            useValue: { newTemporaryDrivingLicense, postHealthDeclaration },
+          },
+          { provide: LOGGER_PROVIDER, useValue: logger },
+          {
+            provide: ConfigService,
+            useClass: jest.fn(() => ({ get: () => 'http://localhost' })),
+          },
+          {
+            provide: AttachmentS3Service,
+            useValue: { getFiles: jest.fn(async () => []) },
+          },
+          {
+            provide: SharedTemplateApiService,
+            useClass: jest.fn(() => ({
+              async getPaymentStatus() {
+                return { fulfilled: true }
+              },
+              async sendEmail() {
+                return 'messageId'
+              },
+            })),
+          },
+        ],
+      }).compile()
+
+      service = module.get(DrivingLicenseSubmissionService)
+    })
+
+    it('passes no biometric IDs when the persisted flag is off, even if selectLicensePhoto is set', async () => {
+      const user = createCurrentUser()
+      const application = createApplication({
+        answers: {
+          ...baseAnswers,
+          isBTempRedesignEnabled: false,
+          selectLicensePhoto: 'facial-1',
+        },
+        externalData: thjodskraExternalData,
+        typeId: ApplicationTypes.DRIVING_LICENSE,
+        status: ApplicationStatus.IN_PROGRESS,
+      })
+
+      const res = await service.submitApplication({
+        application,
+        auth: user,
+        currentUserLocale: 'is',
+      })
+
+      expect(res).toEqual({ success: true })
+      expect(newTemporaryDrivingLicense).toHaveBeenCalledTimes(1)
+
+      const [, , input] = newTemporaryDrivingLicense.mock.calls[0]
+      expect(input).toMatchObject({
+        photoBiometricsId: null,
+        signatureBiometricsId: null,
+      })
+    })
+
+    it('resolves photo and signature biometric IDs when a Thjodskra photo is selected', async () => {
+      const user = createCurrentUser()
+      const application = createApplication({
+        answers: {
+          ...baseAnswers,
+          isBTempRedesignEnabled: true,
+          selectLicensePhoto: 'facial-1',
+        },
+        externalData: thjodskraExternalData,
+        typeId: ApplicationTypes.DRIVING_LICENSE,
+        status: ApplicationStatus.IN_PROGRESS,
+      })
+
+      const res = await service.submitApplication({
+        application,
+        auth: user,
+        currentUserLocale: 'is',
+      })
+
+      expect(res).toEqual({ success: true })
+      const [, , input] = newTemporaryDrivingLicense.mock.calls[0]
+      expect(input).toMatchObject({
+        photoBiometricsId: 'facial-1',
+        signatureBiometricsId: 'sig-1',
+      })
+    })
+
+    it('sends null biometric IDs when the RLS quality photo is selected', async () => {
+      const user = createCurrentUser()
+      const application = createApplication({
+        answers: {
+          ...baseAnswers,
+          isBTempRedesignEnabled: true,
+          selectLicensePhoto: 'qualityPhoto',
+        },
+        externalData: {
+          qualityPhotoAndSignature: {
+            data: { pohto: 'somebase64' },
+            status: 'success',
+            date: new Date(),
+          },
+        },
+        typeId: ApplicationTypes.DRIVING_LICENSE,
+        status: ApplicationStatus.IN_PROGRESS,
+      })
+
+      const res = await service.submitApplication({
+        application,
+        auth: user,
+        currentUserLocale: 'is',
+      })
+
+      expect(res).toEqual({ success: true })
+      const [, , input] = newTemporaryDrivingLicense.mock.calls[0]
+      expect(input).toMatchObject({
+        photoBiometricsId: null,
+        signatureBiometricsId: null,
+      })
+      expect(postHealthDeclaration).not.toHaveBeenCalled()
+    })
+
+    it('carries biometric IDs on both postHealthDeclaration and newTemporaryDrivingLicense when a health certificate is needed', async () => {
+      const user = createCurrentUser()
+      const application = createApplication({
+        answers: {
+          ...baseAnswers,
+          isBTempRedesignEnabled: true,
+          selectLicensePhoto: 'facial-1',
+          healthDeclaration: { hasEpilepsy: 'yes' },
+        },
+        externalData: thjodskraExternalData,
+        typeId: ApplicationTypes.DRIVING_LICENSE,
+        status: ApplicationStatus.IN_PROGRESS,
+      })
+
+      const res = await service.submitApplication({
+        application,
+        auth: user,
+        currentUserLocale: 'is',
+      })
+
+      expect(res).toEqual({ success: true })
+
+      expect(postHealthDeclaration).toHaveBeenCalledTimes(1)
+      const [, healthModel] = postHealthDeclaration.mock.calls[0]
+      expect(healthModel).toMatchObject({
+        photoBiometricsId: 'facial-1',
+        signatureBiometricsId: 'sig-1',
+      })
+
+      expect(newTemporaryDrivingLicense).toHaveBeenCalledTimes(1)
+      const [, , input] = newTemporaryDrivingLicense.mock.calls[0]
+      expect(input).toMatchObject({
+        photoBiometricsId: 'facial-1',
+        signatureBiometricsId: 'sig-1',
+      })
+    })
+  })
 })

--- a/libs/application/template-api-modules/src/lib/modules/templates/transport-authority/driving-license-submission/driving-license-submission.spec.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/transport-authority/driving-license-submission/driving-license-submission.spec.ts
@@ -504,11 +504,11 @@ describe('DrivingLicenseSubmissionService', () => {
       expect(res).toEqual({ success: true })
       expect(newTemporaryDrivingLicense).toHaveBeenCalledTimes(1)
 
+      // Flag off → biometric IDs are omitted entirely (not sent as null),
+      // keeping the RLS request byte-identical to the pre-redesign flow.
       const [, , input] = newTemporaryDrivingLicense.mock.calls[0]
-      expect(input).toMatchObject({
-        photoBiometricsId: null,
-        signatureBiometricsId: null,
-      })
+      expect(input.photoBiometricsId).toBeUndefined()
+      expect(input.signatureBiometricsId).toBeUndefined()
     })
 
     it('resolves photo and signature biometric IDs when a Thjodskra photo is selected', async () => {

--- a/libs/application/templates/driving-license/src/fields/EligibilitySummary/EligibilitySummary.tsx
+++ b/libs/application/templates/driving-license/src/fields/EligibilitySummary/EligibilitySummary.tsx
@@ -12,21 +12,22 @@ export const EligibilitySummary: FC<
 > = ({ application }) => {
   const { setValue, watch } = useFormContext()
 
-  // The redesign flag is written by a hidden input on this same screen
+  // The redesign flags are written by hidden inputs on this same screen
   // (sectionRequirements.ts), so `application.answers` is still stale on
   // first render. Read live form state first, fall back to answers for
   // returning visits after the value has been persisted.
-  const flagFromForm = watch('is65RenewalRedesignEnabled')
-  const flagFromAnswers = getValueViaPath(
-    application.answers,
-    'is65RenewalRedesignEnabled',
-  )
   const is65RenewalRedesignEnabled =
-    flagFromForm === true || flagFromAnswers === true
+    watch('is65RenewalRedesignEnabled') === true ||
+    getValueViaPath(application.answers, 'is65RenewalRedesignEnabled') === true
+
+  const isBTempRedesignEnabled =
+    watch('isBTempRedesignEnabled') === true ||
+    getValueViaPath(application.answers, 'isBTempRedesignEnabled') === true
 
   const { eligibility, loading, error } = useEligibility(
     application,
     is65RenewalRedesignEnabled,
+    isBTempRedesignEnabled,
   )
 
   useEffect(() => {

--- a/libs/application/templates/driving-license/src/fields/EligibilitySummary/fakeEligibility.spec.ts
+++ b/libs/application/templates/driving-license/src/fields/EligibilitySummary/fakeEligibility.spec.ts
@@ -1,0 +1,34 @@
+import { RequirementKey } from '@island.is/api/schema'
+import { fakeEligibility } from './fakeEligibility'
+import { B_TEMP } from '../../lib/constants'
+
+describe('fakeEligibility — B-temp redesign photo gate', () => {
+  it('blocks eligibility and reports an unmet photo requirement when the flag is on and no photo exists', () => {
+    const result = fakeEligibility(B_TEMP, 365, false, false, true)
+
+    expect(result.isEligible).toBe(false)
+    expect(result.requirements).toContainEqual({
+      key: RequirementKey.hasNoPhoto,
+      requirementMet: false,
+    })
+  })
+
+  it('allows eligibility and reports a met photo requirement when the flag is on and a photo exists', () => {
+    const result = fakeEligibility(B_TEMP, 365, true, false, true)
+
+    expect(result.isEligible).toBe(true)
+    expect(result.requirements).toContainEqual({
+      key: RequirementKey.hasNoPhoto,
+      requirementMet: true,
+    })
+  })
+
+  it('does not gate on a photo when the B-temp redesign flag is off', () => {
+    const result = fakeEligibility(B_TEMP, 365, false, false, false)
+
+    expect(result.isEligible).toBe(true)
+    expect(
+      result.requirements.some((r) => r.key === RequirementKey.hasNoPhoto),
+    ).toBe(false)
+  })
+})

--- a/libs/application/templates/driving-license/src/fields/EligibilitySummary/fakeEligibility.ts
+++ b/libs/application/templates/driving-license/src/fields/EligibilitySummary/fakeEligibility.ts
@@ -2,6 +2,7 @@ import { ApplicationEligibility, RequirementKey } from '@island.is/api/schema'
 import {
   B_FULL,
   B_FULL_RENEWAL_65,
+  B_TEMP,
   BE,
   DrivingLicenseApplicationFor,
 } from '../../lib/constants'
@@ -11,10 +12,12 @@ export const fakeEligibility = (
   daysOfResidency = 365,
   hasPhoto = true,
   is65RenewalRedesignEnabled = false,
+  isBTempRedesignEnabled = false,
 ): ApplicationEligibility => {
   const usesPhotoGate =
     applicationFor === BE ||
-    (applicationFor === B_FULL_RENEWAL_65 && is65RenewalRedesignEnabled)
+    (applicationFor === B_FULL_RENEWAL_65 && is65RenewalRedesignEnabled) ||
+    (applicationFor === B_TEMP && isBTempRedesignEnabled)
 
   return {
     isEligible: usesPhotoGate ? hasPhoto : true,

--- a/libs/application/templates/driving-license/src/fields/EligibilitySummary/useEligibility.ts
+++ b/libs/application/templates/driving-license/src/fields/EligibilitySummary/useEligibility.ts
@@ -9,6 +9,7 @@ import { useQuery, gql } from '@apollo/client'
 import {
   B_FULL,
   B_FULL_RENEWAL_65,
+  B_TEMP,
   BE,
   codesExtendedLicenseCategories,
   DrivingLicenseApplicationFor,
@@ -40,6 +41,7 @@ export interface UseEligibilityResult {
 export const useEligibility = (
   application: Application,
   is65RenewalRedesignEnabled: boolean,
+  isBTempRedesignEnabled: boolean,
 ): UseEligibilityResult => {
   const fakeData = getValueViaPath<DrivingLicenseFakeData>(
     application.answers,
@@ -89,7 +91,8 @@ export const useEligibility = (
 
   const usesNewPhotoSelector =
     applicationFor === BE ||
-    (applicationFor === B_FULL_RENEWAL_65 && is65RenewalRedesignEnabled)
+    (applicationFor === B_FULL_RENEWAL_65 && is65RenewalRedesignEnabled) ||
+    (applicationFor === B_TEMP && isBTempRedesignEnabled)
 
   if (usingFakeData) {
     let hasPhoto: boolean
@@ -123,6 +126,7 @@ export const useEligibility = (
         parseInt(fakeData?.howManyDaysHaveYouLivedInIceland.toString(), 10),
         hasPhoto,
         is65RenewalRedesignEnabled,
+        isBTempRedesignEnabled,
       ),
     }
   }
@@ -222,6 +226,27 @@ export const useEligibility = (
             !hasAnyInvalidRemarks &&
             hasUsablePhoto,
         requirements,
+      },
+    }
+  }
+
+  if (application.answers.applicationFor === B_TEMP && isBTempRedesignEnabled) {
+    const hasUsablePhoto = computeUsablePhoto()
+
+    return {
+      loading: loading,
+      eligibility: {
+        isEligible: loading
+          ? undefined
+          : (data.drivingLicenseApplicationEligibility?.isEligible ?? false) &&
+            hasUsablePhoto,
+        requirements: [
+          ...eligibility,
+          {
+            key: RequirementKey.hasNoPhoto,
+            requirementMet: hasUsablePhoto,
+          },
+        ],
       },
     }
   }

--- a/libs/application/templates/driving-license/src/forms/draft/getForm.ts
+++ b/libs/application/templates/driving-license/src/forms/draft/getForm.ts
@@ -8,6 +8,7 @@ import { subSectionOtherCountryDirections } from './subSectionOtherCountryDirect
 import { subSectionQualityPhoto } from './subSectionQualityPhoto'
 import { subSectionQualityPhoto65 } from './subSectionQualityPhoto65'
 import { subSectionQualityPhotoBE } from './subSectionQualityPhotoBE'
+import { subSectionQualityPhotoTemp } from './subSectionQualityPhotoTemp'
 import { subSectionDelivery } from './subSectionDelivery'
 import { subSectionHealthDeclaration } from './subSectionHealthDeclaration'
 import { subSectionSummary } from './subSectionSummary'
@@ -34,6 +35,7 @@ export const draft: Form = buildForm({
         subSectionQualityPhoto,
         subSectionQualityPhoto65,
         subSectionQualityPhotoBE,
+        subSectionQualityPhotoTemp,
         subSectionDelivery,
         subSectionHealthDeclaration,
         subSectionSummary,

--- a/libs/application/templates/driving-license/src/forms/draft/subSectionQualityPhotoTemp.ts
+++ b/libs/application/templates/driving-license/src/forms/draft/subSectionQualityPhotoTemp.ts
@@ -1,0 +1,139 @@
+import {
+  buildAlertMessageField,
+  buildDescriptionField,
+  buildMultiField,
+  buildRadioField,
+  buildSubSection,
+  getValueViaPath,
+} from '@island.is/application/core'
+import { Application } from '@island.is/application/types'
+import { requirementsMessages, m } from '../../lib/messages'
+import { B_TEMP } from '../../lib/constants'
+import {
+  hasNoDrivingLicenseInOtherCountry,
+  hasUsableRlsQualityPhoto,
+  isVisible,
+} from '../../lib/utils'
+import { createPhotoComponent } from '../../fields/CreatePhoto'
+
+interface ThjodskraImage {
+  biometricId: string
+  content: string
+  contentSpecification: string
+}
+
+export const subSectionQualityPhotoTemp = buildSubSection({
+  id: 'photoStepTemp',
+  title: m.photoSelectionTitle,
+  condition: isVisible(
+    (answers) => answers.applicationFor === B_TEMP,
+    (answers) => getValueViaPath(answers, 'isBTempRedesignEnabled') === true,
+    hasNoDrivingLicenseInOtherCountry,
+  ),
+  children: [
+    buildMultiField({
+      id: 'selectPhoto',
+      title: m.photoSelectionTitle,
+      description: m.photoSelectionDescription,
+      children: [
+        buildAlertMessageField({
+          id: 'noUsablePhotoAlert',
+          title: requirementsMessages.beLicenseQualityPhotoTitle,
+          message: requirementsMessages.beLicenseQualityPhotoDescription,
+          alertType: 'warning',
+          condition: (_answers, externalData) => {
+            const thjodskraPhotos =
+              getValueViaPath<ThjodskraImage[]>(
+                externalData,
+                'allPhotosFromThjodskra.data.images',
+              ) ?? []
+            const hasThjodskraFacial = thjodskraPhotos.some(
+              (p) => p.contentSpecification === 'FACIAL',
+            )
+
+            return (
+              !hasThjodskraFacial && !hasUsableRlsQualityPhoto(externalData)
+            )
+          },
+        }),
+        buildRadioField({
+          id: 'selectLicensePhoto',
+          title: '',
+          disabled: false,
+          defaultValue: (application: Application) => {
+            const { externalData } = application
+
+            const thjodskraPhotos =
+              getValueViaPath<ThjodskraImage[]>(
+                externalData,
+                'allPhotosFromThjodskra.data.images',
+              ) ?? []
+
+            const facialPhotos = thjodskraPhotos.filter(
+              (p) => p.contentSpecification === 'FACIAL',
+            )
+
+            if (facialPhotos.length > 0) {
+              return facialPhotos[0].biometricId
+            }
+
+            if (hasUsableRlsQualityPhoto(externalData)) {
+              return 'qualityPhoto'
+            }
+
+            return undefined
+          },
+          options: ({ externalData }) => {
+            const options: Array<{
+              value: string
+              label: typeof m.usePassportImage
+              illustration?: ReturnType<typeof createPhotoComponent>
+            }> = []
+
+            // Thjodskra facial photos
+            const thjodskraPhotos =
+              getValueViaPath<ThjodskraImage[]>(
+                externalData,
+                'allPhotosFromThjodskra.data.images',
+              ) ?? []
+
+            const facialPhotos = thjodskraPhotos.filter(
+              (p) => p.contentSpecification === 'FACIAL',
+            )
+
+            for (const photo of facialPhotos) {
+              options.push({
+                value: photo.biometricId,
+                label: m.usePassportImage,
+                illustration: createPhotoComponent(photo.content),
+              })
+            }
+
+            // Quality photo from getqualityphotoandsignature. The binary
+            // (`pohto`) may be null for legacy records — createPhotoComponent
+            // falls back to a placeholder, and submission resolves the photo
+            // by reference, so offer the option whenever a record exists.
+            if (hasUsableRlsQualityPhoto(externalData)) {
+              const photoAndSig = getValueViaPath<{ pohto?: string | null }>(
+                externalData,
+                'qualityPhotoAndSignature.data',
+              )
+              options.push({
+                value: 'qualityPhoto',
+                label: m.useDriversLicenseImage,
+                illustration: createPhotoComponent(
+                  photoAndSig?.pohto ?? undefined,
+                ),
+              })
+            }
+
+            return options
+          },
+        }),
+        buildDescriptionField({
+          id: 'photoDescription',
+        }),
+      ],
+    }),
+  ],
+})

--- a/libs/application/templates/driving-license/src/forms/prerequisites/getForm.ts
+++ b/libs/application/templates/driving-license/src/forms/prerequisites/getForm.ts
@@ -15,6 +15,7 @@ interface DrivingLicenseFormConfig {
   allowBELicense?: boolean
   allow65Renewal?: boolean
   allow65RenewalRedesign?: boolean
+  allowBTempRedesign?: boolean
   allowAdvanced?: boolean
 }
 
@@ -24,6 +25,7 @@ export const getForm = ({
   allowBELicense = false,
   allow65Renewal = false,
   allow65RenewalRedesign = false,
+  allowBTempRedesign = false,
   allowAdvanced = false,
 }: DrivingLicenseFormConfig): Form =>
   buildForm({
@@ -50,7 +52,7 @@ export const getForm = ({
               ]
             : []),
           ...(allowAdvanced ? [sectionAdvancedLicenseSelection] : []),
-          sectionRequirements(allow65RenewalRedesign),
+          sectionRequirements(allow65RenewalRedesign, allowBTempRedesign),
         ],
       }),
       buildSection({

--- a/libs/application/templates/driving-license/src/forms/prerequisites/sectionApplicationFor.ts
+++ b/libs/application/templates/driving-license/src/forms/prerequisites/sectionApplicationFor.ts
@@ -56,7 +56,12 @@ export const sectionApplicationFor = (
               )
 
               if (fakeData?.useFakeData === 'yes') {
-                currentLicense = fakeData.currentLicense ?? null
+                // 'none' must stay falsy — it is a string, so it would
+                // otherwise read as "has a license" and disable B-temp.
+                currentLicense =
+                  fakeData.currentLicense && fakeData.currentLicense !== 'none'
+                    ? fakeData.currentLicense
+                    : null
                 categories =
                   fakeData.currentLicense === 'temp'
                     ? [{ nr: 'B', validToCode: 8 }]

--- a/libs/application/templates/driving-license/src/forms/prerequisites/sectionFakeData.ts
+++ b/libs/application/templates/driving-license/src/forms/prerequisites/sectionFakeData.ts
@@ -126,7 +126,7 @@ export const sectionFakeData = buildSubSection({
         }),
         buildRadioField({
           id: 'fakeData.hasThjodskraPhoto',
-          title: 'BE / 65+ endurnýjun: Mynd úr Þjóðskrá?',
+          title: 'BE / B-temp / 65+ endurnýjun: Mynd úr Þjóðskrá?',
           width: 'half',
           condition: allowFakeCondition(YES),
           defaultValue: 'real',
@@ -147,7 +147,8 @@ export const sectionFakeData = buildSubSection({
         }),
         buildRadioField({
           id: 'fakeData.hasRLSPhoto',
-          title: 'BE / 65+ endurnýjun: Gæðamynd úr ökuskírteinaskrá (RLS)?',
+          title:
+            'BE / B-temp / 65+ endurnýjun: Gæðamynd úr ökuskírteinaskrá (RLS)?',
           width: 'half',
           condition: allowFakeCondition(YES),
           defaultValue: 'real',

--- a/libs/application/templates/driving-license/src/forms/prerequisites/sectionFakeData.ts
+++ b/libs/application/templates/driving-license/src/forms/prerequisites/sectionFakeData.ts
@@ -75,7 +75,7 @@ export const sectionFakeData = buildSubSection({
           condition: allowFakeCondition(YES),
           options: [
             {
-              value: 'student',
+              value: 'none',
               label: 'Engin',
             },
             {

--- a/libs/application/templates/driving-license/src/forms/prerequisites/sectionRequirements.ts
+++ b/libs/application/templates/driving-license/src/forms/prerequisites/sectionRequirements.ts
@@ -9,7 +9,10 @@ import {
 import { DefaultEvents } from '@island.is/application/types'
 import { m } from '../../lib/messages'
 
-export const sectionRequirements = (allow65RenewalRedesign = false) =>
+export const sectionRequirements = (
+  allow65RenewalRedesign = false,
+  allowBTempRedesign = false,
+) =>
   buildSubSection({
     id: 'requirements',
     title: m.applicationEligibilityTitle,
@@ -22,6 +25,10 @@ export const sectionRequirements = (allow65RenewalRedesign = false) =>
           buildHiddenInput({
             id: 'is65RenewalRedesignEnabled',
             defaultValue: () => allow65RenewalRedesign,
+          }),
+          buildHiddenInput({
+            id: 'isBTempRedesignEnabled',
+            defaultValue: () => allowBTempRedesign,
           }),
           buildCustomField({
             title: m.eligibilityRequirementTitle,

--- a/libs/application/templates/driving-license/src/lib/dataSchema.ts
+++ b/libs/application/templates/driving-license/src/lib/dataSchema.ts
@@ -94,4 +94,8 @@ export const dataSchema = z.object({
   // tried first but fired prematurely at the prerequisites→draft transition,
   // before the user had reached the upload screen, blocking advance.
   is65RenewalRedesignEnabled: z.boolean().optional(),
+  // Captured into answers via a hidden input during prerequisites so the
+  // B-temp photo selector / eligibility gating and the submission service can
+  // branch on the redesign flag. Same mechanism as is65RenewalRedesignEnabled.
+  isBTempRedesignEnabled: z.boolean().optional(),
 })

--- a/libs/application/templates/driving-license/src/lib/drivingLicenseTemplate.ts
+++ b/libs/application/templates/driving-license/src/lib/drivingLicenseTemplate.ts
@@ -114,6 +114,10 @@ const DrivingLicenseTemplate: ApplicationTemplate<
                     featureFlags[
                       DrivingLicenseFeatureFlags.ALLOW_65_RENEWAL_REDESIGN
                     ],
+                  allowBTempRedesign:
+                    featureFlags[
+                      DrivingLicenseFeatureFlags.ALLOW_B_TEMP_REDESIGN
+                    ],
                   allowAdvanced:
                     featureFlags[DrivingLicenseFeatureFlags.ALLOW_ADVANCED],
                 })

--- a/libs/application/templates/driving-license/src/lib/getApplicationFeatureFlags.ts
+++ b/libs/application/templates/driving-license/src/lib/getApplicationFeatureFlags.ts
@@ -6,6 +6,7 @@ export enum DrivingLicenseFeatureFlags {
   ALLOW_BE_LICENSE = 'isBEApplicationEnabled',
   ALLOW_65_RENEWAL = 'is65RenewalApplicationEnabled',
   ALLOW_65_RENEWAL_REDESIGN = 'is65RenewalRedesignEnabled',
+  ALLOW_B_TEMP_REDESIGN = 'isBTempRedesignEnabled',
   ALLOW_ADVANCED = 'isDrivingLicenseAdvancedEnabled',
 }
 
@@ -18,6 +19,7 @@ export const getApplicationFeatureFlags = async (
     DrivingLicenseFeatureFlags.ALLOW_BE_LICENSE,
     DrivingLicenseFeatureFlags.ALLOW_65_RENEWAL,
     DrivingLicenseFeatureFlags.ALLOW_65_RENEWAL_REDESIGN,
+    DrivingLicenseFeatureFlags.ALLOW_B_TEMP_REDESIGN,
     DrivingLicenseFeatureFlags.ALLOW_ADVANCED,
   ]
 

--- a/libs/clients/driving-license/src/lib/drivingLicenseApi.service.ts
+++ b/libs/clients/driving-license/src/lib/drivingLicenseApi.service.ts
@@ -435,6 +435,8 @@ export class DrivingLicenseApi {
     email: string
     phone: string
     auth: string
+    photoBiometricsId?: string | null
+    signatureBiometricsId?: string | null
   }) {
     try {
       const response =
@@ -450,6 +452,8 @@ export class DrivingLicenseApi {
             email: params.email,
             gsm: params.phone,
             authority: params.jurisdictionId,
+            photoBiometricsId: params.photoBiometricsId,
+            signatureBiometricsId: params.signatureBiometricsId,
           },
         })
       if (!response.result) {

--- a/libs/clients/driving-license/src/v5/clientConfig.json
+++ b/libs/clients/driving-license/src/v5/clientConfig.json
@@ -114,6 +114,16 @@
             "schema": { "type": "string", "default": "5.0" }
           }
         ],
+        "requestBody": {
+          "description": "Optional confirmation model with additional data",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Models.V5.ConfirmBEApplicationModel"
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK",
@@ -4548,12 +4558,14 @@
         "description": "Dto for image and signature data"
       },
       "Dto.V5.ImageDto": {
+        "required": ["dateRegistered", "image", "socialSecurityNumber"],
         "type": "object",
         "properties": {
           "id": {
             "type": "integer",
             "description": "Picture id",
-            "format": "int32"
+            "format": "int32",
+            "nullable": true
           },
           "socialSecurityNumber": {
             "type": "string",
@@ -4574,17 +4586,20 @@
           "quality": {
             "type": "integer",
             "description": "Quality",
-            "format": "int32"
+            "format": "int32",
+            "nullable": true
           },
           "program": {
             "type": "integer",
             "description": "Belongs to what program",
-            "format": "int32"
+            "format": "int32",
+            "nullable": true
           },
           "type": {
             "type": "integer",
             "description": "Type of image",
-            "format": "int32"
+            "format": "int32",
+            "nullable": true
           }
         },
         "additionalProperties": false,
@@ -4822,20 +4837,51 @@
       "Dto.V5.PenaltyPointDetailDto": {
         "type": "object",
         "properties": {
-          "caseNr": { "type": "string", "nullable": true },
-          "ssn": { "type": "string", "nullable": true },
+          "caseNr": {
+            "type": "string",
+            "description": "Case number",
+            "nullable": true
+          },
+          "ssn": {
+            "type": "string",
+            "description": "Social security number of the offender",
+            "nullable": true
+          },
           "offenseDate": {
             "type": "string",
+            "description": "Date the offense was committed",
             "format": "date-time",
             "nullable": true
           },
-          "penalty": { "type": "string", "nullable": true },
-          "penaltyStatus": { "type": "string", "nullable": true },
-          "points": { "type": "integer", "format": "int32", "nullable": true },
-          "districtName": { "type": "string", "nullable": true },
-          "statusCode": { "type": "string", "nullable": true }
+          "penalty": {
+            "type": "string",
+            "description": "Penalty description",
+            "nullable": true
+          },
+          "penaltyStatus": {
+            "type": "string",
+            "description": "Current status of the penalty",
+            "nullable": true
+          },
+          "points": {
+            "type": "integer",
+            "description": "Number of penalty points",
+            "format": "int32",
+            "nullable": true
+          },
+          "districtName": {
+            "type": "string",
+            "description": "Name of the district that issued the penalty",
+            "nullable": true
+          },
+          "statusCode": {
+            "type": "string",
+            "description": "Status code",
+            "nullable": true
+          }
         },
-        "additionalProperties": false
+        "additionalProperties": false,
+        "description": "Penalty point detail entry"
       },
       "Dto.V5.PenaltyPointsDto": {
         "required": ["ok"],
@@ -5022,6 +5068,19 @@
         },
         "additionalProperties": false,
         "description": "Health declaration when applying for driver's license"
+      },
+      "Models.V5.ConfirmBEApplicationModel": {
+        "type": "object",
+        "properties": {
+          "testFinished": {
+            "type": "string",
+            "description": "Date the BE driving test was completed (date only, e.g. \"2025-03-15\")",
+            "format": "date",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Request model for confirming a BE license application is finished"
       },
       "Models.V5.LicenseProductionErrorMsgModel": {
         "type": "object",
@@ -5432,6 +5491,16 @@
             "type": "string",
             "description": "Applicant mobile number",
             "nullable": true
+          },
+          "photoBiometricsId": {
+            "type": "string",
+            "description": "Biometrics ID for photo from temporary image store",
+            "nullable": true
+          },
+          "signatureBiometricsId": {
+            "type": "string",
+            "description": "Biometrics ID for signature from temporary image store",
+            "nullable": true
           }
         },
         "additionalProperties": false,
@@ -5489,6 +5558,16 @@
           },
           "healthDeclaration": {
             "$ref": "#/components/schemas/Models.HealthDeclarationModel"
+          },
+          "photoBiometricsId": {
+            "type": "string",
+            "description": "Biometrics ID for photo from temporary image store",
+            "nullable": true
+          },
+          "signatureBiometricsId": {
+            "type": "string",
+            "description": "Biometrics ID for signature from temporary image store",
+            "nullable": true
           }
         },
         "additionalProperties": false,


### PR DESCRIPTION
## What

Adds the redesigned photo flow to the **B-temp** (Bráðabirgðaskírteini — first temporary licence) driving-licence application, gated behind a new `isBTempRedesignEnabled` feature flag. With the flag on:

- **Photo selector** in the draft form — choose a Þjóðskrá passport photo or an RLS quality photo instead of bringing a physical photo (mirrors the BE / 65+ redesign).
- **Eligibility-check photo gating** — when no usable photo exists the applicant is blocked on the requirements step with the "Gæðavottuð mynd" alert.
- The chosen photo is submitted to RLS via the new `photoBiometricsId` / `signatureBiometricsId` fields on the v5 temporary-licence models, carried on both the `postHealthDeclaration` and `newTemporaryDrivingLicense` calls.

With the flag off, the B-temp flow is unchanged from today.

Also included:

- v5 OpenAPI client sync (`clientConfig.json`) for the new biometric fields.
- Fix for a pre-existing fake-data bug where the "Engin" (no licence) option emitted a truthy string and disabled the B-temp choice.

### Out of scope — follow-up

The health-certificate **file upload** (part of the BE/65+ redesign) is **not** included. The RLS temporary-licence models have no `contentList` field, so an uploaded file cannot be delivered to RLS. This needs a backend change (add `contentList` to the temporary models); until then B-temp keeps today's health flow (questions + "bring along" checkbox).

### Action required before enabling

The `isBTempRedesignEnabled` flag must be created in ConfigCat. It defaults to `false`, so this PR is inert until the flag exists and is turned on.

## Why

Brings the B-temp flow in line with the BE and 65+ redesigns — letting first-time applicants pick an existing digital photo rather than bringing a physical passport photo to the district office.

## Screenshots / Gifs

N/A — gated behind `isBTempRedesignEnabled` (off by default).

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added biometric photo submission capability for temporary driving license applications.
  * Introduced photo selection interface allowing users to choose from Thjodskra facial photos or quality photo options when applying for temporary licenses.
  * Added photo requirement validation for temporary license applications, ensuring users have usable photos available before proceeding.

* **Chores**
  * Updated API configuration to support biometric identifiers in temporary license requests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/island-is/island.is/pull/22607?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->