### PR TITLE
fix(web-sitemap-worker): Prune ms from timestamps in xml sitemap files and reduce cronjob frequency

### DIFF
--- a/apps/services/cms-importer/infra/cms-importer-worker.ts
+++ b/apps/services/cms-importer/infra/cms-importer-worker.ts
@@ -82,9 +82,9 @@ export const webSitemapImportSetup =
       .command('node')
       .args('main.cjs', '--job', 'web-sitemap')
       .extraAttributes({
-        dev: { schedule: '0 0 * * *' },
-        staging: { schedule: '0 0 * * 0' },
-        prod: { schedule: '0 */3 * * *' },
+        dev: { schedule: '0 3 */2 * *' },
+        staging: { schedule: '0 4 * * 0' },
+        prod: { schedule: '0 0 * * *' },
       })
 
 export const cmsCleanupSetup = (): ServiceBuilder<'cms-importer-cms-cleanup'> =>

--- a/apps/services/cms-importer/src/app/web-sitemap/utils.ts
+++ b/apps/services/cms-importer/src/app/web-sitemap/utils.ts
@@ -25,7 +25,9 @@ export type SitemapUrl = {
 }
 
 export const generateSitemapUrlString = (url: SitemapUrl) => {
-  const lastmod = url.lastmod ? `<lastmod>${url.lastmod}</lastmod>` : ''
+  const lastmod = url.lastmod
+    ? `<lastmod>${url.lastmod.split('.')[0]}+00:00</lastmod>`
+    : ''
   const xhtmlLinks =
     Boolean(url.loc[LOCALE]) && Boolean(url.loc[EN_LOCALE])
       ? `

--- a/apps/services/cms-importer/src/app/web-sitemap/web-sitemap.service.ts
+++ b/apps/services/cms-importer/src/app/web-sitemap/web-sitemap.service.ts
@@ -162,7 +162,7 @@ export class WebSitemapService {
 
     if (urls.length > 0) await flushSitemapUrlsToFile()
 
-    const timestamp = new Date().toISOString()
+    const timestamp = `${new Date().toISOString().split('.')[0]}+00:00`
 
     await this.uploadXmlFile(
       `<?xml version="1.0" encoding="UTF-8"?>

--- a/charts/islandis-services/cms-importer-web-sitemap/values.dev.yaml
+++ b/charts/islandis-services/cms-importer-web-sitemap/values.dev.yaml
@@ -68,7 +68,7 @@ resources:
   requests:
     cpu: '100m'
     memory: '128Mi'
-schedule: '0 0 * * *'
+schedule: '0 3 */2 * *'
 secrets:
   CONFIGCAT_SDK_KEY: '/k8s/configcat/CONFIGCAT_SDK_KEY'
   CONTENTFUL_MANAGEMENT_ACCESS_TOKEN: '/k8s/contentful-entry-tagger/CONTENTFUL_MANAGEMENT_ACCESS_TOKEN'

--- a/charts/islandis-services/cms-importer-web-sitemap/values.prod.yaml
+++ b/charts/islandis-services/cms-importer-web-sitemap/values.prod.yaml
@@ -68,7 +68,7 @@ resources:
   requests:
     cpu: '100m'
     memory: '128Mi'
-schedule: '0 */3 * * *'
+schedule: '0 0 * * *'
 secrets:
   CONFIGCAT_SDK_KEY: '/k8s/configcat/CONFIGCAT_SDK_KEY'
   CONTENTFUL_MANAGEMENT_ACCESS_TOKEN: '/k8s/contentful-entry-tagger/CONTENTFUL_MANAGEMENT_ACCESS_TOKEN'

--- a/charts/islandis-services/cms-importer-web-sitemap/values.staging.yaml
+++ b/charts/islandis-services/cms-importer-web-sitemap/values.staging.yaml
@@ -68,7 +68,7 @@ resources:
   requests:
     cpu: '100m'
     memory: '128Mi'
-schedule: '0 0 * * 0'
+schedule: '0 4 * * 0'
 secrets:
   CONFIGCAT_SDK_KEY: '/k8s/configcat/CONFIGCAT_SDK_KEY'
   CONTENTFUL_MANAGEMENT_ACCESS_TOKEN: '/k8s/contentful-entry-tagger/CONTENTFUL_MANAGEMENT_ACCESS_TOKEN'

--- a/charts/islandis/values.dev.yaml
+++ b/charts/islandis/values.dev.yaml
@@ -1418,7 +1418,7 @@ cms-importer-web-sitemap:
     requests:
       cpu: '100m'
       memory: '128Mi'
-  schedule: '0 0 * * *'
+  schedule: '0 3 */2 * *'
   secrets:
     CONFIGCAT_SDK_KEY: '/k8s/configcat/CONFIGCAT_SDK_KEY'
     CONTENTFUL_MANAGEMENT_ACCESS_TOKEN: '/k8s/contentful-entry-tagger/CONTENTFUL_MANAGEMENT_ACCESS_TOKEN'

--- a/charts/islandis/values.prod.yaml
+++ b/charts/islandis/values.prod.yaml
@@ -1406,7 +1406,7 @@ cms-importer-web-sitemap:
     requests:
       cpu: '100m'
       memory: '128Mi'
-  schedule: '0 */3 * * *'
+  schedule: '0 0 * * *'
   secrets:
     CONFIGCAT_SDK_KEY: '/k8s/configcat/CONFIGCAT_SDK_KEY'
     CONTENTFUL_MANAGEMENT_ACCESS_TOKEN: '/k8s/contentful-entry-tagger/CONTENTFUL_MANAGEMENT_ACCESS_TOKEN'

--- a/charts/islandis/values.staging.yaml
+++ b/charts/islandis/values.staging.yaml
@@ -1357,7 +1357,7 @@ cms-importer-web-sitemap:
     requests:
       cpu: '100m'
       memory: '128Mi'
-  schedule: '0 0 * * 0'
+  schedule: '0 4 * * 0'
   secrets:
     CONFIGCAT_SDK_KEY: '/k8s/configcat/CONFIGCAT_SDK_KEY'
     CONTENTFUL_MANAGEMENT_ACCESS_TOKEN: '/k8s/contentful-entry-tagger/CONTENTFUL_MANAGEMENT_ACCESS_TOKEN'


### PR DESCRIPTION
# Prune ms from timestamps in xml sitemap files and reduce cronjob frequency



## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [x] No AI tools were used in preparing this pull request
- [ ] AI tools were used in preparing this pull request
      Tools used:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized sitemap lastmod formatting to an ISO timestamp without fractional seconds and with explicit +00:00 timezone; missing lastmod now emits empty output.
* **Chores**
  * Adjusted scheduling for sitemap import jobs across environments to change execution intervals.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/island-is/island.is/pull/22653?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->