### PR TITLE
fix(my-pages): PDF modal download text

### DIFF
--- a/libs/portals/my-pages/core/src/components/PdfModal/PdfModal.tsx
+++ b/libs/portals/my-pages/core/src/components/PdfModal/PdfModal.tsx
@@ -174,9 +174,9 @@ export const PdfModal = ({
             variant="utility"
             size="small"
             onClick={handleDownload}
-            aria-label={isMobile ? formatMessage(m.download) : undefined}
+            aria-label={isMobile ? formatMessage(m.get) : undefined}
           >
-            {isMobile ? undefined : formatMessage(m.download)}
+            {isMobile ? undefined : formatMessage(m.get)}
           </Button>
           <DialogDismiss
             render={


### PR DESCRIPTION
# My pages - PDF modal

Use "Sækja" instead of "Niðurhala" 

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [x] No AI tools were used in preparing this pull request
- [ ] AI tools were used in preparing this pull request
      Tools used:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the label text on the download button in the PDF modal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->