### PR TITLE
feat(application-system): Standardizing VMST action application conclusions and cards

### DIFF
--- a/libs/application/api/history/src/lib/dto/history.dto.ts
+++ b/libs/application/api/history/src/lib/dto/history.dto.ts
@@ -28,7 +28,8 @@ export class HistoryResponseDto {
   ) {
     this.date = timeStamp
     if (message) {
-      this.log = formatMessage(message)
+      const values = typeof message === 'object' ? message.values : undefined
+      this.log = formatMessage(message, values)
       if (subjectAndActorText) {
         this.subLog = subjectAndActorText
       } else {

--- a/libs/application/templates/vmst/confirm-job-search/src/forms/completedForm/index.ts
+++ b/libs/application/templates/vmst/confirm-job-search/src/forms/completedForm/index.ts
@@ -12,6 +12,7 @@ export const completedForm = buildForm({
   children: [
     buildFormConclusionSection({
       alertTitle: cm.completedFormAlertTitle,
+      multiFieldTitle: cm.multiFieldTitle,
       alertMessage: '',
       accordion: true,
       expandableIntro: {
@@ -23,6 +24,7 @@ export const completedForm = buildForm({
       descriptionFieldTitle: cm.completedFormDescriptionFieldTitle,
       descriptionFieldDescription: cm.descriptionFieldDescription,
       bottomButtonMessage: cm.bottomButtonMessage,
+      bottomButtonLabel: cm.bottomButtonLabel,
     }),
   ],
 })

--- a/libs/application/templates/vmst/confirm-job-search/src/lib/messages/application.ts
+++ b/libs/application/templates/vmst/confirm-job-search/src/lib/messages/application.ts
@@ -40,4 +40,9 @@ export const application = defineMessages({
       'Vinnumálastofnun hefur móttekið umsókn þína og er hún komin til afgreiðslu.',
     description: 'Successful submission title',
   },
+  applicationSent: {
+    id: 'vmst.cjs.application:applicationSent',
+    defaultMessage: 'Atvinnuleit staðfest',
+    description: 'History log message when application is sent',
+  },
 })

--- a/libs/application/templates/vmst/confirm-job-search/src/lib/messages/conclusion.ts
+++ b/libs/application/templates/vmst/confirm-job-search/src/lib/messages/conclusion.ts
@@ -1,6 +1,11 @@
 import { defineMessages } from 'react-intl'
 
 export const conclusion = defineMessages({
+  multiFieldTitle: {
+    id: 'vmst.cjs.application:conclusion.multiFieldTitle',
+    defaultMessage: 'Staðfesting',
+    description: 'Title for the multi field on completed form',
+  },
   completedFormAlertTitle: {
     id: 'vmst.cjs.application:conclusion.completedFormAlertTitle',
     defaultMessage:
@@ -34,7 +39,17 @@ export const conclusion = defineMessages({
   bottomButtonMessage: {
     id: 'vmst.cjs.application:conclusion.bottomButtonMessage',
     defaultMessage:
-      'Á mínum síðum og í appi getur þú nú nálgast margvíslegar upplýsingar um stöðu þína varðandi atvinnuleysisbæturnar.',
+      'Á mínum síðum og í appi ísland.is getur þú nú nálgast staðfestingu á því að þessi aðgerð hafi verið framkvæmd.',
     description: 'Bottom info message',
+  },
+  bottomButtonLabel: {
+    id: 'vmst.cjs.application:conclusion.bottomButtonLabel',
+    defaultMessage: 'Opna Mínar síður',
+    description: 'Bottom button label on completed form',
+  },
+  bottomButtonLink: {
+    id: 'vmst.cjs.application:conclusion.bottomButtonLink',
+    defaultMessage: '/minarsidur/umsoknir',
+    description: 'Bottom button link on completed form',
   },
 })

--- a/libs/application/templates/vmst/confirm-job-search/src/lib/messages/conclusion.ts
+++ b/libs/application/templates/vmst/confirm-job-search/src/lib/messages/conclusion.ts
@@ -47,9 +47,4 @@ export const conclusion = defineMessages({
     defaultMessage: 'Opna Mínar síður',
     description: 'Bottom button label on completed form',
   },
-  bottomButtonLink: {
-    id: 'vmst.cjs.application:conclusion.bottomButtonLink',
-    defaultMessage: '/minarsidur/umsoknir',
-    description: 'Bottom button link on completed form',
-  },
 })

--- a/libs/application/templates/vmst/confirm-job-search/src/lib/template.ts
+++ b/libs/application/templates/vmst/confirm-job-search/src/lib/template.ts
@@ -74,6 +74,18 @@ const template: ApplicationTemplate<
           progress: 0.4,
           status: FormModes.DRAFT,
           lifecycle: pruneAfterDays(2),
+          actionCard: {
+            tag: {
+              label: am.actionCardDraft,
+              variant: 'blue',
+            },
+            historyLogs: [
+              {
+                logMessage: am.applicationSent,
+                onEvent: DefaultEvents.SUBMIT,
+              },
+            ],
+          },
           onExit: defineTemplateApi({
             action: 'completeApplication',
           }),

--- a/libs/application/templates/vmst/confirm-travel/src/forms/completedForm/index.ts
+++ b/libs/application/templates/vmst/confirm-travel/src/forms/completedForm/index.ts
@@ -11,11 +11,14 @@ export const completedForm = buildForm({
   children: [
     buildFormConclusionSection({
       alertTitle: completedFormMessages.alertTitle,
-      expandableHeader: completedFormMessages.expandableHeader,
-      expandableDescription: completedFormMessages.expandableDescription,
+      multiFieldTitle: completedFormMessages.multiFieldTitle,
+      alertMessage: '',
       descriptionFieldTitle: completedFormMessages.descriptionFieldTitle,
       descriptionFieldDescription:
         completedFormMessages.descriptionFieldDescription,
+      accordion: false,
+      bottomButtonLabel: completedFormMessages.bottomButtonLabel,
+      bottomButtonMessage: completedFormMessages.bottomButtonMessage,
     }),
   ],
 })

--- a/libs/application/templates/vmst/confirm-travel/src/lib/messages.ts
+++ b/libs/application/templates/vmst/confirm-travel/src/lib/messages.ts
@@ -26,6 +26,11 @@ export const applicationMessages = defineMessages({
     defaultMessage: 'Tilkynna dvöl erlendis',
     description: `Application's name`,
   },
+  applicationSent: {
+    id: 'vmst.ct.application:applicationMessages.applicationSent',
+    defaultMessage: 'Tilkynning móttekin fyrir tímabil: {from} - {to}',
+    description: 'History log message when application is sent',
+  },
 })
 
 export const prerequisitesForm = {
@@ -110,21 +115,15 @@ export const mainForm = defineMessages({
 })
 
 export const completedForm = defineMessages({
+  multiFieldTitle: {
+    id: 'vmst.ct.application:completedForm.multiFieldTitle',
+    defaultMessage: 'Staðfesting',
+    description: 'Title for the multi field on completed form',
+  },
   alertTitle: {
     id: 'vmst.ct.application:completedForm.alertTitle',
     defaultMessage: 'Tilkynning um dvöl erlendis hefur verið móttekin',
     description: 'completed form alert title',
-  },
-  expandableHeader: {
-    id: 'vmst.ct.application:completedForm.expandableHeader',
-    defaultMessage: 'Hvað gerist næst?',
-    description: 'completed form expandable header',
-  },
-  expandableDescription: {
-    id: 'vmst.ct.application:completedForm.expandableDescription#markdown',
-    defaultMessage:
-      'Þetta er lýsing á því hvað gerist eftir að umsókn hefur verið send inn',
-    description: 'completed form expandable description',
   },
   descriptionFieldTitle: {
     id: 'vmst.ct.application:completedForm.descriptionFieldTitle',
@@ -136,6 +135,22 @@ export const completedForm = defineMessages({
     defaultMessage:
       'Skoðaðu nánari upplýsingar á upplýsingasíðu Vinnumálastofnuna',
     description: 'completed form description field description',
+  },
+  bottomButtonMessage: {
+    id: 'vmst.ct.application:completedForm.bottomButtonMessage',
+    defaultMessage:
+      'Á mínum síðum og í appi ísland.is getur þú nú nálgast staðfestingu á því að þessi aðgerð hafi verið framkvæmd.',
+    description: 'Bottom info message on completed form',
+  },
+  bottomButtonLabel: {
+    id: 'vmst.ct.application:completedForm.bottomButtonLabel',
+    defaultMessage: 'Opna Mínar síður',
+    description: 'Bottom button label on completed form',
+  },
+  bottomButtonLink: {
+    id: 'vmst.ct.application:completedForm.bottomButtonLink',
+    defaultMessage: '/minarsidur/umsoknir',
+    description: 'Bottom button link on completed form',
   },
 })
 

--- a/libs/application/templates/vmst/confirm-travel/src/lib/messages.ts
+++ b/libs/application/templates/vmst/confirm-travel/src/lib/messages.ts
@@ -147,11 +147,6 @@ export const completedForm = defineMessages({
     defaultMessage: 'Opna Mínar síður',
     description: 'Bottom button label on completed form',
   },
-  bottomButtonLink: {
-    id: 'vmst.ct.application:completedForm.bottomButtonLink',
-    defaultMessage: '/minarsidur/umsoknir',
-    description: 'Bottom button link on completed form',
-  },
 })
 
 export const errorMessages = defineMessages({

--- a/libs/application/templates/vmst/confirm-travel/src/lib/template.ts
+++ b/libs/application/templates/vmst/confirm-travel/src/lib/template.ts
@@ -16,11 +16,14 @@ import { ConfirmTravelUnemploymentBenefitsSchema } from './dataSchema'
 import {
   DefaultStateLifeCycle,
   EphemeralStateLifeCycle,
+  getValueViaPath,
   pruneAfterDays,
 } from '@island.is/application/core'
 import { applicationMessages } from './messages'
 import { Features } from '@island.is/feature-flags'
 import { getEligibility } from '../dataProviders'
+import format from 'date-fns/format'
+import is from 'date-fns/locale/is'
 
 const template: ApplicationTemplate<
   ApplicationContext,
@@ -75,6 +78,36 @@ const template: ApplicationTemplate<
           progress: 0.4,
           status: FormModes.DRAFT,
           lifecycle: pruneAfterDays(2),
+          actionCard: {
+            tag: {
+              label: applicationMessages.actionCardDraft,
+              variant: 'blue',
+            },
+            historyLogs: [
+              {
+                logMessage: (application) => {
+                  const fromStr = getValueViaPath<string>(
+                    application.answers,
+                    'date.from',
+                  )
+                  const toStr = getValueViaPath<string>(
+                    application.answers,
+                    'date.to',
+                  )
+                  const formatDate = (d?: string) =>
+                    d ? format(new Date(d), 'd. MMMM yyyy', { locale: is }) : ''
+                  return {
+                    ...applicationMessages.applicationSent,
+                    values: {
+                      from: formatDate(fromStr),
+                      to: formatDate(toStr),
+                    },
+                  }
+                },
+                onEvent: DefaultEvents.SUBMIT,
+              },
+            ],
+          },
           onExit: defineTemplateApi({
             action: 'submitApplication',
           }),

--- a/libs/application/templates/vmst/de-register-unemployment-benefits/src/forms/completedForm/index.ts
+++ b/libs/application/templates/vmst/de-register-unemployment-benefits/src/forms/completedForm/index.ts
@@ -11,12 +11,14 @@ export const completedForm = buildForm({
   logo: DirectorateOfLabourLogo,
   children: [
     buildFormConclusionSection({
+      multiFieldTitle: completedFormMessages.multiFieldTitle,
       alertTitle: completedFormMessages.alertTitle,
-      expandableHeader: completedFormMessages.expandableHeader,
-      expandableDescription: completedFormMessages.expandableDescription,
       descriptionFieldTitle: completedFormMessages.descriptionFieldTitle,
       descriptionFieldDescription:
         completedFormMessages.descriptionFieldDescription,
+      accordion: false,
+      bottomButtonLabel: completedFormMessages.bottomButtonLabel,
+      bottomButtonMessage: completedFormMessages.bottomButtonMessage,
     }),
   ],
 })

--- a/libs/application/templates/vmst/de-register-unemployment-benefits/src/lib/messages.ts
+++ b/libs/application/templates/vmst/de-register-unemployment-benefits/src/lib/messages.ts
@@ -114,6 +114,11 @@ export const mainForm = {
 }
 
 export const completedForm = defineMessages({
+  multiFieldTitle: {
+    id: 'vmst.dub.application:completedForm.multiFieldTitle',
+    defaultMessage: 'Staðfesting',
+    description: 'Title for the multi field on completed form',
+  },
   alertTitle: {
     id: 'vmst.dub.application:completedForm.alertTitle',
     defaultMessage: 'Tilkynning um afskráningu hefur verið móttekin',
@@ -141,6 +146,17 @@ export const completedForm = defineMessages({
       'Skoðaðu nánari upplýsingar á upplýsingasíðu Vinnumálastofnuna',
     description: 'completed form description field description',
   },
+  bottomButtonMessage: {
+    id: 'vmst.dub.application:completedForm.bottomButtonMessage',
+    defaultMessage:
+      'Á mínum síðum og í appi ísland.is getur þú nú nálgast staðfestingu á því að þessi aðgerð hafi verið framkvæmd.',
+    description: 'Bottom info message on completed form',
+  },
+  bottomButtonLabel: {
+    id: 'vmst.dub.application:completedForm.bottomButtonLabel',
+    defaultMessage: 'Opna Mínar síður',
+    description: 'Bottom button label on completed form',
+  },
 })
 
 export const applicationMessages = {
@@ -156,7 +172,7 @@ export const applicationMessages = {
   },
   actionCardSubmitted: {
     id: 'vmst.dub.application:applicationMessages.actionCardSubmitted',
-    defaultMessage: 'Umsókn send inn',
+    defaultMessage: 'Afgreidd',
     description: 'Action card tag for submitted application',
   },
   institutionName: {
@@ -168,6 +184,11 @@ export const applicationMessages = {
     id: 'vmst.dub.application:name',
     defaultMessage: 'Afskráning af atvinnuleysisbótum',
     description: `Application's name`,
+  },
+  applicationSent: {
+    id: 'vmst.dub.application:applicationMessages.applicationSent',
+    defaultMessage: 'Afskráning móttekin',
+    description: 'History log message when application is sent',
   },
 }
 

--- a/libs/application/templates/vmst/de-register-unemployment-benefits/src/lib/template.ts
+++ b/libs/application/templates/vmst/de-register-unemployment-benefits/src/lib/template.ts
@@ -14,7 +14,6 @@ import { ApiActions, Events, Roles, States } from '../utils/constants'
 import { CodeOwners } from '@island.is/shared/constants'
 import { DeregisterUnemploymentBenefitsSchema } from './dataSchema'
 import {
-  coreHistoryMessages,
   DefaultStateLifeCycle,
   EphemeralStateLifeCycle,
   pruneAfterDays,
@@ -51,12 +50,6 @@ const DeregisterUnemploymentBenefitsTemplate: ApplicationTemplate<
               label: applicationMessages.actionCardPrerequisites,
               variant: 'blue',
             },
-            historyLogs: [
-              {
-                logMessage: coreHistoryMessages.applicationStarted,
-                onEvent: DefaultEvents.SUBMIT,
-              },
-            ],
           },
           roles: [
             {
@@ -93,7 +86,7 @@ const DeregisterUnemploymentBenefitsTemplate: ApplicationTemplate<
             },
             historyLogs: [
               {
-                logMessage: coreHistoryMessages.applicationSent,
+                logMessage: applicationMessages.applicationSent,
                 onEvent: DefaultEvents.SUBMIT,
               },
             ],

--- a/libs/application/templates/vmst/edit-unemployment-information/src/forms/completedForm/index.ts
+++ b/libs/application/templates/vmst/edit-unemployment-information/src/forms/completedForm/index.ts
@@ -11,6 +11,7 @@ export const completedForm = buildForm({
   title: applicationMessages.completedFormAlertTitle,
   children: [
     buildFormConclusionSection({
+      multiFieldTitle: applicationMessages.multiFieldTitle,
       alertTitle: applicationMessages.completedFormAlertTitle,
       alertMessage: '',
       accordion: false,
@@ -18,6 +19,8 @@ export const completedForm = buildForm({
         applicationMessages.completedFormDescriptionFieldTitle,
       descriptionFieldDescription:
         applicationMessages.completedFormDescriptionFieldDescription,
+      bottomButtonLabel: applicationMessages.bottomButtonLabel,
+      bottomButtonMessage: applicationMessages.bottomButtonMessage,
     }),
   ],
 })

--- a/libs/application/templates/vmst/edit-unemployment-information/src/lib/messages.ts
+++ b/libs/application/templates/vmst/edit-unemployment-information/src/lib/messages.ts
@@ -307,6 +307,11 @@ export const application = defineMessages({
     defaultMessage: 'Vista breytingar og staðfesta',
     description: 'Submit button label',
   },
+  multiFieldTitle: {
+    id: 'vmst.eui.application:multiFieldTitle',
+    defaultMessage: 'Staðfesting',
+    description: 'Title for the multi field on completed form',
+  },
   completedFormAlertTitle: {
     id: 'vmst.eui.application:completedFormAlertTitle',
     defaultMessage: 'Breytingar þínar hafa verið vistaðar',
@@ -322,6 +327,22 @@ export const application = defineMessages({
     defaultMessage:
       'Skoðaðu nánari upplýsingar á upplýsingasíðu Vinnumálastofnunar',
     description: 'Description for description field when form is completed',
+  },
+  bottomButtonMessage: {
+    id: 'vmst.eui.application:bottomButtonMessage',
+    defaultMessage:
+      'Á mínum síðum og í appi ísland.is getur þú nú nálgast staðfestingu á því að þessi aðgerð hafi verið framkvæmd.',
+    description: 'Bottom info message on completed form',
+  },
+  bottomButtonLabel: {
+    id: 'vmst.eui.application:bottomButtonLabel',
+    defaultMessage: 'Opna Mínar síður',
+    description: 'Bottom button label on completed form',
+  },
+  bottomButtonLink: {
+    id: 'vmst.eui.application:bottomButtonLink',
+    defaultMessage: '/minarsidur/umsoknir',
+    description: 'Bottom button link on completed form',
   },
 })
 

--- a/libs/application/templates/vmst/edit-unemployment-information/src/lib/messages.ts
+++ b/libs/application/templates/vmst/edit-unemployment-information/src/lib/messages.ts
@@ -339,11 +339,6 @@ export const application = defineMessages({
     defaultMessage: 'Opna Mínar síður',
     description: 'Bottom button label on completed form',
   },
-  bottomButtonLink: {
-    id: 'vmst.eui.application:bottomButtonLink',
-    defaultMessage: '/minarsidur/umsoknir',
-    description: 'Bottom button link on completed form',
-  },
 })
 
 export const errorMessages = defineMessages({


### PR DESCRIPTION
Attach a link to issue if relevant

## What

Specify what you're trying to achieve

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Copilot (Claude Opus 4.6)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added action cards to draft application states with submission status and history entries that show formatted details (e.g., from/to dates).
  * Enhanced completed form screens across templates with multi-field titles and updated bottom button labels/messages.
  * Added user-facing "application sent" history messages for several templates.

* **Bug Fixes**
  * Fixed history log parameterization so dynamic values from structured messages display correctly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/island-is/island.is/pull/22662?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->