### PR TITLE
fix(native-app): Make sure to show message in finance and no numbers if undefined

### DIFF
--- a/apps/native/app/src/app/(auth)/(tabs)/more/finance/index.tsx
+++ b/apps/native/app/src/app/(auth)/(tabs)/more/finance/index.tsx
@@ -133,7 +133,7 @@ export default function FinanceScreen() {
           </View>
         )}
       </SafeAreaView>
-      {chargeTypeTotal !== undefined && (
+      {(showLoading || chargeTypeTotal !== undefined) && (
         <TableViewCell
           style={{
             marginTop: 16,
@@ -157,7 +157,9 @@ export default function FinanceScreen() {
               />
             ) : (
               <Typography size={20} weight="600">
-                {`${intl.formatNumber(chargeTypeTotal)} kr.`}
+                {chargeTypeTotal
+                  ? `${intl.formatNumber(chargeTypeTotal)} kr.`
+                  : ''}
               </Typography>
             )
           }

--- a/apps/native/app/src/app/(auth)/(tabs)/more/finance/index.tsx
+++ b/apps/native/app/src/app/(auth)/(tabs)/more/finance/index.tsx
@@ -9,7 +9,14 @@ import { GetFinanceStatus } from '@/graphql/types/finance.types'
 import { useGetFinanceStatusQuery } from '@/graphql/types/schema'
 import { useMyPagesLinks } from '@/lib/my-pages-links'
 import { useBrowser } from '@/hooks/use-browser'
-import { Button, Heading, Skeleton, TableViewCell, Typography } from '@/ui'
+import {
+  Alert,
+  Button,
+  Heading,
+  Skeleton,
+  TableViewCell,
+  Typography,
+} from '@/ui'
 import { FinanceStatusCard } from '../../../../../components/finance-status-card'
 import { StackScreen } from '../../../../../components/stack-screen'
 import { testIDs } from '@/utils/test-ids'
@@ -38,19 +45,21 @@ export default function FinanceScreen() {
 
   const organizations = financeStatusData?.organizations ?? []
 
-  function getChargeTypeTotal() {
-    const organizationChargeTypes = organizations.map((org) => org.chargeTypes)
-    const allChargeTypes = (organizationChargeTypes?.flat() ?? []) as Array<{
-      totals: number
-    }>
+  function getChargeTypeTotal(): number | undefined {
+    if (!res.data?.getFinanceStatus) {
+      return undefined
+    }
+    const allChargeTypes = organizations.flatMap(
+      (org) => org.chargeTypes ?? [],
+    ) as Array<{ totals: number }>
 
-    const chargeTypeTotal =
-      allChargeTypes.length > 0
-        ? allChargeTypes.reduce((a, b) => a + b.totals, 0)
-        : 0
-
-    return chargeTypeTotal
+    if (allChargeTypes.length === 0) {
+      return undefined
+    }
+    return allChargeTypes.reduce((a, b) => a + (b?.totals ?? 0), 0)
   }
+
+  const chargeTypeTotal = getChargeTypeTotal()
 
   const financeStatusZero = financeStatusData?.statusTotals === 0
 
@@ -114,35 +123,46 @@ export default function FinanceScreen() {
             defaultMessage="Hér sérð þú sundurliðun skulda og/eða inneigna hjá ríkissjóði og stofnunum."
           />
         </Typography>
+        {financeStatusData?.message && (
+          <View style={{ marginTop: 16, marginBottom: 16 }}>
+            <Alert
+              type="warning"
+              message={financeStatusData.message}
+              hasBorder
+            />
+          </View>
+        )}
       </SafeAreaView>
-      <TableViewCell
-        style={{
-          marginTop: 16,
-          marginBottom: 24,
-        }}
-        title={
-          <Typography size={13} style={{ marginBottom: 4 }}>
-            <FormattedMessage
-              id="finance.statusCard.total"
-              defaultMessage="Samtals"
-            />
-            :
-          </Typography>
-        }
-        subtitle={
-          showLoading ? (
-            <Skeleton
-              active
-              style={{ borderRadius: 4, width: 150 }}
-              height={26}
-            />
-          ) : (
-            <Typography size={20} weight="600">{`${intl.formatNumber(
-              getChargeTypeTotal(),
-            )} kr.`}</Typography>
-          )
-        }
-      />
+      {chargeTypeTotal !== undefined && (
+        <TableViewCell
+          style={{
+            marginTop: 16,
+            marginBottom: 24,
+          }}
+          title={
+            <Typography size={13} style={{ marginBottom: 4 }}>
+              <FormattedMessage
+                id="finance.statusCard.total"
+                defaultMessage="Samtals"
+              />
+              :
+            </Typography>
+          }
+          subtitle={
+            showLoading ? (
+              <Skeleton
+                active
+                style={{ borderRadius: 4, width: 150 }}
+                height={26}
+              />
+            ) : (
+              <Typography size={20} weight="600">
+                {`${intl.formatNumber(chargeTypeTotal)} kr.`}
+              </Typography>
+            )
+          }
+        />
+      )}
       {scheduleButtonVisible && (
         <SafeAreaView
           style={{


### PR DESCRIPTION
## What

Show message from finance status query if present and make sure to not show 0 kr if we don't receive any numbers.

## Why

To prevent showing wrong information and show message if present. 

## Screenshots / Gifs

After the change when message is present and no numbers are received:
<img width="436" height="923" alt="Screenshot 2026-06-02 at 10 20 38" src="https://github.com/user-attachments/assets/37ad286a-34d8-4fe1-b5ae-ed60423744ab" />


## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added warning alert display in the Finance screen when relevant status messages are available.

* **Bug Fixes**
  * Prevented a table entry from showing unless loading or charge totals exist.
  * Total charge subtitle now hides for zero values and only shows currency when appropriate.
  * Improved handling of missing or incomplete finance data to avoid incorrect calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->