### PR TITLE
feat(driving-license): honor fake-data flag in teachers and jurisdictions providers

### DIFF
--- a/libs/application/template-api-modules/src/lib/modules/shared/api/driving-license/driving-license.service.ts
+++ b/libs/application/template-api-modules/src/lib/modules/shared/api/driving-license/driving-license.service.ts
@@ -26,6 +26,8 @@ import {
   buildFakeQualityPhotoAndSignature,
   buildFakeAllPhotosFromThjodskra,
   buildFakeDrivingAssessment,
+  buildFakeTeachers,
+  buildFakeJurisdictions,
 } from './drivingLicenseFakeData'
 
 @Injectable()
@@ -122,7 +124,13 @@ export class DrivingLicenseProviderService extends BaseTemplateApiService {
       })
   }
 
-  async teachers(): Promise<TeacherV4[]> {
+  async teachers({
+    application,
+  }: TemplateApiModuleActionProps): Promise<TeacherV4[]> {
+    if (getFakeData(application.answers)) {
+      return buildFakeTeachers()
+    }
+
     const teachers = await this.drivingLicenseService.getTeachersV4()
     if (teachers) {
       return teachers.sort(sortTeachers)
@@ -306,7 +314,13 @@ export class DrivingLicenseProviderService extends BaseTemplateApiService {
     }
   }
 
-  async jurisdictions(): Promise<Jurisdiction[]> {
+  async jurisdictions({
+    application,
+  }: TemplateApiModuleActionProps): Promise<Jurisdiction[]> {
+    if (getFakeData(application.answers)) {
+      return buildFakeJurisdictions()
+    }
+
     return await this.drivingLicenseService.getListOfJurisdictions()
   }
 

--- a/libs/application/template-api-modules/src/lib/modules/shared/api/driving-license/drivingLicenseFakeData.ts
+++ b/libs/application/template-api-modules/src/lib/modules/shared/api/driving-license/drivingLicenseFakeData.ts
@@ -1,5 +1,6 @@
 import { getValueViaPath, YES } from '@island.is/application/core'
 import { FormValue } from '@island.is/application/types'
+import { Jurisdiction, TeacherV4 } from '@island.is/clients/driving-license'
 import {
   DrivingLicenseFakeData,
   HasQualitySignature,
@@ -151,3 +152,21 @@ export const buildFakeDrivingAssessment = (): StudentAssessment => {
     studentNationalId: '123456-7890',
   }
 }
+
+export const buildFakeTeachers = (): TeacherV4[] => [
+  {
+    name: 'Bílar Kennar Ekilsson',
+    nationalId: '1234567890',
+    driverLicenseId: 1873312,
+  },
+  {
+    name: 'Ökukennarinn Æfingakonungur',
+    nationalId: '0987654321',
+    driverLicenseId: 50361046,
+  },
+]
+
+export const buildFakeJurisdictions = (): Jurisdiction[] => [
+  { id: 1, name: 'Sýslumaðurinn á höfuðborgarsvæðinu', zip: 105 },
+  { id: 37, name: 'Sýslumaðurinn á Vesturlandi', zip: 310 },
+]


### PR DESCRIPTION
## Why

`DrivingLicenseShared.teachers` and `DrivingLicenseShared.jurisdictions` were the only driving-license data providers that didn't honor `fakeData.useFakeData`. They always hit RLS via X-Road, which means local development breaks whenever the shared dev X-Road security server's signing token is locked out — both providers 500 even with fake data enabled, leaving the BE / 65+ flows untestable without working X-Road.

## What

- `drivingLicenseFakeData.ts` — added `buildFakeTeachers` and `buildFakeJurisdictions` (two mock entries each).
- `driving-license.service.ts` — `teachers()` and `jurisdictions()` now short-circuit via `getFakeData(application.answers)`, exactly like `currentLicense` and the other fake-data-aware providers already do.

After this, BE and 65+ flows can be exercised end-to-end with `Gervigögn → Já` even when the shared dev X-Road is unavailable.

## Test plan

- [ ] Lint clean (0 errors on `application-template-api-modules`)
- [ ] Existing email spec still passes (verifies TS compile via ts-jest)
- [ ] Manually: start a new driving-license application locally, enable fake data, advance past prerequisites — `teachers` and `jurisdictions` provider statuses should be `success` with mock data instead of `failure / 500`