### PR TITLE
feat(user-notification): add feature flags for national/company registry checks

### DIFF
--- a/apps/services/user-notification/src/app/modules/notifications/notificationsWorker/notificationsWorker.service.ts
+++ b/apps/services/user-notification/src/app/modules/notifications/notificationsWorker/notificationsWorker.service.ts
@@ -734,7 +734,7 @@ export class NotificationsWorkerService {
   ): Promise<boolean> {
     const enabled = await this.featureFlagService.getValue(
       Features.isUserNotificationDeceasedCheckEnabled,
-      true,
+      false,
       { nationalId } as User,
     )
 
@@ -761,7 +761,7 @@ export class NotificationsWorkerService {
   ): Promise<boolean> {
     const enabled = await this.featureFlagService.getValue(
       Features.isUserNotificationInactiveCompanyCheckEnabled,
-      true,
+      false,
       { nationalId } as User,
     )
 

--- a/apps/services/user-notification/src/app/modules/notifications/notificationsWorker/notificationsWorker.service.ts
+++ b/apps/services/user-notification/src/app/modules/notifications/notificationsWorker/notificationsWorker.service.ts
@@ -732,6 +732,16 @@ export class NotificationsWorkerService {
     nationalId: string,
     messageId: string,
   ): Promise<boolean> {
+    const enabled = await this.featureFlagService.getValue(
+      Features.isUserNotificationDeceasedCheckEnabled,
+      true,
+      { nationalId } as User,
+    )
+
+    if (!enabled) {
+      return false
+    }
+
     try {
       const individual =
         await this.nationalRegistryService.getAllDataIndividual(nationalId)

--- a/apps/services/user-notification/src/app/modules/notifications/notificationsWorker/notificationsWorker.service.ts
+++ b/apps/services/user-notification/src/app/modules/notifications/notificationsWorker/notificationsWorker.service.ts
@@ -759,6 +759,16 @@ export class NotificationsWorkerService {
     nationalId: string,
     messageId: string,
   ): Promise<boolean> {
+    const enabled = await this.featureFlagService.getValue(
+      Features.isUserNotificationInactiveCompanyCheckEnabled,
+      true,
+      { nationalId } as User,
+    )
+
+    if (!enabled) {
+      return false
+    }
+
     try {
       const company = await this.companyRegistryService.getCompany(nationalId)
       return company !== null && company.status === INACTIVE_COMPANY_STATUS

--- a/libs/feature-flags/src/lib/features.ts
+++ b/libs/feature-flags/src/lib/features.ts
@@ -165,6 +165,9 @@ export enum Features {
 
   delegationTypesWithNotificationsEnabled = 'delegationTypesWithNotificationsEnabled',
 
+  // Should user-notification worker check deceased status via national registry
+  isUserNotificationDeceasedCheckEnabled = 'isUserNotificationDeceasedCheckEnabled',
+
   // Allow fake data
   digitalTachographDriversCardAllowFakeData = 'digitalTachographDriversCardAllowFakeData',
 

--- a/libs/feature-flags/src/lib/features.ts
+++ b/libs/feature-flags/src/lib/features.ts
@@ -168,6 +168,9 @@ export enum Features {
   // Should user-notification worker check deceased status via national registry
   isUserNotificationDeceasedCheckEnabled = 'isUserNotificationDeceasedCheckEnabled',
 
+  // Should user-notification worker check inactive company status via company registry
+  isUserNotificationInactiveCompanyCheckEnabled = 'isUserNotificationInactiveCompanyCheckEnabled',
+
   // Allow fake data
   digitalTachographDriversCardAllowFakeData = 'digitalTachographDriversCardAllowFakeData',
 


### PR DESCRIPTION
# Add feature flags for national/company registry checks

## What

- Add feature flag `isUserNotificationDeceasedCheckEnabled` and gate the `isRecipientDeceased` check (Midlun) behind it.
- Add feature flag `isUserNotificationInactiveCompanyCheckEnabled` and gate the `isCompanyInactive` check (RSK) behind it.
- Both flags default to `false` — the checks are skipped until explicitly enabled in ConfigCat.

## Why

- We want enable/disable either check globally via ConfigCat

## Screenshots / Gifs

N/A

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added feature flags to control deceased status and inactive company validation checks in user notifications, enabling these checks to be toggled independently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->