### PR TITLE
fix(web): Organization pages - Don't have a header for landing page theme

### DIFF
--- a/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
+++ b/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
@@ -227,6 +227,8 @@ export const OrganizationHeader: React.FC<
     isSubpage,
   }
 
+  if (organizationPage.theme === 'landing_page') return null
+
   return <DefaultHeader {...defaultProps} />
 }
 


### PR DESCRIPTION
# Organization pages - Don't have a header for landing page theme

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [x] No AI tools were used in preparing this pull request
- [ ] AI tools were used in preparing this pull request
      Tools used:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed header display on organization landing pages to align with intended visual design.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->