### PR TITLE
fix(j-s): allow prosecutor represenatives to view court record pdf

### DIFF
--- a/apps/judicial-system/backend/src/app/modules/case/case.controller.ts
+++ b/apps/judicial-system/backend/src/app/modules/case/case.controller.ts
@@ -523,6 +523,7 @@ export class CaseController {
     courtOfAppealsRegistrarRule,
     courtOfAppealsAssistantRule,
     publicProsecutorStaffRule,
+    prosecutorRepresentativeRule,
   )
   @Get([
     'case/:caseId/courtRecord',

--- a/apps/judicial-system/backend/src/app/modules/case/test/caseController/caseControllerRolesRules.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/case/test/caseController/caseControllerRolesRules.spec.ts
@@ -125,6 +125,7 @@ describe('CaseController - Get court record pdf rules', () => {
     courtOfAppealsRegistrarRule,
     courtOfAppealsAssistantRule,
     publicProsecutorStaffRule,
+    prosecutorRepresentativeRule,
   ])
 })
 


### PR DESCRIPTION
[Asana](https://app.asana.com/1/203394141643832/project/1199153462262248/task/1215226569590354?focus=true)
## What

Allow prosecutor represenatives to view court record pdf

## Why

Request from users

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Cursor


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prosecutor representatives can now access court record PDFs.
  * Includes prosecutor representatives among roles authorized to retrieve court record PDFs.

* **Tests**
  * Role-authorization tests updated to cover prosecutor representative access to court record PDFs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/island-is/island.is/pull/22707?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->