### PR TITLE
fix(native-app): app lock screen modals

### DIFF
--- a/apps/native/app/app.json
+++ b/apps/native/app/app.json
@@ -3,7 +3,7 @@
     "name": "IslandApp",
     "displayName": "Ísland.is",
     "slug": "island-app",
-    "version": "1.43.3",
+    "version": "1.43.4",
     "orientation": "portrait",
     "icon": "./assets/images/island_is/icon.png",
     "scheme": "is.island.app",

--- a/apps/native/app/src/components/app-lock/app-lock.tsx
+++ b/apps/native/app/src/components/app-lock/app-lock.tsx
@@ -103,9 +103,19 @@ function useShouldShowLock() {
 }
 
 export function AppLock() {
+  const router = useRouter()
   const shouldShow = useShouldShowLock()
   const [renderable, setRenderable] = useState(shouldShow)
   const opacity = useSharedValue(shouldShow ? 1 : 0)
+
+  // Dismiss any stack-presented modals before showing the lock.
+  // Without this, iOS layers our RN <Modal> beneath an
+  // already-presented formSheet.
+  useEffect(() => {
+    if (shouldShow && router.canDismiss()) {
+      router.dismissAll()
+    }
+  }, [shouldShow, router])
 
   // Instant show; fade out on unlock. Re-lock mid-fade snaps back to 1.
   useEffect(() => {


### PR DESCRIPTION
## What

Make sure to close modals when app lock gets triggered.

## Why

To prevent lock screen to get opened behind the modals. Was not an issue on android but decided to do also for android to keep consistency.

Already tested on a release build and works good 👌 

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude
