### PR TITLE
fix(j-s): Restrict indictment case reopen button visibility

### DIFF
--- a/apps/judicial-system/web/src/components/CaseInfo/CaseInfo.spec.tsx
+++ b/apps/judicial-system/web/src/components/CaseInfo/CaseInfo.spec.tsx
@@ -2,6 +2,7 @@ import { render, screen } from '@testing-library/react'
 
 import {
   AppealCaseState,
+  CaseIndictmentRulingDecision,
   CaseState,
   CaseType,
   Defendant,
@@ -156,5 +157,18 @@ describe('CourtCaseInfo - reopen button visibility', () => {
     expect(
       screen.getByRole('button', { name: 'Enduropna mál' }),
     ).toBeInTheDocument()
+  })
+
+  it('hides the reopen button when the indictment ruling decision is withdrawal', () => {
+    const withdrawnCase = {
+      ...completedIndictmentCase,
+      indictmentRulingDecision: CaseIndictmentRulingDecision.WITHDRAWAL,
+    }
+
+    renderComponent(UserRole.DISTRICT_COURT_JUDGE, withdrawnCase)
+
+    expect(
+      screen.queryByRole('button', { name: 'Enduropna mál' }),
+    ).not.toBeInTheDocument()
   })
 })

--- a/apps/judicial-system/web/src/components/CaseInfo/CaseInfo.spec.tsx
+++ b/apps/judicial-system/web/src/components/CaseInfo/CaseInfo.spec.tsx
@@ -77,6 +77,8 @@ describe('CourtCaseInfo - reopen button visibility', () => {
   const completedIndictmentCase = {
     ...mockCase(CaseType.INDICTMENT),
     state: CaseState.COMPLETED,
+    indictmentCompletedDate: '2024-01-01',
+    indictmentSentToPublicProsecutorDate: '2024-01-02',
   }
 
   const renderComponent = (
@@ -166,6 +168,19 @@ describe('CourtCaseInfo - reopen button visibility', () => {
     }
 
     renderComponent(UserRole.DISTRICT_COURT_JUDGE, withdrawnCase)
+
+    expect(
+      screen.queryByRole('button', { name: 'Enduropna mál' }),
+    ).not.toBeInTheDocument()
+  })
+
+  it('hides the reopen button when the case has not been sent to public prosecutor', () => {
+    const notSentCase = {
+      ...completedIndictmentCase,
+      indictmentSentToPublicProsecutorDate: undefined,
+    }
+
+    renderComponent(UserRole.DISTRICT_COURT_JUDGE, notSentCase)
 
     expect(
       screen.queryByRole('button', { name: 'Enduropna mál' }),

--- a/apps/judicial-system/web/src/components/CaseInfo/CaseInfo.tsx
+++ b/apps/judicial-system/web/src/components/CaseInfo/CaseInfo.tsx
@@ -153,6 +153,7 @@ export const CourtCaseInfo: FC<Props> = ({ workingCase }) => {
   const [isSubmitting, setIsSubmitting] = useState<boolean>(false)
 
   const canReopenCase =
+    isDistrictCourtUser(user) &&
     workingCase.indictmentRulingDecision !==
       CaseIndictmentRulingDecision.WITHDRAWAL &&
     Boolean(
@@ -192,7 +193,7 @@ export const CourtCaseInfo: FC<Props> = ({ workingCase }) => {
                 </Text>
               </Box>
             )}
-            {isDistrictCourtUser(user) && canReopenCase && (
+            {canReopenCase && (
               <Button
                 variant="text"
                 colorScheme="destructive"

--- a/apps/judicial-system/web/src/components/CaseInfo/CaseInfo.tsx
+++ b/apps/judicial-system/web/src/components/CaseInfo/CaseInfo.tsx
@@ -20,6 +20,7 @@ import { core } from '@island.is/judicial-system-web/messages'
 import {
   AppealCaseState,
   Case,
+  CaseIndictmentRulingDecision,
   CaseType,
   Defendant,
 } from '@island.is/judicial-system-web/src/graphql/schema'
@@ -179,6 +180,8 @@ export const CourtCaseInfo: FC<Props> = ({ workingCase }) => {
               </Box>
             )}
             {isDistrictCourtUser(user) &&
+              workingCase.indictmentRulingDecision !==
+                CaseIndictmentRulingDecision.WITHDRAWAL &&
               (!workingCase.appealCase ||
                 workingCase.appealCase.appealState ===
                   AppealCaseState.COMPLETED ||

--- a/apps/judicial-system/web/src/components/CaseInfo/CaseInfo.tsx
+++ b/apps/judicial-system/web/src/components/CaseInfo/CaseInfo.tsx
@@ -152,6 +152,19 @@ export const CourtCaseInfo: FC<Props> = ({ workingCase }) => {
   const [reopenReason, setReopenReason] = useState<string>('')
   const [isSubmitting, setIsSubmitting] = useState<boolean>(false)
 
+  const canReopenCase =
+    workingCase.indictmentRulingDecision !==
+      CaseIndictmentRulingDecision.WITHDRAWAL &&
+    Boolean(
+      workingCase.indictmentCompletedDate &&
+        workingCase.indictmentSentToPublicProsecutorDate &&
+        workingCase.indictmentSentToPublicProsecutorDate >
+          workingCase.indictmentCompletedDate,
+    ) &&
+    (!workingCase.appealCase ||
+      workingCase.appealCase.appealState === AppealCaseState.COMPLETED ||
+      workingCase.appealCase.appealState === AppealCaseState.WITHDRAWN)
+
   return (
     <>
       <Box component="section" marginBottom={5}>
@@ -179,23 +192,16 @@ export const CourtCaseInfo: FC<Props> = ({ workingCase }) => {
                 </Text>
               </Box>
             )}
-            {isDistrictCourtUser(user) &&
-              workingCase.indictmentRulingDecision !==
-                CaseIndictmentRulingDecision.WITHDRAWAL &&
-              (!workingCase.appealCase ||
-                workingCase.appealCase.appealState ===
-                  AppealCaseState.COMPLETED ||
-                workingCase.appealCase.appealState ===
-                  AppealCaseState.WITHDRAWN) && (
-                <Button
-                  variant="text"
-                  colorScheme="destructive"
-                  size="small"
-                  onClick={() => setModalVisible('REOPEN')}
-                >
-                  Enduropna mál
-                </Button>
-              )}
+            {isDistrictCourtUser(user) && canReopenCase && (
+              <Button
+                variant="text"
+                colorScheme="destructive"
+                size="small"
+                onClick={() => setModalVisible('REOPEN')}
+              >
+                Enduropna mál
+              </Button>
+            )}
           </Box>
         ) : (
           <ProsecutorAndDefendantsEntries workingCase={workingCase} />
@@ -250,8 +256,8 @@ export const CourtCaseInfo: FC<Props> = ({ workingCase }) => {
             <Box marginBottom={4}>
               <Input
                 name="reopenReason"
-                label="Ástæða enduropnunar"
-                placeholder="Skráðu ástæðu enduropnunar hér..."
+                label="Ástæða enduropnunar máls"
+                placeholder="Skráðu ástæðu enduropnunar máls, t.d. vegna endurupptöku eða niðurstöðu Landsréttar."
                 textarea
                 rows={6}
                 value={reopenReason}


### PR DESCRIPTION
## What

Tightens the conditions under which the "Enduropna mál" button is shown on completed indictment cases in `CourtCaseInfo`:

- **Hidden for withdrawn cases** (`indictmentRulingDecision === WITHDRAWAL`) — previously the button was visible but clicking through would result in an error toast from the backend
- **Hidden until sent to public prosecutor** — prevents reopening cases that are still in the completion pipeline ("Sakamál í frágangi")
- **Hidden when case has an active appeal** (APPEALED or RECEIVED state) — already enforced by the backend, now also enforced in the UI
- **Visible when appeal is completed or withdrawn** — these states allow reopening

The visibility logic is extracted into a `canReopenCase` variable for readability.

## Why

The reopen button was showing in situations where reopening is not allowed, leading to a confusing error toast after the user had already gone through the confirmation modal. This stops the user earlier with a better UX.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced reopen case button visibility to correctly hide it in specific scenarios, including when indictment withdrawal decisions exist or the indictment has not been submitted to the prosecutor.
  * Updated guidance text and field labels in the case reopening dialog to provide clearer instructions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/island-is/island.is/pull/22661?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
