### PR TITLE
fix(web): Hide course instance label based on boolean in cms

### DIFF
--- a/apps/web/screens/Organization/Courses/CourseDetails.tsx
+++ b/apps/web/screens/Organization/Courses/CourseDetails.tsx
@@ -173,12 +173,15 @@ const CourseDetails: Screen<CourseDetailsProps, CourseDetailsScreenContext> = ({
         </Text>
         <Box>{webRichText(course.description)}</Box>
         <Stack space={3}>
-          <Text variant="h2" as="h2">
-            {n(
-              'courseInstancesLabel',
-              activeLocale === 'is' ? 'Næstu námskeið' : 'Upcoming courses',
-            )}
-          </Text>
+          {(course.instances.length > 0 ||
+            course.showPlaceholderTextIfNoCourseInstances) && (
+            <Text variant="h2" as="h2">
+              {n(
+                'courseInstancesLabel',
+                activeLocale === 'is' ? 'Næstu námskeið' : 'Upcoming courses',
+              )}
+            </Text>
+          )}
           {course.instances.length === 0 &&
             course.showPlaceholderTextIfNoCourseInstances && (
               <Text>


### PR DESCRIPTION
# Hide course instance label based on boolean in cms

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [x] No AI tools were used in preparing this pull request
- [ ] AI tools were used in preparing this pull request
      Tools used:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
- Refined course details display logic. The "upcoming courses" section heading now renders conditionally based on whether course instances are available or placeholder configuration settings are enabled. This enhancement ensures the section heading only displays when relevant, reducing unnecessary visual elements and improving the overall clarity and user experience when no upcoming courses are present.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/island-is/island.is/pull/22667?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->