### PR TITLE
feat(driving-license): forward sendPlasticToPerson to BE submission

### DIFF
--- a/libs/api/domains/driving-license/src/lib/drivingLicense.service.ts
+++ b/libs/api/domains/driving-license/src/lib/drivingLicense.service.ts
@@ -587,6 +587,7 @@ export class DrivingLicenseService {
       contentList: input.contentList,
       photoBiometricsId: input.photoBiometricsId,
       signatureBiometricsId: input.signatureBiometricsId,
+      sendPlasticToPerson: input.sendPlasticToPerson,
       healthDeclarationModel: input.healthDeclarationModel,
     })
 

--- a/libs/api/domains/driving-license/src/lib/drivingLicense.type.ts
+++ b/libs/api/domains/driving-license/src/lib/drivingLicense.type.ts
@@ -74,6 +74,7 @@ export interface NewBEDrivingLicenseInput {
   contentList?: NewBEDrivingLicenseContentItem[]
   photoBiometricsId?: string | null
   signatureBiometricsId?: string | null
+  sendPlasticToPerson?: boolean
   healthDeclarationModel: NewBEHealthDeclaration
 }
 

--- a/libs/application/template-api-modules/src/lib/modules/templates/transport-authority/driving-license-submission/driving-license-submission.service.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/transport-authority/driving-license-submission/driving-license-submission.service.ts
@@ -661,6 +661,7 @@ export class DrivingLicenseSubmissionService extends BaseTemplateApiService {
           contentList,
           photoBiometricsId,
           signatureBiometricsId,
+          sendPlasticToPerson: deliveryMethod === Pickup.POST,
           healthDeclarationModel,
         },
       )

--- a/libs/application/template-api-modules/src/lib/modules/templates/transport-authority/driving-license-submission/driving-license-submission.spec.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/transport-authority/driving-license-submission/driving-license-submission.spec.ts
@@ -609,4 +609,131 @@ describe('DrivingLicenseSubmissionService', () => {
       })
     })
   })
+
+  describe('BE branch', () => {
+    let service: DrivingLicenseSubmissionService
+    let applyForBELicense: jest.Mock
+
+    const baseAnswers = {
+      applicationFor: 'BE',
+      email: 'mock@email.com',
+      phone: '9999999',
+    }
+
+    beforeEach(async () => {
+      applyForBELicense = jest.fn(async () => ({
+        success: true,
+        errorMessage: null,
+      }))
+
+      const module = await Test.createTestingModule({
+        imports: [
+          ConfigModule.forRoot({
+            isGlobal: true,
+            load: [emailModuleConfig],
+          }),
+        ],
+        providers: [
+          DrivingLicenseSubmissionService,
+          EmailService,
+          AdapterService,
+          {
+            provide: DrivingLicenseService,
+            useValue: { applyForBELicense },
+          },
+          { provide: LOGGER_PROVIDER, useValue: logger },
+          {
+            provide: ConfigService,
+            useClass: jest.fn(() => ({ get: () => 'http://localhost' })),
+          },
+          {
+            provide: AttachmentS3Service,
+            useValue: { getFiles: jest.fn(async () => []) },
+          },
+          {
+            provide: SharedTemplateApiService,
+            useClass: jest.fn(() => ({
+              async getPaymentStatus() {
+                return { fulfilled: true }
+              },
+              async sendEmail() {
+                return 'messageId'
+              },
+            })),
+          },
+        ],
+      }).compile()
+
+      service = module.get(DrivingLicenseSubmissionService)
+    })
+
+    it('forwards sendPlasticToPerson: true when the delivery method is post (home delivery)', async () => {
+      const user = createCurrentUser()
+      const application = createApplication({
+        answers: {
+          ...baseAnswers,
+          delivery: { deliveryMethod: 'post', jurisdiction: '37' },
+        },
+        typeId: ApplicationTypes.DRIVING_LICENSE,
+        status: ApplicationStatus.IN_PROGRESS,
+      })
+
+      const res = await service.submitApplication({
+        application,
+        auth: user,
+        currentUserLocale: 'is',
+      })
+
+      expect(res).toEqual({ success: true })
+      expect(applyForBELicense).toHaveBeenCalledTimes(1)
+      const [, , input] = applyForBELicense.mock.calls[0]
+      expect(input).toMatchObject({
+        jurisdiction: 37,
+        sendPlasticToPerson: true,
+      })
+    })
+
+    it('forwards sendPlasticToPerson: false when the delivery method is district (pickup)', async () => {
+      const user = createCurrentUser()
+      const application = createApplication({
+        answers: {
+          ...baseAnswers,
+          delivery: { deliveryMethod: 'district', jurisdiction: '37' },
+        },
+        typeId: ApplicationTypes.DRIVING_LICENSE,
+        status: ApplicationStatus.IN_PROGRESS,
+      })
+
+      await service.submitApplication({
+        application,
+        auth: user,
+        currentUserLocale: 'is',
+      })
+
+      expect(applyForBELicense).toHaveBeenCalledTimes(1)
+      const [, , input] = applyForBELicense.mock.calls[0]
+      expect(input.sendPlasticToPerson).toBe(false)
+    })
+
+    it('defaults sendPlasticToPerson to false (pickup) when no delivery method is set', async () => {
+      const user = createCurrentUser()
+      const application = createApplication({
+        answers: {
+          ...baseAnswers,
+        },
+        typeId: ApplicationTypes.DRIVING_LICENSE,
+        status: ApplicationStatus.IN_PROGRESS,
+      })
+
+      await service.submitApplication({
+        application,
+        auth: user,
+        currentUserLocale: 'is',
+      })
+
+      expect(applyForBELicense).toHaveBeenCalledTimes(1)
+      const [, , input] = applyForBELicense.mock.calls[0]
+      expect(input.sendPlasticToPerson).toBe(false)
+    })
+  })
 })

