### PR TITLE
fix(native-app): Make sure back button from vehicle details work correctly on android

### DIFF
--- a/apps/native/app/src/app/(auth)/(tabs)/more/_layout.tsx
+++ b/apps/native/app/src/app/(auth)/(tabs)/more/_layout.tsx
@@ -6,7 +6,7 @@ import {
 } from '../../../../constants/screen-options'
 
 export const unstable_settings = {
-  initalRouteName: 'index',
+  initialRouteName: 'index',
   'vehicles/[id]/index': {
     initialRouteName: 'vehicles',
   },

--- a/apps/native/app/src/app/(auth)/(tabs)/more/index.tsx
+++ b/apps/native/app/src/app/(auth)/(tabs)/more/index.tsx
@@ -90,7 +90,7 @@ export default function MoreScreen() {
             testID={testIDs.MORE_CARD_VEHICLES}
             title={intl.formatMessage({ id: 'profile.vehicles' })}
             icon={vehicleIcon}
-            onPress={() => router.navigate('/more/vehicles')}
+            onPress={() => router.push('/more/vehicles')}
           />
         </Row>
         <Row>

--- a/apps/native/app/src/components/vehicle-item.tsx
+++ b/apps/native/app/src/components/vehicle-item.tsx
@@ -58,7 +58,7 @@ export const VehicleItem = React.memo(
             if (!item.permno) {
               return
             }
-            router.navigate({
+            router.push({
               pathname: '/more/vehicles/[id]',
               params: { id: item.permno, title: item.make },
             })


### PR DESCRIPTION
## What

When navigating to vehicle details screen on android the back button goes back to more and then vehicles and then more again. 

Verified on android physical device that this fixes it. Still works correctly on iOS.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a configuration error preventing proper initialization of the navigation menu structure.
  * Improved navigation behavior for vehicle-related screens, ensuring smoother transitions when accessing vehicle details from different sections of the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->