### PR TITLE
fix(download-service): force attachment download for education PDFs

### DIFF
--- a/apps/download-service/src/app/modules/education-documents/education-document.controller.ts
+++ b/apps/download-service/src/app/modules/education-documents/education-document.controller.ts
@@ -70,7 +70,7 @@ export class EducationController {
       res.header('Content-length', buffer.length.toString())
       res.header(
         'Content-Disposition',
-        `inline; filename=${user.nationalId}-skoli-${UniversityShortIdMap[uni]}-${url}.pdf`,
+        `attachment; filename="${user.nationalId}-skoli-${UniversityShortIdMap[uni]}-${url}.pdf"`,
       )
       res.header('Content-Type', 'application/pdf')
       res.header('Pragma', 'no-cache')
@@ -114,7 +114,7 @@ export class EducationController {
       res.header('Content-length', buffer.length.toString())
       res.header(
         'Content-Disposition',
-        `inline; filename=${user.nationalId}-namsmat-${assignmentResultId}.pdf`,
+        `attachment; filename="${user.nationalId}-namsmat-${assignmentResultId}.pdf"`,
       )
       res.header('Content-Type', 'application/pdf')
       res.header('Pragma', 'no-cache')


### PR DESCRIPTION
# ...

[Attach a link to issue if relevant](https://digitaliceland.zendesk.com/agent/tickets/512052)

## What

Use attachment PDF downloads instead of inline

## Why

Users are confused when they save the attachments and it shows `api` instead of a real file name. This is simpler and less confusing and the file name attribute actually works correctly now.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [x] No AI tools were used in preparing this pull request
- [ ] AI tools were used in preparing this pull request
      Tools used:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Education document PDFs now download to your device instead of opening directly in your browser. This applies to graduation certificates and primary school assignment results. Files now save automatically for offline access with better user control over file management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->