--- a/libs/clients/driving-license/src/lib/drivingLicenseApi.service.ts
+++ b/libs/clients/driving-license/src/lib/drivingLicenseApi.service.ts
@@ -585,6 +585,7 @@ export class DrivingLicenseApi {
     contentList?: v5.ContractsRLSApplicationSystemRLSApplicationContentModel[]
     photoBiometricsId?: string | null
     signatureBiometricsId?: string | null
+    sendPlasticToPerson?: boolean
     healthDeclarationModel: v5.ModelsHealthDeclarationModel
   }): Promise<boolean> {
     const response = await this.applicationV5.apiApplicationsV5ApplyforBePost({
@@ -600,6 +601,7 @@ export class DrivingLicenseApi {
         contentList: params.contentList,
         photoBiometricsId: params.photoBiometricsId,
         signatureBiometricsId: params.signatureBiometricsId,
+        sendPlasticToPerson: params.sendPlasticToPerson,
         healthDeclarationModel: params.healthDeclarationModel,
       },
     })

--- a/libs/clients/driving-license/src/v5/clientConfig.json
+++ b/libs/clients/driving-license/src/v5/clientConfig.json
@@ -5141,6 +5141,11 @@
             "description": "If person chooses signature from þjóðskrá, then this is\r\na placeholder for that biometric id",
             "nullable": true
           },
+          "sendPlasticToPerson": {
+            "type": "boolean",
+            "description": "Person requests plastic to be sent to them",
+            "nullable": true
+          },
           "healthDeclarationModel": {
             "$ref": "#/components/schemas/Models.HealthDeclarationModel"
           }


### PR DESCRIPTION
Note: this should not be merged until at least june 16.

## What

Forward the user's delivery choice into the **BE-category** driving-license submission as the new RLS `sendPlasticToPerson` field:

- `post` → `true` (license mailed to the applicant's home)
- `district` / unset → `false` (pickup at the office of the applicant's legal domicile)

## Why

The BE flow already collects the delivery choice (post vs district pickup) and charges the `AY145` delivery fee, but the submission **never forwarded it to RLS** — so the card defaulted to pickup regardless of what the applicant picked and paid for. RLS added `sendPlasticToPerson` to the BE model; this closes the gap, matching the other license types (B-full/B-temp send `sendLicenseInMail`; 65+ renewal sends `sendPlasticToPerson`).

## Changes

- Add `sendPlasticToPerson` to the checked-in v5 OpenAPI config (`clientConfig.json`) for the `PostApplicationForBEModel`. The generated client (`gen/fetch/**`) is git-ignored and produced from `clientConfig.json` by the `codegen/backend-client` step, so no generated files are committed.
- Thread it through: client `postApplyForBELicense` → api-domain `NewBEDrivingLicenseInput` / `applyForBELicense` → submission service BE branch (`deliveryMethod === Pickup.POST`).
- BE-branch unit tests: post→`true`, district→`false`, unset→`false`.

This is a **minimal, targeted** spec patch — only the BE field — not a full live-spec resync. Only `sendPlasticToPerson` is sent (no `pickupPlasticAtDistrict`), per the RLS contract.

## Notes

- BE is behind a feature flag. The field is live in RLS **dev**; it must reach RLS **prod** before this ships to prod (nullable, low risk).
- **Out of scope / follow-up:** a fresh live v5 pull shows RLS has dropped `pickupPlasticAtDistrict` and `renewalDate` from `Models.V5.PostRenewal65` (the active 65+ renewal model; the legacy `PostRenewal65AndOver` is unchanged). Our `postApplyForRenewal65` still sends those. To be reconciled in a separate PR after confirming with the RLS team whether the removal is intentional — deliberately **not** bundled here to keep this an additive change.

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Belgium driving license applications now include a delivery preference: choose home delivery (plastic sent) or district pickup; the system maps your selection automatically.

* **Tests**
  * Added tests ensuring delivery method is correctly translated into the backend request (home delivery vs. pickup).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->