### PR TITLE
fix(native-app): Fix UI for update app screen and make sure it is not closable when it shouldn't be

### DIFF
--- a/apps/native/app/src/app/(auth)/(modals)/update-app.tsx
+++ b/apps/native/app/src/app/(auth)/(modals)/update-app.tsx
@@ -1,12 +1,6 @@
 import React, { useEffect } from 'react'
 import { useIntl, FormattedMessage } from 'react-intl'
-import {
-  View,
-  Image,
-  SafeAreaView,
-  Linking,
-  BackHandler,
-} from 'react-native'
+import { View, Image, SafeAreaView, Linking, BackHandler } from 'react-native'
 import styled from 'styled-components/native'
 import { Stack, router, useLocalSearchParams } from 'expo-router'
 

--- a/apps/native/app/src/app/(auth)/(modals)/update-app.tsx
+++ b/apps/native/app/src/app/(auth)/(modals)/update-app.tsx
@@ -1,25 +1,27 @@
 import React, { useEffect } from 'react'
 import { useIntl, FormattedMessage } from 'react-intl'
-import { View, Image, Linking, BackHandler } from 'react-native'
+import {
+  View,
+  Image,
+  Linking,
+  BackHandler,
+  useWindowDimensions,
+} from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import styled from 'styled-components/native'
-import { Stack, router, useLocalSearchParams } from 'expo-router'
+import { router, useLocalSearchParams } from 'expo-router'
 
 import { Button, Typography } from '@/ui'
 import logo from '@/assets/logo/logo-64w.png'
 import illustrationSrc from '@/assets/illustrations/digital-services-m1-dots.png'
 import { isIos } from '@/utils/devices'
 import { preferencesStore } from '@/stores/preferences-store'
-import { modalScreenOptions } from '../../../constants/screen-options'
-import {
-  spacingItem,
-  navbarCloseItem,
-} from '../../../components/navbar/navbar-items'
 
-const Text = styled.View`
+const Text = styled.View<{ isSmallDevice: boolean }>`
   margin-horizontal: ${({ theme }) => theme.spacing[7]}px;
   text-align: center;
-  margin-vertical: ${({ theme }) => theme.spacing[5]}px;
+  margin-vertical: ${({ theme, isSmallDevice }) =>
+    isSmallDevice ? theme.spacing[3] : theme.spacing[5]}px;
 `
 
 const Host = styled.View`
@@ -28,9 +30,10 @@ const Host = styled.View`
   flex: 1;
 `
 
-const ButtonWrapper = styled.View`
+const ButtonWrapper = styled.View<{ isSmallDevice: boolean }>`
   padding-horizontal: ${({ theme }) => theme.spacing[2]}px;
