### PR TITLE
fix(native-app): add ref for category/sender name to show when loading

### DIFF
--- a/apps/native/app/src/app/(auth)/(tabs)/inbox/index.tsx
+++ b/apps/native/app/src/app/(auth)/(tabs)/inbox/index.tsx
@@ -219,6 +219,24 @@ export default function InboxScreen() {
     return res.data?.documentsV2?.categories ?? []
   }, [res.data])
 
+  // Remember sender/category names across query refetches so the active filter
+  // tags keep showing the name (never the ID) while the next response loads
+  // after a filter is removed.
+  const filterNamesRef = useRef({
+    senders: new Map<string, string>(),
+    categories: new Map<string, string>(),
+  })
+  for (const sender of availableSenders) {
+    if (sender.id && sender.name) {
+      filterNamesRef.current.senders.set(sender.id, sender.name.trim())
+    }
+  }
+  for (const category of availableCategories) {
+    if (category.id && category.name) {
+      filterNamesRef.current.categories.set(category.id, category.name)
+    }
+  }
+
   const allDocumentsSelected =
     selectedItems.length === res.data?.documentsV2?.data?.length
 
@@ -733,13 +751,16 @@ export default function InboxScreen() {
                 )}
                 {!!senderNationalId.length &&
                   senderNationalId.map((senderId) => {
-                    const name = availableSenders.find(
-                      (sender) => sender.id === senderId,
-                    )
+                    const name =
+                      filterNamesRef.current.senders.get(senderId) ??
+                      availableSenders
+                        .find((sender) => sender.id === senderId)
+                        ?.name?.trim() ??
+                      senderId
                     return (
                       <Tag
                         key={senderId}
-                        title={name?.name?.trim() ?? senderId}
+                        title={name}
                         closable
                         onClose={() =>
                           inboxFilterStore.setState((state) => ({
@@ -753,13 +774,16 @@ export default function InboxScreen() {
                   })}
                 {!!categoryIds.length &&
                   categoryIds.map((categoryId) => {
-                    const name = availableCategories.find(
-                      (category) => category.id === categoryId,
-                    )
+                    const name =
+                      filterNamesRef.current.categories.get(categoryId) ??
+                      availableCategories.find(
+                        (category) => category.id === categoryId,
+                      )?.name ??
+                      categoryId
                     return (
                       <Tag
                         key={categoryId}
-                        title={name?.name ?? categoryId}
+                        title={name}
                         closable
                         onClose={() =>
                           inboxFilterStore.setState((state) => ({


### PR DESCRIPTION
## What

Make sure we never show the id for filters when removing filters from the inbox filtering.

## Screenshots / Gifs

Before:

https://github.com/user-attachments/assets/adfff1f5-267e-42c5-a9b5-15565a0f5d31



After:

https://github.com/user-attachments/assets/4ba619bb-4b1d-4047-8388-f80384950e6b



## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability of filter labels in the inbox. Sender and category display names now persist correctly across data refreshes, ensuring a consistent filtering experience without display name interruptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->