### PR TITLE
fix(services-user-profile): prevent empty primary email placeholder on IDS skip (hotfix)

### DIFF
--- a/apps/services/user-profile/migrations/20260518100000-remove-empty-primary-email-placeholders.js
+++ b/apps/services/user-profile/migrations/20260518100000-remove-empty-primary-email-placeholders.js
@@ -1,0 +1,17 @@
+'use strict'
+
+module.exports = {
+  up: (queryInterface) => {
+    return queryInterface.sequelize.query(`
+      DELETE FROM emails
+      WHERE "primary" = true
+        AND (email IS NULL OR email = '')
+        AND email_status IN ('EMPTY', 'NOT_DEFINED');
+    `)
+  },
+
+  down: () => {
+    // Not reversible — placeholder rows carried no information to reconstruct
+    return Promise.resolve()
+  },
+}

--- a/apps/services/user-profile/src/app/user-profile/test/me-user-profile.controller.spec.ts
+++ b/apps/services/user-profile/src/app/user-profile/test/me-user-profile.controller.spec.ts
@@ -29,6 +29,7 @@ import { DataStatus } from '../types/dataStatusTypes'
 import { NudgeType } from '../../types/nudge-type'
 import { ClientType } from '../../types/ClientType'
 import { PostNudgeDto } from '../dto/post-nudge.dto'
+import { CreateEmailDto } from '../dto/create-emails.dto'
 import { ActorProfile } from '../models/actor-profile.model'
 import { Emails } from '../models/emails.model'
 import { NUDGE_INTERVAL, SKIP_INTERVAL } from '../user-profile.service'
@@ -1271,6 +1272,88 @@ describe('MeUserProfileController', () => {
         }
       },
     )
