### PR TITLE
fix(ojoi): Update maintext ojoi size max

### DIFF
--- a/libs/application/templates/official-journal-of-iceland/src/hooks/useUpdateApplication.ts
+++ b/libs/application/templates/official-journal-of-iceland/src/hooks/useUpdateApplication.ts
@@ -84,7 +84,13 @@ export const useApplication = ({ applicationId }: OJOIUseApplicationParams) => {
     const payloadSize = new Blob([JSON.stringify(mutationInput)]).size
     if (payloadSize > MAX_APPLICATION_PAYLOAD_BYTES) {
       console.error('Error: Attachment too large')
-      setValue(InputFields.misc.mainTextAsFile, true)
+      await updateApplicationV2({
+        path: InputFields.misc.mainTextAsFile,
+        value: true,
+        onError: (err) => {
+          console.error('Failed to persist mainTextAsFile flag:', err)
+        },
+      })
       cb && cb()
       return
     }

--- a/libs/application/templates/official-journal-of-iceland/src/hooks/useUpdateApplication.ts
+++ b/libs/application/templates/official-journal-of-iceland/src/hooks/useUpdateApplication.ts
@@ -8,7 +8,10 @@ import {
 import { useLocale } from '@island.is/localization'
 import { partialSchema } from '../lib/dataSchema'
 import { InputFields, OJOIApplication } from '../lib/types'
-import { DEBOUNCE_INPUT_TIMER } from '../lib/constants'
+import {
+  DEBOUNCE_INPUT_TIMER,
+  MAX_APPLICATION_PAYLOAD_BYTES,
+} from '../lib/constants'
 import { ApplicationTypes } from '@island.is/application/types'
 import { Application } from '@island.is/api/schema'
 import { POST_APPLICATION_MUTATION } from '../graphql/queries'
@@ -26,11 +29,6 @@ type UpdateApplicationProps = {
   value: any
   onComplete?: () => void
   onError?: (error: Error) => void
-}
-
-interface GraphQLProblem {
-  detail?: string
-  stack?: string
 }
 
 export const useApplication = ({ applicationId }: OJOIUseApplicationParams) => {
@@ -76,29 +74,25 @@ export const useApplication = ({ applicationId }: OJOIUseApplicationParams) => {
     input: Partial<partialSchema>,
     cb?: () => void,
   ) => {
+    const mutationInput = {
+      id: applicationId,
+      answers: {
+        ...input,
+      },
+    }
+
+    const payloadSize = new Blob([JSON.stringify(mutationInput)]).size
+    if (payloadSize > MAX_APPLICATION_PAYLOAD_BYTES) {
+      console.error('Error: Attachment too large')
+      setValue(InputFields.misc.mainTextAsFile, true)
+      cb && cb()
+      return
+    }
+
     await updateApplicationMutation({
       variables: {
         locale,
-        input: {
-          id: applicationId,
-          answers: {
-            ...input,
-          },
-        },
-      },
-      onError: (err) => {
-        // if error stack contains PayloadTooLargeError display too large message
-        const applicationTooLarge = err.graphQLErrors.some((graphQLError) => {
-          const problem = graphQLError.extensions?.problem as GraphQLProblem
-          return (
-            problem?.detail === 'request entity too large' ||
-            problem?.stack?.includes('PayloadTooLargeError')
-          )
-        })
-        if (applicationTooLarge) {
-          console.error('Error: Attachment too large')
-          setValue(InputFields.misc.mainTextAsFile, true)
-        }
+        input: mutationInput,
       },
     })
 

--- a/libs/application/templates/official-journal-of-iceland/src/lib/constants.ts
+++ b/libs/application/templates/official-journal-of-iceland/src/lib/constants.ts
@@ -69,6 +69,9 @@ export const SIGNATURE_INDEX = '{institutionIndex}'
 export const INTERVAL_TIMER = 3000
 export const DEBOUNCE_INPUT_TIMER = 333
 
+// Gateway (apps/api) enforces a 100kb JSON body limit. Leave headroom for other metadata.
+export const MAX_APPLICATION_PAYLOAD_BYTES = 90 * 1024
+
 export enum FileNames {
   DOCUMENT = 'document',
   ADDITIONS = 'additions',


### PR DESCRIPTION
## What

Update maintext ojoi size max

## Why

We're not catching the previous error. Need to update to different handling.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Client now estimates JSON payload size before submission and, when the limit is exceeded, automatically converts large application text to a file format, prevents the oversized submission, and triggers the provided callback where applicable.

* **New Features**
  * Introduced a client-side payload size limit constant to enforce safe submission thresholds and avoid server rejections.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/island-is/island.is/pull/22642?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->