### PR TITLE
fix(estate): use correct YES const in applicantInReviewForm

### DIFF
--- a/libs/application/templates/estate/src/forms/InReview/applicantInReviewForm.ts
+++ b/libs/application/templates/estate/src/forms/InReview/applicantInReviewForm.ts
@@ -9,12 +9,11 @@ import {
   buildRadioField,
   buildCheckboxField,
   getValueViaPath,
-  YES,
 } from '@island.is/application/core'
 import { Form, FormModes, DefaultEvents } from '@island.is/application/types'
 import { format as formatNationalId } from 'kennitala'
 import { m } from '../../lib/messages'
-import { EstateTypes } from '../../lib/constants'
+import { EstateTypes, YES } from '../../lib/constants'
 import { EstateMember } from '../../types'
 import { allPartiesHaveApproved } from '../../lib/utils/allPartiesHaveApproved'
 


### PR DESCRIPTION
Fix wrong YES const being used in estate application, which was blocking the process from moving forwards

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [x] No AI tools were used in preparing this pull request
- [ ] AI tools were used in preparing this pull request
      Tools used:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed signing confirmation checkbox functionality in the applicant in-review form to ensure proper validation during submission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->