### PR TITLE
fix(auth-api-lib): use National Registry v3 for incoming ward delegations

### DIFF
--- a/apps/services/auth/delegation-api/src/app/delegations/test/delegation-index/delegation-index.service.spec.ts
+++ b/apps/services/auth/delegation-api/src/app/delegations/test/delegation-index/delegation-index.service.spec.ts
@@ -31,6 +31,7 @@ import {
 } from '@island.is/auth-api-lib'
 import { RskRelationshipsClient } from '@island.is/clients-rsk-relationships'
 import { NationalRegistryClientService } from '@island.is/clients/national-registry-v2'
+import { NationalRegistryV3ClientService } from '@island.is/clients/national-registry-v3'
 import { FixtureFactory } from '@island.is/services/auth/testing'
 import {
   AuthDelegationProvider,
@@ -47,6 +48,7 @@ describe('DelegationsIndexService', () => {
   let factory: FixtureFactory
   let sequelize: Sequelize
   let nationalRegistryApi: NationalRegistryClientService
+  let nationalRegistryV3Api: NationalRegistryV3ClientService
   let rskApi: RskRelationshipsClient
   let delegationModel: typeof Delegation
   let delegationScopeModel: typeof DelegationScope
@@ -97,6 +99,25 @@ describe('DelegationsIndexService', () => {
       .spyOn(nationalRegistryApi, 'getCustodyChildren')
       .mockImplementation(async () => testCase.fromChildren)
 
+    // mock national registry v3 (Midlun) for the ward delegation v3 code path
+    jest
+      .spyOn(nationalRegistryV3Api, 'getAllDataIndividual')
+      .mockImplementation(async (nationalId: string) => {
+        if (nationalId === user.nationalId) {
+          return {
+            kennitala: nationalId,
+            forsja: {
+              born: testCase.fromChildren.map((childId) => ({
+                barnKennitala: childId,
+                barnNafn: faker.name.findName(),
+              })),
+            },
+          }
+        }
+
+        return { kennitala: nationalId, nafn: faker.name.findName() }
+      })
+
     // mock rsk for procuration delegations
     jest
       .spyOn(rskApi, 'getIndividualRelationships')
@@ -129,6 +150,8 @@ describe('DelegationsIndexService', () => {
           name: faker.name.findName(),
         }),
       )
+
+    nationalRegistryV3Api = app.get(NationalRegistryV3ClientService)
 
     rskApi = app.get(RskRelationshipsClient)
   })

--- a/apps/services/auth/ids-api/src/app/delegations/test/delegations-filters.spec.ts
+++ b/apps/services/auth/ids-api/src/app/delegations/test/delegations-filters.spec.ts
@@ -11,6 +11,7 @@ import {
 import { RskRelationshipsClient } from '@island.is/clients-rsk-relationships'
 import { NationalRegistryClientService } from '@island.is/clients/national-registry-v2'
 import { NationalRegistryV3ClientService } from '@island.is/clients/national-registry-v3'
+import { FeatureFlagService, Features } from '@island.is/nest/feature-flags'
 import { FixtureFactory } from '@island.is/services/auth/testing'
 import {
   AuthDelegationProvider,
@@ -73,6 +74,19 @@ describe('DelegationsController', () => {
           .spyOn(nationalRegistryV3FeatureService, 'getValue')
           .mockImplementation(async () => featureFlag)
 
+        // Ward delegations are gated by their own flag; tie it to the same
+        // parametrized value so both the v2 and v3 code paths are covered.
+        const featureFlagService = app.get(FeatureFlagService)
+        const getValueOriginal =
+          featureFlagService.getValue.bind(featureFlagService)
+        jest
+          .spyOn(featureFlagService, 'getValue')
+          .mockImplementation((feature, ...args) =>
+            feature === Features.isDelegationIncomingWardV3Enabled
+              ? Promise.resolve(featureFlag)
+              : getValueOriginal(feature, ...args),
+          )
+
         factory = new FixtureFactory(app)
       })
 
@@ -133,6 +147,26 @@ describe('DelegationsController', () => {
             jest
               .spyOn(nationalRegistryApi, 'getCustodyChildren')
               .mockImplementation(async () => testCase.fromChildren)
+
+            jest
+              .spyOn(nationalRegistryV3Api, 'getAllDataIndividual')
+              .mockImplementation(async (nationalId: string) => {
+                // Parent lookup returns the custody children via Midlun's forsja.born
+                if (nationalId === testCase.user.nationalId) {
+                  return {
+                    kennitala: nationalId,
+                    forsja: {
+                      born: testCase.fromChildren.map((childId) => ({
+                        barnKennitala: childId,
+                        barnNafn: faker.name.findName(),
+                      })),
+                    },
+                  }
+                }
+
+                // Per-child lookup returns that child's individual record
+                return { kennitala: nationalId, nafn: faker.name.findName() }
+              })
 
             jest
               .spyOn(rskApi, 'getIndividualRelationships')

--- a/apps/services/auth/public-api/src/app/modules/delegations/actorDelegations.controller.spec.ts
+++ b/apps/services/auth/public-api/src/app/modules/delegations/actorDelegations.controller.spec.ts
@@ -23,10 +23,7 @@ import {
 } from '@island.is/auth-api-lib'
 import { AuthScope } from '@island.is/auth/scopes'
 import { RskRelationshipsClient } from '@island.is/clients-rsk-relationships'
-import {
-  IndividualDto,
-  NationalRegistryClientService,
-} from '@island.is/clients/national-registry-v2'
+import { NationalRegistryClientService } from '@island.is/clients/national-registry-v2'
 import { NationalRegistryV3ClientService } from '@island.is/clients/national-registry-v3'
 import {
   createClient,
@@ -240,26 +237,10 @@ describe('ActorDelegationsController', () => {
             ),
           ]
 
-          beforeAll(async () => {
-            nationalRegistryApiSpy = jest
-              .spyOn(nationalRegistryApi, 'getIndividual')
-              .mockImplementation(async (id) => {
-                if (deceasedNationalIds.includes(id)) {
-                  return null
-                }
-
-                const user = nationalRegistryUsers.find(
-                  (u) => u?.nationalId === id,
-                )
-
-                return user ?? null
-              })
-            const nationalRegistryV3FeatureService = app.get(
-              NationalRegistryV3FeatureService,
-            )
-            jest
-              .spyOn(nationalRegistryV3FeatureService, 'getValue')
-              .mockImplementation(async () => featureFlag)
+          // Default Midlun (national-registry-v3) mock used across this block.
+          // The ward describe overrides it with a custody-aware mock and restores
+          // it via this function in its afterAll to avoid leaking into other blocks.
+          const applyDefaultV3Mock = () => {
             nationalRegistryV3ApiSpy = jest
               .spyOn(nationalRegistryV3Api, 'getAllDataIndividual')
               .mockImplementation(async (id) => {
@@ -282,6 +263,29 @@ describe('ActorDelegationsController', () => {
                     }
                   : null
               })
+          }
+
+          beforeAll(async () => {
+            nationalRegistryApiSpy = jest
+              .spyOn(nationalRegistryApi, 'getIndividual')
+              .mockImplementation(async (id) => {
+                if (deceasedNationalIds.includes(id)) {
+                  return null
+                }
+
+                const user = nationalRegistryUsers.find(
+                  (u) => u?.nationalId === id,
+                )
+
+                return user ?? null
+              })
+            const nationalRegistryV3FeatureService = app.get(
+              NationalRegistryV3FeatureService,
+            )
+            jest
+              .spyOn(nationalRegistryV3FeatureService, 'getValue')
+              .mockImplementation(async () => featureFlag)
+            applyDefaultV3Mock()
           })
 
           it('should return only valid delegations', async () => {
@@ -729,17 +733,31 @@ describe('ActorDelegationsController', () => {
             let getForsja: jest.SpyInstance
             let clientInstance: any
 
-            const mockForKt = (kt: string): void => {
+            // Custody-aware Midlun mock for the national-registry-v3 code path.
+            // Parent lookup returns the wards via forsja.born; per-child lookup
+            // returns that child's individual record.
+            const mockV3ForChildren = (childIds: string[]): void => {
               jest
-                .spyOn(clientInstance, 'getIndividual')
-                .mockResolvedValueOnce({
-                  nationalId: kt,
-                  name: nationalRegistryUser.name,
-                } as IndividualDto)
+                .spyOn(nationalRegistryV3Api, 'getAllDataIndividual')
+                .mockImplementation(async (id) => {
+                  if (id === user.nationalId) {
+                    return {
+                      kennitala: id,
+                      forsja: {
+                        born: childIds.map((childId) => ({
+                          barnKennitala: childId,
+                          barnNafn: nationalRegistryUser.name,
+                        })),
+                      },
+                    }
+                  }
 
-              jest
-                .spyOn(clientInstance, 'getCustodyChildren')
-                .mockResolvedValueOnce([kt])
+                  return { kennitala: id, nafn: nationalRegistryUser.name }
+                })
+            }
+
+            const mockForKt = (kt: string): void => {
+              mockV3ForChildren([kt])
             }
 
             beforeEach(() => {
@@ -747,10 +765,14 @@ describe('ActorDelegationsController', () => {
               getForsja = jest
                 .spyOn(clientInstance, 'getCustodyChildren')
                 .mockResolvedValue([nationalRegistryUser.nationalId])
+              mockV3ForChildren([nationalRegistryUser.nationalId])
             })
 
             afterAll(() => {
               getForsja.mockRestore()
+              // Restore the default Midlun mock so the custody-aware override does
+              // not leak into the procuring / personal-representative blocks.
+              applyDefaultV3Mock()
             })
 
             it('should return delegations', async () => {

--- a/libs/auth-api-lib/src/lib/delegations/delegations-incoming-ward.service.ts
+++ b/libs/auth-api-lib/src/lib/delegations/delegations-incoming-ward.service.ts
@@ -9,6 +9,8 @@ import {
   IndividualDto,
   NationalRegistryClientService,
 } from '@island.is/clients/national-registry-v2'
+import { NationalRegistryV3ClientService } from '@island.is/clients/national-registry-v3'
+import { FeatureFlagService, Features } from '@island.is/nest/feature-flags'
 import { LOGGER_PROVIDER } from '@island.is/logging'
 import {
   AuthDelegationProvider,
@@ -19,6 +21,8 @@ import {
 export class DelegationsIncomingWardService {
   constructor(
     private nationalRegistryClient: NationalRegistryClientService,
+    private nationalRegistryV3Client: NationalRegistryV3ClientService,
+    private readonly featureFlagService: FeatureFlagService,
     @Inject(LOGGER_PROVIDER)
     private logger: Logger,
   ) {}
@@ -42,33 +46,16 @@ export class DelegationsIncomingWardService {
     }
 
     try {
-      const response = await this.nationalRegistryClient.getCustodyChildren(
+      const useNationalRegistryV3 = await this.featureFlagService.getValue(
+        Features.isDelegationIncomingWardV3Enabled,
+        false,
         user,
       )
 
-      const distinct = response.filter(
-        (r: string, i: number) => response.indexOf(r) === i,
-      )
-
-      const resultPromises = distinct.map(async (nationalId) =>
-        this.nationalRegistryClient.getIndividual(nationalId),
-      )
-
-      const result = await Promise.all(resultPromises)
-
       // delegations for legal guardians of children under 18
-      const legalGuardianDelegations = result
-        .filter((p): p is IndividualDto => p !== null)
-        .map(
-          (p) =>
-            <DelegationDTO>{
-              toNationalId: user.nationalId,
-              fromNationalId: p.nationalId,
-              fromName: p.name,
-              type: AuthDelegationType.LegalGuardian,
-              provider: AuthDelegationProvider.NationalRegistry,
-            },
-        )
+      const legalGuardianDelegations = useNationalRegistryV3
+        ? await this.getLegalGuardianDelegationsV3(user)
+        : await this.getLegalGuardianDelegationsV2(user)
 
       // delegations for legal guardians of children under 16
       const legalGuardianMinorDelegations = legalGuardianDelegations
@@ -84,5 +71,66 @@ export class DelegationsIncomingWardService {
     }
 
     return []
+  }
+
+  private async getLegalGuardianDelegationsV3(
+    user: User,
+  ): Promise<DelegationDTO[]> {
+    const individual = await this.nationalRegistryV3Client.getAllDataIndividual(
+      user.nationalId,
+    )
+
+    // Midlun returns each ward (kennitala + name) on the guardian's own record,
+    // so there is no need for a follow-up lookup per child.
+    const children = (individual?.forsja?.born ?? []).filter(
+      (child) => !!child.barnKennitala && !!child.barnNafn,
+    )
+
+    const distinct = children.filter(
+      (child, i) =>
+        children.findIndex(
+          (other) => other.barnKennitala === child.barnKennitala,
+        ) === i,
+    )
+
+    return distinct.map(
+      (child) =>
+        <DelegationDTO>{
+          toNationalId: user.nationalId,
+          fromNationalId: child.barnKennitala,
+          fromName: child.barnNafn,
+          type: AuthDelegationType.LegalGuardian,
+          provider: AuthDelegationProvider.NationalRegistry,
+        },
+    )
+  }
+
+  private async getLegalGuardianDelegationsV2(
+    user: User,
+  ): Promise<DelegationDTO[]> {
+    const response = await this.nationalRegistryClient.getCustodyChildren(user)
+
+    const distinct = response.filter(
+      (r: string, i: number) => response.indexOf(r) === i,
+    )
+
+    const result = await Promise.all(
+      distinct.map(async (nationalId) =>
+        this.nationalRegistryClient.getIndividual(nationalId),
+      ),
+    )
+
+    return result
+      .filter((p): p is IndividualDto => p !== null)
+      .map(
+        (p) =>
+          <DelegationDTO>{
+            toNationalId: user.nationalId,
+            fromNationalId: p.nationalId,
+            fromName: p.name,
+            type: AuthDelegationType.LegalGuardian,
+            provider: AuthDelegationProvider.NationalRegistry,
+          },
+      )
   }
 }

--- a/libs/feature-flags/src/lib/features.ts
+++ b/libs/feature-flags/src/lib/features.ts
@@ -156,6 +156,9 @@ export enum Features {
   // Should auth api use national registry v3 for checking deceased status
   isNationalRegistryV3DeceasedStatusEnabled = 'isNationalRegistryV3DeceasedStatusEnabled',
 
+  // Should auth api use national registry v3 (Midlun) for incoming ward (legal guardian) delegations
+  isDelegationIncomingWardV3Enabled = 'isDelegationIncomingWardV3Enabled',
+
   // Should applicaton-system use national registry v3
   shouldApplicationSystemUseNationalRegistryV3 = 'shouldApplicationSystemUseNationalRegistryV3',
 


### PR DESCRIPTION
## What

- Add the `isDelegationIncomingWardV3Enabled` feature flag.
- Gate `DelegationsIncomingWardService` on the new flag: use National Registry v3 (Midlun) `getAllDataIndividual` when enabled, and fall back to the v2 `getCustodyChildren` / `getIndividual` path when disabled.
- Build legal-guardian (ward) delegations directly from the guardian's Midlun `forsja.born` (kennitala + name) in a single call — no per-child lookups.
- Update auth service tests (ids-api, public-api, delegation-api) to cover the v3 ward path.

## Why

- The v2 `/forsja` + per-individual lookups are being superseded by National Registry v3 (Midlun); this migrates incoming ward delegations to the new source.
- Flag-gated so the cutover can be rolled out safely — defaults off, preserving existing v2 behaviour until the flag is enabled.
- Midlun already returns each ward's kennitala and name on the guardian's own record, so the previous per-child fan-out (1+N calls) is collapsed into a single call.

## Screenshots / Gifs

N/A

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for National Registry V3 backend for processing legal guardian ward delegations, controlled by a feature flag enabling gradual rollout.

* **Tests**
  * Expanded test coverage to validate the new National Registry V3 delegation workflow and ensure compatibility with existing implementations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/island-is/island.is/pull/22697?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->