### PR TITLE
feat(web): Verdict judges at endurupptokudomur should not have title displayed

### DIFF
--- a/libs/clients/verdicts/src/lib/verdicts-client.service.ts
+++ b/libs/clients/verdicts/src/lib/verdicts-client.service.ts
@@ -279,7 +279,7 @@ export class VerdictsClientService {
                   name: judge.name ?? '',
                   title: !goproItem.court?.name
                     ?.toLowerCase()
-                    ?.startsWith('endurupp')
+                    ?.startsWith('enduruppt')
                     ? judge.title ?? ''
                     : '',
                 }))

--- a/libs/clients/verdicts/src/lib/verdicts-client.service.ts
+++ b/libs/clients/verdicts/src/lib/verdicts-client.service.ts
@@ -275,7 +275,14 @@ export class VerdictsClientService {
           verdictDate: goproItem.verdictDate,
           verdictJudges:
             goproItem.court?.code !== 'landsrettur'
-              ? goproItem.judges ?? []
+              ? (goproItem.judges ?? []).map((judge) => ({
+                  name: judge.name ?? '',
+                  title: !goproItem.court?.name
+                    ?.toLowerCase()
+                    ?.startsWith('endurupp')
+                    ? judge.title ?? ''
+                    : '',
+                }))
               : [],
           keywords: goproItem.keywords ?? [],
           presentings: goproItem.presentings ?? '',


### PR DESCRIPTION
# Verdict judges at endurupptokudomur should not have title displayed

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [x] No AI tools were used in preparing this pull request
- [ ] AI tools were used in preparing this pull request
      Tools used:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Verdicts now properly display judges with names and conditional title information based on court type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->