### PR TITLE
fix(estate): infinite loading spinner after rejecting

### DIFF
--- a/libs/application/templates/estate/src/forms/InReview/assigneeStatusForm.ts
+++ b/libs/application/templates/estate/src/forms/InReview/assigneeStatusForm.ts
@@ -1,0 +1,42 @@
+import {
+  buildForm,
+  buildSection,
+  buildMultiField,
+  buildAlertMessageField,
+} from '@island.is/application/core'
+import { Form, FormModes } from '@island.is/application/types'
+import { m } from '../../lib/messages'
+
+// Read-only status screen for assignees while the application is back with
+// the applicant (in draft after a rejection/edit, or in payment). Assignees
+// keep visibility of the application in these states but have no actions, so
+// this form only informs them of the current status. Without a form for the
+// ASSIGNEE role the form shell never resolves a form and renders an infinite
+// loader.
+export const assigneeStatusForm: Form = buildForm({
+  id: 'assigneeStatusForm',
+  title: m.inReviewGeneralTitle,
+  mode: FormModes.IN_PROGRESS,
+  renderLastScreenButton: true,
+  children: [
+    buildSection({
+      id: 'assigneeStatus',
+      title: m.assigneeStatusTitle,
+      children: [
+        buildMultiField({
+          id: 'assigneeStatus.info',
+          title: m.assigneeStatusTitle,
+          children: [
+            buildAlertMessageField({
+              id: 'assigneeStatus.alert',
+              title: m.assigneeStatusTitle,
+              message: m.assigneeStatusDescription,
+              alertType: 'info',
+              marginTop: 3,
+            }),
+          ],
+        }),
+      ],
+    }),
+  ],
+})

--- a/libs/application/templates/estate/src/forms/InReview/index.ts
+++ b/libs/application/templates/estate/src/forms/InReview/index.ts
@@ -1,2 +1,3 @@
 export { applicantInReviewForm } from './applicantInReviewForm'
 export { assigneeInReviewForm } from './assigneeInReviewForm'
+export { assigneeStatusForm } from './assigneeStatusForm'

--- a/libs/application/templates/estate/src/lib/EstateTemplate.spec.ts
+++ b/libs/application/templates/estate/src/lib/EstateTemplate.spec.ts
@@ -461,7 +461,8 @@ describe('EstateTemplate', () => {
       Roles.APPLICANT_PERMIT_FOR_UNDIVIDED_ESTATE,
       Roles.APPLICANT_DIVISION_OF_ESTATE_BY_HEIRS,
     ])('should define %s in the payment state', (roleId) => {
-      const stateConfig = EstateTemplate.stateMachineConfig.states[States.payment]
+      const stateConfig =
+        EstateTemplate.stateMachineConfig.states[States.payment]
       const roleIds = stateConfig?.meta?.roles?.map((role) => role.id)
       expect(roleIds).toContain(roleId)
     })

--- a/libs/application/templates/estate/src/lib/EstateTemplate.spec.ts
+++ b/libs/application/templates/estate/src/lib/EstateTemplate.spec.ts
@@ -436,6 +436,37 @@ describe('EstateTemplate', () => {
     })
   })
 
