### PR TITLE
feat(native-app): app add notifications module to home screen

### DIFF
--- a/apps/native/app/src/app/(auth)/(modals)/homescreen-options.tsx
+++ b/apps/native/app/src/app/(auth)/(modals)/homescreen-options.tsx
@@ -18,6 +18,11 @@ export default function HomeOptionsScreen() {
     false,
     null,
   )
+  const isNotificationsWidgetEnabled = useFeatureFlag(
+    'isNotificationWidgetEnabled',
+    false,
+    null,
+  )
   const vehiclesWidgetEnabled = usePreferencesStore(
     ({ vehiclesWidgetEnabled }) => vehiclesWidgetEnabled,
   )
@@ -55,18 +60,21 @@ export default function HomeOptionsScreen() {
         })
       },
     },
-    // TODO add feature flag
-    {
-      enabled: notificationsWidgetEnabled,
-      label: intl.formatMessage({
-        id: 'homeOptions.notifications',
-      }),
-      onValueChange: (value: boolean) => {
-        preferencesStore.setState({
-          notificationsWidgetEnabled: value,
-        })
-      },
-    },
+    ...(isNotificationsWidgetEnabled
+      ? [
+          {
+            enabled: notificationsWidgetEnabled,
+            label: intl.formatMessage({
+              id: 'homeOptions.notifications',
+            }),
+            onValueChange: (value: boolean) => {
+              preferencesStore.setState({
+                notificationsWidgetEnabled: value,
+              })
+            },
+          },
+        ]
+      : []),
     {
       enabled: inboxWidgetEnabled,
       label: intl.formatMessage({

--- a/apps/native/app/src/app/(auth)/(modals)/homescreen-options.tsx
+++ b/apps/native/app/src/app/(auth)/(modals)/homescreen-options.tsx
@@ -39,6 +39,9 @@ export default function HomeOptionsScreen() {
   const graphicWidgetEnabled = usePreferencesStore(
     ({ graphicWidgetEnabled }) => graphicWidgetEnabled,
   )
+  const notificationsWidgetEnabled = usePreferencesStore(
+    ({ notificationsWidgetEnabled }) => notificationsWidgetEnabled,
+  )
 
   const items = [
     {
@@ -49,6 +52,18 @@ export default function HomeOptionsScreen() {
       onValueChange: (value: boolean) => {
         preferencesStore.setState({
           graphicWidgetEnabled: value,
+        })
+      },
+    },
+    // TODO add feature flag
+    {
+      enabled: notificationsWidgetEnabled,
+      label: intl.formatMessage({
+        id: 'homeOptions.notifications',
+      }),
+      onValueChange: (value: boolean) => {
+        preferencesStore.setState({
+          notificationsWidgetEnabled: value,
         })
       },
     },

--- a/apps/native/app/src/app/(auth)/(modals)/homescreen-options.tsx
+++ b/apps/native/app/src/app/(auth)/(modals)/homescreen-options.tsx
@@ -23,6 +23,11 @@ export default function HomeOptionsScreen() {
     false,
     null,
   )
+  const isInboxWidgetDisabled = useFeatureFlag(
+    'isPostholfWidgetDisabled',
+    false,
+    null,
+  )
   const vehiclesWidgetEnabled = usePreferencesStore(
     ({ vehiclesWidgetEnabled }) => vehiclesWidgetEnabled,
   )
@@ -75,17 +80,21 @@ export default function HomeOptionsScreen() {
           },
         ]
       : []),
-    {
-      enabled: inboxWidgetEnabled,
-      label: intl.formatMessage({
-        id: 'homeOptions.inbox',
-      }),
-      onValueChange: (value: boolean) => {
-        preferencesStore.setState({
-          inboxWidgetEnabled: value,
-        })
-      },
-    },
+    ...(isInboxWidgetDisabled === false
+      ? [
+          {
+            enabled: inboxWidgetEnabled,
+            label: intl.formatMessage({
+              id: 'homeOptions.inbox',
+            }),
+            onValueChange: (value: boolean) => {
+              preferencesStore.setState({
+                inboxWidgetEnabled: value,
+              })
+            },
+          },
+        ]
+      : []),
     ...(isAppointmentsEnabled
       ? [
           {

--- a/apps/native/app/src/app/(auth)/(modals)/homescreen-options.tsx
+++ b/apps/native/app/src/app/(auth)/(modals)/homescreen-options.tsx
@@ -46,25 +46,11 @@ export default function HomeOptionsScreen() {
   const appointmentsWidgetEnabled = usePreferencesStore(
     ({ appointmentsWidgetEnabled }) => appointmentsWidgetEnabled,
   )
-  const graphicWidgetEnabled = usePreferencesStore(
-    ({ graphicWidgetEnabled }) => graphicWidgetEnabled,
-  )
   const notificationsWidgetEnabled = usePreferencesStore(
     ({ notificationsWidgetEnabled }) => notificationsWidgetEnabled,
   )
 
   const items = [
-    {
-      enabled: graphicWidgetEnabled,
-      label: intl.formatMessage({
-        id: 'homeOptions.graphic',
-      }),
-      onValueChange: (value: boolean) => {
-        preferencesStore.setState({
-          graphicWidgetEnabled: value,
-        })
-      },
-    },
     ...(isNotificationsWidgetEnabled
       ? [
           {

--- a/apps/native/app/src/app/(auth)/(tabs)/index/index.tsx
+++ b/apps/native/app/src/app/(auth)/(tabs)/index/index.tsx
@@ -48,6 +48,11 @@ import {
   useGetAppointmentsQuery,
   validateAppointmentsInitialData,
 } from '@/components/home/appointments-module'
+import {
+  NotificationsModule,
+  useGetUserNotificationsQuery,
+  validateNotificationsInitialData,
+} from '@/components/home/notifications-module'
 import { BaseAppointmentStatuses } from '@/constants/base-appointment-statuses'
 import { useFeatureFlag } from '@/components/providers/feature-flag-provider'
 import { INCLUDED_LICENSE_TYPES } from '@/constants/wallet.constants'
@@ -114,6 +119,9 @@ export default function HomeScreen() {
   const appointmentsWidgetEnabled = usePreferencesStore(
     ({ appointmentsWidgetEnabled }) => appointmentsWidgetEnabled,
   )
+  const notificationsWidgetEnabled = usePreferencesStore(
+    ({ notificationsWidgetEnabled }) => notificationsWidgetEnabled,
+  )
   const widgetsInitialised = usePreferencesStore(
     ({ widgetsInitialised }) => widgetsInitialised,
   )
@@ -173,6 +181,14 @@ export default function HomeScreen() {
     skip: !appointmentsWidgetEnabled || !isAppointmentsEnabled,
   })
 
+  const notificationsRes = useGetUserNotificationsQuery({
+    variables: {
+      input: { limit: 3 },
+      locale: useLocale(),
+    },
+    skip: !notificationsWidgetEnabled,
+  })
+
   useEffect(() => {
     // If widgets have not been initialized, validate data and set state accordingly
     if (!widgetsInitialised) {
@@ -194,12 +210,18 @@ export default function HomeScreen() {
         ...airDiscountRes,
       })
 
+      const shouldShowNotificationsWidget = validateNotificationsInitialData({
+        ...notificationsRes,
+      })
+
       preferencesStore.setState({
         inboxWidgetEnabled: shouldShowInboxWidget,
         licensesWidgetEnabled: shouldShowLicensesWidget,
         applicationsWidgetEnabled: shouldShowApplicationsWidget,
         vehiclesWidgetEnabled: shouldShowVehiclesWidget,
         airDiscountWidgetEnabled: shouldShowAirDiscountWidget,
+        // TODO add feature flag
+        notificationsWidgetEnabled: shouldShowNotificationsWidget,
         ...(isAppointmentsEnabled !== null && {
           appointmentsWidgetEnabled: isAppointmentsEnabled
             ? validateAppointmentsInitialData({ ...appointmentsRes })
@@ -216,6 +238,7 @@ export default function HomeScreen() {
         airDiscountRes.loading ||
         vehiclesRes.loading ||
         appointmentsRes.loading ||
+        notificationsRes.loading ||
         isAppointmentsEnabled === null
       ) {
         return
@@ -230,6 +253,7 @@ export default function HomeScreen() {
     airDiscountRes.loading,
     vehiclesRes.loading,
     appointmentsRes.loading,
+    notificationsRes.loading,
     widgetsInitialised,
     inboxRes,
     licensesRes,
@@ -237,6 +261,7 @@ export default function HomeScreen() {
     vehiclesRes,
     airDiscountRes,
     appointmentsRes,
+    notificationsRes,
     isAppointmentsEnabled,
   ])
 
@@ -285,6 +310,8 @@ export default function HomeScreen() {
         appointmentsWidgetEnabled &&
           isAppointmentsEnabled &&
           appointmentsRes.refetch(),
+        // TODO add feature flag
+        notificationsWidgetEnabled && notificationsRes.refetch(),
       ].filter(Boolean)
 
       await Promise.all(promises)
@@ -300,12 +327,14 @@ export default function HomeScreen() {
     airDiscountRes,
     vehiclesRes,
     appointmentsRes,
+    notificationsRes,
     vehiclesWidgetEnabled,
     airDiscountWidgetEnabled,
     applicationsWidgetEnabled,
     licensesWidgetEnabled,
     inboxWidgetEnabled,
     appointmentsWidgetEnabled,
+    notificationsWidgetEnabled,
     isAppointmentsEnabled,
   ])
 
@@ -313,6 +342,12 @@ export default function HomeScreen() {
     {
       id: 'hello',
       component: <HelloModule />,
+    },
+    {
+      id: 'notifications',
+      component: notificationsWidgetEnabled ? (
+        <NotificationsModule {...notificationsRes} />
+      ) : null,
     },
     {
       id: 'inbox',
@@ -364,6 +399,7 @@ export default function HomeScreen() {
           airDiscountRes.networkStatus,
           vehiclesRes.networkStatus,
           appointmentsRes.networkStatus,
+          notificationsRes.networkStatus,
         ]}
         options={{
           headerTitle: '',

--- a/apps/native/app/src/app/(auth)/(tabs)/index/index.tsx
+++ b/apps/native/app/src/app/(auth)/(tabs)/index/index.tsx
@@ -104,6 +104,11 @@ export default function HomeScreen() {
     false,
     null,
   )
+  const isInboxWidgetDisabled = useFeatureFlag(
+    'isPostholfWidgetDisabled',
+    false,
+    null,
+  )
 
   const [refetching, setRefetching] = useState(false)
 
@@ -142,7 +147,7 @@ export default function HomeScreen() {
     variables: {
       input: { page: 1, pageSize: 3 },
     },
-    skip: !inboxWidgetEnabled,
+    skip: !inboxWidgetEnabled || isInboxWidgetDisabled !== false,
   })
 
   const licensesRes = useListLicensesQuery({
@@ -217,11 +222,15 @@ export default function HomeScreen() {
       })
 
       preferencesStore.setState({
-        inboxWidgetEnabled: shouldShowInboxWidget,
         licensesWidgetEnabled: shouldShowLicensesWidget,
         applicationsWidgetEnabled: shouldShowApplicationsWidget,
         vehiclesWidgetEnabled: shouldShowVehiclesWidget,
         airDiscountWidgetEnabled: shouldShowAirDiscountWidget,
+        ...(isInboxWidgetDisabled !== null && {
+          inboxWidgetEnabled: isInboxWidgetDisabled
+            ? false
+            : shouldShowInboxWidget,
+        }),
         ...(isAppointmentsEnabled !== null && {
           appointmentsWidgetEnabled: isAppointmentsEnabled
             ? validateAppointmentsInitialData({ ...appointmentsRes })
@@ -245,7 +254,8 @@ export default function HomeScreen() {
         appointmentsRes.loading ||
         notificationsRes.loading ||
         isAppointmentsEnabled === null ||
-        isNotificationsWidgetEnabled === null
+        isNotificationsWidgetEnabled === null ||
+        isInboxWidgetDisabled === null
       ) {
         return
       }
@@ -270,6 +280,7 @@ export default function HomeScreen() {
     notificationsRes,
     isAppointmentsEnabled,
     isNotificationsWidgetEnabled,
+    isInboxWidgetDisabled,
   ])
 
   const renderItem = useCallback(
@@ -310,7 +321,9 @@ export default function HomeScreen() {
     try {
       const promises = [
         applicationsWidgetEnabled && applicationsRes.refetch(),
-        inboxWidgetEnabled && inboxRes.refetch(),
+        inboxWidgetEnabled &&
+          isInboxWidgetDisabled === false &&
+          inboxRes.refetch(),
         licensesWidgetEnabled && licensesRes.refetch(),
         airDiscountWidgetEnabled && airDiscountRes.refetch(),
         vehiclesWidgetEnabled && vehiclesRes.refetch(),
@@ -345,6 +358,7 @@ export default function HomeScreen() {
     notificationsWidgetEnabled,
     isAppointmentsEnabled,
     isNotificationsWidgetEnabled,
+    isInboxWidgetDisabled,
   ])
 
   const data = [
@@ -361,7 +375,10 @@ export default function HomeScreen() {
     },
     {
       id: 'inbox',
-      component: inboxWidgetEnabled ? <InboxModule {...inboxRes} /> : null,
+      component:
+        inboxWidgetEnabled && isInboxWidgetDisabled === false ? (
+          <InboxModule {...inboxRes} />
+        ) : null,
     },
     {
       id: 'appointments',

--- a/apps/native/app/src/app/(auth)/(tabs)/index/index.tsx
+++ b/apps/native/app/src/app/(auth)/(tabs)/index/index.tsx
@@ -99,6 +99,12 @@ export default function HomeScreen() {
     false,
     null,
   )
+  const isNotificationsWidgetEnabled = useFeatureFlag(
+    'isNotificationWidgetEnabled',
+    false,
+    null,
+  )
+
   const [refetching, setRefetching] = useState(false)
 
   const vehiclesWidgetEnabled = usePreferencesStore(
@@ -186,7 +192,7 @@ export default function HomeScreen() {
       input: { limit: 3 },
       locale: useLocale(),
     },
-    skip: !notificationsWidgetEnabled,
+    skip: !notificationsWidgetEnabled || !isNotificationsWidgetEnabled,
   })
 
   useEffect(() => {
@@ -210,21 +216,20 @@ export default function HomeScreen() {
         ...airDiscountRes,
       })
 
-      const shouldShowNotificationsWidget = validateNotificationsInitialData({
-        ...notificationsRes,
-      })
-
       preferencesStore.setState({
         inboxWidgetEnabled: shouldShowInboxWidget,
         licensesWidgetEnabled: shouldShowLicensesWidget,
         applicationsWidgetEnabled: shouldShowApplicationsWidget,
         vehiclesWidgetEnabled: shouldShowVehiclesWidget,
         airDiscountWidgetEnabled: shouldShowAirDiscountWidget,
-        // TODO add feature flag
-        notificationsWidgetEnabled: shouldShowNotificationsWidget,
         ...(isAppointmentsEnabled !== null && {
           appointmentsWidgetEnabled: isAppointmentsEnabled
             ? validateAppointmentsInitialData({ ...appointmentsRes })
+            : false,
+        }),
+        ...(isNotificationsWidgetEnabled !== null && {
+          notificationsWidgetEnabled: isNotificationsWidgetEnabled
+            ? validateNotificationsInitialData({ ...notificationsRes })
             : false,
         }),
       })
@@ -239,7 +244,8 @@ export default function HomeScreen() {
         vehiclesRes.loading ||
         appointmentsRes.loading ||
         notificationsRes.loading ||
-        isAppointmentsEnabled === null
+        isAppointmentsEnabled === null ||
+        isNotificationsWidgetEnabled === null
       ) {
         return
       }
@@ -263,6 +269,7 @@ export default function HomeScreen() {
     appointmentsRes,
     notificationsRes,
     isAppointmentsEnabled,
+    isNotificationsWidgetEnabled,
   ])
 
   const renderItem = useCallback(
@@ -310,8 +317,9 @@ export default function HomeScreen() {
         appointmentsWidgetEnabled &&
           isAppointmentsEnabled &&
           appointmentsRes.refetch(),
-        // TODO add feature flag
-        notificationsWidgetEnabled && notificationsRes.refetch(),
+        notificationsWidgetEnabled &&
+          isNotificationsWidgetEnabled &&
+          notificationsRes.refetch(),
       ].filter(Boolean)
 
       await Promise.all(promises)
@@ -336,6 +344,7 @@ export default function HomeScreen() {
     appointmentsWidgetEnabled,
     notificationsWidgetEnabled,
     isAppointmentsEnabled,
+    isNotificationsWidgetEnabled,
   ])
 
   const data = [
@@ -345,9 +354,10 @@ export default function HomeScreen() {
     },
     {
       id: 'notifications',
-      component: notificationsWidgetEnabled ? (
-        <NotificationsModule {...notificationsRes} />
-      ) : null,
+      component:
+        notificationsWidgetEnabled && isNotificationsWidgetEnabled ? (
+          <NotificationsModule {...notificationsRes} />
+        ) : null,
     },
     {
       id: 'inbox',

--- a/apps/native/app/src/components/home/hello-module.tsx
+++ b/apps/native/app/src/components/home/hello-module.tsx
@@ -1,85 +1,18 @@
-import * as FileSystem from 'expo-file-system'
-import React, { useEffect } from 'react'
+import React from 'react'
 import { FormattedMessage } from 'react-intl'
-import { Image, SafeAreaView } from 'react-native'
+import { SafeAreaView } from 'react-native'
 import styled, { useTheme } from 'styled-components/native'
 
-import { useGetFrontPageImageQuery } from '@/graphql/types/schema'
 import { useAuthStore } from '@/stores/auth-store'
-import { usePreferencesStore } from '@/stores/preferences-store'
-import { Skeleton, Typography } from '@/ui'
+import { Typography } from '@/ui'
 
 const Host = styled.View`
   margin-bottom: ${({ theme }) => theme.spacing[2]}px;
 `
 
-const ImageWrapper = styled.View`
-  margin-top: ${({ theme }) => theme.spacing[3]}px;
-`
-
-const getFileExtension = (url: string): string => {
-  const extension = url.split('.').pop()
-  return extension ? `.${extension}` : ''
-}
-
 export const HelloModule = React.memo(() => {
   const theme = useTheme()
-  const { graphicWidgetEnabled } = usePreferencesStore()
   const { userInfo } = useAuthStore()
-  const [imageSrc, setImageSrc] = React.useState<string | undefined>(undefined)
-
-  const { data: image, loading } = useGetFrontPageImageQuery({
-    variables: { input: { pageIdentifier: 'frontpage' } },
-  })
-
-  // Need to add extension to the title due to an issue in react native https://github.com/facebook/react-native/issues/42234
-  const fileExtension = image?.getFrontpage?.imageMobile?.url
-    ? getFileExtension(image?.getFrontpage?.imageMobile?.url)
-    : ''
-
-  const titleWithExtension = image?.getFrontpage?.imageMobile?.title
-    ? `${image?.getFrontpage?.imageMobile?.title}${fileExtension}`
-    : undefined
-
-  const handleImage = async () => {
-    if (!image || !titleWithExtension) {
-      return
-    }
-
-    const imageCacheDir = new FileSystem.Directory(
-      new FileSystem.Directory(FileSystem.Paths.cache).uri + 'homeScreenImages',
-    )
-    const localFile = new FileSystem.File(
-      imageCacheDir.uri + titleWithExtension,
-    )
-
-    // Use image from cache if it exists
-    if (localFile.exists) {
-      setImageSrc(localFile.uri)
-    } else {
-      const imageSource = image.getFrontpage?.imageMobile?.url
-      if (!imageSource) {
-        return
-      }
-      setImageSrc(imageSource)
-      // Download image and save in cache
-      try {
-        if (!imageCacheDir.exists) {
-          imageCacheDir.create()
-        }
-        const response = await fetch(imageSource)
-        const buffer = await response.arrayBuffer()
-        localFile.write(new Uint8Array(buffer))
-      } catch (e) {
-        console.error(e)
-        // Do nothing, try again next time
-      }
-    }
-  }
-
-  useEffect(() => {
-    handleImage()
-  }, [image])
 
   return (
     <SafeAreaView
@@ -98,22 +31,6 @@ export const HelloModule = React.memo(() => {
         >
           {userInfo?.name}
         </Typography>
-        {graphicWidgetEnabled && imageSrc && (
-          <ImageWrapper>
-            {loading ? (
-              <Skeleton
-                height={167}
-                style={{ borderRadius: theme.spacing[1] }}
-              />
-            ) : (
-              <Image
-                source={{ uri: imageSrc }}
-                style={{ height: 167 }}
-                resizeMode="contain"
-              />
-            )}
-          </ImageWrapper>
-        )}
       </Host>
     </SafeAreaView>
   )

--- a/apps/native/app/src/components/home/notifications-module.tsx
+++ b/apps/native/app/src/components/home/notifications-module.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { FormattedMessage, useIntl } from 'react-intl'
-import { Image, SafeAreaView, TouchableOpacity } from 'react-native'
+import { Image, View, TouchableOpacity } from 'react-native'
 import styled, { useTheme } from 'styled-components/native'
 import { ApolloError } from '@apollo/client'
 
@@ -87,7 +87,7 @@ const NotificationsModule = React.memo(
     }
 
     return (
-      <SafeAreaView style={{ marginTop: theme.spacing[2] }}>
+      <View style={{ marginTop: theme.spacing[2] }}>
         <Host>
           <TouchableOpacity
             disabled={!notifications.length}
@@ -156,7 +156,7 @@ const NotificationsModule = React.memo(
             ))
           )}
         </Host>
-      </SafeAreaView>
+      </View>
     )
   },
 )

--- a/apps/native/app/src/components/home/notifications-module.tsx
+++ b/apps/native/app/src/components/home/notifications-module.tsx
@@ -78,6 +78,7 @@ const NotificationsModule = React.memo(
       void markUserNotificationAsRead({ variables: { id: notification.id } })
       navigateToUniversalLink({
         link: notification.message?.link?.url,
+        fromScreen: '/notifications',
       })
     }
 

--- a/apps/native/app/src/components/home/notifications-module.tsx
+++ b/apps/native/app/src/components/home/notifications-module.tsx
@@ -1,0 +1,163 @@
+import React from 'react'
+import { FormattedMessage, useIntl } from 'react-intl'
+import { Image, SafeAreaView, TouchableOpacity } from 'react-native'
+import styled, { useTheme } from 'styled-components/native'
+import { ApolloError } from '@apollo/client'
+
+import {
+  Typography,
+  Heading,
+  ChevronRight,
+  ListItemSkeleton,
+  EmptyCard,
+  NotificationCard,
+} from '@/ui'
+import emptyIllustrationSrc from '@/assets/illustrations/le-company-s3.png'
+import { router } from 'expo-router'
+import {
+  GetUserNotificationsQuery,
+  Notification,
+  useGetUserNotificationsQuery,
+  useMarkUserNotificationAsReadMutation,
+} from '@/graphql/types/schema'
+import { navigateToUniversalLink } from '@/lib/deep-linking'
+
+const Host = styled.View`
+  margin-bottom: ${({ theme }) => theme.spacing[2]}px;
+`
+
+const EmptyWrapper = styled.View`
+  margin-horizontal: ${({ theme }) => theme.spacing[2]}px;
+`
+
+const FALLBACK_ICON_URL =
+  'https://images.ctfassets.net/8k0h54kbe6bj/6XhCz5Ss17OVLxpXNVDxAO/d3d6716bdb9ecdc5041e6baf68b92ba6/coat_of_arms.svg'
+
+const HOME_NOTIFICATIONS_LIMIT = 3
+
+interface NotificationsModuleProps {
+  data: GetUserNotificationsQuery | undefined
+  loading: boolean
+  error?: ApolloError | undefined
+}
+
+const validateNotificationsInitialData = ({
+  data,
+  loading,
+}: {
+  data: GetUserNotificationsQuery | undefined
+  loading: boolean
+}) => {
+  if (loading) {
+    return true
+  }
+
+  if (data?.userNotifications?.data?.length) {
+    return true
+  }
+
+  return false
+}
+
+const NotificationsModule = React.memo(
+  ({ data, loading, error }: NotificationsModuleProps) => {
+    const theme = useTheme()
+    const intl = useIntl()
+    const [markUserNotificationAsRead] = useMarkUserNotificationAsReadMutation()
+
+    if (error && !data) {
+      return null
+    }
+
+    const notifications = (data?.userNotifications?.data ?? []).slice(
+      0,
+      HOME_NOTIFICATIONS_LIMIT,
+    )
+
+    const onNotificationPress = (notification: Notification) => {
+      void markUserNotificationAsRead({ variables: { id: notification.id } })
+      navigateToUniversalLink({
+        link: notification.message?.link?.url,
+      })
+    }
+
+    return (
+      <SafeAreaView style={{ marginTop: theme.spacing[2] }}>
+        <Host>
+          <TouchableOpacity
+            disabled={!notifications.length}
+            onPress={() => router.navigate('/notifications')}
+            style={{ marginHorizontal: theme.spacing[2] }}
+          >
+            <Heading
+              button={
+                notifications.length === 0 ? null : (
+                  <TouchableOpacity
+                    onPress={() => router.navigate('/notifications')}
+                    style={{
+                      flexDirection: 'row',
+                      alignItems: 'center',
+                    }}
+                  >
+                    <Typography variant="heading5" color={theme.color.blue400}>
+                      <FormattedMessage id="button.seeAll" />
+                    </Typography>
+                    <ChevronRight />
+                  </TouchableOpacity>
+                )
+              }
+            >
+              <FormattedMessage id="homeOptions.notifications" />
+            </Heading>
+          </TouchableOpacity>
+          {loading && !data ? (
+            Array.from({ length: HOME_NOTIFICATIONS_LIMIT })
+              .map((_, id) => ({ id: String(id) }))
+              .map((item) => (
+                <ListItemSkeleton key={item.id} multilineMessage />
+              ))
+          ) : notifications.length === 0 ? (
+            <EmptyWrapper>
+              <EmptyCard
+                text={intl.formatMessage({
+                  id: 'notifications.emptyListTitle',
+                })}
+                image={
+                  <Image
+                    source={emptyIllustrationSrc}
+                    resizeMode="contain"
+                    style={{ height: 72, width: 55 }}
+                  />
+                }
+                link={null}
+              />
+            </EmptyWrapper>
+          ) : (
+            notifications.map((item) => (
+              <NotificationCard
+                key={item.id}
+                id={item.id}
+                title={item.message.title}
+                message={item.message.displayBody}
+                date={new Date(item.metadata.sent)}
+                icon={{
+                  uri: `${
+                    item.sender.logoUrl ?? FALLBACK_ICON_URL
+                  }?w=64&h=64&fit=pad&fm=png`,
+                }}
+                unread={!item.metadata.read}
+                onPress={() => onNotificationPress(item)}
+              />
+            ))
+          )}
+        </Host>
+      </SafeAreaView>
+    )
+  },
+)
+
+export {
+  NotificationsModule,
+  useGetUserNotificationsQuery,
+  validateNotificationsInitialData,
+}

--- a/apps/native/app/src/components/home/notifications-module.tsx
+++ b/apps/native/app/src/components/home/notifications-module.tsx
@@ -75,7 +75,11 @@ const NotificationsModule = React.memo(
     )
 
     const onNotificationPress = (notification: Notification) => {
-      void markUserNotificationAsRead({ variables: { id: notification.id } })
+      void markUserNotificationAsRead({
+        variables: { id: notification.id },
+      }).catch(() => {
+        // ignore mark-as-read failures; navigation should still proceed
+      })
       navigateToUniversalLink({
         link: notification.message?.link?.url,
         fromScreen: '/notifications',

--- a/apps/native/app/src/graphql/queries/profile.graphql
+++ b/apps/native/app/src/graphql/queries/profile.graphql
@@ -13,15 +13,6 @@ query GetProfile {
   }
 }
 
-query GetFrontPageImage($input: GetFrontpageInput!) {
-  getFrontpage(input: $input) {
-    imageMobile {
-      title
-      url
-    }
-  }
-}
-
 mutation UpdateProfile($input: UpdateUserProfileInput!) {
   updateProfile(input: $input) {
     nationalId

--- a/apps/native/app/src/messages/en.ts
+++ b/apps/native/app/src/messages/en.ts
@@ -200,6 +200,7 @@ export const en: TranslatedMessages = {
   'homeOptions.heading.subtitle':
     'Here you can configure what is displayed on the home screen.',
   'homeOptions.graphic': 'Display graphic',
+  'homeOptions.notifications': 'Latest notifications',
   'homeOptions.inbox': 'Latest in inbox',
   'homeOptions.licenses': 'Licenses',
   'homeOptions.applications': 'Applications',

--- a/apps/native/app/src/messages/en.ts
+++ b/apps/native/app/src/messages/en.ts
@@ -199,7 +199,6 @@ export const en: TranslatedMessages = {
   'homeOptions.heading.title': 'Configure home screen',
   'homeOptions.heading.subtitle':
     'Here you can configure what is displayed on the home screen.',
-  'homeOptions.graphic': 'Display graphic',
   'homeOptions.notifications': 'Latest notifications',
   'homeOptions.inbox': 'Latest in inbox',
   'homeOptions.licenses': 'Licenses',

--- a/apps/native/app/src/messages/is.ts
+++ b/apps/native/app/src/messages/is.ts
@@ -198,7 +198,6 @@ export const is = {
   'homeOptions.heading.title': 'Stilla heimaskjá',
   'homeOptions.heading.subtitle':
     'Hér er hægt að stilla hvað birtist á heimaskjá.',
-  'homeOptions.graphic': 'Birta myndskreytingu',
   'homeOptions.notifications': 'Nýjustu tilkynningar',
   'homeOptions.inbox': 'Nýjast í pósthólfinu',
   'homeOptions.licenses': 'Skírteini',

--- a/apps/native/app/src/messages/is.ts
+++ b/apps/native/app/src/messages/is.ts
@@ -199,6 +199,7 @@ export const is = {
   'homeOptions.heading.subtitle':
     'Hér er hægt að stilla hvað birtist á heimaskjá.',
   'homeOptions.graphic': 'Birta myndskreytingu',
+  'homeOptions.notifications': 'Nýjustu tilkynningar',
   'homeOptions.inbox': 'Nýjast í pósthólfinu',
   'homeOptions.licenses': 'Skírteini',
   'homeOptions.applications': 'Umsóknir',

--- a/apps/native/app/src/stores/preferences-store.ts
+++ b/apps/native/app/src/stores/preferences-store.ts
@@ -27,6 +27,7 @@ export interface PreferencesStore {
   vehiclesWidgetEnabled: boolean
   airDiscountWidgetEnabled: boolean
   appointmentsWidgetEnabled: boolean
+  notificationsWidgetEnabled: boolean
   widgetsInitialised: boolean
   skippedSoftUpdate: boolean
   lastUsedPasskey: number
@@ -70,6 +71,7 @@ const defaultPreferences = {
   vehiclesWidgetEnabled: true,
   airDiscountWidgetEnabled: true,
   appointmentsWidgetEnabled: true,
+  notificationsWidgetEnabled: true,
   widgetsInitialised: false,
   skippedSoftUpdate: false,
   lastUsedPasskey: 0,

--- a/apps/native/app/src/stores/preferences-store.ts
+++ b/apps/native/app/src/stores/preferences-store.ts
@@ -20,7 +20,6 @@ export interface PreferencesStore {
   hasAcceptedBiometrics: boolean
   hasOnboardedPasskeys: boolean
   hasCreatedPasskey: boolean
-  graphicWidgetEnabled: boolean
   inboxWidgetEnabled: boolean
   applicationsWidgetEnabled: boolean
   licensesWidgetEnabled: boolean
@@ -64,7 +63,6 @@ const defaultPreferences = {
   hasAcceptedBiometrics: false,
   hasOnboardedPasskeys: false,
   hasCreatedPasskey: false,
-  graphicWidgetEnabled: true,
   inboxWidgetEnabled: true,
   applicationsWidgetEnabled: true,
   licensesWidgetEnabled: true,


### PR DESCRIPTION
## What

Add notifications module to home screen in app. Hidden behind a feature flag `isNotificationWidgetEnabled`.
Add feature flag to head inbox module on home screen in app: `isPostholfWidgetDisabled`.
Removing graphic from home screen in app.

## Screenshots / Gifs

https://github.com/user-attachments/assets/54c94248-c80b-4536-b2fc-4cfabc4a1add


## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Home notifications widget with preview, "See all" navigation, and ability to mark notifications as read.
  * Toggle in home customization to enable/disable notifications.

* **Changes**
  * Removed front-page graphic/image widget from home screen and options.
  * Inbox widget can now be disabled via its feature flag.
  * Preferences default includes notifications widget enabled; translations updated for notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->