### PR TITLE
fix(bff): allow prefixed beta-dev urls in bff

### DIFF
--- a/apps/services/bff/src/app/utils/validate-uri.spec.ts
+++ b/apps/services/bff/src/app/utils/validate-uri.spec.ts
@@ -101,4 +101,16 @@ describe('validateUri', () => {
       ),
     ).toBe(false)
   })
+
+  it('should return false for arbitrary-prefix hostname when beta host is allowed', () => {
+    // "evil.sub" contains a dot — not a valid DNS slug — so it must be rejected
+    // even though the full hostname ends with "-beta.dev01.devland.is".
+    const betaAllowedUris = ['https://beta.dev01.devland.is/stjornbord']
+    expect(
+      validateUri(
+        'https://evil.sub-beta.dev01.devland.is/stjornbord',
+        betaAllowedUris,
+      ),
+    ).toBe(false)
+  })
 })

--- a/apps/services/bff/src/app/utils/validate-uri.spec.ts
+++ b/apps/services/bff/src/app/utils/validate-uri.spec.ts
@@ -81,4 +81,24 @@ describe('validateUri', () => {
       validateUri('https://beta.dev01.devland.is/different-path', allowedUris),
     ).toBe(false)
   })
+
+  it('should return true for feature deployment hostnames when beta host is allowed', () => {
+    const betaAllowedUris = ['https://beta.dev01.devland.is/minarsidur']
+    expect(
+      validateUri(
+        'https://featcreate-pdf-viewer-beta.dev01.devland.is/minarsidur/menntun/grunnskoli/nemendur',
+        betaAllowedUris,
+      ),
+    ).toBe(true)
+  })
+
+  it('should return false for non-feature subdomain when only beta host is allowed', () => {
+    const betaAllowedUris = ['https://beta.dev01.devland.is/minarsidur']
+    expect(
+      validateUri(
+        'https://evil-beta.staging01.devland.is/minarsidur',
+        betaAllowedUris,
+      ),
+    ).toBe(false)
+  })
 })

--- a/apps/services/bff/src/app/utils/validate-uri.ts
+++ b/apps/services/bff/src/app/utils/validate-uri.ts
@@ -35,12 +35,18 @@ export const validateUri = (uri: string, allowedUris: string[]): boolean => {
       const parsedAllowedUri = new URL(allowedUri.trim().toLowerCase())
 
       const isSameProtocol = parsedUri.protocol === parsedAllowedUri.protocol
-      const isSameHostname =
-        parsedUri.hostname === parsedAllowedUri.hostname ||
-        // Allow feature deployment hostnames, e.g. "feat-foo-beta.dev01.devland.is"
-        // when "beta.dev01.devland.is" is an allowed hostname.
-        (parsedAllowedUri.hostname.startsWith('beta.') &&
-          parsedUri.hostname.endsWith(`-${parsedAllowedUri.hostname}`))
+      let isSameHostname = parsedUri.hostname === parsedAllowedUri.hostname
+      // Allow feature deployment hostnames, e.g. "feat-foo-beta.dev01.devland.is"
+      // when "beta.dev01.devland.is" is an allowed hostname.
+      if (!isSameHostname && parsedAllowedUri.hostname.startsWith('beta.')) {
+        const suffix = `-${parsedAllowedUri.hostname}`
+        if (parsedUri.hostname.endsWith(suffix)) {
+          const prefix = parsedUri.hostname.slice(0, -suffix.length)
+          // Restrict to valid DNS/k8s slug — prevents arbitrary-prefix open redirects
+          // via crafted hostnames (e.g. "evil.sub-beta.dev01.devland.is").
+          isSameHostname = /^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(prefix)
+        }
+      }
       const isSamePathname =
         parsedUri.pathname === parsedAllowedUri.pathname ||
         parsedUri.pathname.startsWith(parsedAllowedUri.pathname)

--- a/apps/services/bff/src/app/utils/validate-uri.ts
+++ b/apps/services/bff/src/app/utils/validate-uri.ts
@@ -40,9 +40,7 @@ export const validateUri = (uri: string, allowedUris: string[]): boolean => {
         // Allow feature deployment hostnames, e.g. "feat-foo-beta.dev01.devland.is"
         // when "beta.dev01.devland.is" is an allowed hostname.
         (parsedAllowedUri.hostname.startsWith('beta.') &&
-          parsedUri.hostname.endsWith(
-            `-${parsedAllowedUri.hostname}`,
-          ))
+          parsedUri.hostname.endsWith(`-${parsedAllowedUri.hostname}`))
       const isSamePathname =
         parsedUri.pathname === parsedAllowedUri.pathname ||
         parsedUri.pathname.startsWith(parsedAllowedUri.pathname)

--- a/apps/services/bff/src/app/utils/validate-uri.ts
+++ b/apps/services/bff/src/app/utils/validate-uri.ts
@@ -35,7 +35,14 @@ export const validateUri = (uri: string, allowedUris: string[]): boolean => {
       const parsedAllowedUri = new URL(allowedUri.trim().toLowerCase())
 
       const isSameProtocol = parsedUri.protocol === parsedAllowedUri.protocol
-      const isSameHostname = parsedUri.hostname === parsedAllowedUri.hostname
+      const isSameHostname =
+        parsedUri.hostname === parsedAllowedUri.hostname ||
+        // Allow feature deployment hostnames, e.g. "feat-foo-beta.dev01.devland.is"
+        // when "beta.dev01.devland.is" is an allowed hostname.
+        (parsedAllowedUri.hostname.startsWith('beta.') &&
+          parsedUri.hostname.endsWith(
+            `-${parsedAllowedUri.hostname}`,
+          ))
       const isSamePathname =
         parsedUri.pathname === parsedAllowedUri.pathname ||
         parsedUri.pathname.startsWith(parsedAllowedUri.pathname)


### PR DESCRIPTION
## What

* Allow prefixed dev urls through bff.

## Why

* Download service doesn't work on feature deploys since the urls are prefixed.

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved URI validation to accept allowed beta-style hostnames for feature deployments while enforcing protocol/path checks and allowed-prefix formatting.

* **Tests**
  * Added tests for accepting a valid beta-style hostname variant, rejecting non-feature subdomain hosts when only the beta host is allowed, and rejecting arbitrary-prefix hostnames even if they end with the beta suffix.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/island-is/island.is/pull/22703?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->