### PR TITLE
fix(starfatorg): when new API, populate categories properly

### DIFF
--- a/apps/web/screens/IcelandicGovernmentInstitutionVacancies/IcelandicGovernmentInstitutionVacanciesList.tsx
+++ b/apps/web/screens/IcelandicGovernmentInstitutionVacancies/IcelandicGovernmentInstitutionVacanciesList.tsx
@@ -156,10 +156,14 @@ const IcelandicGovernmentInstitutionVacanciesList: Screen<
     let shouldBeShown = searchTermMatches
 
     if (parameters.fieldOfWork.length > 0) {
+      // The new API populates the "Störf" filter from the jobCategory field
+      const fieldOfWorkValue = useNewApiOverride
+        ? vacancy.jobCategory
+        : vacancy.fieldOfWork
       shouldBeShown = Boolean(
         shouldBeShown &&
-          vacancy.fieldOfWork &&
-          parameters.fieldOfWork.includes(vacancy.fieldOfWork),
+          fieldOfWorkValue &&
+          parameters.fieldOfWork.includes(fieldOfWorkValue),
       )
     }
 
@@ -186,8 +190,12 @@ const IcelandicGovernmentInstitutionVacanciesList: Screen<
   })
 
   const fieldOfWorkOptions = useMemo(
-    () => mapVacanciesField(vacancies, 'fieldOfWork'),
-    [vacancies],
+    () =>
+      mapVacanciesField(
+        vacancies,
+        useNewApiOverride ? 'jobCategory' : 'fieldOfWork',
+      ),
+    [vacancies, useNewApiOverride],
   )
 
   const locationOptions = useMemo(

--- a/apps/web/screens/queries/IcelandicGovernmentInstitutionVacancies.ts
+++ b/apps/web/screens/queries/IcelandicGovernmentInstitutionVacancies.ts
@@ -9,6 +9,7 @@ export const GET_ICELANDIC_GOVERNMENT_INSTITUTION_VACANCIES = gql`
       vacancies {
         id
         fieldOfWork
+        jobCategory
         title
         intro
         applicationDeadlineFrom

--- a/libs/api/domains/icelandic-government-institution-vacancies/src/lib/models/icelandicGovernmentInstitutionVacancy.model.ts
+++ b/libs/api/domains/icelandic-government-institution-vacancies/src/lib/models/icelandicGovernmentInstitutionVacancy.model.ts
@@ -23,6 +23,9 @@ class IcelandicGovernmentInstitutionVacancyListItemBase {
   fieldOfWork?: string
 
   @Field({ nullable: true })
+  jobCategory?: string
+
+  @Field({ nullable: true })
   title?: string
 
   @Field({ nullable: true })

--- a/libs/api/domains/icelandic-government-institution-vacancies/src/lib/utils.spec.ts
+++ b/libs/api/domains/icelandic-government-institution-vacancies/src/lib/utils.spec.ts
@@ -1,4 +1,8 @@
-import { sortVacancyList, VacancyWithCreationDate } from './utils'
+import {
+  mapIcelandicGovernmentInstitutionVacanciesFromElfur,
+  sortVacancyList,
+  VacancyWithCreationDate,
+} from './utils'
 
 describe('sortVacancyList', () => {
   const createVacancy = (
@@ -106,5 +110,34 @@ describe('sortVacancyList', () => {
 
     // Original order should be maintained when all dates equal
     expect(vacancies.map((v) => v.id)).toEqual(['1', '2', '3'])
+  })
+})
+
+describe('mapIcelandicGovernmentInstitutionVacanciesFromElfur', () => {
+  it('should map jobCategory (starfssvid) separately from fieldOfWork (job title)', async () => {
+    const result = await mapIcelandicGovernmentInstitutionVacanciesFromElfur([
+      {
+        vacancyID: '1',
+        heading: 'Hjúkrunarfræðingur óskast',
+        jobTitle: 'Hjúkrunarfræðingur',
+        jobCategory: 'Heilbrigðisþjónusta',
+      },
+    ])
+
+    expect(result).toHaveLength(1)
+    expect(result[0].fieldOfWork).toBe('Hjúkrunarfræðingur')
+    expect(result[0].jobCategory).toBe('Heilbrigðisþjónusta')
+  })
+
+  it('should leave jobCategory undefined when the API omits it', async () => {
+    const result = await mapIcelandicGovernmentInstitutionVacanciesFromElfur([
+      {
+        vacancyID: '1',
+        heading: 'Starf',
+        jobTitle: 'Sérfræðingur',
+      },
+    ])
+
+    expect(result[0].jobCategory).toBeUndefined()
   })
 })

--- a/libs/api/domains/icelandic-government-institution-vacancies/src/lib/utils.ts
+++ b/libs/api/domains/icelandic-government-institution-vacancies/src/lib/utils.ts
@@ -143,6 +143,7 @@ export const mapIcelandicGovernmentInstitutionVacanciesFromElfur = async (
       applicationDeadlineTo: formatDate(item.openTo),
       intro: '',
       fieldOfWork: item.jobTitle ?? undefined,
+      jobCategory: item.jobCategory ?? undefined,
       institutionName: item.orgName ?? undefined,
       institutionReferenceIdentifier: (() => {
         const orgNrStr =
@@ -263,6 +264,7 @@ export const mapIcelandicGovernmentInstitutionVacancyByIdResponseFromElfur =
       applicationDeadlineTo: formatDate(vacancy.openTo),
       intro,
       fieldOfWork: vacancy.jobTitle ?? undefined,
+      jobCategory: vacancy.jobCategory ?? undefined,
       institutionName: vacancy.orgName ?? undefined,
       institutionReferenceIdentifier: (() => {
         const orgNrStr =


### PR DESCRIPTION
## What

When using new Starfatorg API, Populate the category filter using the correct data field from the external API

## Why

Was previously populating category filter with job title, which was obviously wrong

## Screenshots / Gifs



## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced government institution vacancy listings with improved job category data handling to support better filtering and categorization of available positions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->