### PR TITLE
fix(hh-courses-application): Stop fetching health center info for professional courses

### DIFF
--- a/apps/web/screens/Organization/Courses/CourseDetails.tsx
+++ b/apps/web/screens/Organization/Courses/CourseDetails.tsx
@@ -114,6 +114,7 @@ const CourseDetails: Screen<CourseDetailsProps, CourseDetailsScreenContext> = ({
       JSON.stringify({
         courseId: course.id,
         courseInstanceId: instance.id,
+        courseListPageId: course.courseListPageId,
       }),
     )
 

--- a/libs/application/templates/hh/courses/src/forms/mainForm/userInformation.ts
+++ b/libs/application/templates/hh/courses/src/forms/mainForm/userInformation.ts
@@ -71,10 +71,12 @@ export const userInformation = buildSection({
               'currentHealthcenter.data.healthCenter',
             ),
           defaultValue: (application: Application) =>
-            getValueViaPath(
-              application.externalData,
-              'currentHealthcenter.data.healthCenter',
-            ),
+            !isCourseForProfessionals(application.answers)
+              ? getValueViaPath(
+                  application.externalData,
+                  'currentHealthcenter.data.healthCenter',
+                )
+              : '',
         }),
         buildAlertMessageField({
           id: 'userInformation.noHealthcenterAlert',

--- a/libs/application/templates/hh/courses/src/graphql/index.ts
+++ b/libs/application/templates/hh/courses/src/graphql/index.ts
@@ -6,6 +6,7 @@ export const GET_COURSE_SELECT_OPTIONS_QUERY = gql`
       items {
         id
         title
+        courseListPageId
       }
     }
   }

--- a/libs/application/templates/hh/courses/src/lib/messages.ts
+++ b/libs/application/templates/hh/courses/src/lib/messages.ts
@@ -16,9 +16,16 @@ export const m = {
     applicationTitleWithCourse: {
       id: 'hh.courses.application:general.applicationTitleWithCourse',
       defaultMessage:
-        '{value} - Námskeið hjá Heilsugæslunni á höfuðborgarsvæðinu',
+        '{value} - Námskeið fyrir almenning (Heilsugæsla höfuðborgarsvæðisins)',
       description:
         'Title of application with course name, shown in the application list',
+    },
+    applicationTitleWithCourseForProfessionals: {
+      id: 'hh.courses.application:general.applicationTitleWithCourseForProfessionals',
+      defaultMessage:
+        '{value} - Námskeið fyrir fagfólk (Heilsugæsla höfuðborgarsvæðisins)',
+      description:
+        'Title of application with course name, shown in the application list for professionals',
     },
     shorterApplicationTitle: {
       id: 'hh.courses.application:general.shorterApplicationTitle',

--- a/libs/application/templates/hh/courses/src/lib/messages.ts
+++ b/libs/application/templates/hh/courses/src/lib/messages.ts
@@ -13,6 +13,12 @@ export const m = {
         'Skráning á námskeið hjá Heilsugæslu höfuðborgarsvæðisins',
       description: 'Title of application',
     },
+    applicationTitleForProfessionals: {
+      id: 'hh.courses.application:general.applicationTitleForProfessionals',
+      defaultMessage:
+        'Skráning á námskeið fyrir fagfólk (Heilsugæsla höfuðborgarsvæðisins)',
+      description: 'Title of application for professionals',
+    },
     applicationTitleWithCourse: {
       id: 'hh.courses.application:general.applicationTitleWithCourse',
       defaultMessage:

--- a/libs/application/templates/hh/courses/src/lib/template.ts
+++ b/libs/application/templates/hh/courses/src/lib/template.ts
@@ -51,6 +51,8 @@ const template: ApplicationTemplate<
             : m.general.applicationTitleWithCourse,
           value: courseTitle,
         }
+      : isCourseForProfessionals(application.answers)
+      ? m.general.applicationTitleForProfessionals
       : m.general.applicationTitle
   },
   codeOwner: CodeOwners.Stefna,

--- a/libs/application/templates/hh/courses/src/lib/template.ts
+++ b/libs/application/templates/hh/courses/src/lib/template.ts
@@ -31,7 +31,7 @@ import {
 import { m } from './messages'
 import { getChargeItems } from '../utils/getChargeItems'
 import { hasCourseBeenFullyBooked } from '../utils/hasCourseBeenFullyBooked'
-import { isCourseForProfessionals } from '@/utils/isCourseForProfessionals'
+import { isCourseForProfessionals } from '../utils/isCourseForProfessionals'
 
 const template: ApplicationTemplate<
   ApplicationContext,

--- a/libs/application/templates/hh/courses/src/lib/template.ts
+++ b/libs/application/templates/hh/courses/src/lib/template.ts
@@ -31,6 +31,7 @@ import {
 import { m } from './messages'
 import { getChargeItems } from '../utils/getChargeItems'
 import { hasCourseBeenFullyBooked } from '../utils/hasCourseBeenFullyBooked'
+import { isCourseForProfessionals } from '@/utils/isCourseForProfessionals'
 
 const template: ApplicationTemplate<
   ApplicationContext,
@@ -45,7 +46,9 @@ const template: ApplicationTemplate<
     )
     return courseTitle
       ? {
-          name: m.general.applicationTitleWithCourse,
+          name: isCourseForProfessionals(application.answers)
+            ? m.general.applicationTitleWithCourseForProfessionals
+            : m.general.applicationTitleWithCourse,
           value: courseTitle,
         }
       : m.general.applicationTitle

--- a/libs/application/templates/hh/courses/src/utils/isCourseForProfessionals.ts
+++ b/libs/application/templates/hh/courses/src/utils/isCourseForProfessionals.ts
@@ -1,11 +1,18 @@
 import { getValueViaPath } from '@island.is/application/core'
 import { getCachedCourseListPageId } from './loadOptions'
+import { parseQueryParamValue } from './parseQueryParamValue'
 
-const COURSE_LIST_PAGE_ID_FOR_PROFESSIONALS = '147YftiWFQsBcbUFFe2rj1'
+export const COURSE_LIST_PAGE_ID_FOR_PROFESSIONALS = '147YftiWFQsBcbUFFe2rj1'
 
 export const isCourseForProfessionals = (
   answers: Record<string, unknown>,
 ): boolean => {
+  const initialQuery = getValueViaPath<string>(answers, 'initialQuery', '')
+  const courseListPageIdFromQuery =
+    parseQueryParamValue(initialQuery)?.courseListPageId
+  if (courseListPageIdFromQuery)
+    return courseListPageIdFromQuery === COURSE_LIST_PAGE_ID_FOR_PROFESSIONALS
+
   const courseId = getValueViaPath<string>(answers, 'courseSelect', '')
   return (
     getCachedCourseListPageId(courseId) ===

--- a/libs/application/templates/hh/courses/src/utils/loadOptions.ts
+++ b/libs/application/templates/hh/courses/src/utils/loadOptions.ts
@@ -15,6 +15,10 @@ import {
   GET_COURSE_BY_ID_QUERY,
   GET_COURSE_SELECT_OPTIONS_QUERY,
 } from '../graphql'
+import {
+  COURSE_LIST_PAGE_ID_FOR_PROFESSIONALS,
+  isCourseForProfessionals,
+} from './isCourseForProfessionals'
 
 const cache = storageFactory(() => localStorage)
 
@@ -41,6 +45,7 @@ export const doesCourseInstanceHaveChargeItemCode = (
 
 export const loadCourseSelectOptions = async ({
   apolloClient,
+  application,
 }: AsyncSelectContext) => {
   const { data } = await apolloClient.query<
     Query,
@@ -55,10 +60,16 @@ export const loadCourseSelectOptions = async ({
       },
     },
   })
-  return data.getCourseSelectOptions.items.map((item) => ({
-    value: item.id,
-    label: item.title,
-  }))
+  return data.getCourseSelectOptions.items
+    .filter((item) =>
+      isCourseForProfessionals(application.answers)
+        ? item.courseListPageId === COURSE_LIST_PAGE_ID_FOR_PROFESSIONALS
+        : item.courseListPageId !== COURSE_LIST_PAGE_ID_FOR_PROFESSIONALS,
+    )
+    .map((item) => ({
+      value: item.id,
+      label: item.title,
+    }))
 }
 
 export const getCachedCourseListPageId = (

--- a/libs/application/templates/hh/courses/src/utils/loadOptions.ts
+++ b/libs/application/templates/hh/courses/src/utils/loadOptions.ts
@@ -19,6 +19,8 @@ import {
   COURSE_LIST_PAGE_ID_FOR_PROFESSIONALS,
   isCourseForProfessionals,
 } from './isCourseForProfessionals'
+import { getValueViaPath } from '@island.is/application/core'
+import { parseQueryParamValue } from './parseQueryParamValue'
 
 const cache = storageFactory(() => localStorage)
 
@@ -60,12 +62,23 @@ export const loadCourseSelectOptions = async ({
       },
     },
   })
+
+  const initialQuery = parseQueryParamValue(
+    getValueViaPath<string>(application.answers, 'initialQuery', ''),
+  )
+
+  const queryItem = data.getCourseSelectOptions.items.find(
+    (item) => item.id === initialQuery?.courseId,
+  )
+
   return data.getCourseSelectOptions.items
-    .filter((item) =>
-      isCourseForProfessionals(application.answers)
+    .filter((item) => {
+      if (queryItem?.courseListPageId)
+        return item.courseListPageId === queryItem?.courseListPageId
+      return isCourseForProfessionals(application.answers)
         ? item.courseListPageId === COURSE_LIST_PAGE_ID_FOR_PROFESSIONALS
-        : item.courseListPageId !== COURSE_LIST_PAGE_ID_FOR_PROFESSIONALS,
-    )
+        : item.courseListPageId !== COURSE_LIST_PAGE_ID_FOR_PROFESSIONALS
+    })
     .map((item) => ({
       value: item.id,
       label: item.title,

--- a/libs/application/templates/hh/courses/src/utils/parseQueryParamValue.ts
+++ b/libs/application/templates/hh/courses/src/utils/parseQueryParamValue.ts
@@ -1,6 +1,8 @@
 export const parseQueryParamValue = (
   value?: string,
-): { courseId?: string; courseInstanceId?: string } | undefined => {
+):
+  | { courseId?: string; courseInstanceId?: string; courseListPageId?: string }
+  | undefined => {
   if (!value) return undefined
   try {
     const parsedValue = JSON.parse(value)

--- a/libs/cms/src/lib/cms.contentful.service.ts
+++ b/libs/cms/src/lib/cms.contentful.service.ts
@@ -1869,7 +1869,7 @@ export class CmsContentfulService {
       content_type: 'course',
       limit: 1000,
       include: 0,
-      select: 'fields.title,sys',
+      select: 'fields.title,sys,fields.courseListPage',
       'fields.courseListPage.sys.contentType.sys.id': 'courseListPage',
       'fields.courseListPage.fields.organization.sys.id': input.organizationId,
     }

--- a/libs/cms/src/lib/cms.contentful.service.ts
+++ b/libs/cms/src/lib/cms.contentful.service.ts
@@ -1884,6 +1884,7 @@ export class CmsContentfulService {
     const items = response.items.map((item) => ({
       id: item.sys.id,
       title: item.fields.title,
+      courseListPageId: item.fields.courseListPage?.sys?.id,
     }))
 
     items.sort(sortAlpha('title'))

--- a/libs/cms/src/lib/cms.contentful.service.ts
+++ b/libs/cms/src/lib/cms.contentful.service.ts
@@ -1868,7 +1868,7 @@ export class CmsContentfulService {
     const params = {
       content_type: 'course',
       limit: 1000,
-      include: 0,
+      include: 1,
       select: 'fields.title,sys,fields.courseListPage',
       'fields.courseListPage.sys.contentType.sys.id': 'courseListPage',
       'fields.courseListPage.fields.organization.sys.id': input.organizationId,

--- a/libs/cms/src/lib/cms.contentful.service.ts
+++ b/libs/cms/src/lib/cms.contentful.service.ts
@@ -1878,7 +1878,7 @@ export class CmsContentfulService {
       await this.contentfulRepository.getLocalizedEntries<types.ICourseFields>(
         input.lang,
         params,
-        0,
+        1,
       )
 
     const items = response.items.map((item) => ({

--- a/libs/cms/src/lib/models/course.model.ts
+++ b/libs/cms/src/lib/models/course.model.ts
@@ -196,6 +196,9 @@ class CourseSelectOption {
 
   @Field(() => String)
   title!: string
+
+  @Field(() => String, { nullable: true })
+  courseListPageId?: string | null
 }
 
 @ObjectType()


### PR DESCRIPTION
# Stop fetching health center info for professional courses

Shift the hh courses application into two groups.

1. Professional courses (there we stop storing health center info)
2. Public courses

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [x] No AI tools were used in preparing this pull request
- [ ] AI tools were used in preparing this pull request
      Tools used:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Course selection now filters options by course type (professional vs non-professional).
  * URL query parameter support added to improve course type detection.
  * Course selection and registration payloads now include an additional page identifier.
  * Application title now adapts messaging for professional vs non-professional courses.

* **Bug Fixes**
  * Health center information now displays only for non-professional course applications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->