### PR TITLE
feat(services-payments): log charge code distribution at create and success

### DIFF
--- a/apps/services/payments/src/app/cardPayment/applePayPayment.saga.ts
+++ b/apps/services/payments/src/app/cardPayment/applePayPayment.saga.ts
@@ -175,6 +175,12 @@ export const createApplePayPaymentSaga = (
     execute: async (ctx) => {
       const { paymentResult } = requireStepResult(ctx, 'CHARGE_APPLE_PAY')
 
+      await paymentFlowService.logChargeCodeDistribution(
+        ctx.paymentFlowId,
+        'paid',
+        'apple_pay',
+      )
+
       await paymentFlowService.logPaymentFlowUpdate(
         {
           paymentFlowId: ctx.paymentFlowId,

--- a/apps/services/payments/src/app/cardPayment/cardPayment.saga.ts
+++ b/apps/services/payments/src/app/cardPayment/cardPayment.saga.ts
@@ -163,6 +163,12 @@ export const createCardPaymentSaga = (
     execute: async (ctx) => {
       const { paymentResult } = requireStepResult(ctx, 'CHARGE_CARD')
 
+      await paymentFlowService.logChargeCodeDistribution(
+        ctx.paymentFlowId,
+        'paid',
+        PaymentMethod.CARD,
+      )
+
       await paymentFlowService.logPaymentFlowUpdate(
         {
           paymentFlowId: ctx.paymentFlowId,

--- a/apps/services/payments/src/app/cardPayment/cardPayment.saga.ts
+++ b/apps/services/payments/src/app/cardPayment/cardPayment.saga.ts
@@ -166,7 +166,7 @@ export const createCardPaymentSaga = (
       await paymentFlowService.logChargeCodeDistribution(
         ctx.paymentFlowId,
         'paid',
-        PaymentMethod.CARD,
+        'card',
       )
 
       await paymentFlowService.logPaymentFlowUpdate(

--- a/apps/services/payments/src/app/invoicePayment/invoicePayment.controller.ts
+++ b/apps/services/payments/src/app/invoicePayment/invoicePayment.controller.ts
@@ -201,7 +201,7 @@ export class InvoicePaymentController {
       await this.paymentFlowService.logChargeCodeDistribution(
         paymentFlowId,
         'paid',
-        PaymentMethod.INVOICE,
+        'invoice',
       )
 
       await this.paymentFlowService.logPaymentFlowUpdate(

--- a/apps/services/payments/src/app/invoicePayment/invoicePayment.controller.ts
+++ b/apps/services/payments/src/app/invoicePayment/invoicePayment.controller.ts
@@ -198,6 +198,12 @@ export class InvoicePaymentController {
     callbackInput: { receptionID: string },
   ): Promise<void> {
     try {
+      await this.paymentFlowService.logChargeCodeDistribution(
+        paymentFlowId,
+        'paid',
+        PaymentMethod.INVOICE,
+      )
+
       await this.paymentFlowService.logPaymentFlowUpdate(
         {
           paymentFlowId,

--- a/apps/services/payments/src/app/paymentFlow/paymentFlow.service.ts
+++ b/apps/services/payments/src/app/paymentFlow/paymentFlow.service.ts
@@ -161,6 +161,13 @@ export class PaymentFlowService {
           },
         )
 
+        await this.logChargeCodeDistribution(
+          paymentFlow.id,
+          'created',
+          undefined,
+          processedCharges,
+        )
+
         return {
           id: paymentFlow.id,
           urls: {
@@ -182,6 +189,55 @@ export class PaymentFlowService {
           e instanceof Error ? e.message : String(e),
           PaymentServiceCode.CouldNotCreatePaymentFlow,
         ),
+      )
+    }
+  }
+
+  /**
+   * Emits a structured log line with the charge code + quantity distribution
+   * for a payment flow. Used to build a Datadog widget that shows which
+   * charge codes are being created vs. paid.
+   *
+   * Best-effort: any failure is logged and swallowed so it can never block
+   * the main flow. Titles are intentionally omitted to avoid an FJS catalog
+   * lookup on hot paths — the dashboard groups by `code`.
+   */
+  async logChargeCodeDistribution(
+    paymentFlowId: string,
+    state: 'created' | 'paid',
+    paymentMethod?: PaymentMethod,
+    preFetchedCharges?: { chargeItemCode: string; quantity: number }[],
+  ): Promise<void> {
+    try {
+      let charges = preFetchedCharges
+      if (!charges) {
+        const dbCharges = await this.paymentFlowChargeModel.findAll({
+          where: { paymentFlowId },
+          attributes: ['chargeItemCode', 'quantity'],
+        })
+        charges = dbCharges.map((c) => ({
+          chargeItemCode: c.chargeItemCode,
+          quantity: c.quantity,
+        }))
+      }
+
+      this.logger.info(
+        `[${paymentFlowId}] Charge code distribution: ${state}`,
+        {
+          chargeCodeDistribution: {
+            state,
+            paymentMethod: paymentMethod ?? null,
+            codes: charges.map((c) => ({
+              code: c.chargeItemCode,
+              count: c.quantity,
+            })),
+          },
+        },
+      )
+    } catch (error) {
+      this.logger.warn(
+        `[${paymentFlowId}] Failed to log charge code distribution`,
+        { error },
       )
     }
   }

--- a/apps/services/payments/src/app/paymentFlow/paymentFlow.service.ts
+++ b/apps/services/payments/src/app/paymentFlow/paymentFlow.service.ts
@@ -135,7 +135,7 @@ export class PaymentFlowService {
         chargeDetails.catalogItems,
       )
 
-      return await this.sequelize.transaction(async (transaction) => {
+      const result = await this.sequelize.transaction(async (transaction) => {
         const paymentFlow = await this.paymentFlowModel.create(
           {
             ...paymentInfo,
@@ -161,13 +161,6 @@ export class PaymentFlowService {
           },
         )
 
-        await this.logChargeCodeDistribution(
-          paymentFlow.id,
-          'created',
-          undefined,
-          processedCharges,
-        )
-
         return {
           id: paymentFlow.id,
           urls: {
@@ -176,6 +169,15 @@ export class PaymentFlowService {
           },
         }
       })
+
+      await this.logChargeCodeDistribution(
+        result.id,
+        'created',
+        undefined,
+        processedCharges,
+      )
+
+      return result
     } catch (e) {
       this.logger.error('Failed to create payment url', e)
 

--- a/apps/services/payments/src/app/paymentFlow/paymentFlow.service.ts
+++ b/apps/services/payments/src/app/paymentFlow/paymentFlow.service.ts
@@ -205,7 +205,7 @@ export class PaymentFlowService {
   async logChargeCodeDistribution(
     paymentFlowId: string,
     state: 'created' | 'paid',
-    paymentMethod?: PaymentMethod,
+    paymentMethod?: 'card' | 'apple_pay' | 'invoice',
     preFetchedCharges?: { chargeItemCode: string; quantity: number }[],
   ): Promise<void> {
     try {


### PR DESCRIPTION
## What

Adds a fault-tolerant logChargeCodeDistribution helper on PaymentFlowService that emits a structured log with codes + quantities. Called at payment flow creation (data already in scope), card payment success, and invoice payment success. 

## Why

Used to build a Datadog widget showing per-code created vs paid.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Opus 4.7


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic recording of charge-code distribution when a payment flow is created.
  * Automatic recording of charge-code distribution when payments complete (card, Apple Pay, invoice), improving charge-item tracking and reporting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/island-is/island.is/pull/22627?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->