+  describe('assignee role coverage', () => {
+    // mapUserToRole returns ASSIGNEE for assignees and enabled estate members
+    // in every state while review is enabled, so each state they can land in
+    // must define the role with a form. Otherwise the form shell never
+    // resolves a form and renders an infinite loader (e.g. an heir reloading
+    // the application after rejecting it back to draft).
+    it.each([
+      States.draft,
+      States.inReview,
+      States.payment,
+      States.signing,
+      States.done,
+    ])('should define an ASSIGNEE role in the %s state', (state) => {
+      const stateConfig = EstateTemplate.stateMachineConfig.states[state]
+      const roleIds = stateConfig?.meta?.roles?.map((role) => role.id)
+      expect(roleIds).toContain(Roles.ASSIGNEE)
+    })
+
+    // The payment state must also define the estate-specific applicant roles,
+    // since mapUserToRole never returns the default 'applicant' role once an
+    // estate type has been selected.
+    it.each([
+      Roles.APPLICANT_PERMIT_FOR_UNDIVIDED_ESTATE,
+      Roles.APPLICANT_DIVISION_OF_ESTATE_BY_HEIRS,
+    ])('should define %s in the payment state', (roleId) => {
+      const stateConfig = EstateTemplate.stateMachineConfig.states[States.payment]
+      const roleIds = stateConfig?.meta?.roles?.map((role) => role.id)
+      expect(roleIds).toContain(roleId)
+    })
+  })
+
   describe('stateMachineOptions', () => {
     it('should have assignEstateMembers action defined', () => {
       expect(

--- a/libs/application/templates/estate/src/lib/EstateTemplate.ts
+++ b/libs/application/templates/estate/src/lib/EstateTemplate.ts
@@ -20,6 +20,7 @@ import {
   InstitutionNationalIds,
 } from '@island.is/application/types'
 import { buildPaymentState } from '@island.is/application/utils'
+import { PaymentForm } from '@island.is/application/ui-forms'
 import { m } from './messages'
 import { estateSchema } from './dataSchema'
 import {
@@ -212,6 +213,18 @@ const EstateTemplate: ApplicationTemplate<
                 SyslumadurPaymentCatalogApi,
                 MockableSyslumadurPaymentCatalogApi,
               ],
+            },
+            {
+              // Assignees keep visibility after rejecting (assignees are not
+              // cleared on REJECT) and estate members always map to ASSIGNEE
+              // while review is enabled. Without a form for this role the
+              // form shell renders an infinite loader.
+              id: Roles.ASSIGNEE,
+              formLoader: () =>
+                import('../forms/InReview').then((val) =>
+                  Promise.resolve(val.assigneeStatusForm),
+                ),
+              read: 'all',
             },
           ],
           actionCard: {
@@ -407,9 +420,44 @@ const EstateTemplate: ApplicationTemplate<
           },
         },
       },
-      [States.payment]: buildPaymentState({
+      [States.payment]: buildPaymentState<EstateEvent>({
         organizationId: InstitutionNationalIds.SYSLUMENN,
         chargeItems: getChargeItems,
+        // mapUserToRole never returns the default 'applicant' role once an
+        // estate type has been selected, so the payment state needs explicit
+        // roles for the estate-specific applicant roles. Assignees also keep
+        // visibility while the applicant pays and get a read-only status form.
+        roles: [
+          ...[
+            Roles.APPLICANT_PERMIT_FOR_UNDIVIDED_ESTATE,
+            Roles.APPLICANT_DIVISION_OF_ESTATE_BY_HEIRS,
+          ].map((roleId) => ({
+            id: roleId,
+            formLoader: async () => PaymentForm,
+            actions: [
+              {
+                event: DefaultEvents.SUBMIT,
+                name: 'Panta',
+                type: 'primary' as const,
+              },
+              {
+                event: DefaultEvents.ABORT,
+                name: 'Hætta við',
+                type: 'primary' as const,
+              },
+            ],
+            write: 'all' as const,
+            delete: true,
+          })),
+          {
+            id: Roles.ASSIGNEE,
+            formLoader: () =>
+              import('../forms/InReview').then((val) =>
+                Promise.resolve(val.assigneeStatusForm),
+              ),
+            read: 'all' as const,
+          },
+        ],
         submitTarget: [
           {
             target: States.signing,
@@ -629,6 +677,16 @@ const EstateTemplate: ApplicationTemplate<
             },
             {
               id: Roles.APPLICANT_DIVISION_OF_ESTATE_BY_HEIRS,
+              formLoader: () =>
+                import('../forms/Done').then((val) =>
+                  Promise.resolve(val.done),
+                ),
+              read: 'all',
+            },
+            {
+              // Estate members map to ASSIGNEE while review is enabled and
+              // can open a completed application, e.g. from My Pages.
+              id: Roles.ASSIGNEE,
               formLoader: () =>
                 import('../forms/Done').then((val) =>
                   Promise.resolve(val.done),

--- a/libs/application/templates/estate/src/lib/messages.ts
+++ b/libs/application/templates/estate/src/lib/messages.ts
@@ -1531,6 +1531,19 @@ export const m = defineMessages({
       'Þú hefur samþykkt gögnin í umsókninni. Umsóknin verður send til sýslumanns þegar allir erfingjar hafa samþykkt.',
     description: 'Assignee approved description',
   },
+  assigneeStatusTitle: {
+    id: 'es.application:assigneeStatus.title',
+    defaultMessage: 'Umsókn í vinnslu hjá umsækjanda',
+    description:
+      'Assignee status title when the application is back with the applicant',
+  },
+  assigneeStatusDescription: {
+    id: 'es.application:assigneeStatus.description',
+    defaultMessage:
+      'Umsóknin er í vinnslu hjá umsækjanda. Þú færð tilkynningu þegar kemur að næstu skrefum.',
+    description:
+      'Assignee status description when the application is back with the applicant',
+  },
 
   // Signing state messages
   signingTitle: {

--- a/libs/application/templates/estate/src/lib/messages.ts
+++ b/libs/application/templates/estate/src/lib/messages.ts
@@ -1539,8 +1539,7 @@ export const m = defineMessages({
   },
   assigneeStatusDescription: {
     id: 'es.application:assigneeStatus.description',
-    defaultMessage:
-      'Umsóknin er í vinnslu hjá umsækjanda. Þú færð tilkynningu þegar kemur að næstu skrefum.',
+    defaultMessage: 'Umsóknin er í vinnslu hjá umsækjanda.',
     description:
       'Assignee status description when the application is back with the applicant',
   },


### PR DESCRIPTION
## What

Fix infinite loading screen in estate application after rejecting signature

## Why

Infinite loading screens are bad

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Assignees can view a read-only status summary (title and descriptive message) when an application is returned to the applicant, during payment, and can view completed applications.
  * Assignee visibility and role access extended across draft, payment, signing, in-review, and done states; localized messages added for the assignee status UI.
* **Tests**
  * Added coverage to ensure assignee role presence across relevant states and payment-specific applicant role checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->