### PR TITLE
fix(j-s): Harden defender file access when downloading zip

### DIFF
--- a/apps/judicial-system/backend/src/app/modules/case/limitedAccessCase.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/case/limitedAccessCase.service.ts
@@ -35,7 +35,7 @@ import { nowFactory, uuidFactory } from '../../factories'
 import { CivilClaimantService, DefendantService } from '../defendant'
 import {
   FileService,
-  getConfirmedDefendantClientsForDefender,
+  getConfirmedDefendantsForDefender,
   getDefenceUserCaseFileCategories,
   getDefenceUserCutoffDate,
   getDefenderVisiblePoliceCaseNumbers,
@@ -869,12 +869,12 @@ export class LimitedAccessCaseService {
         )
       })
 
-      const myDefendantClients = getConfirmedDefendantClientsForDefender(
+      const myDefendants = getConfirmedDefendantsForDefender(
         user.nationalId,
         theCase.defendants,
       )
 
-      myDefendantClients.forEach((defendant) =>
+      myDefendants.forEach((defendant) =>
         defendant.subpoenas?.forEach((subpoena) =>
           promises.push(
             this.tryAddGeneratedPdfToFilesToZip(
@@ -891,7 +891,7 @@ export class LimitedAccessCaseService {
         ),
       )
 
-      const allMyClientsDismissed = Boolean(
+      const allMyDefendantsDismissed = Boolean(
         getDefenceUserCutoffDate(
           user.nationalId,
           theCase.defendants,
@@ -904,7 +904,7 @@ export class LimitedAccessCaseService {
         !theCase.caseFiles?.some(
           (file) => file.category === CaseFileCategory.COURT_RECORD,
         ) &&
-        !allMyClientsDismissed &&
+        !allMyDefendantsDismissed &&
         hasGeneratedCourtRecordPdf(
           theCase.state,
           theCase.indictmentRulingDecision,

--- a/apps/judicial-system/backend/src/app/modules/case/limitedAccessCase.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/case/limitedAccessCase.service.ts
@@ -24,6 +24,7 @@ import {
   dateTypes,
   defendantEventTypes,
   eventTypes,
+  hasGeneratedCourtRecordPdf,
   isIndictmentCase,
   isRequestCase,
   stringTypes,
@@ -34,6 +35,7 @@ import { nowFactory, uuidFactory } from '../../factories'
 import { CivilClaimantService, DefendantService } from '../defendant'
 import {
   FileService,
+  getConfirmedDefendantClientsForDefender,
   getDefenceUserCaseFileCategories,
   getDefenceUserCutoffDate,
   getDefenderVisiblePoliceCaseNumbers,
@@ -867,7 +869,12 @@ export class LimitedAccessCaseService {
         )
       })
 
-      theCase.defendants?.forEach((defendant) =>
+      const myDefendantClients = getConfirmedDefendantClientsForDefender(
+        user.nationalId,
+        theCase.defendants,
+      )
+
+      myDefendantClients.forEach((defendant) =>
         defendant.subpoenas?.forEach((subpoena) =>
           promises.push(
             this.tryAddGeneratedPdfToFilesToZip(
@@ -884,12 +891,29 @@ export class LimitedAccessCaseService {
         ),
       )
 
-      if (
+      const allMyClientsDismissed = Boolean(
+        getDefenceUserCutoffDate(
+          user.nationalId,
+          theCase.defendants,
+          theCase.civilClaimants,
+        ),
+      )
+
+      const shouldIncludeGeneratedCourtRecord =
         allowedCaseFileCategories.includes(CaseFileCategory.COURT_RECORD) &&
         !theCase.caseFiles?.some(
           (file) => file.category === CaseFileCategory.COURT_RECORD,
+        ) &&
+        !allMyClientsDismissed &&
+        hasGeneratedCourtRecordPdf(
+          theCase.state,
+          theCase.indictmentRulingDecision,
+          theCase.withCourtSessions,
+          theCase.courtSessions,
+          user,
         )
-      ) {
+
+      if (shouldIncludeGeneratedCourtRecord) {
         promises.push(
           this.tryAddGeneratedPdfToFilesToZip(
             this.pdfService.getCourtRecordPdfForIndictmentCase(

--- a/apps/judicial-system/backend/src/app/modules/case/test/limitedAccessCaseService/getAllFilesZip.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/case/test/limitedAccessCaseService/getAllFilesZip.spec.ts
@@ -34,13 +34,12 @@ const makeDefendant = (overrides: Partial<Defendant> = {}): Defendant =>
     subpoenas: [],
     policeCaseNumbers: ['007-2026-1'],
     ...overrides,
-  }) as Defendant
+  } as Defendant)
 
 const makeEventLog = (
   eventType: DefendantEventType,
   created: Date,
-): DefendantEventLog =>
-  ({ eventType, created }) as unknown as DefendantEventLog
+): DefendantEventLog => ({ eventType, created } as unknown as DefendantEventLog)
 
 const makeIndictmentCase = (overrides: Partial<Case> = {}): Case =>
   ({
@@ -54,7 +53,7 @@ const makeIndictmentCase = (overrides: Partial<Case> = {}): Case =>
     withCourtSessions: true,
     courtSessions: [{ isConfirmed: true }],
     ...overrides,
-  }) as Case
+  } as Case)
 
 describe('LimitedAccessCaseService - getAllFilesZip', () => {
   let limitedAccessCaseService: LimitedAccessCaseService
@@ -68,7 +67,8 @@ describe('LimitedAccessCaseService - getAllFilesZip', () => {
   } as User
 
   beforeEach(async () => {
-    const { limitedAccessCaseService: service } = await createTestingCaseModule()
+    const { limitedAccessCaseService: service } =
+      await createTestingCaseModule()
 
     limitedAccessCaseService = service
     mockPdfService = (
@@ -114,11 +114,7 @@ describe('LimitedAccessCaseService - getAllFilesZip', () => {
         defendants: [clientDefendant, otherDefendant],
       })
 
-      await limitedAccessCaseService.getAllFilesZip(
-        theCase,
-        user,
-        transaction,
-      )
+      await limitedAccessCaseService.getAllFilesZip(theCase, user, transaction)
 
       expect(mockPdfService.getSubpoenaPdf).toHaveBeenCalledTimes(1)
       expect(mockPdfService.getSubpoenaPdf).toHaveBeenCalledWith(
@@ -137,11 +133,7 @@ describe('LimitedAccessCaseService - getAllFilesZip', () => {
         courtSessions: [{ isConfirmed: true }],
       })
 
-      await limitedAccessCaseService.getAllFilesZip(
-        theCase,
-        user,
-        transaction,
-      )
+      await limitedAccessCaseService.getAllFilesZip(theCase, user, transaction)
 
       expect(
         mockPdfService.getCourtRecordPdfForIndictmentCase,
@@ -163,11 +155,7 @@ describe('LimitedAccessCaseService - getAllFilesZip', () => {
         ],
       })
 
-      await limitedAccessCaseService.getAllFilesZip(
-        theCase,
-        user,
-        transaction,
-      )
+      await limitedAccessCaseService.getAllFilesZip(theCase, user, transaction)
 
       expect(
         mockPdfService.getCourtRecordPdfForIndictmentCase,
@@ -181,11 +169,7 @@ describe('LimitedAccessCaseService - getAllFilesZip', () => {
         caseFiles: [],
       })
 
-      await limitedAccessCaseService.getAllFilesZip(
-        theCase,
-        user,
-        transaction,
-      )
+      await limitedAccessCaseService.getAllFilesZip(theCase, user, transaction)
 
       expect(
         mockPdfService.getCourtRecordPdfForIndictmentCase,

--- a/apps/judicial-system/backend/src/app/modules/case/test/limitedAccessCaseService/getAllFilesZip.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/case/test/limitedAccessCaseService/getAllFilesZip.spec.ts
@@ -96,22 +96,22 @@ describe('LimitedAccessCaseService - getAllFilesZip', () => {
   })
 
   describe('subpoenas', () => {
-    it('should only generate subpoena pdfs for confirmed defender clients', async () => {
-      const subpoenaForClient = { id: uuid() } as Subpoena
-      const subpoenaForOther = { id: uuid() } as Subpoena
-      const clientDefendant = makeDefendant({
-        id: 'client-1',
-        name: 'Client One',
-        subpoenas: [subpoenaForClient],
+    it('should only generate subpoena pdfs for defendants the defender is confirmed for', async () => {
+      const subpoenaForDefendant = { id: uuid() } as Subpoena
+      const subpoenaForOtherDefendant = { id: uuid() } as Subpoena
+      const representedDefendant = makeDefendant({
+        id: 'defendant-1',
+        name: 'Defendant One',
+        subpoenas: [subpoenaForDefendant],
       })
       const otherDefendant = makeDefendant({
-        id: 'client-2',
-        name: 'Client Two',
+        id: 'defendant-2',
+        name: 'Defendant Two',
         defenderNationalId: '0202020202',
-        subpoenas: [subpoenaForOther],
+        subpoenas: [subpoenaForOtherDefendant],
       })
       const theCase = makeIndictmentCase({
-        defendants: [clientDefendant, otherDefendant],
+        defendants: [representedDefendant, otherDefendant],
       })
 
       await limitedAccessCaseService.getAllFilesZip(
@@ -123,9 +123,9 @@ describe('LimitedAccessCaseService - getAllFilesZip', () => {
       expect(mockPdfService.getSubpoenaPdf).toHaveBeenCalledTimes(1)
       expect(mockPdfService.getSubpoenaPdf).toHaveBeenCalledWith(
         theCase,
-        clientDefendant,
+        representedDefendant,
         transaction,
-        subpoenaForClient,
+        subpoenaForDefendant,
       )
     })
   })
@@ -148,7 +148,7 @@ describe('LimitedAccessCaseService - getAllFilesZip', () => {
       ).not.toHaveBeenCalled()
     })
 
-    it('should not generate court record pdf when all defender clients are dismissed', async () => {
+    it('should not generate court record pdf when all represented defendants are dismissed', async () => {
       const dismissedAt = new Date('2024-01-10')
       const theCase = makeIndictmentCase({
         defendants: [

--- a/apps/judicial-system/backend/src/app/modules/case/test/limitedAccessCaseService/getAllFilesZip.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/case/test/limitedAccessCaseService/getAllFilesZip.spec.ts
@@ -1,0 +1,195 @@
+import { Transaction } from 'sequelize'
+import { v4 as uuid } from 'uuid'
+
+import {
+  CaseState,
+  CaseType,
+  DefendantEventType,
+  User,
+  UserRole,
+} from '@island.is/judicial-system/types'
+
+import { createTestingCaseModule } from '../createTestingCaseModule'
+
+import { PdfService } from '../../pdf.service'
+import {
+  Case,
+  Defendant,
+  DefendantEventLog,
+  Subpoena,
+} from '../../../repository'
+import { LimitedAccessCaseService } from '../../limitedAccessCase.service'
+
+const defenderNationalId = '0101010101'
+const pdfBuffer = Buffer.from('pdf')
+
+const makeDefendant = (overrides: Partial<Defendant> = {}): Defendant =>
+  ({
+    id: uuid(),
+    name: 'Defendant',
+    isDefenderChoiceConfirmed: true,
+    caseFilesSharedWithDefender: true,
+    defenderNationalId,
+    eventLogs: [],
+    subpoenas: [],
+    policeCaseNumbers: ['007-2026-1'],
+    ...overrides,
+  }) as Defendant
+
+const makeEventLog = (
+  eventType: DefendantEventType,
+  created: Date,
+): DefendantEventLog =>
+  ({ eventType, created }) as unknown as DefendantEventLog
+
+const makeIndictmentCase = (overrides: Partial<Case> = {}): Case =>
+  ({
+    id: uuid(),
+    type: CaseType.INDICTMENT,
+    state: CaseState.SUBMITTED,
+    defendants: [makeDefendant()],
+    civilClaimants: [],
+    caseFiles: [],
+    policeCaseNumbers: ['007-2026-1'],
+    withCourtSessions: true,
+    courtSessions: [{ isConfirmed: true }],
+    ...overrides,
+  }) as Case
+
+describe('LimitedAccessCaseService - getAllFilesZip', () => {
+  let limitedAccessCaseService: LimitedAccessCaseService
+  let mockPdfService: PdfService
+  let transaction: Transaction
+  let zipFilesSpy: jest.SpyInstance
+
+  const user = {
+    nationalId: defenderNationalId,
+    role: UserRole.DEFENDER,
+  } as User
+
+  beforeEach(async () => {
+    const { limitedAccessCaseService: service } = await createTestingCaseModule()
+
+    limitedAccessCaseService = service
+    mockPdfService = (
+      limitedAccessCaseService as unknown as { pdfService: PdfService }
+    ).pdfService
+    transaction = {} as Transaction
+
+    zipFilesSpy = jest
+      .spyOn(limitedAccessCaseService as any, 'zipFiles')
+      .mockResolvedValue(Buffer.from('zip'))
+
+    jest.spyOn(mockPdfService, 'getIndictmentPdf').mockResolvedValue(pdfBuffer)
+    jest
+      .spyOn(mockPdfService, 'getCaseFilesRecordPdf')
+      .mockResolvedValue(pdfBuffer)
+    jest.spyOn(mockPdfService, 'getSubpoenaPdf').mockResolvedValue(pdfBuffer)
+    jest
+      .spyOn(mockPdfService, 'getCourtRecordPdfForIndictmentCase')
+      .mockResolvedValue(pdfBuffer)
+  })
+
+  afterEach(() => {
+    zipFilesSpy.mockRestore()
+    jest.restoreAllMocks()
+  })
+
+  describe('subpoenas', () => {
+    it('should only generate subpoena pdfs for confirmed defender clients', async () => {
+      const subpoenaForClient = { id: uuid() } as Subpoena
+      const subpoenaForOther = { id: uuid() } as Subpoena
+      const clientDefendant = makeDefendant({
+        id: 'client-1',
+        name: 'Client One',
+        subpoenas: [subpoenaForClient],
+      })
+      const otherDefendant = makeDefendant({
+        id: 'client-2',
+        name: 'Client Two',
+        defenderNationalId: '0202020202',
+        subpoenas: [subpoenaForOther],
+      })
+      const theCase = makeIndictmentCase({
+        defendants: [clientDefendant, otherDefendant],
+      })
+
+      await limitedAccessCaseService.getAllFilesZip(
+        theCase,
+        user,
+        transaction,
+      )
+
+      expect(mockPdfService.getSubpoenaPdf).toHaveBeenCalledTimes(1)
+      expect(mockPdfService.getSubpoenaPdf).toHaveBeenCalledWith(
+        theCase,
+        clientDefendant,
+        transaction,
+        subpoenaForClient,
+      )
+    })
+  })
+
+  describe('generated court record', () => {
+    it('should not generate court record pdf when withCourtSessions is false', async () => {
+      const theCase = makeIndictmentCase({
+        withCourtSessions: false,
+        courtSessions: [{ isConfirmed: true }],
+      })
+
+      await limitedAccessCaseService.getAllFilesZip(
+        theCase,
+        user,
+        transaction,
+      )
+
+      expect(
+        mockPdfService.getCourtRecordPdfForIndictmentCase,
+      ).not.toHaveBeenCalled()
+    })
+
+    it('should not generate court record pdf when all defender clients are dismissed', async () => {
+      const dismissedAt = new Date('2024-01-10')
+      const theCase = makeIndictmentCase({
+        defendants: [
+          makeDefendant({
+            eventLogs: [
+              makeEventLog(
+                DefendantEventType.INDICTMENT_DISMISSED,
+                dismissedAt,
+              ),
+            ],
+          }),
+        ],
+      })
+
+      await limitedAccessCaseService.getAllFilesZip(
+        theCase,
+        user,
+        transaction,
+      )
+
+      expect(
+        mockPdfService.getCourtRecordPdfForIndictmentCase,
+      ).not.toHaveBeenCalled()
+    })
+
+    it('should generate court record pdf when court sessions are confirmed and no uploaded court record exists', async () => {
+      const theCase = makeIndictmentCase({
+        withCourtSessions: true,
+        courtSessions: [{ isConfirmed: true }],
+        caseFiles: [],
+      })
+
+      await limitedAccessCaseService.getAllFilesZip(
+        theCase,
+        user,
+        transaction,
+      )
+
+      expect(
+        mockPdfService.getCourtRecordPdfForIndictmentCase,
+      ).toHaveBeenCalledWith(theCase, user, transaction)
+    })
+  })
+})

--- a/apps/judicial-system/backend/src/app/modules/case/test/limitedAccessCaseService/getAllFilesZip.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/case/test/limitedAccessCaseService/getAllFilesZip.spec.ts
@@ -11,7 +11,6 @@ import {
 
 import { createTestingCaseModule } from '../createTestingCaseModule'
 
-import { PdfService } from '../../pdf.service'
 import {
   Case,
   Defendant,
@@ -19,6 +18,7 @@ import {
   Subpoena,
 } from '../../../repository'
 import { LimitedAccessCaseService } from '../../limitedAccessCase.service'
+import { PdfService } from '../../pdf.service'
 
 const defenderNationalId = '0101010101'
 const pdfBuffer = Buffer.from('pdf')

--- a/apps/judicial-system/backend/src/app/modules/file/guards/caseFileCategory.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/file/guards/caseFileCategory.spec.ts
@@ -1,14 +1,20 @@
 import { Defendant } from '../../repository'
-import { getDefenderVisiblePoliceCaseNumbers } from './caseFileCategory'
+import {
+  getConfirmedDefendantClientsForDefender,
+  getDefenderVisiblePoliceCaseNumbers,
+  isConfirmedDefenderOfSpecificDefendant,
+} from './caseFileCategory'
 
 const makeDefendant = (
   overrides: Partial<{
+    id: string
     defenderNationalId: string
     isDefenderChoiceConfirmed: boolean
     policeCaseNumbers: string[]
   }> = {},
 ): Defendant =>
   ({
+    id: overrides.id ?? 'defendant-id',
     defenderNationalId: overrides.defenderNationalId ?? null,
     isDefenderChoiceConfirmed: overrides.isDefenderChoiceConfirmed ?? false,
     policeCaseNumbers: overrides.policeCaseNumbers ?? [],
@@ -185,5 +191,126 @@ describe('getDefenderVisiblePoliceCaseNumbers', () => {
     )
 
     expect(result).toEqual(['007-2026-1'])
+  })
+})
+
+describe('getConfirmedDefendantClientsForDefender', () => {
+  it('should return only defendants where user is confirmed defender', () => {
+    const confirmedClient = makeDefendant({
+      id: 'client-1',
+      defenderNationalId: '1234567890',
+      isDefenderChoiceConfirmed: true,
+    })
+    const unconfirmedClient = makeDefendant({
+      id: 'client-2',
+      defenderNationalId: '1234567890',
+      isDefenderChoiceConfirmed: false,
+    })
+    const otherDefenderClient = makeDefendant({
+      id: 'client-3',
+      defenderNationalId: '0987654321',
+      isDefenderChoiceConfirmed: true,
+    })
+
+    const result = getConfirmedDefendantClientsForDefender('1234567890', [
+      confirmedClient,
+      unconfirmedClient,
+      otherDefenderClient,
+    ])
+
+    expect(result).toEqual([confirmedClient])
+  })
+
+  it('should return multiple defendants when defender represents multiple clients', () => {
+    const client1 = makeDefendant({
+      id: 'client-1',
+      defenderNationalId: '1234567890',
+      isDefenderChoiceConfirmed: true,
+    })
+    const client2 = makeDefendant({
+      id: 'client-2',
+      defenderNationalId: '1234567890',
+      isDefenderChoiceConfirmed: true,
+    })
+
+    const result = getConfirmedDefendantClientsForDefender('1234567890', [
+      client1,
+      client2,
+    ])
+
+    expect(result).toEqual([client1, client2])
+  })
+
+  it('should return empty array when defendants is undefined', () => {
+    const result = getConfirmedDefendantClientsForDefender(
+      '1234567890',
+      undefined,
+    )
+
+    expect(result).toEqual([])
+  })
+
+  it('should return empty array when no defendants match', () => {
+    const defendants = [
+      makeDefendant({
+        defenderNationalId: '0987654321',
+        isDefenderChoiceConfirmed: true,
+      }),
+    ]
+
+    const result = getConfirmedDefendantClientsForDefender(
+      '1234567890',
+      defendants,
+    )
+
+    expect(result).toEqual([])
+  })
+})
+
+describe('isConfirmedDefenderOfSpecificDefendant', () => {
+  it('should return true when user is confirmed defender of the specific defendant', () => {
+    const defendants = [
+      makeDefendant({
+        id: 'client-1',
+        defenderNationalId: '1234567890',
+        isDefenderChoiceConfirmed: true,
+      }),
+      makeDefendant({
+        id: 'client-2',
+        defenderNationalId: '0987654321',
+        isDefenderChoiceConfirmed: true,
+      }),
+    ]
+
+    const result = isConfirmedDefenderOfSpecificDefendant(
+      '1234567890',
+      'client-1',
+      defendants,
+    )
+
+    expect(result).toBe(true)
+  })
+
+  it('should return false when user is not confirmed defender of the specific defendant', () => {
+    const defendants = [
+      makeDefendant({
+        id: 'client-1',
+        defenderNationalId: '1234567890',
+        isDefenderChoiceConfirmed: true,
+      }),
+      makeDefendant({
+        id: 'client-2',
+        defenderNationalId: '0987654321',
+        isDefenderChoiceConfirmed: true,
+      }),
+    ]
+
+    const result = isConfirmedDefenderOfSpecificDefendant(
+      '1234567890',
+      'client-2',
+      defendants,
+    )
+
+    expect(result).toBe(false)
   })
 })

--- a/apps/judicial-system/backend/src/app/modules/file/guards/caseFileCategory.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/file/guards/caseFileCategory.spec.ts
@@ -1,6 +1,6 @@
 import { Defendant } from '../../repository'
 import {
-  getConfirmedDefendantClientsForDefender,
+  getConfirmedDefendantsForDefender,
   getDefenderVisiblePoliceCaseNumbers,
   isConfirmedDefenderOfSpecificDefendant,
 } from './caseFileCategory'
@@ -194,58 +194,55 @@ describe('getDefenderVisiblePoliceCaseNumbers', () => {
   })
 })
 
-describe('getConfirmedDefendantClientsForDefender', () => {
+describe('getConfirmedDefendantsForDefender', () => {
   it('should return only defendants where user is confirmed defender', () => {
-    const confirmedClient = makeDefendant({
-      id: 'client-1',
+    const confirmedDefendant = makeDefendant({
+      id: 'defendant-1',
       defenderNationalId: '1234567890',
       isDefenderChoiceConfirmed: true,
     })
-    const unconfirmedClient = makeDefendant({
-      id: 'client-2',
+    const unconfirmedDefendant = makeDefendant({
+      id: 'defendant-2',
       defenderNationalId: '1234567890',
       isDefenderChoiceConfirmed: false,
     })
-    const otherDefenderClient = makeDefendant({
-      id: 'client-3',
+    const otherDefenderDefendant = makeDefendant({
+      id: 'defendant-3',
       defenderNationalId: '0987654321',
       isDefenderChoiceConfirmed: true,
     })
 
-    const result = getConfirmedDefendantClientsForDefender('1234567890', [
-      confirmedClient,
-      unconfirmedClient,
-      otherDefenderClient,
+    const result = getConfirmedDefendantsForDefender('1234567890', [
+      confirmedDefendant,
+      unconfirmedDefendant,
+      otherDefenderDefendant,
     ])
 
-    expect(result).toEqual([confirmedClient])
+    expect(result).toEqual([confirmedDefendant])
   })
 
-  it('should return multiple defendants when defender represents multiple clients', () => {
-    const client1 = makeDefendant({
-      id: 'client-1',
+  it('should return multiple defendants when defender represents multiple defendants', () => {
+    const defendant1 = makeDefendant({
+      id: 'defendant-1',
       defenderNationalId: '1234567890',
       isDefenderChoiceConfirmed: true,
     })
-    const client2 = makeDefendant({
-      id: 'client-2',
+    const defendant2 = makeDefendant({
+      id: 'defendant-2',
       defenderNationalId: '1234567890',
       isDefenderChoiceConfirmed: true,
     })
 
-    const result = getConfirmedDefendantClientsForDefender('1234567890', [
-      client1,
-      client2,
+    const result = getConfirmedDefendantsForDefender('1234567890', [
+      defendant1,
+      defendant2,
     ])
 
-    expect(result).toEqual([client1, client2])
+    expect(result).toEqual([defendant1, defendant2])
   })
 
   it('should return empty array when defendants is undefined', () => {
-    const result = getConfirmedDefendantClientsForDefender(
-      '1234567890',
-      undefined,
-    )
+    const result = getConfirmedDefendantsForDefender('1234567890', undefined)
 
     expect(result).toEqual([])
   })
@@ -258,10 +255,7 @@ describe('getConfirmedDefendantClientsForDefender', () => {
       }),
     ]
 
-    const result = getConfirmedDefendantClientsForDefender(
-      '1234567890',
-      defendants,
-    )
+    const result = getConfirmedDefendantsForDefender('1234567890', defendants)
 
     expect(result).toEqual([])
   })
@@ -271,12 +265,12 @@ describe('isConfirmedDefenderOfSpecificDefendant', () => {
   it('should return true when user is confirmed defender of the specific defendant', () => {
     const defendants = [
       makeDefendant({
-        id: 'client-1',
+        id: 'defendant-1',
         defenderNationalId: '1234567890',
         isDefenderChoiceConfirmed: true,
       }),
       makeDefendant({
-        id: 'client-2',
+        id: 'defendant-2',
         defenderNationalId: '0987654321',
         isDefenderChoiceConfirmed: true,
       }),
@@ -284,7 +278,7 @@ describe('isConfirmedDefenderOfSpecificDefendant', () => {
 
     const result = isConfirmedDefenderOfSpecificDefendant(
       '1234567890',
-      'client-1',
+      'defendant-1',
       defendants,
     )
 
@@ -294,12 +288,12 @@ describe('isConfirmedDefenderOfSpecificDefendant', () => {
   it('should return false when user is not confirmed defender of the specific defendant', () => {
     const defendants = [
       makeDefendant({
-        id: 'client-1',
+        id: 'defendant-1',
         defenderNationalId: '1234567890',
         isDefenderChoiceConfirmed: true,
       }),
       makeDefendant({
-        id: 'client-2',
+        id: 'defendant-2',
         defenderNationalId: '0987654321',
         isDefenderChoiceConfirmed: true,
       }),
@@ -307,7 +301,7 @@ describe('isConfirmedDefenderOfSpecificDefendant', () => {
 
     const result = isConfirmedDefenderOfSpecificDefendant(
       '1234567890',
-      'client-2',
+      'defendant-2',
       defendants,
     )
 

--- a/apps/judicial-system/backend/src/app/modules/file/guards/caseFileCategory.ts
+++ b/apps/judicial-system/backend/src/app/modules/file/guards/caseFileCategory.ts
@@ -380,7 +380,7 @@ export const getDefenderVisiblePoliceCaseNumbers = (
   )
 }
 
-export const getConfirmedDefendantClientsForDefender = (
+export const getConfirmedDefendantsForDefender = (
   userNationalId: string,
   defendants?: Defendant[],
 ): Defendant[] => {
@@ -399,6 +399,6 @@ export const isConfirmedDefenderOfSpecificDefendant = (
   defendantId: string,
   defendants?: Defendant[],
 ): boolean =>
-  getConfirmedDefendantClientsForDefender(userNationalId, defendants).some(
+  getConfirmedDefendantsForDefender(userNationalId, defendants).some(
     (defendant) => defendant.id === defendantId,
   )

--- a/apps/judicial-system/backend/src/app/modules/file/guards/caseFileCategory.ts
+++ b/apps/judicial-system/backend/src/app/modules/file/guards/caseFileCategory.ts
@@ -379,3 +379,26 @@ export const getDefenderVisiblePoliceCaseNumbers = (
     (pcn) => assignedToMe.has(pcn) || !allAssigned.has(pcn),
   )
 }
+
+export const getConfirmedDefendantClientsForDefender = (
+  userNationalId: string,
+  defendants?: Defendant[],
+): Defendant[] => {
+  return (defendants ?? []).filter(
+    (defendant) =>
+      defendant.isDefenderChoiceConfirmed &&
+      defendant.defenderNationalId &&
+      normalizeAndFormatNationalId(userNationalId).includes(
+        defendant.defenderNationalId,
+      ),
+  )
+}
+
+export const isConfirmedDefenderOfSpecificDefendant = (
+  userNationalId: string,
+  defendantId: string,
+  defendants?: Defendant[],
+): boolean =>
+  getConfirmedDefendantClientsForDefender(userNationalId, defendants).some(
+    (defendant) => defendant.id === defendantId,
+  )

--- a/apps/judicial-system/backend/src/app/modules/file/index.ts
+++ b/apps/judicial-system/backend/src/app/modules/file/index.ts
@@ -2,8 +2,10 @@ export { FileService } from './file.service'
 export { PoliceDigitalCaseFileService } from './policeDigitalCaseFiles/policeDigitalCaseFile.service'
 export {
   canLimitedAccessUserViewCaseFile,
+  getConfirmedDefendantClientsForDefender,
   getDefenceUserCaseFileCategories,
   getDefenceUserCutoffDate,
   getDefenderVisiblePoliceCaseNumbers,
+  isConfirmedDefenderOfSpecificDefendant,
 } from './guards/caseFileCategory'
 export { canDefenceUserViewCivilClaimCaseFile } from './guards/civilClaimFileVisibility'

--- a/apps/judicial-system/backend/src/app/modules/file/index.ts
+++ b/apps/judicial-system/backend/src/app/modules/file/index.ts
@@ -2,7 +2,7 @@ export { FileService } from './file.service'
 export { PoliceDigitalCaseFileService } from './policeDigitalCaseFiles/policeDigitalCaseFile.service'
 export {
   canLimitedAccessUserViewCaseFile,
-  getConfirmedDefendantClientsForDefender,
+  getConfirmedDefendantsForDefender,
   getDefenceUserCaseFileCategories,
   getDefenceUserCutoffDate,
   getDefenderVisiblePoliceCaseNumbers,

--- a/apps/judicial-system/backend/src/app/modules/subpoena/guards/defenderSubpoenaAccess.guard.ts
+++ b/apps/judicial-system/backend/src/app/modules/subpoena/guards/defenderSubpoenaAccess.guard.ts
@@ -1,0 +1,48 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+  Injectable,
+} from '@nestjs/common'
+
+import { isDefenceUser } from '@island.is/judicial-system/types'
+
+import { isConfirmedDefenderOfSpecificDefendant } from '../../file'
+import { Case, Defendant } from '../../repository'
+
+@Injectable()
+export class DefenderSubpoenaAccessGuard implements CanActivate {
+  canActivate(context: ExecutionContext): boolean {
+    const request = context.switchToHttp().getRequest()
+    const user = request.user?.currentUser
+    const theCase: Case = request.case
+    const defendant: Defendant = request.defendant
+
+    if (!user || !theCase || !defendant) {
+      throw new ForbiddenException()
+    }
+
+    if (!isDefenceUser(user)) {
+      return true
+    }
+
+    const allDefendants = [
+      ...(theCase.defendants ?? []),
+      ...(theCase.splitCases?.flatMap((c) => c.defendants ?? []) ?? []),
+    ]
+
+    if (
+      !isConfirmedDefenderOfSpecificDefendant(
+        user.nationalId,
+        defendant.id,
+        allDefendants,
+      )
+    ) {
+      throw new ForbiddenException(
+        `Defender is not confirmed for defendant ${defendant.id}`,
+      )
+    }
+
+    return true
+  }
+}

--- a/apps/judicial-system/backend/src/app/modules/subpoena/guards/test/defenderSubpoenaAccessGuard.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/subpoena/guards/test/defenderSubpoenaAccessGuard.spec.ts
@@ -52,7 +52,10 @@ describe('Defender Subpoena Access Guard', () => {
     beforeEach(() => {
       mockRequest.mockReturnValueOnce({
         user: {
-          currentUser: { role: UserRole.DEFENDER, nationalId: defenderNationalId },
+          currentUser: {
+            role: UserRole.DEFENDER,
+            nationalId: defenderNationalId,
+          },
         },
         case: theCase,
         defendant: { id: defendantId },
@@ -105,7 +108,9 @@ describe('Defender Subpoena Access Guard', () => {
 
     beforeEach(() => {
       mockRequest.mockReturnValueOnce({
-        user: { currentUser: { role: UserRole.PROSECUTOR, nationalId: '1234567890' } },
+        user: {
+          currentUser: { role: UserRole.PROSECUTOR, nationalId: '1234567890' },
+        },
         case: { id: uuid(), defendants: [] },
         defendant: { id: uuid() },
       })

--- a/apps/judicial-system/backend/src/app/modules/subpoena/guards/test/defenderSubpoenaAccessGuard.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/subpoena/guards/test/defenderSubpoenaAccessGuard.spec.ts
@@ -1,0 +1,137 @@
+import { v4 as uuid } from 'uuid'
+
+import { ExecutionContext, ForbiddenException } from '@nestjs/common'
+
+import { UserRole } from '@island.is/judicial-system/types'
+
+import { DefenderSubpoenaAccessGuard } from '../defenderSubpoenaAccess.guard'
+
+interface Then {
+  result: boolean
+  error: Error
+}
+
+type GivenWhenThen = () => Then
+
+describe('Defender Subpoena Access Guard', () => {
+  const mockRequest = jest.fn()
+  let givenWhenThen: GivenWhenThen
+
+  beforeEach(() => {
+    givenWhenThen = (): Then => {
+      const guard = new DefenderSubpoenaAccessGuard()
+      const then = {} as Then
+
+      try {
+        then.result = guard.canActivate({
+          switchToHttp: () => ({ getRequest: mockRequest }),
+        } as unknown as ExecutionContext)
+      } catch (error) {
+        then.error = error as Error
+      }
+
+      return then
+    }
+  })
+
+  describe('defender is confirmed for the defendant', () => {
+    const defendantId = uuid()
+    const defenderNationalId = '1234567890'
+    const theCase = {
+      id: uuid(),
+      defendants: [
+        {
+          id: defendantId,
+          isDefenderChoiceConfirmed: true,
+          defenderNationalId,
+        },
+      ],
+    }
+    let then: Then
+
+    beforeEach(() => {
+      mockRequest.mockReturnValueOnce({
+        user: {
+          currentUser: { role: UserRole.DEFENDER, nationalId: defenderNationalId },
+        },
+        case: theCase,
+        defendant: { id: defendantId },
+      })
+
+      then = givenWhenThen()
+    })
+
+    it('should activate', () => {
+      expect(then.result).toBe(true)
+    })
+  })
+
+  describe('defender is not confirmed for the defendant', () => {
+    const defendantId = uuid()
+    const theCase = {
+      id: uuid(),
+      defendants: [
+        {
+          id: defendantId,
+          isDefenderChoiceConfirmed: true,
+          defenderNationalId: '0987654321',
+        },
+      ],
+    }
+    let then: Then
+
+    beforeEach(() => {
+      mockRequest.mockReturnValueOnce({
+        user: {
+          currentUser: { role: UserRole.DEFENDER, nationalId: '1234567890' },
+        },
+        case: theCase,
+        defendant: { id: defendantId },
+      })
+
+      then = givenWhenThen()
+    })
+
+    it('should throw ForbiddenException', () => {
+      expect(then.error).toBeInstanceOf(ForbiddenException)
+      expect(then.error.message).toBe(
+        `Defender is not confirmed for defendant ${defendantId}`,
+      )
+    })
+  })
+
+  describe('non-defence user', () => {
+    let then: Then
+
+    beforeEach(() => {
+      mockRequest.mockReturnValueOnce({
+        user: { currentUser: { role: UserRole.PROSECUTOR, nationalId: '1234567890' } },
+        case: { id: uuid(), defendants: [] },
+        defendant: { id: uuid() },
+      })
+
+      then = givenWhenThen()
+    })
+
+    it('should activate', () => {
+      expect(then.result).toBe(true)
+    })
+  })
+
+  describe('missing user', () => {
+    let then: Then
+
+    beforeEach(() => {
+      mockRequest.mockReturnValueOnce({
+        case: { id: uuid() },
+        defendant: { id: uuid() },
+      })
+
+      then = givenWhenThen()
+    })
+
+    it('should throw ForbiddenException', () => {
+      expect(then.error).toBeInstanceOf(ForbiddenException)
+    })
+  })
+})

--- a/apps/judicial-system/backend/src/app/modules/subpoena/limitedAccessSubpoena.controller.ts
+++ b/apps/judicial-system/backend/src/app/modules/subpoena/limitedAccessSubpoena.controller.ts
@@ -33,6 +33,7 @@ import {
 } from '../case'
 import { CurrentDefendant, SplitDefendantExistsGuard } from '../defendant'
 import { Case, Defendant, Subpoena } from '../repository'
+import { DefenderSubpoenaAccessGuard } from './guards/defenderSubpoenaAccess.guard'
 import { CurrentSubpoena } from './guards/subpoena.decorator'
 import { SubpoenaExistsGuard } from './guards/subpoenaExists.guard'
 
@@ -47,6 +48,7 @@ import { SubpoenaExistsGuard } from './guards/subpoenaExists.guard'
   new CaseTypeGuard(indictmentCases),
   CaseReadGuard,
   SplitDefendantExistsGuard,
+  DefenderSubpoenaAccessGuard,
   SubpoenaExistsGuard,
 )
 export class LimitedAccessSubpoenaController {

--- a/apps/judicial-system/backend/src/app/modules/subpoena/test/limitedAccessSubpoenaController/limitedAccessSubpoenaControllerGuards.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/subpoena/test/limitedAccessSubpoenaController/limitedAccessSubpoenaControllerGuards.spec.ts
@@ -4,6 +4,7 @@ import { indictmentCases } from '@island.is/judicial-system/types'
 import { verifyGuards } from '../../../../test'
 import { CaseExistsGuard, CaseReadGuard, CaseTypeGuard } from '../../../case'
 import { SplitDefendantExistsGuard } from '../../../defendant'
+import { DefenderSubpoenaAccessGuard } from '../../guards/defenderSubpoenaAccess.guard'
 import { SubpoenaExistsGuard } from '../../guards/subpoenaExists.guard'
 import { LimitedAccessSubpoenaController } from '../../limitedAccessSubpoena.controller'
 
@@ -18,6 +19,7 @@ describe('LimitedAccessSubpoenaController - Top-level Guards', () => {
       CaseTypeGuard,
       CaseReadGuard,
       SplitDefendantExistsGuard,
+      DefenderSubpoenaAccessGuard,
       SubpoenaExistsGuard,
     ],
     [{ guard: CaseTypeGuard, prop: { allowedCaseTypes: indictmentCases } }],

--- a/apps/judicial-system/web/src/components/IndictmentCaseFilesList/IndictmentCaseFilesList.spec.tsx
+++ b/apps/judicial-system/web/src/components/IndictmentCaseFilesList/IndictmentCaseFilesList.spec.tsx
@@ -80,4 +80,62 @@ describe('IndictmentCaseFilesList', () => {
       screen.queryByText(/Skjalaskrá 007-2026-2\.pdf/),
     ).not.toBeInTheDocument()
   })
+
+  it('should only show defender-visible subpoenas', () => {
+    render(
+      <IntlProviderWrapper>
+        <ApolloProviderWrapper>
+          <UserContext.Provider
+            value={{
+              user: {
+                id: 'defender-user-id',
+                role: UserRole.DEFENDER,
+                nationalId: '1234567890',
+                name: 'Defender',
+              },
+            }}
+          >
+            <IndictmentCaseFilesList
+              workingCase={{
+                ...mockCase(CaseType.INDICTMENT),
+                defendants: [
+                  {
+                    id: 'defendant-1',
+                    name: 'Defendant One',
+                    isDefenderChoiceConfirmed: true,
+                    defenderNationalId: '1234567890',
+                    subpoenas: [
+                      {
+                        id: 'subpoena-1',
+                        created: '2026-01-15T12:00:00.000Z',
+                      },
+                    ],
+                  },
+                  {
+                    id: 'defendant-2',
+                    name: 'Defendant Two',
+                    isDefenderChoiceConfirmed: true,
+                    defenderNationalId: '0987654321',
+                    subpoenas: [
+                      {
+                        id: 'subpoena-2',
+                        created: '2026-01-16T12:00:00.000Z',
+                      },
+                    ],
+                  },
+                ],
+              }}
+            />
+          </UserContext.Provider>
+        </ApolloProviderWrapper>
+      </IntlProviderWrapper>,
+    )
+
+    expect(
+      screen.queryByText(/Fyrirkall Defendant One/),
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByText(/Fyrirkall Defendant Two/),
+    ).not.toBeInTheDocument()
+  })
 })

--- a/apps/judicial-system/web/src/components/IndictmentCaseFilesList/IndictmentCaseFilesList.spec.tsx
+++ b/apps/judicial-system/web/src/components/IndictmentCaseFilesList/IndictmentCaseFilesList.spec.tsx
@@ -131,9 +131,7 @@ describe('IndictmentCaseFilesList', () => {
       </IntlProviderWrapper>,
     )
 
-    expect(
-      screen.queryByText(/Fyrirkall Defendant One/),
-    ).toBeInTheDocument()
+    expect(screen.queryByText(/Fyrirkall Defendant One/)).toBeInTheDocument()
     expect(
       screen.queryByText(/Fyrirkall Defendant Two/),
     ).not.toBeInTheDocument()

--- a/apps/judicial-system/web/src/components/IndictmentCaseFilesList/IndictmentCaseFilesList.tsx
+++ b/apps/judicial-system/web/src/components/IndictmentCaseFilesList/IndictmentCaseFilesList.tsx
@@ -319,7 +319,24 @@ const IndictmentCaseFilesList: FC<Props> = ({
     [workingCase],
   )
 
-  const showSubpoenaPdf = displayGeneratedPDFs && allSubpoenas.length > 0
+  const visibleSubpoenas = useMemo(() => {
+    if (!isDefenceUser(user)) {
+      return allSubpoenas
+    }
+
+    const normalizedUserNationalId = normalizeAndFormatNationalId(
+      user?.nationalId ?? '',
+    )
+
+    return allSubpoenas.filter(
+      ({ defendant }) =>
+        defendant.isDefenderChoiceConfirmed &&
+        defendant.defenderNationalId &&
+        normalizedUserNationalId.includes(defendant.defenderNationalId),
+    )
+  }, [allSubpoenas, user])
+
+  const showSubpoenaPdf = displayGeneratedPDFs && visibleSubpoenas.length > 0
 
   const filteredFiles = useFilteredCaseFiles(
     workingCase.caseFiles,
@@ -478,7 +495,7 @@ const IndictmentCaseFilesList: FC<Props> = ({
               heading="h4"
               variant="h4"
             />
-            {allSubpoenas.map(({ defendant, subpoena, caseId }) => {
+            {visibleSubpoenas.map(({ defendant, subpoena, caseId }) => {
               const subpoenaFileName = formatMessage(
                 strings.subpoenaButtonText,
                 {


### PR DESCRIPTION
[Asana](https://app.asana.com/1/203394141643832/project/1212657017130395/task/1215161282459034?focus=true)

## What

Harden defender file access. What they get from the zip should match what they see in the UI. Before, there were files included in the zip that should not have been visible to a defender in certain situations.

## Why

So defenders don´t see something they shouldn't.

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Cursor


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Defenders only see subpoena PDFs for defendants they represent; subpoena lists show only relevant entries.
  * Limited-access subpoena endpoint now enforces defender-confirmation checks before serving PDFs.
  * Court-record PDFs generation is further restricted by defender confirmations and case/session conditions.

* **Tests**
  * Added tests covering defender subpoena access/visibility and conditional court-record PDF generation and zipping.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/island-is/island.is/pull/22709?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->