### PR TITLE
fix(web): Disallow fetching court agenda items for past dates

### DIFF
--- a/apps/web/screens/CourtAgendas/CourtAgendas.tsx
+++ b/apps/web/screens/CourtAgendas/CourtAgendas.tsx
@@ -1,6 +1,8 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useIntl } from 'react-intl'
 import cn from 'classnames'
+import addDays from 'date-fns/addDays'
+import startOfDay from 'date-fns/startOfDay'
 import isEqual from 'lodash/isEqual'
 import {
   parseAsArrayOf,
@@ -212,6 +214,8 @@ interface CourtAgendasProps {
   lawyers: GetVerdictLawyersQuery['webVerdictLawyers']['lawyers']
   scheduleTypes: Query['webCourtScheduleTypes']
   caseTypes: GetVerdictCaseFilterOptionsPerCourtQuery['webVerdictCaseFilterOptionsPerCourt']
+  minDateFrom: string
+  minDateTo: string
 }
 
 const buildCourtInput = (
@@ -448,6 +452,8 @@ interface FiltersProps {
   scheduleTypesOptions: { label: string; value: string }[]
   caseTypesOptions: { label: string; value: string }[]
   showScheduleTypeFilter: boolean
+  minDateFrom: string
+  minDateTo: string
 }
 
 const Filters = ({
@@ -461,6 +467,8 @@ const Filters = ({
   scheduleTypesOptions,
   caseTypesOptions,
   showScheduleTypeFilter,
+  minDateFrom,
+  minDateTo,
 }: FiltersProps) => {
   const { formatMessage } = useIntl()
   const filterAccordionItemIds = useMemo(
@@ -549,6 +557,7 @@ const Filters = ({
                   }}
                   value={queryState[QueryParam.DATE_FROM]}
                   maxDate={queryState[QueryParam.DATE_TO]}
+                  minDate={new Date(minDateFrom)}
                 />
                 <DebouncedDatePicker
                   debounceTimeInMs={DEBOUNCE_TIME_IN_MS}
@@ -558,7 +567,9 @@ const Filters = ({
                     updateQueryState(QueryParam.DATE_TO, date)
                   }}
                   value={queryState[QueryParam.DATE_TO]}
-                  minDate={queryState[QueryParam.DATE_FROM]}
+                  minDate={
+                    queryState[QueryParam.DATE_FROM] ?? new Date(minDateTo)
+                  }
                 />
               </Stack>
               <Box display="flex" justifyContent="flexEnd">
@@ -868,7 +879,7 @@ const CourtAgendas: CustomScreen<CourtAgendasProps> = (props) => {
       tags.push({
         label: `${formatMessage(m.listPage.dateFromLabel)}: ${format(
           queryState[QueryParam.DATE_FROM],
-          'P',
+          'dd.MM.yyyy',
         )}`,
         onClick: () => {
           updateQueryState(QueryParam.DATE_FROM, null)
@@ -881,7 +892,7 @@ const CourtAgendas: CustomScreen<CourtAgendasProps> = (props) => {
       tags.push({
         label: `${formatMessage(m.listPage.dateToLabel)}: ${format(
           queryState[QueryParam.DATE_TO],
-          'P',
+          'dd.MM.yyyy',
         )}`,
         onClick: () => {
           updateQueryState(QueryParam.DATE_TO, null)
@@ -1413,6 +1424,8 @@ const CourtAgendas: CustomScreen<CourtAgendasProps> = (props) => {
                   scheduleTypesOptions={scheduleTypesOptions}
                   caseTypesOptions={caseTypesOptions}
                   showScheduleTypeFilter={showScheduleTypeFilter}
+                  minDateFrom={props.minDateFrom}
+                  minDateTo={props.minDateTo}
                 />
                 <Box
                   background="blue100"
@@ -1486,6 +1499,8 @@ const CourtAgendas: CustomScreen<CourtAgendasProps> = (props) => {
                         scheduleTypesOptions={scheduleTypesOptions}
                         caseTypesOptions={caseTypesOptions}
                         showScheduleTypeFilter={showScheduleTypeFilter}
+                        minDateFrom={props.minDateFrom}
+                        minDateTo={props.minDateTo}
                       />
                     </Box>
                   </Filter>
@@ -1691,7 +1706,12 @@ CourtAgendas.getProps = async ({ apolloClient, customPageData, query }) => {
 
   const items = courtAgendasResponse.data.webCourtAgendas.items
 
+  const today = startOfDay(new Date())
+  const yesterday = addDays(today, -1)
+
   return {
+    minDateFrom: yesterday.toISOString(),
+    minDateTo: today.toISOString(),
     initialData: {
       visibleCourtAgendas: items.slice(0, ITEMS_PER_PAGE),
       invisibleCourtAgendas: items.slice(ITEMS_PER_PAGE),

--- a/apps/web/screens/CourtAgendas/CourtAgendas.tsx
+++ b/apps/web/screens/CourtAgendas/CourtAgendas.tsx
@@ -1707,10 +1707,9 @@ CourtAgendas.getProps = async ({ apolloClient, customPageData, query }) => {
   const items = courtAgendasResponse.data.webCourtAgendas.items
 
   const today = startOfDay(new Date())
-  const yesterday = addDays(today, -1)
 
   return {
-    minDateFrom: yesterday.toISOString(),
+    minDateFrom: today.toISOString(),
     minDateTo: today.toISOString(),
     initialData: {
       visibleCourtAgendas: items.slice(0, ITEMS_PER_PAGE),

--- a/apps/web/screens/Verdicts/VerdictsList.tsx
+++ b/apps/web/screens/Verdicts/VerdictsList.tsx
@@ -1171,7 +1171,7 @@ const VerdictsList: CustomScreen<VerdictsListProps> = (props) => {
       tags.push({
         label: `${formatMessage(m.listPage.dateFromLabel)}: ${format(
           queryState[QueryParam.DATE_FROM],
-          'P',
+          'dd.MM.yyyy',
         )}`,
         onClick: () => {
           updateQueryState(QueryParam.DATE_FROM, null)
@@ -1184,7 +1184,7 @@ const VerdictsList: CustomScreen<VerdictsListProps> = (props) => {
       tags.push({
         label: `${formatMessage(m.listPage.dateToLabel)}: ${format(
           queryState[QueryParam.DATE_TO],
-          'P',
+          'dd.MM.yyyy',
         )}`,
         onClick: () => {
           updateQueryState(QueryParam.DATE_TO, null)

--- a/libs/clients/verdicts/src/lib/verdicts-client.service.ts
+++ b/libs/clients/verdicts/src/lib/verdicts-client.service.ts
@@ -273,17 +273,7 @@ export class VerdictsClientService {
           court: goproItem.court?.name ?? '',
           caseNumber: goproItem.caseNumber ?? '',
           verdictDate: goproItem.verdictDate,
-          verdictJudges:
-            goproItem.court?.code !== 'landsrettur'
-              ? (goproItem.judges ?? []).map((judge) => ({
-                  name: judge.name ?? '',
-                  title: !goproItem.court?.name
-                    ?.toLowerCase()
-                    ?.startsWith('enduruppt')
-                    ? judge.title ?? ''
-                    : '',
-                }))
-              : [],
+          verdictJudges: [],
           keywords: goproItem.keywords ?? [],
           presentings: goproItem.presentings ?? '',
         })
@@ -574,6 +564,20 @@ export class VerdictsClientService {
 
     const { goproCourtAgendasApi } = await this.getAuthenticatedGoproApis()
 
+    const yesterday = new Date()
+    yesterday.setDate(yesterday.getDate() - 1)
+    yesterday.setHours(0, 0, 0, 0)
+
+    const parsedInputDateFrom = input.dateFrom
+      ? safelyConvertStringToDate(input.dateFrom, 'dateFrom', this.logger)
+      : undefined
+    const effectiveGoproDateFrom =
+      parsedInputDateFrom && parsedInputDateFrom >= yesterday
+        ? parsedInputDateFrom
+        : yesterday
+    const goproDateFrom = effectiveGoproDateFrom.toISOString()
+    const goproDateTo = input.dateTo || undefined
+
     const [supremeCourtResponse, goproResponse] = await Promise.allSettled([
       shouldFetchSupremeCourtAgendas
         ? this.supremeCourtApi.apiV2VerdictGetAgendasPost({
@@ -605,12 +609,8 @@ export class VerdictsClientService {
             pageNumber: pageNumber,
             courts: goproCourtsForApi,
             itemsPerPage,
-            dateFrom: input.dateFrom
-              ? input.dateFrom
-              : !input.dateTo
-              ? this.getDefaultDateFrom().dateString
-              : undefined,
-            dateTo: input.dateTo ? input.dateTo : undefined,
+            dateFrom: goproDateFrom,
+            dateTo: goproDateTo,
             lawyer: input.lawyer ? input.lawyer : undefined,
             orderBy: 'StartDateTime',
             orderDirection: 'ASC',

--- a/libs/clients/verdicts/src/lib/verdicts-client.service.ts
+++ b/libs/clients/verdicts/src/lib/verdicts-client.service.ts
@@ -564,17 +564,16 @@ export class VerdictsClientService {
 
     const { goproCourtAgendasApi } = await this.getAuthenticatedGoproApis()
 
-    const yesterday = new Date()
-    yesterday.setDate(yesterday.getDate() - 1)
-    yesterday.setHours(0, 0, 0, 0)
+    const today = new Date()
+    today.setHours(0, 0, 0, 0)
 
     const parsedInputDateFrom = input.dateFrom
       ? safelyConvertStringToDate(input.dateFrom, 'dateFrom', this.logger)
       : undefined
     const effectiveGoproDateFrom =
-      parsedInputDateFrom && parsedInputDateFrom >= yesterday
+      parsedInputDateFrom && parsedInputDateFrom >= today
         ? parsedInputDateFrom
-        : yesterday
+        : today
     const goproDateFrom = effectiveGoproDateFrom.toISOString()
     const goproDateTo = input.dateTo || undefined
 


### PR DESCRIPTION
# Disallow fetching court agenda items for past dates

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code v2.1.162 - Sonnet 4.6


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added minimum date constraints to court agenda filters so date ranges cannot go earlier than the allowed cutoff; applies consistently on desktop and mobile.
  * Server provides the earliest selectable date for agenda searches to align UI and results.

* **Bug Fixes**
  * Standardized date filter tags to dd.MM.yyyy across agendas and verdicts.
  * Verdict list no longer displays inferred judge titles for some items.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->