### PR TITLE
chore(j-s): remove unused TINY_MCE_API_KEY secret from web infra

### DIFF
--- a/apps/judicial-system/web/infra/judicial-system-web.ts
+++ b/apps/judicial-system/web/infra/judicial-system-web.ts
@@ -19,7 +19,6 @@ export const serviceSetup = (services: {
         '/k8s/judicial-system/NATIONAL_REGISTRY_API_KEY',
       LAWYERS_ICELAND_API_KEY: '/k8s/judicial-system/LAWYERS_ICELAND_API_KEY',
       SUPPORT_EMAIL: '/k8s/judicial-system/SUPPORT_EMAIL',
-      TINY_MCE_API_KEY: '/k8s/judicial-system/TINY_MCE_API_KEY',
     })
     .liveness('/liveness')
     .readiness({ path: '/readiness', timeoutSeconds: 10 })

--- a/charts/judicial-system-services/judicial-system-web/values.dev.yaml
+++ b/charts/judicial-system-services/judicial-system-web/values.dev.yaml
@@ -89,7 +89,6 @@ secrets:
   LAWYERS_ICELAND_API_KEY: '/k8s/judicial-system/LAWYERS_ICELAND_API_KEY'
   NATIONAL_REGISTRY_API_KEY: '/k8s/judicial-system/NATIONAL_REGISTRY_API_KEY'
   SUPPORT_EMAIL: '/k8s/judicial-system/SUPPORT_EMAIL'
-  TINY_MCE_API_KEY: '/k8s/judicial-system/TINY_MCE_API_KEY'
 securityContext:
   allowPrivilegeEscalation: false
   privileged: false

--- a/charts/judicial-system-services/judicial-system-web/values.prod.yaml
+++ b/charts/judicial-system-services/judicial-system-web/values.prod.yaml
@@ -89,7 +89,6 @@ secrets:
   LAWYERS_ICELAND_API_KEY: '/k8s/judicial-system/LAWYERS_ICELAND_API_KEY'
   NATIONAL_REGISTRY_API_KEY: '/k8s/judicial-system/NATIONAL_REGISTRY_API_KEY'
   SUPPORT_EMAIL: '/k8s/judicial-system/SUPPORT_EMAIL'
-  TINY_MCE_API_KEY: '/k8s/judicial-system/TINY_MCE_API_KEY'
 securityContext:
   allowPrivilegeEscalation: false
   privileged: false

--- a/charts/judicial-system-services/judicial-system-web/values.staging.yaml
+++ b/charts/judicial-system-services/judicial-system-web/values.staging.yaml
@@ -89,7 +89,6 @@ secrets:
   LAWYERS_ICELAND_API_KEY: '/k8s/judicial-system/LAWYERS_ICELAND_API_KEY'
   NATIONAL_REGISTRY_API_KEY: '/k8s/judicial-system/NATIONAL_REGISTRY_API_KEY'
   SUPPORT_EMAIL: '/k8s/judicial-system/SUPPORT_EMAIL'
-  TINY_MCE_API_KEY: '/k8s/judicial-system/TINY_MCE_API_KEY'
 securityContext:
   allowPrivilegeEscalation: false
   privileged: false

--- a/charts/judicial-system/values.dev.yaml
+++ b/charts/judicial-system/values.dev.yaml
@@ -561,7 +561,6 @@ judicial-system-web:
     LAWYERS_ICELAND_API_KEY: '/k8s/judicial-system/LAWYERS_ICELAND_API_KEY'
     NATIONAL_REGISTRY_API_KEY: '/k8s/judicial-system/NATIONAL_REGISTRY_API_KEY'
     SUPPORT_EMAIL: '/k8s/judicial-system/SUPPORT_EMAIL'
-    TINY_MCE_API_KEY: '/k8s/judicial-system/TINY_MCE_API_KEY'
   securityContext:
     allowPrivilegeEscalation: false
     privileged: false

--- a/charts/judicial-system/values.prod.yaml
+++ b/charts/judicial-system/values.prod.yaml
@@ -561,7 +561,6 @@ judicial-system-web:
     LAWYERS_ICELAND_API_KEY: '/k8s/judicial-system/LAWYERS_ICELAND_API_KEY'
     NATIONAL_REGISTRY_API_KEY: '/k8s/judicial-system/NATIONAL_REGISTRY_API_KEY'
     SUPPORT_EMAIL: '/k8s/judicial-system/SUPPORT_EMAIL'
-    TINY_MCE_API_KEY: '/k8s/judicial-system/TINY_MCE_API_KEY'
   securityContext:
     allowPrivilegeEscalation: false
     privileged: false

--- a/charts/judicial-system/values.staging.yaml
+++ b/charts/judicial-system/values.staging.yaml
@@ -561,7 +561,6 @@ judicial-system-web:
     LAWYERS_ICELAND_API_KEY: '/k8s/judicial-system/LAWYERS_ICELAND_API_KEY'
     NATIONAL_REGISTRY_API_KEY: '/k8s/judicial-system/NATIONAL_REGISTRY_API_KEY'
     SUPPORT_EMAIL: '/k8s/judicial-system/SUPPORT_EMAIL'
-    TINY_MCE_API_KEY: '/k8s/judicial-system/TINY_MCE_API_KEY'
   securityContext:
     allowPrivilegeEscalation: false
     privileged: false


### PR DESCRIPTION
## What
Removes the `TINY_MCE_API_KEY` secret reference from the judicial-system-web infra service setup.

## Why
TinyMCE is now self-hosted (#22609), so the API key is no longer needed. This removes the dangling secret reference from the infra config.

## Screenshots / Gifs
Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] I have rebased against main before asking for a review
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated service infrastructure configuration by removing an outdated secret mapping.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/island-is/island.is/pull/22617?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->