### PR TITLE
fix(j-s): Track indictment reopened in event log and invalidate reviewed date

### DIFF
--- a/apps/judicial-system/backend/src/app/modules/case/case.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/case/case.service.ts
@@ -1448,6 +1448,18 @@ export class CaseService {
         transaction,
       )
     }
+
+    if (
+      theCase.state === CaseState.COMPLETED &&
+      updatedCase.state === CaseState.RECEIVED
+    ) {
+      return this.eventLogService.createWithUser(
+        EventType.INDICTMENT_REOPENED,
+        theCase.id,
+        user,
+        transaction,
+      )
+    }
   }
 
   private handleStateChangeEventLogUpdatesForRequest(

--- a/apps/judicial-system/backend/src/app/modules/case/interceptors/case.interceptor.ts
+++ b/apps/judicial-system/backend/src/app/modules/case/interceptors/case.interceptor.ts
@@ -631,7 +631,9 @@ const transformCase = (
         EventType.INDICTMENT_REOPENED,
         theCase.eventLogs,
       )
-      return reopenedDate && reopenedDate > reviewedDate ? undefined : reviewedDate
+      return reopenedDate && reopenedDate > reviewedDate
+        ? undefined
+        : reviewedDate
     })(),
     indictmentSentToPublicProsecutorDate: EventLog.getEventLogDateByEventType(
       EventType.INDICTMENT_SENT_TO_PUBLIC_PROSECUTOR,

--- a/apps/judicial-system/backend/src/app/modules/case/interceptors/case.interceptor.ts
+++ b/apps/judicial-system/backend/src/app/modules/case/interceptors/case.interceptor.ts
@@ -621,10 +621,18 @@ const transformCase = (
       [EventType.CASE_SENT_TO_COURT, EventType.INDICTMENT_CONFIRMED],
       theCase.eventLogs,
     ),
-    indictmentReviewedDate: DefendantEventLog.getEventLogDateByEventType(
-      DefendantEventType.INDICTMENT_REVIEWED,
-      theCase.defendants?.flatMap((defendant) => defendant.eventLogs || []),
-    ),
+    indictmentReviewedDate: (() => {
+      const reviewedDate = DefendantEventLog.getEventLogDateByEventType(
+        DefendantEventType.INDICTMENT_REVIEWED,
+        theCase.defendants?.flatMap((defendant) => defendant.eventLogs || []),
+      )
+      if (!reviewedDate) return undefined
+      const reopenedDate = EventLog.getEventLogDateByEventType(
+        EventType.INDICTMENT_REOPENED,
+        theCase.eventLogs,
+      )
+      return reopenedDate && reopenedDate > reviewedDate ? undefined : reviewedDate
+    })(),
     indictmentSentToPublicProsecutorDate: EventLog.getEventLogDateByEventType(
       EventType.INDICTMENT_SENT_TO_PUBLIC_PROSECUTOR,
       theCase.eventLogs,

--- a/apps/judicial-system/backend/src/app/modules/case/test/caseController/update.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/case/test/caseController/update.spec.ts
@@ -1094,5 +1094,14 @@ describe('CaseController - Update', () => {
         body: { type: IndictmentCaseNotificationType.INDICTMENT_REOPENED },
       })
     })
+
+    it('should create INDICTMENT_REOPENED event log', () => {
+      expect(mockEventLogService.createWithUser).toHaveBeenCalledWith(
+        EventType.INDICTMENT_REOPENED,
+        caseId,
+        user,
+        transaction,
+      )
+    })
   })
 })

--- a/apps/judicial-system/backend/src/app/modules/event-log/eventLog.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/event-log/eventLog.service.ts
@@ -32,6 +32,7 @@ const allowMultiple: EventType[] = [
   EventType.REQUEST_COMPLETED,
   EventType.INDICTMENT_SENT_TO_PUBLIC_PROSECUTOR,
   EventType.INDICTMENT_COMPLETED,
+  EventType.INDICTMENT_REOPENED,
 ]
 
 const allowOnePerUserRole: EventType[] = [EventType.APPEAL_RESULT_ACCESSED]

--- a/libs/judicial-system/types/src/lib/eventLog.ts
+++ b/libs/judicial-system/types/src/lib/eventLog.ts
@@ -15,6 +15,7 @@ export enum EventType {
   COURT_DATE_SCHEDULED = 'COURT_DATE_SCHEDULED',
   REQUEST_COMPLETED = 'REQUEST_COMPLETED', // Request case is completed
   INDICTMENT_SPLIT_COMPLETED = 'INDICTMENT_SPLIT_COMPLETED',
+  INDICTMENT_REOPENED = 'INDICTMENT_REOPENED',
 }
 
 export const eventTypes = Object.values(EventType)


### PR DESCRIPTION
## What

- Adds `INDICTMENT_REOPENED` to the `EventType` enum
- Emits an `INDICTMENT_REOPENED` event log entry when an indictment case transitions from `COMPLETED` back to `RECEIVED` (i.e. on reopen)
- Updates the `indictmentReviewedDate` computed field in the case interceptor to return `undefined` if a more recent `INDICTMENT_REOPENED` event exists — effectively invalidating the reviewed date after a reopen without deleting event log records

## Why

The event log is append-only and records are never deleted (they are a historical representation of events). When a case is reopened, the `indictmentReviewedDate` was still being derived from the old `INDICTMENT_REVIEWED` event, making it appear as if the indictment was still reviewed. By recording the reopen as an event and comparing timestamps, we can correctly treat the case as not reviewed after a reopen.

## Screenshots / Gifs


## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Event logging added for reopened indictment cases (new reopened event type supported).
  * Case review date logic updated to account for reopened indictment events so displayed review dates reflect reopens.
  * Event logging now allows multiple reopened events to be recorded for a case.

* **Tests**
  * Added test coverage ensuring reopened indictment events are created and queued for notifications.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/island-is/island.is/pull/22686?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->