### PR TITLE
feat(j-s): move empty item/section filtering into InfoCard

### DIFF
--- a/apps/judicial-system/web/src/components/InfoCard/InfoCard.spec.tsx
+++ b/apps/judicial-system/web/src/components/InfoCard/InfoCard.spec.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-
 import { MockedProvider } from '@apollo/client/testing'
 import { render, screen } from '@testing-library/react'
 

--- a/apps/judicial-system/web/src/components/InfoCard/InfoCard.spec.tsx
+++ b/apps/judicial-system/web/src/components/InfoCard/InfoCard.spec.tsx
@@ -1,3 +1,5 @@
+import React from 'react'
+
 import { MockedProvider } from '@apollo/client/testing'
 import { render, screen } from '@testing-library/react'
 
@@ -6,7 +8,70 @@ import { LocaleProvider } from '@island.is/localization'
 import { DefendantInfo } from './DefendantInfo/DefendantInfo'
 import InfoCard from './InfoCard'
 
+const renderInfoCard = (sections: React.ComponentProps<typeof InfoCard>['sections']) =>
+  render(
+    <MockedProvider>
+      <LocaleProvider locale="is" messages={{}}>
+        <InfoCard sections={sections} />
+      </LocaleProvider>
+    </MockedProvider>,
+  )
+
 describe('InfoCard', () => {
+  describe('empty item filtering', () => {
+    test('does not render an item with an empty values array', async () => {
+      renderInfoCard([
+        {
+          id: 'sec',
+          items: [
+            { id: 'empty', title: 'Hidden title', values: [] },
+            { id: 'visible', title: 'Visible title', values: ['Visible value'] },
+          ],
+        },
+      ])
+
+      await screen.findByText('Visible title')
+      expect(screen.queryByText('Hidden title')).toBeNull()
+    })
+
+    test('does not render an item whose first value is falsy', async () => {
+      renderInfoCard([
+        {
+          id: 'sec',
+          items: [
+            { id: 'falsy', title: 'Falsy title', values: [null as unknown as string] },
+            { id: 'visible', title: 'Visible title', values: ['Value'] },
+          ],
+        },
+      ])
+
+      await screen.findByText('Visible title')
+      expect(screen.queryByText('Falsy title')).toBeNull()
+    })
+  })
+
+  describe('empty section filtering', () => {
+    test('does not render a section where all items are empty', async () => {
+      renderInfoCard([
+        {
+          id: 'empty-section',
+          items: [
+            { id: 'a', title: 'Hidden A', values: [] },
+            { id: 'b', title: 'Hidden B', values: [null as unknown as string] },
+          ],
+        },
+        {
+          id: 'visible-section',
+          items: [{ id: 'c', title: 'Visible title', values: ['Value'] }],
+        },
+      ])
+
+      await screen.findByText('Visible title')
+      expect(screen.queryByText('Hidden A')).toBeNull()
+      expect(screen.queryByText('Hidden B')).toBeNull()
+    })
+  })
+
   test('should display the assigned defender name if that info is provided even though the defender email is not', async () => {
     // Arrange
     render(

--- a/apps/judicial-system/web/src/components/InfoCard/InfoCard.spec.tsx
+++ b/apps/judicial-system/web/src/components/InfoCard/InfoCard.spec.tsx
@@ -7,7 +7,9 @@ import { LocaleProvider } from '@island.is/localization'
 import { DefendantInfo } from './DefendantInfo/DefendantInfo'
 import InfoCard from './InfoCard'
 
-const renderInfoCard = (sections: React.ComponentProps<typeof InfoCard>['sections']) =>
+const renderInfoCard = (
+  sections: React.ComponentProps<typeof InfoCard>['sections'],
+) =>
   render(
     <MockedProvider>
       <LocaleProvider locale="is" messages={{}}>
@@ -24,7 +26,11 @@ describe('InfoCard', () => {
           id: 'sec',
           items: [
             { id: 'empty', title: 'Hidden title', values: [] },
-            { id: 'visible', title: 'Visible title', values: ['Visible value'] },
+            {
+              id: 'visible',
+              title: 'Visible title',
+              values: ['Visible value'],
+            },
           ],
         },
       ])
@@ -38,7 +44,11 @@ describe('InfoCard', () => {
         {
           id: 'sec',
           items: [
-            { id: 'falsy', title: 'Falsy title', values: [null as unknown as string] },
+            {
+              id: 'falsy',
+              title: 'Falsy title',
+              values: [null as unknown as string],
+            },
             { id: 'visible', title: 'Visible title', values: ['Value'] },
           ],
         },

--- a/apps/judicial-system/web/src/components/InfoCard/InfoCard.tsx
+++ b/apps/judicial-system/web/src/components/InfoCard/InfoCard.tsx
@@ -26,13 +26,22 @@ interface Props {
 const InfoCard: FC<Props> = (props) => {
   const { sections } = props
 
+  const visibleSections = sections
+    .map((section) => ({
+      ...section,
+      items: section.items.filter(
+        (item) => item.values.length > 0 && !!item.values[0],
+      ),
+    }))
+    .filter((section) => section.items.length > 0)
+
   return (
     <BlueBox className={grid({ gap: 3 })}>
-      {sections.map((section, index) => (
+      {visibleSections.map((section, index) => (
         <Box
           className={cn(styles.grid, {
             [styles.twoCols]: section.columns === 2,
-            [styles.renderDividerFull]: index !== sections.length - 1,
+            [styles.renderDividerFull]: index !== visibleSections.length - 1,
           })}
           key={section.id}
         >

--- a/apps/judicial-system/web/src/components/InfoCard/InfoCardActiveIndictment.tsx
+++ b/apps/judicial-system/web/src/components/InfoCard/InfoCardActiveIndictment.tsx
@@ -44,7 +44,6 @@ const InfoCardActiveIndictment: React.FC<Props> = (props) => {
     courtCaseNumber,
     splitCases,
     splitCase,
-    showItem,
   } = useInfoCardItems()
 
   const excludedDefendants =
@@ -73,13 +72,13 @@ const InfoCardActiveIndictment: React.FC<Props> = (props) => {
         {
           id: 'case-info-section',
           items: [
-            ...(showItem(indictmentCreated) ? [indictmentCreated] : []),
+            indictmentCreated,
             prosecutor(workingCase.type, onProsecutorClick),
             policeCaseNumbers,
             ...(workingCase.judge ? [judge] : []),
             ...(workingCase.registrar ? [registrar] : []),
             court,
-            ...(showItem(courtCaseNumber) ? [courtCaseNumber] : []),
+            courtCaseNumber,
             offenses,
           ],
           columns: 2,

--- a/apps/judicial-system/web/src/components/InfoCard/InfoCardClosedIndictment.tsx
+++ b/apps/judicial-system/web/src/components/InfoCard/InfoCardClosedIndictment.tsx
@@ -24,7 +24,6 @@ const InfoCardClosedIndictment: FC<Props> = (props) => {
   const { user } = useContext(UserContext)
 
   const {
-    showItem,
     defendants,
     cancelledAndDismissedDefendants,
     policeCaseNumbers,
@@ -83,7 +82,7 @@ const InfoCardClosedIndictment: FC<Props> = (props) => {
             policeCaseNumbers,
             courtCaseNumber,
             prosecutorsOffice,
-            ...(showItem(mergeCase) ? [mergeCase] : []),
+            mergeCase,
             court,
             prosecutor(workingCase.type),
             judge,

--- a/apps/judicial-system/web/src/components/InfoCard/useInfoCardItems.tsx
+++ b/apps/judicial-system/web/src/components/InfoCard/useInfoCardItems.tsx
@@ -49,10 +49,6 @@ const useInfoCardItems = () => {
   const { workingCase } = useContext(FormContext)
   const { limitedAccess, user } = useContext(UserContext)
 
-  // helper for info card items. If items have no values they will have [{falsy value}]
-  const showItem = (item: Item) =>
-    isNonEmptyArray(item.values) && !!item.values[0]
-
   const defendants = ({
     caseType,
     displayAppealExpirationInfo,
@@ -504,7 +500,6 @@ const useInfoCardItems = () => {
   }
 
   return {
-    showItem,
     defendants,
     cancelledAndDismissedDefendants,
     indictmentCreated,

--- a/apps/judicial-system/web/src/routes/Court/InvestigationCase/Overview/Overview.tsx
+++ b/apps/judicial-system/web/src/routes/Court/InvestigationCase/Overview/Overview.tsx
@@ -72,7 +72,6 @@ const Overview = () => {
     prosecutor,
     caseType,
     victims,
-    showItem,
   } = useInfoCardItems()
 
   const handleNavigationTo = useCallback(
@@ -137,14 +136,10 @@ const Overview = () => {
                   id: 'defendants-section',
                   items: [defendants({ caseType: workingCase.type })],
                 },
-                ...(showItem(victims)
-                  ? [
-                      {
-                        id: 'victims-section',
-                        items: [victims],
-                      },
-                    ]
-                  : []),
+                {
+                  id: 'victims-section',
+                  items: [victims],
+                },
                 {
                   id: 'case-info-section',
                   items: [

--- a/apps/judicial-system/web/src/routes/CourtOfAppeal/Overview/Overview.tsx
+++ b/apps/judicial-system/web/src/routes/CourtOfAppeal/Overview/Overview.tsx
@@ -66,7 +66,6 @@ const Overview = () => {
     registrar,
     caseType,
     victims,
-    showItem,
   } = useInfoCardItems()
 
   const handleNavigationTo = (destination: string) =>
@@ -113,14 +112,10 @@ const Overview = () => {
                     id: 'defendants-section',
                     items: [defendants({ caseType: workingCase.type })],
                   },
-                  ...(showItem(victims)
-                    ? [
-                        {
-                          id: 'victims-section',
-                          items: [victims],
-                        },
-                      ]
-                    : []),
+                  {
+                    id: 'victims-section',
+                    items: [victims],
+                  },
                   {
                     id: 'case-info-section',
                     items: [

--- a/apps/judicial-system/web/src/routes/CourtOfAppeal/Result/Result.tsx
+++ b/apps/judicial-system/web/src/routes/CourtOfAppeal/Result/Result.tsx
@@ -66,7 +66,6 @@ const Result = () => {
     appealAssistant,
     appealJudges,
     victims,
-    showItem,
   } = useInfoCardItems()
 
   const isIndictment = isIndictmentCase(workingCase.type)
@@ -104,14 +103,10 @@ const Result = () => {
                     id: 'defendants-section',
                     items: [defendants({ caseType: workingCase.type })],
                   },
-                  ...(showItem(victims)
-                    ? [
-                        {
-                          id: 'victims-section',
-                          items: [victims],
-                        },
-                      ]
-                    : []),
+                  {
+                    id: 'victims-section',
+                    items: [victims],
+                  },
                   {
                     id: 'case-info-section',
                     items: [

--- a/apps/judicial-system/web/src/routes/Defender/RequestCase/CaseOverview.tsx
+++ b/apps/judicial-system/web/src/routes/Defender/RequestCase/CaseOverview.tsx
@@ -57,7 +57,6 @@ export const CaseOverview = () => {
     appealAssistant,
     appealJudges,
     victims,
-    showItem,
   } = useInfoCardItems()
 
   const shouldDisplayAppealBanner =
@@ -128,14 +127,10 @@ export const CaseOverview = () => {
                   id: 'defendants-section',
                   items: [defendants({ caseType: workingCase.type })],
                 },
-                ...(showItem(victims)
-                  ? [
-                      {
-                        id: 'victims-section',
-                        items: [victims],
-                      },
-                    ]
-                  : []),
+                {
+                  id: 'victims-section',
+                  items: [victims],
+                },
                 {
                   id: 'case-info-section',
                   items: [

--- a/apps/judicial-system/web/src/routes/Prosecutor/InvestigationCase/Overview/Overview.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/InvestigationCase/Overview/Overview.tsx
@@ -82,7 +82,6 @@ export const Overview = () => {
     prosecutor,
     caseType,
     victims,
-    showItem,
   } = useInfoCardItems()
 
   const [modal, setModal] = useState<
@@ -192,14 +191,10 @@ export const Overview = () => {
                   id: 'defendants-section',
                   items: [defendants({ caseType: workingCase.type })],
                 },
-                ...(showItem(victims)
-                  ? [
-                      {
-                        id: 'victims-section',
-                        items: [victims],
-                      },
-                    ]
-                  : []),
+                {
+                  id: 'victims-section',
+                  items: [victims],
+                },
                 {
                   id: 'case-info-section',
                   items: [

--- a/apps/judicial-system/web/src/routes/Shared/SignedVerdictOverview/SignedVerdictOverview.tsx
+++ b/apps/judicial-system/web/src/routes/Shared/SignedVerdictOverview/SignedVerdictOverview.tsx
@@ -184,7 +184,6 @@ export const SignedVerdictOverview: FC = () => {
     appealAssistant,
     appealJudges,
     victims,
-    showItem,
   } = useInfoCardItems()
 
   const [isModifyingDates, setIsModifyingDates] = useState<boolean>(false)
@@ -434,14 +433,10 @@ export const SignedVerdictOverview: FC = () => {
                   id: 'defendants-section',
                   items: [defendants({ caseType: workingCase.type })],
                 },
-                ...(showItem(victims)
-                  ? [
-                      {
-                        id: 'victims-section',
-                        items: [victims],
-                      },
-                    ]
-                  : []),
+                {
+                  id: 'victims-section',
+                  items: [victims],
+                },
                 {
                   id: 'case-info-section',
                   items: [


### PR DESCRIPTION
## What

Move the responsibility for filtering empty items and sections into `InfoCard` itself, rather than having each callsite guard items with `showItem()` before passing them to the component.

`InfoCard` now:
- Filters out items where `values` is empty or the first value is falsy
- Drops entire sections that have no visible items after filtering

`showItem` has been removed from `useInfoCardItems` and all 8 callsites that used it.

## Why

The `showItem` helper was a leaky abstraction — callers shouldn't need to know about InfoCard's rendering rules. Centralising this logic in `InfoCard` makes the callsites simpler and ensures consistent behaviour across the board.

## Screenshots / Gifs


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code
- [ ] No AI tools were used in preparing this pull request