### PR TITLE
fix(j-s): Ruling Order Refresh

### DIFF
--- a/apps/judicial-system/web/src/routes/Shared/AppealToCourtOfAppeals/AppealCaseFiles.tsx
+++ b/apps/judicial-system/web/src/routes/Shared/AppealToCourtOfAppeals/AppealCaseFiles.tsx
@@ -48,7 +48,7 @@ import {
 } from '@island.is/judicial-system-web/src/utils/utils'
 
 const AppealFiles = () => {
-  const { workingCase } = useContext(FormContext)
+  const { workingCase, refreshCase } = useContext(FormContext)
   const { user } = useContext(UserContext)
   const { formatMessage } = useIntl()
   const router = useRouter()
@@ -108,13 +108,16 @@ const AppealFiles = () => {
       TrackedNotificationType.APPEAL_CASE_FILES_UPDATED,
     )
 
+    refreshCase()
+
     setVisibleModal(true)
   }, [
     handleUpload,
     uploadFiles,
-    sendNotification,
     updateUploadFile,
+    sendNotification,
     workingCase.id,
+    refreshCase,
   ])
 
   const handleRemoveFile = (file: UploadFile) => {

--- a/apps/judicial-system/web/src/routes/Shared/AppealToCourtOfAppeals/AppealToCourtOfAppeals.tsx
+++ b/apps/judicial-system/web/src/routes/Shared/AppealToCourtOfAppeals/AppealToCourtOfAppeals.tsx
@@ -45,7 +45,7 @@ import {
 } from '@island.is/judicial-system-web/src/utils/utils'
 
 const AppealToCourtOfAppeals = () => {
-  const { workingCase } = useContext(FormContext)
+  const { workingCase, refreshCase } = useContext(FormContext)
   const { user } = useContext(UserContext)
   const { formatMessage } = useIntl()
   const router = useRouter()
@@ -104,16 +104,19 @@ const AppealToCourtOfAppeals = () => {
 
     const appealCase = await createAppealCase(workingCase.id, rulingFileId)
 
+    refreshCase()
+
     if (appealCase) {
       setVisibleModal('APPEAL_SENT')
     }
   }, [
     handleUpload,
-    createAppealCase,
-    updateUploadFile,
     uploadFiles,
+    updateUploadFile,
+    createAppealCase,
     workingCase.id,
     rulingFileId,
+    refreshCase,
   ])
 
   const handleRemoveFile = (file: UploadFile) => {

--- a/apps/judicial-system/web/src/routes/Shared/AppealToCourtOfAppeals/Statement.tsx
+++ b/apps/judicial-system/web/src/routes/Shared/AppealToCourtOfAppeals/Statement.tsx
@@ -50,7 +50,7 @@ import {
 } from '@island.is/judicial-system-web/src/utils/utils'
 
 const Statement = () => {
-  const { workingCase } = useContext(FormContext)
+  const { workingCase, refreshCase } = useContext(FormContext)
   const { user } = useContext(UserContext)
   const { createAppealEventLog, isCreatingAppealEventLog } = useAppealCase()
   const { formatMessage } = useIntl()
@@ -124,16 +124,19 @@ const Statement = () => {
       AppealEventType.APPEAL_STATEMENT_SENT,
     )
 
+    refreshCase()
+
     if (sent) {
       setVisibleModal('STATEMENT_SENT')
     }
   }, [
     handleUpload,
-    createAppealEventLog,
-    updateUploadFile,
     uploadFiles,
+    updateUploadFile,
     targetAppealCaseId,
+    createAppealEventLog,
     workingCase.id,
+    refreshCase,
   ])
 
   const handleRemoveFile = (file: UploadFile) => {


### PR DESCRIPTION
# Ruling Order Refresh

[Kæra úrskurð undir rekstri máls - Það þarf refresh til að sjá ný kæruskjöl](https://app.asana.com/1/203394141643832/project/1199153462262248/task/1215238822902677)

## What

- Refreshes case after adding ruling order appeal files. This ensures the files are visible without needing a manual refresh.

## Why

- Verified bug

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [x] No AI tools were used in preparing this pull request
- [ ] AI tools were used in preparing this pull request
      Tools used:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Case data now automatically refreshes after uploading appeal documents
* Case data now automatically refreshes after submitting an appeal
* Case data now automatically refreshes after submitting appeal statements

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/island-is/island.is/pull/22718?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->