### PR TITLE
fix(native-app): Only query health data once health tab is opened

### DIFF
--- a/apps/native/app/src/app/(auth)/(tabs)/health/index.tsx
+++ b/apps/native/app/src/app/(auth)/(tabs)/health/index.tsx
@@ -9,7 +9,7 @@ import {
   useWindowDimensions,
   View,
 } from 'react-native'
-import { Href, useRouter } from 'expo-router'
+import { Href, useFocusEffect, useRouter } from 'expo-router'
 import styled, { useTheme } from 'styled-components/native'
 
 import categoriesIcon from '@/assets/icons/categories.png'
@@ -165,6 +165,17 @@ const showErrorComponent = (error: ApolloError) => {
   return <Problem error={error} size="small" />
 }
 
+// We don't want to query health data unless the user opens the health tab
+function useHasBeenFocused() {
+  const [hasBeenFocused, setHasBeenFocused] = useState(false)
+  useFocusEffect(
+    useCallback(() => {
+      setHasBeenFocused(true)
+    }, []),
+  )
+  return hasBeenFocused
+}
+
 export default function HealthOverviewScreen() {
   const router = useRouter()
   const intl = useIntl()
@@ -287,17 +298,29 @@ export default function HealthOverviewScreen() {
     itemsPerRow,
   ])
 
-  const medicinePurchaseRes = useGetMedicineDataQuery()
+  const hasBeenFocused = useHasBeenFocused()
+
+  const medicinePurchaseRes = useGetMedicineDataQuery({
+    skip: !hasBeenFocused,
+  })
   const organDonationRes = useGetOrganDonorStatusQuery({
     variables: {
       locale: useLocale(),
     },
-    skip: !isOrganDonationEnabled,
+    skip: !hasBeenFocused || !isOrganDonationEnabled,
   })
-  const healthInsuranceRes = useGetHealthInsuranceOverviewQuery()
-  const healthCenterRes = useGetHealthCenterQuery()
-  const paymentStatusRes = useGetPaymentStatusQuery()
-  const bloodTypeRes = useGetBloodTypeOverviewQuery()
+  const healthInsuranceRes = useGetHealthInsuranceOverviewQuery({
+    skip: !hasBeenFocused,
+  })
+  const healthCenterRes = useGetHealthCenterQuery({
+    skip: !hasBeenFocused,
+  })
+  const paymentStatusRes = useGetPaymentStatusQuery({
+    skip: !hasBeenFocused,
+  })
+  const bloodTypeRes = useGetBloodTypeOverviewQuery({
+    skip: !hasBeenFocused,
+  })
   const dentistRes = useGetDentistOverviewQuery({
     variables: {
       input: {
@@ -305,6 +328,7 @@ export default function HealthOverviewScreen() {
         dateTo: now,
       },
     },
+    skip: !hasBeenFocused,
   })
   const paymentOverviewRes = useGetPaymentOverviewQuery({
     variables: {
@@ -314,13 +338,14 @@ export default function HealthOverviewScreen() {
         serviceTypeCode: '',
       },
     },
+    skip: !hasBeenFocused,
   })
   const appointmentsRes = useGetAppointmentsQuery({
     variables: {
       from: undefined,
       status: BaseAppointmentStatuses,
     },
-    skip: !isAppointmentsEnabled,
+    skip: !hasBeenFocused || !isAppointmentsEnabled,
     notifyOnNetworkStatusChange: true,
   })
 
@@ -471,7 +496,7 @@ export default function HealthOverviewScreen() {
                 router.navigate('/(auth)/(tabs)/health/appointments')
               }
             />
-            {appointmentsRes.loading && (
+            {(!hasBeenFocused || appointmentsRes.loading) && (
               <AppointmentsContainer>
                 {Array.from({ length: 2 }).map((_, index) => (
                   <GeneralCardSkeleton height={100} key={index} />
@@ -483,14 +508,16 @@ export default function HealthOverviewScreen() {
                 <Problem error={appointmentsRes.error} size="small" />
               </AppointmentsContainer>
             )}
-            {!appointmentsRes.loading &&
+            {hasBeenFocused &&
+              !appointmentsRes.loading &&
               !appointmentsRes.error &&
               appointments.length === 0 && (
                 <AppointmentsContainer>
                   <Problem type="no_data" size="small" />
                 </AppointmentsContainer>
               )}
-            {!appointmentsRes.loading &&
+            {hasBeenFocused &&
+              !appointmentsRes.loading &&
               !appointmentsRes.error &&
               appointments.length > 0 && (
                 <AppointmentsContainer>
@@ -725,7 +752,7 @@ export default function HealthOverviewScreen() {
                     id: 'health.overview.noHealthCenterRegistered',
                   })
             }
-            loading={healthCenterRes.loading}
+            loading={!hasBeenFocused || healthCenterRes.loading}
             fullWidthWarning
             allowEmptyValue={healthCenterRes.error ? true : false}
             warningText={
@@ -763,7 +790,7 @@ export default function HealthOverviewScreen() {
                     id: 'health.overview.noPhysicianRegistered',
                   })
             }
-            loading={healthCenterRes.loading}
+            loading={!hasBeenFocused || healthCenterRes.loading}
             fullWidthWarning
             allowEmptyValue={healthCenterRes.error ? true : false}
             warningText={
@@ -801,7 +828,7 @@ export default function HealthOverviewScreen() {
                   })
             }
             allowEmptyValue={dentistRes.error ? true : false}
-            loading={dentistRes.loading}
+            loading={!hasBeenFocused || dentistRes.loading}
             fullWidthWarning
             warningText={
               dentistRes.error
@@ -838,7 +865,10 @@ export default function HealthOverviewScreen() {
                         : 'health.organDonation.isNotDonorDescription',
                     }) ?? ''
               }`}
-              loading={organDonationRes.loading && !organDonationRes.data}
+              loading={
+                !hasBeenFocused ||
+                (organDonationRes.loading && !organDonationRes.data)
+              }
               fullWidthWarning
               warningText={
                 organDonationRes.error
@@ -884,7 +914,7 @@ export default function HealthOverviewScreen() {
                     id: 'health.overview.noBloodTypeRegistered',
                   })
             }
-            loading={bloodTypeRes.loading}
+            loading={!hasBeenFocused || bloodTypeRes.loading}
             fullWidthWarning
             warningText={
               bloodTypeRes.error


### PR DESCRIPTION
## What

Only query health data when opening the health tab in the app, not when preloading tabs when the user opens the app.

## Why

To reduce load on health related infrastructure

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Health tab now displays loading placeholders while data is being fetched, providing clear visual feedback during the loading process.
  * Multiple form fields in the health section (health center, physician, dentist, organ donation, blood type) show appropriate loading states.
  * Empty states are displayed only after data loading completes, giving users clear indication when no data is available.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/island-is/island.is/pull/22715?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->