### PR TITLE
feat(driving-license): update BE and 65+ submission confirmation copy

### DIFF
--- a/libs/application/template-api-modules/src/lib/modules/templates/transport-authority/driving-license-submission/emailGenerators/EmailUi.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/transport-authority/driving-license-submission/emailGenerators/EmailUi.ts
@@ -65,6 +65,18 @@ export const EmailHeader = (opts?: EmailHeaderOptions) => {
   ]
 }
 
+export const EmailNextSteps = (
+  applicationFor: DrivingLicenseApplicationFor = 'B-full',
+) => {
+  const paragraphs = m.nextSteps[applicationFor]
+
+  if (!paragraphs) {
+    return []
+  }
+
+  return paragraphs.map((copy) => Copy(copy, { align: 'left', small: true }))
+}
+
 type EmailCompleteOptions = {
   selectedDistrictCommissioner?: string
   isHomeDelivery?: boolean

--- a/libs/application/template-api-modules/src/lib/modules/templates/transport-authority/driving-license-submission/emailGenerators/drivingLicenseSubmittedEmail.spec.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/transport-authority/driving-license-submission/emailGenerators/drivingLicenseSubmittedEmail.spec.ts
@@ -8,7 +8,12 @@ import { createCurrentUser } from '@island.is/testing/fixtures'
 import { faker } from '@island.is/shared/mocking'
 
 import { generateDrivingLicenseSubmittedEmail } from './drivingLicenseSubmittedEmail'
-import { EmailComplete, EmailHeader, EmailRequirements } from './EmailUi'
+import {
+  EmailComplete,
+  EmailHeader,
+  EmailNextSteps,
+  EmailRequirements,
+} from './EmailUi'
 import { EmailTemplateGeneratorProps } from '../../../../../types'
 
 describe('driving license submission', () => {
@@ -103,6 +108,84 @@ describe('driving license submission', () => {
       ...EmailHeader({ firstName: 'Jón' }),
       ...EmailRequirements(
         'B-full',
+        willBringQualityPhoto,
+        willBringHealthCert,
+      ),
+      ...(willBringQualityPhoto || willBringHealthCert
+        ? []
+        : EmailComplete({ selectedDistrictCommissioner: 'Sýslumaðurinn' })),
+    ]
+
+    expect(result?.template?.body).toEqual(generated)
+  })
+
+  it('generates a BE email with next-steps prose and no in-person requirements', () => {
+    const result = generateDrivingLicenseSubmittedEmail({
+      application: {
+        ...application,
+        answers: {
+          ...application.answers,
+          applicationFor: 'BE',
+        },
+      },
+      options,
+    })
+
+    const generated = [
+      ...EmailHeader({ applicationFor: 'BE', firstName: 'Jón' }),
+      ...EmailNextSteps('BE'),
+    ]
+
+    expect(result?.template?.body).toEqual(generated)
+  })
+
+  it('generates a redesigned 65+ renewal email with next-steps prose', () => {
+    const result = generateDrivingLicenseSubmittedEmail({
+      application: {
+        ...application,
+        answers: {
+          ...application.answers,
+          applicationFor: 'B-full-renewal-65',
+          is65RenewalRedesignEnabled: true,
+        },
+      },
+      options,
+    })
+
+    const generated = [
+      ...EmailHeader({
+        applicationFor: 'B-full-renewal-65',
+        firstName: 'Jón',
+      }),
+      ...EmailNextSteps('B-full-renewal-65'),
+    ]
+
+    expect(result?.template?.body).toEqual(generated)
+  })
+
+  it('keeps the legacy 65+ renewal email without next-steps prose', () => {
+    const result = generateDrivingLicenseSubmittedEmail({
+      application: {
+        ...application,
+        answers: {
+          ...application.answers,
+          applicationFor: 'B-full-renewal-65',
+          is65RenewalRedesignEnabled: false,
+        },
+      },
+      options,
+    })
+
+    const willBringQualityPhoto = true
+    const willBringHealthCert = true
+
+    const generated = [
+      ...EmailHeader({
+        applicationFor: 'B-full-renewal-65',
+        firstName: 'Jón',
+      }),
+      ...EmailRequirements(
+        'B-full-renewal-65',
         willBringQualityPhoto,
         willBringHealthCert,
       ),

--- a/libs/application/template-api-modules/src/lib/modules/templates/transport-authority/driving-license-submission/emailGenerators/drivingLicenseSubmittedEmail.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/transport-authority/driving-license-submission/emailGenerators/drivingLicenseSubmittedEmail.ts
@@ -3,7 +3,12 @@ import { Message } from '@island.is/email-service'
 import { DrivingLicenseApplicationFor } from '@island.is/application/templates/driving-license'
 import { EmailTemplateGenerator } from '../../../../../types'
 import { m } from './messages'
-import { EmailComplete, EmailHeader, EmailRequirements } from './EmailUi'
+import {
+  EmailComplete,
+  EmailHeader,
+  EmailNextSteps,
+  EmailRequirements,
+} from './EmailUi'
 import { getValueViaPath } from '@island.is/application/core'
 import { ExternalDataNationalRegistry } from '@island.is/application/templates/iceland-health/health-insurance'
 
@@ -22,6 +27,20 @@ export const generateDrivingLicenseSubmittedEmail: EmailTemplateGenerator = (
       application.answers,
       'applicationFor',
     ) ?? 'B-full'
+
+  const is65RenewalRedesignEnabled =
+    getValueViaPath<boolean>(
+      application.answers,
+      'is65RenewalRedesignEnabled',
+    ) === true
+
+  // BE and the redesigned 65+ renewal upload every document with the
+  // application, so the email describes what happens next instead of the
+  // legacy in-person requirements / pickup footer. Legacy 65+ keeps the old
+  // email until the redesign flag has been fully rolled out.
+  const isDigitalDocumentFlow =
+    applicationFor === 'BE' ||
+    (applicationFor === 'B-full-renewal-65' && is65RenewalRedesignEnabled)
 
   const applicantEmail =
     getValueViaPath<string>(application.answers, 'email') ||
@@ -71,6 +90,26 @@ export const generateDrivingLicenseSubmittedEmail: EmailTemplateGenerator = (
     (x) => x.id == selectedJurisdictionId,
   )
 
+  const body = isDigitalDocumentFlow
+    ? [
+        ...EmailHeader({ applicationFor, firstName }),
+        ...EmailNextSteps(applicationFor),
+      ]
+    : [
+        ...EmailHeader({ applicationFor, firstName }),
+        ...EmailRequirements(
+          applicationFor,
+          willBringQualityPhoto,
+          willBringHealthCert,
+        ),
+        ...(willBringQualityPhoto || willBringHealthCert
+          ? []
+          : EmailComplete({
+              selectedDistrictCommissioner: jurisdictionInfo?.name,
+              isHomeDelivery,
+            })),
+      ]
+
   return {
     from: {
       name: email.sender,
@@ -85,20 +124,7 @@ export const generateDrivingLicenseSubmittedEmail: EmailTemplateGenerator = (
     subject: m.drivingLicenseSubject[applicationFor],
     template: {
       title: m.drivingLicenseSubject[applicationFor],
-      body: [
-        ...EmailHeader({ applicationFor, firstName }),
-        ...EmailRequirements(
-          applicationFor,
-          willBringQualityPhoto,
-          willBringHealthCert,
-        ),
-        ...(willBringQualityPhoto || willBringHealthCert
-          ? []
-          : EmailComplete({
-              selectedDistrictCommissioner: jurisdictionInfo?.name,
-              isHomeDelivery,
-            })),
-      ],
+      body,
     },
   }
 }

--- a/libs/application/template-api-modules/src/lib/modules/templates/transport-authority/driving-license-submission/emailGenerators/drivingLicenseSubmittedEmail.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/transport-authority/driving-license-submission/emailGenerators/drivingLicenseSubmittedEmail.ts
@@ -34,10 +34,13 @@ export const generateDrivingLicenseSubmittedEmail: EmailTemplateGenerator = (
       'is65RenewalRedesignEnabled',
     ) === true
 
-  // BE and the redesigned 65+ renewal upload every document with the
-  // application, so the email describes what happens next instead of the
-  // legacy in-person requirements / pickup footer. Legacy 65+ keeps the old
-  // email until the redesign flag has been fully rolled out.
+  // BE and the redesigned 65+ renewal don't have any in-person document
+  // handoff — photos are selected from existing biometric records, and the
+  // health certificate (when required) is uploaded with the application.
+  // The legacy in-person requirements / pickup footer describe a flow that
+  // doesn't apply, so show the digital-flow next-steps prose instead.
+  // Legacy 65+ keeps the old email until the redesign flag has been fully
+  // rolled out.
   const isDigitalDocumentFlow =
     applicationFor === 'BE' ||
     (applicationFor === 'B-full-renewal-65' && is65RenewalRedesignEnabled)

--- a/libs/application/template-api-modules/src/lib/modules/templates/transport-authority/driving-license-submission/emailGenerators/messages.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/transport-authority/driving-license-submission/emailGenerators/messages.ts
@@ -3,14 +3,14 @@ export const m = {
     'B-temp': 'Umsókn um ökunám móttekin',
     'B-full': 'Umsókn um fullnaðarskírteini móttekin',
     'B-full-renewal-65': 'Umsókn um endurnýjun ökuskírteinis móttekin',
-    BE: 'Umsókn um kerruréttindi móttekin',
+    BE: 'Umsókn um BE réttindi móttekin',
   },
   drivingLicenseHeading: {
     'B-temp': 'Umsókn þín um ökunám hefur verið móttekin',
     'B-full': 'Umsókn þín um fullnaðarskírteinið hefur verið móttekin',
     'B-full-renewal-65':
       'Umsókn þín um endurnýjun ökuskírteinis hefur verið móttekin',
-    BE: 'Umsókn þín um kerruréttindi móttekin',
+    BE: 'Umsókn þín um BE réttindi hefur verið móttekin',
   },
   inPersonRequirements: {
     title: {
@@ -49,4 +49,14 @@ export const m = {
     'Þú getur uppfært stafræna ökuskírteinið þitt í <a href="https://island.is/okuskirteini">Ísland.is appinu</a>.',
   ],
   congratulations: 'Góðan daginn',
+  nextSteps: {
+    BE: [
+      'Ef læknisvottorð fylgdi umsókninni verður það nú yfirfarið. Þegar umsókn hefur verið samþykkt verður hún send áfram í ökunámsbók. Ef læknisvottorð uppfyllir ekki skilyrði getur umsókninni verið hafnað. Ef umsókn er hafnað þarf að senda beiðni um endurgreiðslu á endurgreidsla@island.is og sækja aftur um.',
+      'Þegar verklegu prófi er lokið verður ökuskírteinið pantað og afhent samkvæmt því sem valið var í umsóknarferlinu, annað hvort sent eða sótt á valda afgreiðslu.',
+    ],
+    'B-full-renewal-65': [
+      'Ef læknisvottorð fylgdi umsókninni verður það nú yfirfarið. Ef læknisvottorð uppfyllir ekki skilyrði getur umsókninni verið hafnað. Ef umsókn er hafnað þarf að senda beiðni um endurgreiðslu á endurgreidsla@island.is og sækja aftur um.',
+      'Þegar umsóknin hefur verið samþykkt verður ökuskírteinið pantað og afhent samkvæmt því sem valið var í umsóknarferlinu, annað hvort sent eða sótt á valda afgreiðslu.',
+    ],
+  } as Record<string, string[] | undefined>,
 }

--- a/libs/application/templates/driving-license/src/forms/done.ts
+++ b/libs/application/templates/driving-license/src/forms/done.ts
@@ -18,12 +18,17 @@ export const done: Form = buildForm({
           : answers.applicationFor === BE
           ? m.applicationDoneAlertMessageBE
           : answers.applicationFor === B_FULL_RENEWAL_65
-          ? m.applicationDoneAlertMessage65Renewal
+          ? getValueViaPath(answers, 'is65RenewalRedesignEnabled') === true
+            ? m.applicationDoneAlertMessage65RenewalRedesigned
+            : m.applicationDoneAlertMessage65Renewal
           : m.applicationDoneAlertMessageBFull,
       expandableHeader: m.nextStepsTitle,
       expandableIntro: ({ answers }) =>
         answers.applicationFor === BE
           ? m.nextStepsIntroBE
+          : answers.applicationFor === B_FULL_RENEWAL_65 &&
+            getValueViaPath(answers, 'is65RenewalRedesignEnabled') === true
+          ? m.nextStepsIntro65RenewalRedesigned
           : m.nextStepsIntroDefault,
       expandableDescription: ({ answers, externalData }) =>
         answers.applicationFor === B_TEMP

--- a/libs/application/templates/driving-license/src/lib/messages.ts
+++ b/libs/application/templates/driving-license/src/lib/messages.ts
@@ -557,10 +557,15 @@ export const m = defineMessages({
       'Umsókn þín um endurnýjun ökuskírteina fyrir 65 og eldra hefur verið móttekin.',
     description: 'Application received',
   },
+  applicationDoneAlertMessage65RenewalRedesigned: {
+    id: 'dl.application:applicationDoneAlertMessage65RenewalRedesigned',
+    defaultMessage:
+      'Umsókn þín um endurnýjun ökuskírteinis hefur verið móttekin.',
+    description: 'Application received - 65+ renewal (redesigned flow)',
+  },
   applicationDoneAlertMessageBE: {
     id: 'dl.application:applicationDoneAlertMessageBE',
-    defaultMessage:
-      'Umsókn þín um að hefja ökunám fyrir BE réttindi hefur verið móttekin.',
+    defaultMessage: 'Umsókn þín um BE réttindi hefur verið móttekin.',
     description: 'Application received',
   },
   nextStepsTitle: {
@@ -588,13 +593,19 @@ export const m = defineMessages({
   nextStepsIntroBE: {
     id: 'dl.application:nextStepsIntroBE',
     defaultMessage:
-      'Umsókn þín verður nú yfirfarin, þegar því er lokið er stafræn ökunámsbók virkjuð.',
+      'Ef læknisvottorð fylgdi umsókninni verður það nú yfirfarið. Þegar umsókn hefur verið samþykkt verður hún send áfram í ökunámsbók. Ef læknisvottorð uppfyllir ekki skilyrði getur umsókninni verið hafnað. Ef umsókn er hafnað þarf að senda beiðni um endurgreiðslu á endurgreidsla@island.is og sækja aftur um.',
     description: '',
+  },
+  nextStepsIntro65RenewalRedesigned: {
+    id: 'dl.application:nextStepsIntro65RenewalRedesigned',
+    defaultMessage:
+      'Ef læknisvottorð fylgdi umsókninni verður það nú yfirfarið. Ef læknisvottorð uppfyllir ekki skilyrði getur umsókninni verið hafnað. Ef umsókn er hafnað þarf að senda beiðni um endurgreiðslu á endurgreidsla@island.is og sækja aftur um.',
+    description: 'Next steps intro - 65+ renewal (redesigned flow)',
   },
   nextStepsDescriptionBE: {
     id: 'dl.application:nextStepsDescriptionBE#markdown',
     defaultMessage:
-      'Þegar ökunámi og prófi er lokið, pöntum við nýtt ökuskírteini sem við afhendum eftir afhendingamáta sem þú valdir í umsókninni. \n[Stafræn ökunámsbók - starfsreglur](https://island.is/stafraen-oekunamsbok/upplysingar-um-personuvernd)',
+      'Þegar verklegu prófi er lokið verður ökuskírteinið pantað og afhent samkvæmt því sem valið var í umsóknarferlinu, annað hvort sent eða sótt á valda afgreiðslu.',
     description: '',
   },
   // Legacy 65+ flow: user submits the application here, then must take a
@@ -611,7 +622,7 @@ export const m = defineMessages({
   nextStepsDescription65RenewalRedesigned: {
     id: 'dl.application:nextStepsDescription65RenewalRedesigned#markdown',
     defaultMessage:
-      'Umsókn þín hefur verið móttekin ásamt læknisvottorðinu. Starfsmaður fer yfir vottorðið og þegar það hefur verið samþykkt pöntum við nýtt ökuskírteini sem afhent verður samkvæmt þeim afhendingarmáta sem þú valdir í umsókninni.',
+      'Þegar umsóknin hefur verið samþykkt verður ökuskírteinið pantað og afhent samkvæmt því sem valið var í umsóknarferlinu, annað hvort sent eða sótt á valda afgreiðslu.',
     description: '',
   },
   nextStepsInfoLink: {


### PR DESCRIPTION
## Summary

Updates the post-submission **final-screen text** and **confirmation email** for the **BE** and **redesigned 65+** driving-license types.

- **Final screen** — new BE copy on the 3 existing ids; 2 new ids + 1 rewrite for redesigned 65+. `done.ts` branches 65+ on `is65RenewalRedesignEnabled` so legacy 65+ is untouched.
- **Email** — BE + redesigned 65+ now render a "what happens next" prose block; the legacy in-person requirements / pickup footer is skipped for those flows. Legacy 65+, B-full, B-temp unchanged.

## Contentful follow-up

Manual update (entries already exist):
- `dl.application:applicationDoneAlertMessageBE`
- `dl.application:nextStepsIntroBE`
- `dl.application:nextStepsDescriptionBE#markdown`
- `dl.application:nextStepsDescription65RenewalRedesigned#markdown`

Seeded by `extract-strings` (new ids):
- `dl.application:applicationDoneAlertMessage65RenewalRedesigned`
- `dl.application:nextStepsIntro65RenewalRedesigned`

## Test plan

- [x] Email spec — 4 cases pass (B-full, BE, redesigned 65+, legacy 65+)
- [x] Driving-license template tests — 32 pass
- [x] Lint clean
- [x] Verified redesigned 65+ end-to-end locally