-  padding-vertical: ${({ theme }) => theme.spacing[4]}px;
+  padding-vertical: ${({ theme, isSmallDevice }) =>
+    isSmallDevice ? theme.spacing[2] : theme.spacing[4]}px;
   gap: ${({ theme }) => theme.spacing[1]}px;
 `
 
@@ -45,6 +48,8 @@ export default function UpdateAppScreen() {
   }>()
   const closable = closableParam !== 'false'
   const intl = useIntl()
+  const { height } = useWindowDimensions()
+  const isSmallDevice = height < 800
 
   // Make sure if closable = false that android back button does not work
   useEffect(() => {
@@ -57,17 +62,6 @@ export default function UpdateAppScreen() {
 
   return (
     <View style={{ flex: 1 }}>
-      <Stack.Screen
-        options={{
-          ...modalScreenOptions,
-          headerTitle: '',
-          gestureEnabled: closable,
-          sheetGrabberVisible: closable,
-          unstable_headerRightItems: closable
-            ? () => [spacingItem(), navbarCloseItem()]
-            : undefined,
-        }}
-      />
       <SafeAreaView edges={['bottom']} style={{ flex: 1 }}>
         <Host>
           <Image
@@ -75,7 +69,7 @@ export default function UpdateAppScreen() {
             resizeMode="contain"
             style={{ width: 45, height: 45 }}
           />
-          <Text>
+          <Text isSmallDevice={isSmallDevice}>
             <Title variant={'heading2'} textAlign="center">
               <FormattedMessage
                 id="updateApp.title"
@@ -91,13 +85,15 @@ export default function UpdateAppScreen() {
               />
             </Typography>
           </Text>
-          <Image
-            source={illustrationSrc}
-            style={{ width: 210, height: 240 }}
-            resizeMode="contain"
-          />
+          {height > 650 && (
+            <Image
+              source={illustrationSrc}
+              style={{ flex: 1, maxWidth: 210, maxHeight: 240 }}
+              resizeMode="contain"
+            />
+          )}
         </Host>
-        <ButtonWrapper>
+        <ButtonWrapper isSmallDevice={isSmallDevice}>
           <Button
             title={intl.formatMessage({
               id: 'updateApp.button',

--- a/apps/native/app/src/app/(auth)/(modals)/update-app.tsx
+++ b/apps/native/app/src/app/(auth)/(modals)/update-app.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react'
 import { useIntl, FormattedMessage } from 'react-intl'
-import { View, Image, SafeAreaView, Linking, BackHandler } from 'react-native'
+import { View, Image, Linking, BackHandler } from 'react-native'
+import { SafeAreaView } from 'react-native-safe-area-context'
 import styled from 'styled-components/native'
 import { Stack, router, useLocalSearchParams } from 'expo-router'
 
@@ -45,6 +46,7 @@ export default function UpdateAppScreen() {
   const closable = closableParam !== 'false'
   const intl = useIntl()
 
+  // Make sure if closable = false that android back button does not work
   useEffect(() => {
     if (closable) {
       return
@@ -66,7 +68,7 @@ export default function UpdateAppScreen() {
             : undefined,
         }}
       />
-      <SafeAreaView style={{ flex: 1 }}>
+      <SafeAreaView edges={['bottom']} style={{ flex: 1 }}>
         <Host>
           <Image
             source={logo}

--- a/apps/native/app/src/app/(auth)/(modals)/update-app.tsx
+++ b/apps/native/app/src/app/(auth)/(modals)/update-app.tsx
@@ -1,14 +1,25 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import { useIntl, FormattedMessage } from 'react-intl'
-import { View, Image, SafeAreaView, Linking } from 'react-native'
+import {
+  View,
+  Image,
+  SafeAreaView,
+  Linking,
+  BackHandler,
+} from 'react-native'
 import styled from 'styled-components/native'
-import { router, useLocalSearchParams } from 'expo-router'
+import { Stack, router, useLocalSearchParams } from 'expo-router'
 
-import { Button, Typography, NavigationBarSheet } from '@/ui'
+import { Button, Typography } from '@/ui'
 import logo from '@/assets/logo/logo-64w.png'
 import illustrationSrc from '@/assets/illustrations/digital-services-m1-dots.png'
 import { isIos } from '@/utils/devices'
 import { preferencesStore } from '@/stores/preferences-store'
+import { modalScreenOptions } from '../../../constants/screen-options'
+import {
+  spacingItem,
+  navbarCloseItem,
+} from '../../../components/navbar/navbar-items'
 
 const Text = styled.View`
   margin-horizontal: ${({ theme }) => theme.spacing[7]}px;
