### PR TITLE
fix(web): Hide course instance label based on boolean in cms (#22667)

### DIFF
--- a/apps/web/screens/Organization/Courses/CourseDetails.tsx
+++ b/apps/web/screens/Organization/Courses/CourseDetails.tsx
@@ -173,12 +173,15 @@ const CourseDetails: Screen<CourseDetailsProps, CourseDetailsScreenContext> = ({
         </Text>
         <Box>{webRichText(course.description)}</Box>
         <Stack space={3}>
-          <Text variant="h2" as="h2">
-            {n(
-              'courseInstancesLabel',
-              activeLocale === 'is' ? 'Næstu námskeið' : 'Upcoming courses',
-            )}
-          </Text>
+          {(course.instances.length > 0 ||
+            course.showPlaceholderTextIfNoCourseInstances) && (
+            <Text variant="h2" as="h2">
+              {n(
+                'courseInstancesLabel',
+                activeLocale === 'is' ? 'Næstu námskeið' : 'Upcoming courses',
+              )}
+            </Text>
+          )}
           {course.instances.length === 0 &&
             course.showPlaceholderTextIfNoCourseInstances && (
               <Text>


### PR DESCRIPTION
# Hide course instance label based on boolean in cms (#22667)

- [x] No AI tools were used in preparing this pull request
- [ ] AI tools were used in preparing this pull request
      Tools used:
