### PR TITLE
fix(contentful-apps): Allow height overflow for dialogs in sitemap tree field app

### DIFF
--- a/apps/contentful-apps/components/sitemap/utils.ts
+++ b/apps/contentful-apps/components/sitemap/utils.ts
@@ -232,6 +232,7 @@ export const addNode = async (
         otherSlugsEN,
       },
       minHeight: CATEGORY_DIALOG_MIN_HEIGHT,
+      allowHeightOverflow: true,
     })
 
     if (!data) {
@@ -253,6 +254,7 @@ export const addNode = async (
         },
       },
       minHeight: URL_DIALOG_MIN_HEIGHT,
+      allowHeightOverflow: true,
     })
 
     if (!data) {


### PR DESCRIPTION
# Allow height overflow for dialogs in sitemap tree field app

In case users are on smaller screens, we want to make sure the entire dialog gets shown

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [x] No AI tools were used in preparing this pull request
- [ ] AI tools were used in preparing this pull request
      Tools used:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed dialog display issues for sitemap node creation and editing dialogs by allowing proper content overflow handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->