+
+    it.each([NudgeType.NUDGE, NudgeType.SKIP_EMAIL, NudgeType.SKIP_PHONE])(
+      'POST /v2/me/nudge with nudgeType=%s should not create any email rows when no user profile exists yet',
+      async (nudgeType) => {
+        // Act
+        const res = await server.post('/v2/me/nudge').send({
+          nudgeType,
+        } as PostNudgeDto)
+
+        // Assert
+        expect(res.status).toEqual(200)
+
+        const emailsModel = app.get(getModelToken(Emails))
+        const emails = await emailsModel.findAll({
+          where: { nationalId: testUserProfile.nationalId },
+        })
+
+        expect(emails).toHaveLength(0)
+      },
+    )
+
+    it('POST /v2/me/nudge should not create an empty primary email when existing user profile has no emails', async () => {
+      // Arrange — profile with no associated emails (mimics onboarding-skip aftermath)
+      const fixtureFactory = new FixtureFactory(app)
+      await fixtureFactory.createUserProfile({
+        nationalId: testUserProfile.nationalId,
+        mobilePhoneNumber: testUserProfile.mobilePhoneNumber,
+      })
+
+      // Act
+      const res = await server.post('/v2/me/nudge').send({
+        nudgeType: NudgeType.NUDGE,
+      } as PostNudgeDto)
+
+      // Assert
+      expect(res.status).toEqual(200)
+
+      const emailsModel = app.get(getModelToken(Emails))
+      const emails = await emailsModel.findAll({
+        where: { nationalId: testUserProfile.nationalId },
+      })
+
+      expect(emails).toHaveLength(0)
+    })
+
+    it('POST /v2/me/nudge with SKIP_EMAIL followed by POST /v2/actor/emails should create the first primary email without a unique constraint violation', async () => {
+      // Regression: IDS skip used to create an empty primary placeholder row, which
+      // then collided with the partial unique index on (national_id) WHERE primary=true
+      // when the user later added a real email — surfacing as a 500 SequelizeUniqueConstraintError.
+      const fixtureFactory = new FixtureFactory(app)
+      await fixtureFactory.createEmailVerification({
+        nationalId: testUserProfile.nationalId,
+        email: 'first-real@example.com',
+        hash: 'code-123',
+      })
+
+      const nudgeRes = await server.post('/v2/me/nudge').send({
+        nudgeType: NudgeType.SKIP_EMAIL,
+      } as PostNudgeDto)
+      expect(nudgeRes.status).toEqual(200)
+
+      const createRes = await server.post('/v2/actor/emails').send({
+        email: 'first-real@example.com',
+        code: 'code-123',
+      } as CreateEmailDto)
+
+      expect(createRes.status).toEqual(200)
+      expect(createRes.body).toMatchObject({
+        email: 'first-real@example.com',
+        primary: true,
+        emailStatus: DataStatus.VERIFIED,
+      })
+
+      const emailsModel = app.get(getModelToken(Emails))
+      const emails = await emailsModel.findAll({
+        where: { nationalId: testUserProfile.nationalId },
+        useMaster: true,
+      })
+      expect(emails).toHaveLength(1)
+      expect(emails[0].email).toBe('first-real@example.com')
+      expect(emails[0].primary).toBe(true)
+    })
   })
 
   describe('GET v2/me/actor-profiles', () => {

--- a/apps/services/user-profile/src/app/user-profile/user-profile.service.ts
+++ b/apps/services/user-profile/src/app/user-profile/user-profile.service.ts
@@ -558,57 +558,27 @@ export class UserProfileService {
 
     await this.sequelize.transaction(async (t) => {
       if (!currentProfile) {
-        // Creating a new user profile and linking the default email
-        await this.userProfileModel.create(
-          {
-            ...upsertPayload,
-            emails: [
-              {
-                id: uuid(),
-                nationalId,
-                email: '',
-                primary: true,
-                emailStatus: DataStatus.EMPTY,
-              },
-            ],
-          },
-          {
-            transaction: t,
-            useMaster: true,
-            include: [{ model: Emails, as: 'emails' }],
-          },
-        )
+        await this.userProfileModel.create(upsertPayload, {
+          transaction: t,
+          useMaster: true,
+        })
       } else {
-        // Updating existing user profile
         await this.userProfileModel.update(upsertPayload, {
           where: { nationalId },
           transaction: t,
         })
 
-        // Check for existing primary email
         const primaryEmail = await this.emailModel.findOne({
           where: { nationalId, primary: true },
           transaction: t,
           useMaster: true,
         })
 
-        if (!primaryEmail) {
-          // Create a default email if one doesn't exist
-          await this.emailModel.create(
-            {
-              id: uuid(),
-              nationalId,
-              email: '',
-              primary: true,
-              emailStatus: DataStatus.EMPTY,
-            },
-            { transaction: t, useMaster: true },
-          )
-        } else if (
+        if (
+          primaryEmail &&
           primaryEmail.emailStatus === DataStatus.NOT_DEFINED &&
           nudgeType === NudgeType.NUDGE
         ) {
-          // Update email status if applicable
           await primaryEmail.update(
             { emailStatus: DataStatus.EMPTY },
             { transaction: t },
@@ -636,14 +606,7 @@ export class UserProfileService {
     }
 
     return await this.userProfileModel
-      .create(
-        {
-          nationalId,
-          email: '',
-          emailStatus: DataStatus.EMPTY,
-        },
-        { transaction, useMaster: true },
-      )
+      .create({ nationalId }, { transaction, useMaster: true })
       .catch((error) => {
         console.log('Error creating user profile', error)
         throw error


### PR DESCRIPTION
# Prevent empty primary email placeholder on IDS skip (hotfix)

Cherry-pick of #22621 onto `release/2026.5.26.0`.

## What

- Stop creating an empty placeholder email row (`email=''`, `primary=true`, `status='EMPTY'`) in both branches of `confirmNudge`
- Drop dead `email`/`emailStatus` writes from `findOrCreateUserProfile` (columns were removed in migration `20250826122506`)
- Add backfill migration that deletes existing empty primary email placeholder rows
- Add regression tests covering:
  - `confirmNudge` with any nudge type creates no email rows on a new profile
  - `confirmNudge` with `NUDGE` leaves emails empty when profile has none
  - `SKIP_EMAIL` followed by `POST /v2/actor/emails` succeeds end-to-end

## Why

- When a user clicked "Skip" on the IDS email prompt during onboarding, the placeholder row caused later real-email inserts to trip the partial unique index `emails_national_id_primary_unique`, surfacing as `SequelizeUniqueConstraintError ("national_id already exists")`
- This hotfix lands the fix on the active release branch so affected users can complete onboarding without manual intervention

## Screenshots / Gifs

N/A

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code