@@ -40,19 +51,26 @@ export default function UpdateAppScreen() {
   const closable = closableParam !== 'false'
   const intl = useIntl()
 
+  useEffect(() => {
+    if (closable) {
+      return
+    }
+    const sub = BackHandler.addEventListener('hardwareBackPress', () => true)
+    return () => sub.remove()
+  }, [closable])
+
   return (
     <View style={{ flex: 1 }}>
-      <NavigationBarSheet
-        componentId="update-app"
-        title={''}
-        onClosePress={() => {
-          if (closable) {
-            preferencesStore.setState({ skippedSoftUpdate: true })
-            router.back()
-          }
+      <Stack.Screen
+        options={{
+          ...modalScreenOptions,
+          headerTitle: '',
+          gestureEnabled: closable,
+          sheetGrabberVisible: closable,
+          unstable_headerRightItems: closable
+            ? () => [spacingItem(), navbarCloseItem()]
+            : undefined,
         }}
-        style={{ marginHorizontal: 16 }}
-        closable={closable}
       />
       <SafeAreaView style={{ flex: 1 }}>
         <Host>

--- a/apps/native/app/src/app/(auth)/_layout.tsx
+++ b/apps/native/app/src/app/(auth)/_layout.tsx
@@ -121,9 +121,26 @@ export default function AuthLayout() {
         />
         <Stack.Screen
           name="(modals)/update-app"
-          options={{
-            ...modalScreenOptions,
-            headerTitle: '',
+          options={({ route }) => {
+            const closable =
+              (route.params as { closable?: string } | undefined)?.closable !==
+              'false'
+            if (closable) {
+              return {
+                ...modalScreenOptions,
+                headerTitle: '',
+              }
+            }
+            return {
+              ...modalScreenOptions,
+              headerTitle: '',
+              headerShown: false,
+              gestureEnabled: false,
+              sheetGrabberVisible: false,
+              presentation:
+                Platform.OS === 'ios' ? 'fullScreenModal' : 'modal',
+              unstable_headerRightItems: () => [],
+            }
           }}
         />
       </Stack>

--- a/apps/native/app/src/app/(auth)/_layout.tsx
+++ b/apps/native/app/src/app/(auth)/_layout.tsx
@@ -119,6 +119,13 @@ export default function AuthLayout() {
             headerTitle: '',
           }}
         />
+        <Stack.Screen
+          name="(modals)/update-app"
+          options={{
+            ...modalScreenOptions,
+            headerTitle: '',
+          }}
+        />
       </Stack>
       <AppLock />
     </>

--- a/apps/native/app/src/app/(auth)/_layout.tsx
+++ b/apps/native/app/src/app/(auth)/_layout.tsx
@@ -137,8 +137,7 @@ export default function AuthLayout() {
               headerShown: false,
               gestureEnabled: false,
               sheetGrabberVisible: false,
-              presentation:
-                Platform.OS === 'ios' ? 'fullScreenModal' : 'modal',
+              presentation: Platform.OS === 'ios' ? 'fullScreenModal' : 'modal',
               unstable_headerRightItems: () => [],
             }
           }}


### PR DESCRIPTION
## What

We have this screen to either force people to update the app or kindly ask them to do it (modal is closable). When moving the app into expo this screen got left behind so it was both not looking too good and always closable. 

## Why

If we would need in the future to force users to update the app it is handy to keep this working.

## Screenshots / Gifs

Before:
<img width="434" height="915" alt="Screenshot 2026-06-01 at 14 25 05" src="https://github.com/user-attachments/assets/6ada1a04-38ab-4279-8125-4c48c5cb7ea1" />

After:

<img width="441" height="926" alt="Screenshot 2026-06-01 at 14 38 43" src="https://github.com/user-attachments/assets/5db872df-a8d5-4530-a63e-d2d7c949814d" />

<img width="448" height="935" alt="Screenshot 2026-06-01 at 14 38 33" src="https://github.com/user-attachments/assets/692521ae-74b7-41a7-91c6-31afd71d8e67" />

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Update modal respects whether it can be dismissed, preventing or allowing hardware back navigation accordingly.
  * Modal header, gesture and presentation behavior now adapt to platform and dismissibility for a more consistent UX.
  * Layout, spacing and button placement adapt to smaller screens; decorative illustration hides on short viewports to improve readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->