### PR TITLE
feat(contentful-apps): Allow more embed urls

### DIFF
--- a/apps/contentful-apps/pages/fields/embed-link-field.tsx
+++ b/apps/contentful-apps/pages/fields/embed-link-field.tsx
@@ -9,7 +9,7 @@ const ALLOWED_EMBED_URLS = [
   'https://app.powerbi.com',
   'https://portal.land.is',
   'https://www.facebook.com',
-  'https://solmyrkvi.is',
+  'https://solmyrkvi2026.is',
   'https://eclipse2026.is',
 ]
 

--- a/apps/contentful-apps/pages/fields/embed-link-field.tsx
+++ b/apps/contentful-apps/pages/fields/embed-link-field.tsx
@@ -9,6 +9,8 @@ const ALLOWED_EMBED_URLS = [
   'https://app.powerbi.com',
   'https://portal.land.is',
   'https://www.facebook.com',
+  'https://solmyrkvi.is',
+  'https://eclipse2026.is',
 ]
 
 const getIframeSrc = (iframe: string) => {


### PR DESCRIPTION
# Allow more embed urls

Allow solmyrvki2026.is and eclipse2026.is as embed urls since we're embedding a map from that web

- [x] No AI tools were used in preparing this pull request
- [ ] AI tools were used in preparing this pull request
      Tools used:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended embed-link field to support iframe embeds from additional sources (solmyrkvi.is and eclipse2026.is).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/island-is/island.is/pull/22691?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->