### PR TITLE
fix(j-s): Add separate: true to queries that have order set

### DIFF
--- a/apps/judicial-system/backend/src/app/modules/case/guards/test/indictmentCaseExistsForDefendantGuard.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/case/guards/test/indictmentCaseExistsForDefendantGuard.spec.ts
@@ -92,6 +92,7 @@ describe('Indictment Case Exists For Defendant Guard', () => {
                 model: Subpoena,
                 as: 'subpoenas',
                 order: [['created', 'DESC']],
+                separate: true,
               },
               {
                 model: Verdict,
@@ -116,6 +117,7 @@ describe('Indictment Case Exists For Defendant Guard', () => {
             as: 'eventLogs',
             required: false,
             order: [['created', 'DESC']],
+            separate: true,
             where: {
               event_type: EventType.INDICTMENT_SENT_TO_PUBLIC_PROSECUTOR,
             },
@@ -125,6 +127,7 @@ describe('Indictment Case Exists For Defendant Guard', () => {
             as: 'courtSessions',
             required: false,
             order: [['created', 'DESC']],
+            separate: true,
             attributes: ['ruling'],
             where: {
               ruling_type: CourtSessionRulingType.JUDGEMENT,

--- a/apps/judicial-system/backend/src/app/modules/case/internalCase.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/case/internalCase.service.ts
@@ -1635,6 +1635,7 @@ export class InternalCaseService {
               model: Subpoena,
               as: 'subpoenas',
               order: [['created', 'DESC']],
+              separate: true,
             },
             {
               model: Verdict,
@@ -1659,6 +1660,7 @@ export class InternalCaseService {
           as: 'eventLogs',
           required: false,
           order: [['created', 'DESC']],
+          separate: true,
           where: {
             event_type: EventType.INDICTMENT_SENT_TO_PUBLIC_PROSECUTOR,
           },
@@ -1668,6 +1670,7 @@ export class InternalCaseService {
           as: 'courtSessions',
           required: false,
           order: [['created', 'DESC']],
+          separate: true,
           attributes: ['ruling'],
           where: {
             ruling_type: CourtSessionRulingType.JUDGEMENT,
@@ -1760,6 +1763,7 @@ export class InternalCaseService {
           as: 'eventLogs',
           required: false,
           order: [['created', 'DESC']],
+          separate: true,
           where: {
             event_type: EventType.INDICTMENT_SENT_TO_PUBLIC_PROSECUTOR,
           },
@@ -1769,6 +1773,7 @@ export class InternalCaseService {
           as: 'defendants',
           required: true,
           order: [['created', 'DESC']],
+          separate: true,
           where: {
             indictmentReviewDecision: null,
           },

--- a/apps/judicial-system/backend/src/app/modules/case/limitedAccessCase.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/case/limitedAccessCase.service.ts
@@ -512,12 +512,14 @@ export const include: Includeable[] = [
         as: 'defendants',
         required: false,
         order: [['created', 'ASC']],
+        separate: true,
         include: [
           {
             model: Subpoena,
             as: 'subpoenas',
             required: false,
             order: [['created', 'DESC']],
+            separate: true,
             where: { created: { [Op.lt]: col('Case.created') } },
           },
         ],

--- a/apps/judicial-system/backend/src/app/modules/case/limitedAccessCase.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/case/limitedAccessCase.service.ts
@@ -1,5 +1,5 @@
 import archiver from 'archiver'
-import { col, Includeable, Op, Transaction } from 'sequelize'
+import { col, Includeable, literal, Op, Transaction } from 'sequelize'
 import { Writable } from 'stream'
 
 import {
@@ -520,7 +520,13 @@ export const include: Includeable[] = [
             required: false,
             order: [['created', 'DESC']],
             separate: true,
-            where: { created: { [Op.lt]: col('Case.created') } },
+            where: {
+              created: {
+                [Op.lt]: literal(
+                  `(SELECT "created" FROM "case" WHERE "case"."id" = (SELECT "case_id" FROM "defendant" WHERE "defendant"."id" = "Subpoena"."defendant_id"))`,
+                ),
+              },
+            },
           },
         ],
       },

--- a/apps/judicial-system/backend/src/app/modules/repository/types/caseRepository.types.ts
+++ b/apps/judicial-system/backend/src/app/modules/repository/types/caseRepository.types.ts
@@ -1,4 +1,4 @@
-import { col, Includeable, Op } from 'sequelize'
+import { col, Includeable, literal, Op } from 'sequelize'
 
 import {
   appealEventTypes,
@@ -439,7 +439,13 @@ export const caseInclude: Includeable[] = [
             required: false,
             order: [['created', 'DESC']],
             separate: true,
-            where: { created: { [Op.lt]: col('Case.created') } },
+            where: {
+              created: {
+                [Op.lt]: literal(
+                  `(SELECT "created" FROM "case" WHERE "case"."id" = (SELECT "case_id" FROM "defendant" WHERE "defendant"."id" = "Subpoena"."defendant_id"))`,
+                ),
+              },
+            },
           },
         ],
       },

--- a/apps/judicial-system/backend/src/app/modules/repository/types/caseRepository.types.ts
+++ b/apps/judicial-system/backend/src/app/modules/repository/types/caseRepository.types.ts
@@ -431,12 +431,14 @@ export const caseInclude: Includeable[] = [
         as: 'defendants',
         required: false,
         order: [['created', 'ASC']],
+        separate: true,
         include: [
           {
             model: Subpoena,
             as: 'subpoenas',
             required: false,
             order: [['created', 'DESC']],
+            separate: true,
             where: { created: { [Op.lt]: col('Case.created') } },
           },
         ],


### PR DESCRIPTION
[Asana](https://app.asana.com/1/203394141643832/project/1199153462262248/task/1212382348328667?focus=true)

## What

Add separate: true to queries that defined order without setting separate: true.

## Why

order has no effect unless separate is set to true, and is just silently ignored instead.



## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Cursor


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved database loading for case-related details, reducing slow joins and improving responsiveness when viewing cases.
* **Bug Fixes**
  * Corrected how subpoena creation dates are matched to cases to ensure more accurate case/subpoena associations and results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->