### PR TITLE
chore(j-s): replace SWR with fetch in useLawyers and useGeoLocation

### DIFF
--- a/apps/judicial-system/web/src/utils/hooks/useGeoLocation/useGeoLocation.ts
+++ b/apps/judicial-system/web/src/utils/hooks/useGeoLocation/useGeoLocation.ts
@@ -1,20 +1,26 @@
-import useSWR from 'swr'
+import { useEffect, useState } from 'react'
 
 export const useGeoLocation = (): { countryCode: string } => {
-  const { data, error } = useSWR<{ countryCode: string }>(
-    '/api/geoLocation/getCountryCode',
-    (url: string) => fetch(url).then((res) => res.json()),
-    {
-      revalidateIfStale: false,
-      revalidateOnFocus: false,
-      revalidateOnReconnect: false,
-      errorRetryCount: 2,
-    },
-  )
+  const [countryCode, setCountryCode] = useState<string>('')
 
-  if (!data || error) {
-    return { countryCode: '' }
-  }
+  useEffect(() => {
+    const controller = new AbortController()
 
-  return data
+    fetch('/api/geoLocation/getCountryCode', { signal: controller.signal })
+      .then((res) => {
+        if (!res.ok) {
+          throw new Error(`Request failed with status ${res.status}`)
+        }
+
+        return res.json()
+      })
+      .then((res) => setCountryCode(res.countryCode ?? ''))
+      .catch(() => {
+        // Silently ignore errors; country code stays empty
+      })
+
+    return () => controller.abort()
+  }, [])
+
+  return { countryCode }
 }

--- a/apps/judicial-system/web/src/utils/hooks/useLawyers/useLawyers.ts
+++ b/apps/judicial-system/web/src/utils/hooks/useLawyers/useLawyers.ts
@@ -1,6 +1,6 @@
+import { useEffect, useState } from 'react'
 import { useIntl } from 'react-intl'
 import Cookie from 'js-cookie'
-import useSWRImmutable from 'swr/immutable'
 
 import { toast } from '@island.is/island-ui/core'
 import { CSRF_COOKIE_NAME } from '@island.is/judicial-system/consts'
@@ -9,31 +9,40 @@ import { errors as errorMessages } from '@island.is/judicial-system-web/messages
 
 export const useGetLawyers = (shouldFetch?: boolean): Lawyer[] => {
   const { formatMessage } = useIntl()
-  const fetcher = (url: string): Promise<Lawyer[]> => {
+  const [lawyers, setLawyers] = useState<Lawyer[]>([])
+
+  useEffect(() => {
+    if (!shouldFetch) {
+      setLawyers([])
+      return
+    }
+
+    const controller = new AbortController()
+
     const token = Cookie.get(CSRF_COOKIE_NAME)
-    const options = token
-      ? { headers: { authorization: `Bearer ${token}` } }
-      : {}
+    const headers = token ? { authorization: `Bearer ${token}` } : undefined
 
-    return fetch(url, options).then((res) => {
-      if (!res.ok) {
-        throw new Error('Failed to get lawyers from lawyer registry')
-      }
-
-      return res.json()
+    fetch('/api/defender/lawyerRegistry', {
+      headers,
+      signal: controller.signal,
     })
-  }
+      .then((res) => {
+        if (!res.ok) {
+          throw new Error('Failed to get lawyers from lawyer registry')
+        }
 
-  const { data, error } = useSWRImmutable<Lawyer[]>(
-    shouldFetch ? '/api/defender/lawyerRegistry' : null,
-    fetcher,
-    { shouldRetryOnError: false, errorRetryCount: 0 },
-  )
+        return res.json()
+      })
+      .then(setLawyers)
+      .catch((e) => {
+        if (e.name !== 'AbortError') {
+          toast.error(formatMessage(errorMessages.fetchLawyers))
+          setLawyers([])
+        }
+      })
 
-  if (error) {
-    toast.error(formatMessage(errorMessages.fetchLawyers))
-    return []
-  }
+    return () => controller.abort()
+  }, [shouldFetch, formatMessage])
 
-  return data ?? []
+  return lawyers
 }

--- a/package.json
+++ b/package.json
@@ -318,7 +318,6 @@
     "styled-components": "5.3.6",
     "supertest": "4.0.2",
     "swagger-ui-express": "4.3.0",
-    "swr": "1.2.0",
     "testcontainers": "7.23.2",
     "tinymce": "5.10.9",
     "to-querystring": "1.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -35562,7 +35562,6 @@ __metadata:
     styled-components: "npm:5.3.6"
     supertest: "npm:4.0.2"
     swagger-ui-express: "npm:4.3.0"
-    swr: "npm:1.2.0"
     testcontainers: "npm:7.23.2"
     tinymce: "npm:5.10.9"
     to-querystring: "npm:1.1.1"
@@ -49965,15 +49964,6 @@ __metadata:
   dependencies:
     tslib: "npm:^2.0.3"
   checksum: 10/6e21c9e1b3cd5735eb2af679a99ec3efc78a14e3d4d5e3fd594e254b91cfd37185b3d1c6e41b22f53a2cdf5d1b963ce30c0fe8b78337e3fd43d0137084670a5f
-  languageName: node
-  linkType: hard
-
-"swr@npm:1.2.0":
-  version: 1.2.0
-  resolution: "swr@npm:1.2.0"
-  peerDependencies:
-    react: ^16.11.0 || ^17.0.0 || ^18.0.0
-  checksum: 10/acef78b10722fd8ac9451bfef35b79e812d933cf5a7ea03acdb25beddacf9e2fc47afdf12c2ec4c09abdd83b62d2ad10faeed34bc0abc4fa7057cdf29e0c241f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What
Refactors the `useGetLawyers` and `useGeoLocation` hooks to use plain `fetch` with `useEffect`/`useState` instead of SWR, following the existing `useNationalRegistry` pattern. Since these were the only SWR consumers in the monorepo, the now-unused `swr` dependency is removed from `package.json` and `yarn.lock`.

- `useGeoLocation`: fetches once on mount with an `AbortController`; errors leave `countryCode` empty (matching prior behavior).
- `useGetLawyers`: fetches when `shouldFetch` is true, preserves the CSRF token header, toasts the same error message on failure, and returns `Lawyer[]`.
- Both preserve their original return shapes, so consumers (`useLawyerRegistry`, `Header`) need no changes.

## Why
Removes the dependency on SWR for these two simple, low-traffic hooks and aligns them with the codebase's existing fetch pattern, dropping a dependency that was no longer needed elsewhere.

## Screenshots / Gifs
Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code
- [ ] No AI tools were used in preparing this pull request

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated geolocation and lawyer registry data-fetching mechanisms.
  * Refined internal data handling and resource cleanup processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->