### PR TITLE
fix(j-s): use original case id for police digital files in extended and split cases

### DIFF
--- a/apps/judicial-system/web/src/components/IndictmentCaseFilesList/IndictmentCaseFilesList.tsx
+++ b/apps/judicial-system/web/src/components/IndictmentCaseFilesList/IndictmentCaseFilesList.tsx
@@ -393,7 +393,7 @@ const IndictmentCaseFilesList: FC<Props> = ({
     )
 
   const { digitalCaseFiles, digitalCaseFilesLoading, openDigitalCaseFileUrl } =
-    usePoliceDigitalCaseFile(workingCase.id, workingCase.origin)
+    usePoliceDigitalCaseFile()
 
   const showDigitalCaseFilesSection =
     (isDistrictCourtUser(user) || isCourtOfAppealsUser(user)) &&

--- a/apps/judicial-system/web/src/routes/Court/InvestigationCase/Overview/Overview.tsx
+++ b/apps/judicial-system/web/src/routes/Court/InvestigationCase/Overview/Overview.tsx
@@ -62,7 +62,7 @@ const Overview = () => {
   const { user } = useContext(UserContext)
   const { uploadState } = useCourtUpload(workingCase, setWorkingCase)
   const { digitalCaseFiles, digitalCaseFilesLoading, openDigitalCaseFileUrl } =
-    usePoliceDigitalCaseFile(workingCase.id, workingCase.origin)
+    usePoliceDigitalCaseFile()
   const [isDraftingConclusion, setIsDraftingConclusion] = useState<boolean>()
   const {
     defendants,

--- a/apps/judicial-system/web/src/routes/Court/RestrictionCase/Overview/Overview.tsx
+++ b/apps/judicial-system/web/src/routes/Court/RestrictionCase/Overview/Overview.tsx
@@ -65,7 +65,7 @@ export const JudgeOverview = () => {
 
   const { uploadState } = useCourtUpload(workingCase, setWorkingCase)
   const { digitalCaseFiles, digitalCaseFilesLoading, openDigitalCaseFileUrl } =
-    usePoliceDigitalCaseFile(workingCase.id, workingCase.origin)
+    usePoliceDigitalCaseFile()
   const {
     defendants,
     policeCaseNumbers,

--- a/apps/judicial-system/web/src/routes/CourtOfAppeal/Overview/Overview.tsx
+++ b/apps/judicial-system/web/src/routes/CourtOfAppeal/Overview/Overview.tsx
@@ -54,7 +54,7 @@ const Overview = () => {
   const router = useRouter()
   const { user } = useContext(UserContext)
   const { digitalCaseFiles, digitalCaseFilesLoading, openDigitalCaseFileUrl } =
-    usePoliceDigitalCaseFile(workingCase.id, workingCase.origin)
+    usePoliceDigitalCaseFile()
   const {
     defendants,
     policeCaseNumbers,

--- a/apps/judicial-system/web/src/routes/CourtOfAppeal/Result/Result.tsx
+++ b/apps/judicial-system/web/src/routes/CourtOfAppeal/Result/Result.tsx
@@ -50,7 +50,7 @@ const Result = () => {
   const { appealBanner } = useAppealCaseBanner()
   const targetAppealCase = useTargetAppealCaseByAppealCaseId()
   const { digitalCaseFiles, digitalCaseFilesLoading, openDigitalCaseFileUrl } =
-    usePoliceDigitalCaseFile(workingCase.id, workingCase.origin)
+    usePoliceDigitalCaseFile()
 
   const {
     defendants,

--- a/apps/judicial-system/web/src/routes/Prosecutor/Indictments/CaseFile/CaseFile.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/Indictments/CaseFile/CaseFile.tsx
@@ -33,10 +33,7 @@ const CaseFile = () => {
   const { workingCase, isLoadingWorkingCase, caseNotFound } =
     useContext(FormContext)
 
-  const { digitalCaseFiles } = usePoliceDigitalCaseFile(
-    workingCase.id,
-    workingCase.origin,
-  )
+  const { digitalCaseFiles } = usePoliceDigitalCaseFile()
 
   const caseFiles = useMemo(() => {
     return new Map<string, TCaseFile[]>(

--- a/apps/judicial-system/web/src/routes/Prosecutor/Indictments/PoliceCaseFiles/PoliceCaseFilesRoute.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/Indictments/PoliceCaseFiles/PoliceCaseFilesRoute.tsx
@@ -91,7 +91,7 @@ const PoliceUploadListMemo: FC<PoliceUploadListMenuProps> = memo(
       digitalCaseFilesLoading,
       digitalCaseFilesError,
       deletePoliceDigitalCaseFile,
-    } = usePoliceDigitalCaseFile(caseId, caseOrigin)
+    } = usePoliceDigitalCaseFile()
 
     const [policeCaseFilesData, setPoliceCaseFiles] =
       useState<PoliceCaseFilesData>()

--- a/apps/judicial-system/web/src/routes/Prosecutor/InvestigationCase/Overview/Overview.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/InvestigationCase/Overview/Overview.tsx
@@ -132,7 +132,7 @@ export const Overview = () => {
   }
 
   const { digitalCaseFiles, digitalCaseFilesLoading, openDigitalCaseFileUrl } =
-    usePoliceDigitalCaseFile(workingCase.id, workingCase.origin)
+    usePoliceDigitalCaseFile()
 
   const caseFiles =
     workingCase.caseFiles?.filter((file) => !file.category) ?? []

--- a/apps/judicial-system/web/src/routes/Prosecutor/RestrictionCase/Overview/Overview.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/RestrictionCase/Overview/Overview.tsx
@@ -93,7 +93,7 @@ export const Overview = () => {
   } = useInfoCardItems()
 
   const { digitalCaseFiles, digitalCaseFilesLoading, openDigitalCaseFileUrl } =
-    usePoliceDigitalCaseFile(workingCase.id, workingCase.origin)
+    usePoliceDigitalCaseFile()
 
   const handleNextButtonClick = async (caseResentExplanation?: string) => {
     if (!workingCase) {

--- a/apps/judicial-system/web/src/routes/Shared/SignedVerdictOverview/SignedVerdictOverview.tsx
+++ b/apps/judicial-system/web/src/routes/Shared/SignedVerdictOverview/SignedVerdictOverview.tsx
@@ -226,7 +226,7 @@ export const SignedVerdictOverview: FC = () => {
 
   const { appealBanner, appealModals } = useAppealCaseBanner()
   const { digitalCaseFiles, digitalCaseFilesLoading, openDigitalCaseFileUrl } =
-    usePoliceDigitalCaseFile(workingCase.id, workingCase.origin)
+    usePoliceDigitalCaseFile()
 
   /**
    * If the case is not rejected it must be accepted because

--- a/apps/judicial-system/web/src/utils/hooks/usePoliceDigitalCaseFile/index.ts
+++ b/apps/judicial-system/web/src/utils/hooks/usePoliceDigitalCaseFile/index.ts
@@ -9,7 +9,8 @@ import { usePoliceDigitalCaseFilesQuery } from './policeDigitalCaseFiles.generat
 
 const usePoliceDigitalCaseFile = () => {
   const { workingCase, refreshCase } = useContext(FormContext)
-  const { id: caseId, origin: caseOrigin } = workingCase
+  const { id: caseId, origin: caseOrigin, parentCase } = workingCase
+
   const handleCompleted = useCallback(
     (completedData: {
       policeDigitalCaseFiles?: { isNew?: boolean | null }[] | null
@@ -27,7 +28,7 @@ const usePoliceDigitalCaseFile = () => {
     error: digitalCaseFilesError,
     refetch,
   } = usePoliceDigitalCaseFilesQuery({
-    variables: { input: { caseId } },
+    variables: { input: { caseId: parentCase ? parentCase.id : caseId } },
     skip: caseOrigin !== CaseOrigin.LOKE,
     fetchPolicy: 'no-cache',
     errorPolicy: 'all',

--- a/apps/judicial-system/web/src/utils/hooks/usePoliceDigitalCaseFile/index.ts
+++ b/apps/judicial-system/web/src/utils/hooks/usePoliceDigitalCaseFile/index.ts
@@ -8,7 +8,8 @@ import { useDeletePoliceDigitalCaseFileMutation } from './deletePoliceDigitalCas
 import { usePoliceDigitalCaseFilesQuery } from './policeDigitalCaseFiles.generated'
 
 const usePoliceDigitalCaseFile = () => {
-  const { workingCase, isLoadingWorkingCase, refreshCase } = useContext(FormContext)
+  const { workingCase, isLoadingWorkingCase, refreshCase } =
+    useContext(FormContext)
   const { id: caseId, origin: caseOrigin, parentCase, splitCase } = workingCase
 
   const handleCompleted = useCallback(

--- a/apps/judicial-system/web/src/utils/hooks/usePoliceDigitalCaseFile/index.ts
+++ b/apps/judicial-system/web/src/utils/hooks/usePoliceDigitalCaseFile/index.ts
@@ -8,7 +8,7 @@ import { useDeletePoliceDigitalCaseFileMutation } from './deletePoliceDigitalCas
 import { usePoliceDigitalCaseFilesQuery } from './policeDigitalCaseFiles.generated'
 
 const usePoliceDigitalCaseFile = () => {
-  const { workingCase, refreshCase } = useContext(FormContext)
+  const { workingCase, isLoadingWorkingCase, refreshCase } = useContext(FormContext)
   const { id: caseId, origin: caseOrigin, parentCase } = workingCase
 
   const handleCompleted = useCallback(
@@ -29,7 +29,7 @@ const usePoliceDigitalCaseFile = () => {
     refetch,
   } = usePoliceDigitalCaseFilesQuery({
     variables: { input: { caseId: parentCase ? parentCase.id : caseId } },
-    skip: caseOrigin !== CaseOrigin.LOKE,
+    skip: isLoadingWorkingCase || caseOrigin !== CaseOrigin.LOKE,
     fetchPolicy: 'no-cache',
     errorPolicy: 'all',
     onCompleted: handleCompleted,

--- a/apps/judicial-system/web/src/utils/hooks/usePoliceDigitalCaseFile/index.ts
+++ b/apps/judicial-system/web/src/utils/hooks/usePoliceDigitalCaseFile/index.ts
@@ -9,7 +9,7 @@ import { usePoliceDigitalCaseFilesQuery } from './policeDigitalCaseFiles.generat
 
 const usePoliceDigitalCaseFile = () => {
   const { workingCase, isLoadingWorkingCase, refreshCase } = useContext(FormContext)
-  const { id: caseId, origin: caseOrigin, parentCase } = workingCase
+  const { id: caseId, origin: caseOrigin, parentCase, splitCase } = workingCase
 
   const handleCompleted = useCallback(
     (completedData: {
@@ -28,7 +28,7 @@ const usePoliceDigitalCaseFile = () => {
     error: digitalCaseFilesError,
     refetch,
   } = usePoliceDigitalCaseFilesQuery({
-    variables: { input: { caseId: parentCase ? parentCase.id : caseId } },
+    variables: { input: { caseId: parentCase?.id ?? splitCase?.id ?? caseId } },
     skip: isLoadingWorkingCase || caseOrigin !== CaseOrigin.LOKE,
     fetchPolicy: 'no-cache',
     errorPolicy: 'all',

--- a/apps/judicial-system/web/src/utils/hooks/usePoliceDigitalCaseFile/index.ts
+++ b/apps/judicial-system/web/src/utils/hooks/usePoliceDigitalCaseFile/index.ts
@@ -11,6 +11,7 @@ const usePoliceDigitalCaseFile = () => {
   const { workingCase, isLoadingWorkingCase, refreshCase } =
     useContext(FormContext)
   const { id: caseId, origin: caseOrigin, parentCase, splitCase } = workingCase
+  const effectiveCaseId = parentCase?.id ?? splitCase?.id ?? caseId
 
   const handleCompleted = useCallback(
     (completedData: {
@@ -29,7 +30,7 @@ const usePoliceDigitalCaseFile = () => {
     error: digitalCaseFilesError,
     refetch,
   } = usePoliceDigitalCaseFilesQuery({
-    variables: { input: { caseId: parentCase?.id ?? splitCase?.id ?? caseId } },
+    variables: { input: { caseId: effectiveCaseId } },
     skip: isLoadingWorkingCase || caseOrigin !== CaseOrigin.LOKE,
     fetchPolicy: 'no-cache',
     errorPolicy: 'all',
@@ -52,19 +53,19 @@ const usePoliceDigitalCaseFile = () => {
   const openDigitalCaseFileUrl = useCallback(
     (policeDigitalFileId: string) => {
       window.open(
-        `/akaera/rafraen-gogn?caseId=${caseId}&fileId=${policeDigitalFileId}`,
+        `/akaera/rafraen-gogn?caseId=${effectiveCaseId}&fileId=${policeDigitalFileId}`,
         '_blank',
         'noopener',
       )
     },
-    [caseId],
+    [effectiveCaseId],
   )
 
   const deletePoliceDigitalCaseFile = useCallback(
     async (fileId: string) => {
       try {
         const { data } = await deleteMutation({
-          variables: { input: { caseId, fileId } },
+          variables: { input: { caseId: effectiveCaseId, fileId } },
         })
 
         if (data?.deletePoliceDigitalCaseFile) {
@@ -77,7 +78,7 @@ const usePoliceDigitalCaseFile = () => {
         return false
       }
     },
-    [caseId, deleteMutation, refetch],
+    [effectiveCaseId, deleteMutation, refetch],
   )
 
   return {

--- a/apps/judicial-system/web/src/utils/hooks/usePoliceDigitalCaseFile/index.ts
+++ b/apps/judicial-system/web/src/utils/hooks/usePoliceDigitalCaseFile/index.ts
@@ -7,11 +7,9 @@ import { FormContext } from '../../../components'
 import { useDeletePoliceDigitalCaseFileMutation } from './deletePoliceDigitalCaseFile.generated'
 import { usePoliceDigitalCaseFilesQuery } from './policeDigitalCaseFiles.generated'
 
-const usePoliceDigitalCaseFile = (
-  caseId: string,
-  caseOrigin: CaseOrigin | null | undefined,
-) => {
-  const { refreshCase } = useContext(FormContext)
+const usePoliceDigitalCaseFile = () => {
+  const { workingCase, refreshCase } = useContext(FormContext)
+  const { id: caseId, origin: caseOrigin } = workingCase
   const handleCompleted = useCallback(
     (completedData: {
       policeDigitalCaseFiles?: { isNew?: boolean | null }[] | null


### PR DESCRIPTION
## What

- Removes `caseId` and `caseOrigin` params from `usePoliceDigitalCaseFile` — the hook already used `FormContext` for `refreshCase`, so it now reads `workingCase` from there directly
- Skips the query while `isLoadingWorkingCase` is true to prevent a stale request with the previous case's id firing during navigation
- Computes a single `effectiveCaseId` (`parentCase?.id ?? splitCase?.id ?? caseId`) and uses it consistently for the files query, opening a file, and deleting a file — digital police files always live on the original case, so extended and split cases must use the original case's id for every operation

## Why

Digital police case files are always attached to the original case. When viewing an extended case (child) or a split-off case, the query must use the parent/split case's id. Previously only the files query used that fallback, while opening and deleting a file used the working case's id directly — meaning those actions targeted the wrong case for extended/split cases. Consolidating on a single `effectiveCaseId` fixes that inconsistency. Additionally, navigating between cases was triggering a spurious request with the previous case's id before the working case finished loading.

## Screenshots / Gifs


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code
- [ ] No AI tools were used in preparing this pull request

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal retrieval and management of police digital case files across investigation, restriction, indictment, and appeal pages. The system now derives case context from the current page instead of external parameters and avoids querying while case data is loading. All user-facing behavior—file lists, uploads, deletions, refreshes, and document opening—remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->