### PR TITLE
fix(native-app): clipboard app fix

### DIFF
--- a/apps/native/app/src/app/(auth)/(tabs)/inbox/[id]/communications.tsx
+++ b/apps/native/app/src/app/(auth)/(tabs)/inbox/[id]/communications.tsx
@@ -1,4 +1,4 @@
-import Clipboard from 'expo-clipboard'
+import { setStringAsync } from 'expo-clipboard'
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useIntl } from 'react-intl'
 import {
@@ -168,7 +168,7 @@ export default function DocumentCommunicationsScreen() {
               </Typography>
               <Typography variant="body3">{ticketIdValue}</Typography>
               <TouchableOpacity
-                onPress={() => Clipboard.setStringAsync(ticketIdValue)}
+                onPress={() => setStringAsync(ticketIdValue)}
                 style={{ marginLeft: 4 }}
               >
                 <Image

--- a/apps/native/app/src/ui/lib/card/air-discount-card.tsx
+++ b/apps/native/app/src/ui/lib/card/air-discount-card.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { FormattedMessage, useIntl } from 'react-intl'
-import Clipboard from 'expo-clipboard'
+import { setStringAsync } from 'expo-clipboard'
 import styled, { useTheme } from 'styled-components/native'
 
 import { dynamicColor } from '../../utils'
@@ -143,7 +143,7 @@ export function AirDiscountCard({
       </Content>
       {credit !== 0 && (
         <CopyCodeContainer>
-          <CopyCodeButton onPress={() => Clipboard.setStringAsync(code ?? '')}>
+          <CopyCodeButton onPress={() => setStringAsync(code ?? '')}>
             <Typography variant="heading5" color={theme.color.blue400}>
               <FormattedMessage
                 id="airDiscount.copyDiscountCode"

--- a/apps/native/app/src/ui/lib/field/field.tsx
+++ b/apps/native/app/src/ui/lib/field/field.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { useIntl } from 'react-intl'
 import { Image, TouchableOpacity, ViewStyle } from 'react-native'
 import styled from 'styled-components/native'
-import Clipboard from 'expo-clipboard'
+import { setStringAsync } from 'expo-clipboard'
 
 import { Skeleton } from '../skeleton/skeleton'
 import { Typography } from '../typography/typography'
@@ -80,7 +80,7 @@ export function Field({
           )}
           {link?.type === GenericUserLicenseMetaLinksType.Copy && (
             <TouchableOpacity
-              onPress={() => Clipboard.setStringAsync(value ?? '')}
+              onPress={() => setStringAsync(value ?? '')}
               style={{ marginLeft: 4 }}
             >
               <Image

--- a/apps/native/app/src/ui/lib/input/input.tsx
+++ b/apps/native/app/src/ui/lib/input/input.tsx
@@ -1,4 +1,4 @@
-import Clipboard from 'expo-clipboard'
+import { setStringAsync } from 'expo-clipboard'
 import React from 'react'
 import { Image, TouchableOpacity, View, ViewStyle } from 'react-native'
 import styled, { useTheme } from 'styled-components/native'
@@ -126,7 +126,7 @@ export function Input({
                 </Typography>
                 {copy && (
                   <TouchableOpacity
-                    onPress={() => Clipboard.setStringAsync(value ?? '')}
+                    onPress={() => setStringAsync(value ?? '')}
                     style={{ marginLeft: 4 }}
                   >
                     <Image


### PR DESCRIPTION
## What

Use named imports from expo-clipboard.

## Why

After updating the package there are no default exports anymore.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [x] No AI tools were used in preparing this pull request
- [ ] AI tools were used in preparing this pull request
      Tools used:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated clipboard functionality implementation across multiple components to use a simplified import approach, maintaining existing copy-to-clipboard behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->