### PR TITLE
fix(contentful-apps): Allow height overflow for dialogs in sitemap tree field app (#22728)

### DIFF
--- a/apps/contentful-apps/components/sitemap/utils.ts
+++ b/apps/contentful-apps/components/sitemap/utils.ts
@@ -232,6 +232,7 @@ export const addNode = async (
         otherSlugsEN,
       },
       minHeight: CATEGORY_DIALOG_MIN_HEIGHT,
+      allowHeightOverflow: true,
     })
 
     if (!data) {
@@ -253,6 +254,7 @@ export const addNode = async (
         },
       },
       minHeight: URL_DIALOG_MIN_HEIGHT,
+      allowHeightOverflow: true,
     })
 
     if (!data) {


### PR DESCRIPTION
# Allow height overflow for dialogs in sitemap tree field app (#22728)

- [x] No AI tools were used in preparing this pull request
- [ ] AI tools were used in preparing this pull request
      Tools used:
