### PR TITLE
fix(starfatorg): sort job listings from elfur by publish date

### DIFF
--- a/libs/api/domains/icelandic-government-institution-vacancies/src/lib/utils.ts
+++ b/libs/api/domains/icelandic-government-institution-vacancies/src/lib/utils.ts
@@ -168,9 +168,7 @@ export const mapIcelandicGovernmentInstitutionVacanciesFromElfur = async (
       updatedDate: formatDate(item.updatedDate),
       // Internal field for sorting — listings are ordered by the publish/display
       // date (birtingardagsetning), which Elfur exposes as `publishDate`.
-      _creationDate: item.publishDate
-        ? new Date(item.publishDate)
-        : undefined,
+      _creationDate: item.publishDate ? new Date(item.publishDate) : undefined,
     })
   }
 

--- a/libs/api/domains/icelandic-government-institution-vacancies/src/lib/utils.ts
+++ b/libs/api/domains/icelandic-government-institution-vacancies/src/lib/utils.ts
@@ -166,9 +166,10 @@ export const mapIcelandicGovernmentInstitutionVacanciesFromElfur = async (
       // Display fields
       creationDate: formatDate(item.creationDate),
       updatedDate: formatDate(item.updatedDate),
-      // Internal field for sorting
-      _creationDate: item.creationDate
-        ? new Date(item.creationDate)
+      // Internal field for sorting — listings are ordered by the publish/display
+      // date (birtingardagsetning), which Elfur exposes as `publishDate`.
+      _creationDate: item.publishDate
+        ? new Date(item.publishDate)
         : undefined,
     })
   }


### PR DESCRIPTION
## What

When using api=new query param in /starfatorg, sort job listings by publish date, not creation date

## Why

Creation date is an internal system property which indicates when a listing was created. A job could be created in the system on monday and displayed on friday. 

This is also consistent with the old API. 

## Screenshots / Gifs

n/a 

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [x] No AI tools were used in preparing this pull request
- [ ] AI tools were used in preparing this pull request
      Tools used:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Vacancies sorting now uses publication date instead of creation date, improving chronological ordering in listings while preserving displayed creation and updated dates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->