### PR TITLE
fix(application): Default value for employment history

### DIFF
--- a/libs/application/templates/unemployment-benefits/src/forms/mainForm/employmentInformationSection/employmentHistory.ts
+++ b/libs/application/templates/unemployment-benefits/src/forms/mainForm/employmentInformationSection/employmentHistory.ts
@@ -363,6 +363,7 @@ export const employmentHistorySubSection = buildSubSection({
           id: 'employmentHistory.hasWorkedEes',
           title: employmentMessages.employmentHistory.labels.radioEesLabel,
           width: 'half',
+          defaultValue: NO,
           options: [
             {
               value: YES,


### PR DESCRIPTION
## What

Default value set to no for has worked in EES radio field in the unemployment benefits application

## Why

Requested by VMST
[See ticket ](https://digitaliceland.zendesk.com/agent/tickets/507538)

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [x] No AI tools were used in preparing this pull request
- [ ] AI tools were used in preparing this pull request
      Tools used:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the employment history form to correctly default to "No" for the employment question, ensuring consistent and predictable default behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/island-is/island.is/pull/22670?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->