### PR TITLE
chore(j-s): Hide Tiny

### DIFF
--- a/apps/judicial-system/web/src/routes/Court/Indictments/CourtRecord/CourtSessionAccordionItem.tsx
+++ b/apps/judicial-system/web/src/routes/Court/Indictments/CourtRecord/CourtSessionAccordionItem.tsx
@@ -46,7 +46,7 @@ import {
   Modal,
   MultipleValueList,
   SectionHeading,
-  TinyMCE,
+  // TinyMCE,
 } from '@island.is/judicial-system-web/src/components'
 import EditableCaseFile, {
   Supplement,
@@ -1438,7 +1438,40 @@ const CourtSessionAccordionItem: FC<Props> = (props) => {
               )}
               <Box>
                 <SectionHeading title="Bókanir" />
-                <TinyMCE
+                <Input
+                  data-testid="entries"
+                  name="entries"
+                  label="Afstaða ákærða, málflutningur og aðrar bókanir"
+                  value={courtSession.entries || ''}
+                  placeholder="Nánari útlistun á afstöðu ákærða, málflutningsræður og annað sem fram kom í þinghaldi er skráð hér."
+                  onChange={(event) => {
+                    setEntriesErrorMessage('')
+
+                    patchSession(courtSession.id, {
+                      entries: event.target.value,
+                    })
+                  }}
+                  onBlur={(event) => {
+                    validateAndSetErrorMessage(
+                      ['empty'],
+                      event.target.value,
+                      setEntriesErrorMessage,
+                    )
+
+                    patchSession(
+                      courtSession.id,
+                      { entries: event.target.value },
+                      { persist: true },
+                    )
+                  }}
+                  hasError={entriesErrorMessage !== ''}
+                  errorMessage={entriesErrorMessage}
+                  rows={15}
+                  disabled={courtSession.isConfirmed || false}
+                  textarea
+                  required
+                />
+                {/* <TinyMCE
                   data-testid="entries"
                   label="Afstaða ákærða, málflutningur og aðrar bókanir"
                   placeholder="Nánari útlistun á afstöðu ákærða, málflutningsræður og annað sem fram kom í þinghaldi er skráð hér."
@@ -1468,7 +1501,7 @@ const CourtSessionAccordionItem: FC<Props> = (props) => {
                   errorMessage={entriesErrorMessage || undefined}
                   disabled={courtSession.isConfirmed || false}
                   required
-                />
+                /> */}
               </Box>
               <Box>
                 <SectionHeading


### PR DESCRIPTION
## What
Hides the TinyMCE rich text editor in the court session entries field and falls back to a plain textarea Input, mirroring the previous change in #22620.

## Why
TinyMCE needs more work before it can be enabled again.

## Screenshots / Gifs
Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code
- [ ] No AI tools were used in preparing this pull request

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Modified the court record entry field to use plain text input instead of a rich-text editor for the defendant's statement and proceedings documentation field.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/island-is/island.is/pull/22706?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->