### PR TITLE
fix(j-s): Restrict reopening of merged indictment cases

### DIFF
--- a/apps/judicial-system/backend/src/app/modules/case/state/case.state.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/case/state/case.state.spec.ts
@@ -855,6 +855,24 @@ describe('Transition Case', () => {
         },
       )
 
+      it('should not reopen if case has been merged', () => {
+        // Arrange
+        const act = () =>
+          transitionCase(
+            CaseTransition.REOPEN,
+            {
+              id: uuid(),
+              state: fromState,
+              type,
+              mergeCaseId: uuid(),
+            } as Case,
+            { id: uuid() } as User,
+          )
+
+        // Act and assert
+        expect(act).toThrow(ForbiddenException)
+      })
+
       it('should not reopen if appeal is active (APPEALED)', () => {
         // Arrange
         const act = () =>

--- a/apps/judicial-system/backend/src/app/modules/case/state/case.state.ts
+++ b/apps/judicial-system/backend/src/app/modules/case/state/case.state.ts
@@ -182,6 +182,12 @@ const indictmentCaseStateMachine: Map<
           )
         }
 
+        if (theCase.mergeCaseId) {
+          throw new ForbiddenException(
+            'Cannot reopen a case that has been merged',
+          )
+        }
+
         if (
           theCase.appealCase &&
           (theCase.appealCase.appealState === AppealCaseState.APPEALED ||

--- a/apps/judicial-system/web/src/components/CaseInfo/CaseInfo.spec.tsx
+++ b/apps/judicial-system/web/src/components/CaseInfo/CaseInfo.spec.tsx
@@ -174,6 +174,19 @@ describe('CourtCaseInfo - reopen button visibility', () => {
     ).not.toBeInTheDocument()
   })
 
+  it('hides the reopen button when the case has been merged', () => {
+    const mergedCase = {
+      ...completedIndictmentCase,
+      mergeCase: { id: 'merged_case_id' },
+    }
+
+    renderComponent(UserRole.DISTRICT_COURT_JUDGE, mergedCase)
+
+    expect(
+      screen.queryByRole('button', { name: 'Enduropna mál' }),
+    ).not.toBeInTheDocument()
+  })
+
   it('hides the reopen button when the case has not been sent to public prosecutor', () => {
     const notSentCase = {
       ...completedIndictmentCase,

--- a/apps/judicial-system/web/src/components/CaseInfo/CaseInfo.tsx
+++ b/apps/judicial-system/web/src/components/CaseInfo/CaseInfo.tsx
@@ -154,6 +154,7 @@ export const CourtCaseInfo: FC<Props> = ({ workingCase }) => {
 
   const canReopenCase =
     isDistrictCourtUser(user) &&
+    !workingCase.mergeCase &&
     workingCase.indictmentRulingDecision !==
       CaseIndictmentRulingDecision.WITHDRAWAL &&
     Boolean(

--- a/apps/judicial-system/web/src/routes/PublicProsecutor/Indictments/Overview/Overview.strings.ts
+++ b/apps/judicial-system/web/src/routes/PublicProsecutor/Indictments/Overview/Overview.strings.ts
@@ -33,10 +33,4 @@ export const strings = defineMessages({
       'Máli {caseNumber} hefur verið úthlutað til yfirlestrar á {reviewer}.',
     description: 'Notaður sem texti í tilkynningaglugga um yfirlesara.',
   },
-  changeReviewedDecisionButtonText: {
-    id: 'judicial.system.core:public_prosecutor.indictments.overview.change_reviewed_decision_button_text',
-    defaultMessage: 'Breyta ákvörðun',
-    description:
-      'Notaður sem texti fyrir staðfestingartakka þegar ákvörðun ríkissaksóknara er breytt.',
-  },
 })


### PR DESCRIPTION
## What

- Prevents merged indictment cases from being reopened in the backend by throwing a `ForbiddenException` when `mergeCaseId` is set during a `REOPEN` transition
- Hides the reopen button in the frontend (`CaseInfo`) when `mergeCase` is set on the working case
- Removes unused `changeReviewedDecisionButtonText` i18n string from the public prosecutor overview

## Why

Merged indictment cases should not be reopened — they have been consolidated into another case and reopening them would cause inconsistent state.

## Screenshots / Gifs


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Prevented reopening of cases that have been merged
  * The "Reopen case" button is now hidden for merged cases to prevent user error

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/island-is/island.is/pull/22677?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->