### PR TITLE
fix(j-s): disable redundant singleExpand on court record accordion

### DIFF
--- a/apps/judicial-system/web/src/routes/Court/Indictments/CourtRecord/CourtRecord.tsx
+++ b/apps/judicial-system/web/src/routes/Court/Indictments/CourtRecord/CourtRecord.tsx
@@ -86,7 +86,7 @@ const CourtRecord: FC = () => {
         <CourtCaseInfo workingCase={workingCase} />
         {workingCase.withCourtSessions ? (
           <>
-            <Accordion dividerOnTop={false} singleExpand>
+            <Accordion dividerOnTop={false} singleExpand={false}>
               {workingCase.courtSessions?.map((courtSession, index) => (
                 <CourtSessionAccordionItem
                   key={courtSession.id}


### PR DESCRIPTION
## What

Disable the `singleExpand` prop on the `Accordion` in the court record view for indictment cases.

## Why

The `Accordion` component's internal `singleExpand` context manages its own collapsed/expanded state. When `CourtRecord` also controls expansion via `expandedIndex` state and passes `expanded`/`onToggle` props to each `CourtSessionAccordionItem`, the two mechanisms conflict — the icon ends up one step out of sync with the actual expanded state.

Since `CourtRecord` already enforces single-expand behaviour through its own `expandedIndex` state, the `singleExpand` context inside `Accordion` is redundant and causes the bug.

## Screenshots / Gifs

N/A — icon toggle sync fix, no visual layout change.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Court sessions in records can now be expanded multiple at once, allowing easier navigation between sessions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/island-is/island.is/pull/22614?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->