### PR TITLE
fix(j-s): Group sub-article-less laws in legal arguments autofill

### DIFF
--- a/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Indictment/IndictmentCount.spec.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Indictment/IndictmentCount.spec.tsx
@@ -60,7 +60,7 @@ describe('getLegalArguments', () => {
     )
   })
 
-  test('should format legal arguments with 95 and six other articles, not placing "sbr." after grouped articles unless it is the last one', () => {
+  test('should format legal arguments with 95 and three other articles, not placing "sbr." after grouped articles unless it is the last one', () => {
     const lawsBroken = [
       [48, 1],
       [48, 2],
@@ -91,5 +91,69 @@ describe('getLegalArguments', () => {
     expect(result).toEqual(
       'Telst háttsemi þessi varða við 37. gr. og 1., sbr. 2. mgr. 49. gr., sbr. 1. mgr. 95. gr. umferðarlaga nr. 77/2019.',
     )
+  })
+
+  test('should format a zero sub article that is not first', () => {
+    const lawsBroken = [
+      [37, 0],
+      [49, 1],
+      [49, 2],
+      [21, 0],
+      [95, 1],
+    ]
+
+    const result = getLegalArguments(lawsBroken, formatMessage)
+
+    expect(result).toEqual(
+      'Telst háttsemi þessi varða við 37. gr., 21. gr., og 1., sbr. 2. mgr. 49. gr., sbr. 1. mgr. 95. gr. umferðarlaga nr. 77/2019.',
+    )
+  })
+
+  test('should format all zero sub articles', () => {
+    const lawsBroken = [
+      [37, 0],
+      [21, 0],
+      [95, 0],
+    ]
+
+    const result = getLegalArguments(lawsBroken, formatMessage)
+
+    expect(result).toEqual(
+      'Telst háttsemi þessi varða við 37. gr., 21. gr., og 95. gr. umferðarlaga nr. 77/2019.',
+    )
+  })
+
+  test('should format multiple zero sub articles followed by multiple non-zero groups', () => {
+    const lawsBroken = [
+      [37, 0],
+      [21, 0],
+      [49, 1],
+      [49, 2],
+      [58, 1],
+      [95, 1],
+    ]
+
+    const result = getLegalArguments(lawsBroken, formatMessage)
+
+    // The "og" precedes the last non-zero group, so no comma is placed before it
+    expect(result).toEqual(
+      'Telst háttsemi þessi varða við 37. gr., 21. gr., 1., sbr. 2. mgr. 49. gr. og 1. mgr. 58. gr., sbr. 1. mgr. 95. gr. umferðarlaga nr. 77/2019.',
+    )
+  })
+
+  test('should format a single zero sub article on its own', () => {
+    const lawsBroken = [[37, 0]]
+
+    const result = getLegalArguments(lawsBroken, formatMessage)
+
+    expect(result).toEqual(
+      'Telst háttsemi þessi varða við 37. gr. umferðarlaga nr. 77/2019.',
+    )
+  })
+
+  test('should return an empty string when there are no laws broken', () => {
+    const result = getLegalArguments([], formatMessage)
+
+    expect(result).toEqual('')
   })
 })

--- a/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Indictment/IndictmentCount.spec.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Indictment/IndictmentCount.spec.tsx
@@ -156,4 +156,14 @@ describe('getLegalArguments', () => {
 
     expect(result).toEqual('')
   })
+
+  test('should format the general law on its own without a leading comma', () => {
+    const lawsBroken = [[95, 1]]
+
+    const result = getLegalArguments(lawsBroken, formatMessage)
+
+    expect(result).toEqual(
+      'Telst háttsemi þessi varða við sbr. 1. mgr. 95. gr. umferðarlaga nr. 77/2019.',
+    )
+  })
 })

--- a/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Indictment/IndictmentCount.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Indictment/IndictmentCount.tsx
@@ -180,42 +180,53 @@ export const getLegalArguments = (
     return ''
   }
 
-  const relevantLaws =
+  // The general law (95) is always rendered last, prefixed with "sbr.".
+  const hasGeneralLaw =
     lawsCompare(lawsBroken[lawsBroken.length - 1] as Law, generalLaws[0]) === 0
-      ? lawsBroken.slice(0, -1)
-      : lawsBroken
-  let andIndex = -1
-  if (relevantLaws.length > 1) {
-    for (let i = relevantLaws.length - 1; i > 0; i--) {
-      if (relevantLaws[i - 1][0] !== relevantLaws[i][0]) {
-        andIndex = i
-        break
-      }
+  const generalLaw = hasGeneralLaw
+    ? lawsBroken[lawsBroken.length - 1]
+    : undefined
+  const mainLaws = hasGeneralLaw ? lawsBroken.slice(0, -1) : lawsBroken
+
+  // Laws without a sub-article (sub-article 0) are grouped at the start, the
+  // rest are grouped by article (paragraph) number in their original order.
+  const parts: { text: string; isZero: boolean }[] = []
+
+  mainLaws
+    .filter((law) => law[1] === 0)
+    .forEach((law) => parts.push({ text: `${law[0]}. gr.`, isZero: true }))
+
+  const nonZeroLaws = mainLaws.filter((law) => law[1] !== 0)
+  for (let i = 0; i < nonZeroLaws.length; ) {
+    const article = nonZeroLaws[i][0]
+    const subArticles: number[] = []
+    while (i < nonZeroLaws.length && nonZeroLaws[i][0] === article) {
+      subArticles.push(nonZeroLaws[i][1])
+      i++
+    }
+    const subArticleText = subArticles
+      .map((sub, index) => (index === 0 ? `${sub}.` : `, sbr. ${sub}.`))
+      .join('')
+    parts.push({ text: `${subArticleText} mgr. ${article}. gr.`, isZero: false })
+  }
+
+  // Join the parts with ", ", placing "og" before the last one. A grouped
+  // sub-article-less law keeps its trailing comma before the "og".
+  let articles = parts.length > 0 ? parts[0].text : ''
+  for (let i = 1; i < parts.length; i++) {
+    if (i === parts.length - 1) {
+      const commaBeforeOg = parts[i - 1].isZero && i - 1 > 0
+      articles = `${articles}${commaBeforeOg ? ',' : ''} og ${parts[i].text}`
+    } else {
+      articles = `${articles}, ${parts[i].text}`
     }
   }
 
-  // handle the sub-article of the first laws tuple
-  let articles = lawsBroken[0][1] === 0 ? '' : `${lawsBroken[0][1]}.`
-
-  for (let i = 1; i < lawsBroken.length; i++) {
-    let useSbr = true
-    const hasNoArticle = lawsBroken[i - 1][1] === 0
-
-    if (lawsBroken[i][0] !== lawsBroken[i - 1][0]) {
-      articles = `${articles}${hasNoArticle ? '' : ` mgr. `}${
-        lawsBroken[i - 1][0]
-      }. gr.`
-      useSbr = i > andIndex
-    }
-
-    articles = `${articles}${
-      i === andIndex ? ' og' : useSbr ? ', sbr.' : ','
-    } ${lawsBroken[i][1]}.`
+  if (generalLaw) {
+    articles = `${articles}, sbr. ${generalLaw[1]}. mgr. ${generalLaw[0]}. gr.`
   }
 
-  return formatMessage(strings.legalArgumentsAutofill, {
-    articles: `${articles} mgr. ${lawsBroken[lawsBroken.length - 1][0]}. gr.`,
-  })
+  return formatMessage(strings.legalArgumentsAutofill, { articles })
 }
 
 export const IndictmentCount: FC<Props> = ({

--- a/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Indictment/IndictmentCount.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Indictment/IndictmentCount.tsx
@@ -226,7 +226,8 @@ export const getLegalArguments = (
   }
 
   if (generalLaw) {
-    articles = `${articles}, sbr. ${generalLaw[1]}. mgr. ${generalLaw[0]}. gr.`
+    const suffix = `sbr. ${generalLaw[1]}. mgr. ${generalLaw[0]}. gr.`
+    articles = articles ? `${articles}, ${suffix}` : suffix
   }
 
   return formatMessage(strings.legalArgumentsAutofill, { articles })

--- a/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Indictment/IndictmentCount.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Indictment/IndictmentCount.tsx
@@ -207,7 +207,10 @@ export const getLegalArguments = (
     const subArticleText = subArticles
       .map((sub, index) => (index === 0 ? `${sub}.` : `, sbr. ${sub}.`))
       .join('')
-    parts.push({ text: `${subArticleText} mgr. ${article}. gr.`, isZero: false })
+    parts.push({
+      text: `${subArticleText} mgr. ${article}. gr.`,
+      isZero: false,
+    })
   }
 
   // Join the parts with ", ", placing "og" before the last one. A grouped


### PR DESCRIPTION
## What
Reworks `getLegalArguments` in the indictment count form so that laws without a sub-article (sub-article `0`) are grouped together at the start of the generated legal arguments text, and the remaining laws are grouped by article (paragraph) number.

Previously, a sub-article-less law appearing in the middle of the list produced malformed output (e.g. a stray `og 0.58. gr.` with a glued-together article number). The zero-handling logic only ever applied to the first law in the list, never to later ones.

Also expands the test suite from 7 to 12 cases (covering mid-list zeros, all-zero lists, multiple zeros followed by multiple non-zero groups, a single zero on its own, the general-law-only case, and the empty input), and corrects two inaccurate test descriptions.

## Why
The autofilled "heimfærsla" text was incorrect whenever a sub-article-less law (such as the speeding law `[37, 0]`) appeared anywhere other than first in the list, producing text that prosecutors would have to fix manually. Grouping the sub-article-less laws at the start yields correct, consistent legal arguments.

## Note on production impact (correctness / future-proofing)
This change is about **correctness and future-proofing**, not a bug currently visible in production. Today the only sub-article-less law in `offenseLawsMap` is the speeding law `[37, 0]`, and article `37` is lower than every other article (48, 49, 50, 58, 95). Because the laws are sorted by article number ascending (`getUniqueSortedLaws` / `lawsCompare`) before reaching `getLegalArguments`, `37` already sorts to the front on its own — so with the current data the malformed mid-list ordering can never actually occur.

The new code makes "sub-article-less laws go first" an **explicit rule** rather than an incidental side effect of numeric sorting. This keeps the output correct if a future zero sub-article law with a higher article number is ever added (where sorting alone would otherwise place it in the middle and produce the malformed text). The accompanying tests pass inputs in unsorted order to lock this behavior in regardless of the eventual law set.

## Screenshots / Gifs
Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code
- [ ] No AI tools were used in preparing this pull request

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved legal-article formatting in indictment counts: correct ordering, grouping, and separator/prefix placement when multiple articles are combined, with special handling for the general article.

* **Tests**
  * Expanded test coverage for legal-argument formatting edge cases, including various zero sub-article scenarios, punctuation/connector placement, and single/multiple article combinations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->