### PR TITLE
fix(native-app): apply button should be visible to apply clearing inbox filters

### DIFF
--- a/apps/native/app/src/app/(auth)/(tabs)/inbox/filter.tsx
+++ b/apps/native/app/src/app/(auth)/(tabs)/inbox/filter.tsx
@@ -71,6 +71,19 @@ export default function FilterScreen() {
     dateTo
   )
 
+  // Whether the store currently has filters applied. When true, the Apply
+  // button must remain available even if the user has cleared the local state,
+  // so they can commit the cleared state back to the store.
+  const hasAppliedFilters = !!(
+    store.opened ||
+    store.bookmarked ||
+    store.archived ||
+    store.senderNationalId.length ||
+    store.categoryIds.length ||
+    store.dateFrom ||
+    store.dateTo
+  )
+
   const onApplyFilters = useCallback(() => {
     inboxFilterStore.setState({
       opened,
@@ -222,7 +235,7 @@ export default function FilterScreen() {
           </AccordionItem>
         </Accordion>
       </ScrollView>
-      {isSelected && (
+      {(isSelected || hasAppliedFilters) && (
         <ButtonContainer>
           <Button
             title={intl.formatMessage({ id: 'inbox.filterApplyButton' })}


### PR DESCRIPTION
## What

Make sure we can apply cleaning all the inbox filters in the filter view. Currently no possibility to "apply" the cleaning.

## Screenshots / Gifs

Before:


https://github.com/user-attachments/assets/fbf1ce54-8a39-4088-917a-48e4d857b197


After:


https://github.com/user-attachments/assets/edf09d36-c79a-4639-b08a-88b895d5198e



## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude
