### PR TITLE
feat(j-s): feature flag TinyMCE editor

### DIFF
--- a/apps/judicial-system/api/infra/judicial-system-api.ts
+++ b/apps/judicial-system/api/infra/judicial-system-api.ts
@@ -52,8 +52,8 @@ export const serviceSetup = (services: {
       },
       HIDDEN_FEATURES: {
         dev: '',
-        staging: 'APPEAL_RULING_ORDER',
-        prod: 'APPEAL_RULING_ORDER',
+        staging: 'APPEAL_RULING_ORDER,TINY_MCE',
+        prod: 'APPEAL_RULING_ORDER,TINY_MCE',
       },
       REDIS_NODES: {
         dev: json([

--- a/apps/judicial-system/web/src/routes/Court/Indictments/CourtRecord/CourtSessionAccordionItem.tsx
+++ b/apps/judicial-system/web/src/routes/Court/Indictments/CourtRecord/CourtSessionAccordionItem.tsx
@@ -38,15 +38,17 @@ import {
   lowercase,
   Word,
 } from '@island.is/judicial-system/formatters'
+import { Feature } from '@island.is/judicial-system/types'
 import {
   BlueBox,
   DateTime,
+  FeatureContext,
   FileNotFoundModal,
   FormContext,
   Modal,
   MultipleValueList,
   SectionHeading,
-  // TinyMCE,
+  TinyMCE,
 } from '@island.is/judicial-system-web/src/components'
 import EditableCaseFile, {
   Supplement,
@@ -162,6 +164,8 @@ const CourtSessionLabel = forwardRef(
 const CourtSessionAccordionItem: FC<Props> = (props) => {
   const { index, courtSession, isExpanded, onToggle } = props
   const ref = useRef<HTMLDivElement>(null)
+  const { features } = useContext(FeatureContext)
+  const useTinyMCE = features.includes(Feature.TINY_MCE)
   const { workingCase, setWorkingCase, isCaseUpToDate } =
     useContext(FormContext)
   const { onOpen, fileNotFound, dismissFileNotFound } = useFileList({
@@ -1438,70 +1442,71 @@ const CourtSessionAccordionItem: FC<Props> = (props) => {
               )}
               <Box>
                 <SectionHeading title="Bókanir" />
-                <Input
-                  data-testid="entries"
-                  name="entries"
-                  label="Afstaða ákærða, málflutningur og aðrar bókanir"
-                  value={courtSession.entries || ''}
-                  placeholder="Nánari útlistun á afstöðu ákærða, málflutningsræður og annað sem fram kom í þinghaldi er skráð hér."
-                  onChange={(event) => {
-                    setEntriesErrorMessage('')
-
-                    patchSession(courtSession.id, {
-                      entries: event.target.value,
-                    })
-                  }}
-                  onBlur={(event) => {
-                    validateAndSetErrorMessage(
-                      ['empty'],
-                      event.target.value,
-                      setEntriesErrorMessage,
-                    )
-
-                    patchSession(
-                      courtSession.id,
-                      { entries: event.target.value },
-                      { persist: true },
-                    )
-                  }}
-                  hasError={entriesErrorMessage !== ''}
-                  errorMessage={entriesErrorMessage}
-                  rows={15}
-                  disabled={courtSession.isConfirmed || false}
-                  textarea
-                  required
-                />
-                {/* <TinyMCE
-                  data-testid="entries"
-                  label="Afstaða ákærða, málflutningur og aðrar bókanir"
-                  placeholder="Nánari útlistun á afstöðu ákærða, málflutningsræður og annað sem fram kom í þinghaldi er skráð hér."
-                  defaultValue={courtSession.entries || ''}
-                  onChange={(html) => {
-                    setEntriesErrorMessage('')
-                    patchSession(courtSession.id, { entries: html })
-                  }}
-                  onBlur={(html) => {
-                    // Decode entities (e.g. &nbsp;) and strip tags so an
-                    // otherwise-empty paragraph doesn't pass the required check.
-                    const decodedText =
-                      new DOMParser()
-                        .parseFromString(html, 'text/html')
-                        .body.textContent?.trim() ?? ''
-                    validateAndSetErrorMessage(
-                      ['empty'],
-                      decodedText,
-                      setEntriesErrorMessage,
-                    )
-                    patchSession(
-                      courtSession.id,
-                      { entries: html },
-                      { persist: true },
-                    )
-                  }}
-                  errorMessage={entriesErrorMessage || undefined}
-                  disabled={courtSession.isConfirmed || false}
-                  required
-                /> */}
+                {useTinyMCE ? (
+                  <TinyMCE
+                    data-testid="entries"
+                    label="Afstaða ákærða, málflutningur og aðrar bókanir"
+                    placeholder="Nánari útlistun á afstöðu ákærða, málflutningsræður og annað sem fram kom í þinghaldi er skráð hér."
+                    defaultValue={courtSession.entries || ''}
+                    onChange={(html) => {
+                      setEntriesErrorMessage('')
+                      patchSession(courtSession.id, { entries: html })
+                    }}
+                    onBlur={(html) => {
+                      // Decode entities (e.g. &nbsp;) and strip tags so an
+                      // otherwise-empty paragraph doesn't pass the required check.
+                      const decodedText =
+                        new DOMParser()
+                          .parseFromString(html, 'text/html')
+                          .body.textContent?.trim() ?? ''
+                      validateAndSetErrorMessage(
+                        ['empty'],
+                        decodedText,
+                        setEntriesErrorMessage,
+                      )
+                      patchSession(
+                        courtSession.id,
+                        { entries: html },
+                        { persist: true },
+                      )
+                    }}
+                    errorMessage={entriesErrorMessage || undefined}
+                    disabled={courtSession.isConfirmed || false}
+                    required
+                  />
+                ) : (
+                  <Input
+                    data-testid="entries"
+                    name="entries"
+                    label="Afstaða ákærða, málflutningur og aðrar bókanir"
+                    value={courtSession.entries || ''}
+                    placeholder="Nánari útlistun á afstöðu ákærða, málflutningsræður og annað sem fram kom í þinghaldi er skráð hér."
+                    onChange={(event) => {
+                      setEntriesErrorMessage('')
+                      patchSession(courtSession.id, {
+                        entries: event.target.value,
+                      })
+                    }}
+                    onBlur={(event) => {
+                      validateAndSetErrorMessage(
+                        ['empty'],
+                        event.target.value,
+                        setEntriesErrorMessage,
+                      )
+                      patchSession(
+                        courtSession.id,
+                        { entries: event.target.value },
+                        { persist: true },
+                      )
+                    }}
+                    hasError={entriesErrorMessage !== ''}
+                    errorMessage={entriesErrorMessage}
+                    rows={15}
+                    disabled={courtSession.isConfirmed || false}
+                    textarea
+                    required
+                  />
+                )}
               </Box>
               <Box>
                 <SectionHeading

--- a/charts/judicial-system-services/judicial-system-api/values.prod.yaml
+++ b/charts/judicial-system-services/judicial-system-api/values.prod.yaml
@@ -30,7 +30,7 @@ env:
   BACKEND_URL: 'http://web-judicial-system-backend'
   CONTENTFUL_ENVIRONMENT: 'master'
   CONTENTFUL_HOST: 'cdn.contentful.com'
-  HIDDEN_FEATURES: 'APPEAL_RULING_ORDER'
+  HIDDEN_FEATURES: 'APPEAL_RULING_ORDER,TINY_MCE'
   IDENTITY_SERVER_ISSUER_URL: 'https://innskra.island.is'
   LOG_LEVEL: 'info'
   NODE_OPTIONS: '--max-old-space-size=460 --enable-source-maps -r dd-trace/init'

--- a/charts/judicial-system-services/judicial-system-api/values.staging.yaml
+++ b/charts/judicial-system-services/judicial-system-api/values.staging.yaml
@@ -30,7 +30,7 @@ env:
   BACKEND_URL: 'http://web-judicial-system-backend'
   CONTENTFUL_ENVIRONMENT: 'test'
   CONTENTFUL_HOST: 'cdn.contentful.com'
-  HIDDEN_FEATURES: 'APPEAL_RULING_ORDER'
+  HIDDEN_FEATURES: 'APPEAL_RULING_ORDER,TINY_MCE'
   IDENTITY_SERVER_ISSUER_URL: 'https://identity-server.staging01.devland.is'
   LOG_LEVEL: 'info'
   NODE_OPTIONS: '--max-old-space-size=460 --enable-source-maps -r dd-trace/init'

--- a/charts/judicial-system/values.prod.yaml
+++ b/charts/judicial-system/values.prod.yaml
@@ -30,7 +30,7 @@ judicial-system-api:
     BACKEND_URL: 'http://web-judicial-system-backend'
     CONTENTFUL_ENVIRONMENT: 'master'
     CONTENTFUL_HOST: 'cdn.contentful.com'
-    HIDDEN_FEATURES: 'APPEAL_RULING_ORDER'
+    HIDDEN_FEATURES: 'APPEAL_RULING_ORDER,TINY_MCE'
     IDENTITY_SERVER_ISSUER_URL: 'https://innskra.island.is'
     LOG_LEVEL: 'info'
     NODE_OPTIONS: '--max-old-space-size=460 --enable-source-maps -r dd-trace/init'

--- a/charts/judicial-system/values.staging.yaml
+++ b/charts/judicial-system/values.staging.yaml
@@ -30,7 +30,7 @@ judicial-system-api:
     BACKEND_URL: 'http://web-judicial-system-backend'
     CONTENTFUL_ENVIRONMENT: 'test'
     CONTENTFUL_HOST: 'cdn.contentful.com'
-    HIDDEN_FEATURES: 'APPEAL_RULING_ORDER'
+    HIDDEN_FEATURES: 'APPEAL_RULING_ORDER,TINY_MCE'
     IDENTITY_SERVER_ISSUER_URL: 'https://identity-server.staging01.devland.is'
     LOG_LEVEL: 'info'
     NODE_OPTIONS: '--max-old-space-size=460 --enable-source-maps -r dd-trace/init'

--- a/libs/judicial-system/types/src/lib/feature.ts
+++ b/libs/judicial-system/types/src/lib/feature.ts
@@ -1,4 +1,5 @@
 export enum Feature {
   NONE = 'NONE', // must be at least one
   APPEAL_RULING_ORDER = 'APPEAL_RULING_ORDER',
+  TINY_MCE = 'TINY_MCE',
 }


### PR DESCRIPTION
## What

- Adds `TINY_MCE` to the `Feature` enum
- Gates the TinyMCE editor in `CourtSessionAccordionItem` (Bókanir section) behind the flag, falling back to a plain textarea
- Adds `TINY_MCE` to `HIDDEN_FEATURES` for staging and prod in the infra config so it only shows on dev

## Why

TinyMCE needs more testing before it's ready for prod. This flag lets us develop and test it on dev/staging without exposing it to prod users.

## Screenshots / Gifs


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * TinyMCE rich text editor is now enabled in production and staging environments for enhanced editing capabilities in court record entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->