### PR TITLE
fix(native-app): inbox scrolling selecting all documents

### DIFF
--- a/apps/native/app/src/app/(auth)/(tabs)/inbox/index.tsx
+++ b/apps/native/app/src/app/(auth)/(tabs)/inbox/index.tsx
@@ -198,6 +198,7 @@ export default function InboxScreen() {
 
   const [selectState, setSelectedState] = useState(false)
   const [selectedItems, setSelectedItems] = useState<string[]>([])
+  const [selectAllMode, setSelectAllMode] = useState(false)
 
   const res = useListDocumentsQuery({
     variables: {
@@ -258,7 +259,17 @@ export default function InboxScreen() {
   const resetSelectState = () => {
     setSelectedItems([])
     setSelectedState(false)
+    setSelectAllMode(false)
   }
+
+  // Wrap the selectedItems setter passed to individual rows so any manual
+  // toggle disables select-all mode (the user is taking over control).
+  const handleItemSelectionChange = useCallback<
+    React.Dispatch<React.SetStateAction<string[]>>
+  >((updater) => {
+    setSelectAllMode(false)
+    setSelectedItems(updater)
+  }, [])
 
   const onRefresh = useCallback(async () => {
     try {
@@ -280,6 +291,13 @@ export default function InboxScreen() {
 
   const items = useMemo(() => res.data?.documentsV2?.data ?? [], [res.data])
   const isSearch = query.length > 2
+
+  // While select-all mode is on, keep selectedItems in sync with every loaded
+  // document so newly loaded items are also selected by default.
+  useEffect(() => {
+    if (!selectAllMode) return
+    setSelectedItems(items.map((item) => item.id))
+  }, [items, selectAllMode])
 
   const loadMore = async () => {
     if (res.loading || loadingMore) {
@@ -399,7 +417,7 @@ export default function InboxScreen() {
           item={document}
           selectable={selectState}
           selectedItems={selectedItems}
-          setSelectedItems={setSelectedItems}
+          setSelectedItems={handleItemSelectionChange}
           setSelectedState={setSelectedState}
           listParams={{
             ...filters,
@@ -413,7 +431,7 @@ export default function InboxScreen() {
       filters,
       selectState,
       selectedItems,
-      setSelectedItems,
+      handleItemSelectionChange,
       availableCategories,
       isFeature2WayMailboxEnabled,
     ],
@@ -562,12 +580,15 @@ export default function InboxScreen() {
                     fontFamily: fontByWeight('400'),
                   },
                   onPress() {
-                    allDocumentsSelected
-                      ? setSelectedItems([])
-                      : setSelectedItems(
-                          res.data?.documentsV2?.data.map((doc) => doc.id) ??
-                            [],
-                        )
+                    if (allDocumentsSelected) {
+                      setSelectAllMode(false)
+                      setSelectedItems([])
+                    } else {
+                      setSelectAllMode(true)
+                      setSelectedItems(
+                        res.data?.documentsV2?.data.map((doc) => doc.id) ?? [],
+                      )
+                    }
                   },
                 },
               ]

--- a/apps/native/app/src/messages/en.ts
+++ b/apps/native/app/src/messages/en.ts
@@ -229,14 +229,14 @@ export const en: TranslatedMessages = {
 
   // inbox filters
   'inboxFilters.screenTitle': 'Filter documents',
-  'inboxFilters.unreadOnly': 'Show only unread',
+  'inboxFilters.unreadOnly': 'Show unread only',
   'inboxFilters.starred': 'Starred',
   'inboxFilters.archived': 'Archived',
   'inbox.filterButtonTitle': 'Filter',
   'inbox.filterOpenedTagTitle': 'Unread',
   'inbox.filterArchivedTagTitle': 'Archived',
   'inbox.filterStarredTagTitle': 'Starred',
-  'inbox.filterOrganizationTitle': 'Organization',
+  'inbox.filterOrganizationTitle': 'Institution',
   'inbox.filterCategoryTitle': 'Category',
   'inbox.filterDatesTitle': 'Dates',
   'inbox.filterClearButton': 'Clear',


### PR DESCRIPTION
## What

In inbox when selecting all documents and loading more documents, they are not selected. 

## Screenshots / Gifs

Before: 

https://github.com/user-attachments/assets/1f4540a5-9959-4686-b81a-ad6dea6c6f2a

After: 

https://github.com/user-attachments/assets/1299b49c-7b91-4142-b902-ce5ed9ae5c82

(The buttons at the top are somehow off but they are also on main but not in the version in testflight, will take a look at it later).


## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bulk selection functionality in the inbox with enhanced select-all behavior and item synchronization.

* **Localization**
  * Updated inbox filter labels: changed "Show only unread" to "Show unread only" and "Organization" to "Institution" for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->