### PR TITLE
feat(ci): switch to runs-on/cache@v5 with S3 backend

### DIFF
--- a/.github/actions/load-deps/action.yml
+++ b/.github/actions/load-deps/action.yml
@@ -39,12 +39,14 @@ runs:
           --outputsFile=/dev/null
 
     - name: Cache generated files
-      uses: actions/cache@v4
+      uses: runs-on/cache@v5
       id: restore-codegen-cache
       with:
         path: |
           ${{ steps.prepare.outputs.GENERATED_FILES_PATH }}
         key: generated-files-${{ hashFiles(steps.prepare.outputs.INPUTS_LIST_FILE) }}
+      env:
+        RUNS_ON_S3_BUCKET_CACHE: shared-islandis-github-actions-cache
 
     - name: Prepare generated files
       if: steps.restore-codegen-cache.outputs.cache-hit != 'true'

--- a/.github/actions/setup-playwright/action.yml
+++ b/.github/actions/setup-playwright/action.yml
@@ -17,13 +17,14 @@ runs:
         echo "CACHE_KEY=${{ runner.os }}-playwright-${{ hashFiles('yarn.lock') }}-1" >> $GITHUB_OUTPUT
 
     - name: Restore Playwright Cache
-      uses: actions/cache/restore@v4
+      uses: runs-on/cache/restore@v5
       id: restore-playwright-cache
       with:
         path: ~/.cache/ms-playwright
         key: ${{ steps.set-playwright-cache-key.outputs.CACHE_KEY }}
       env:
         AWS_REGION: ${{ env.AWS_REGION || 'eu-west-1' }}
+        RUNS_ON_S3_BUCKET_CACHE: shared-islandis-github-actions-cache
 
     - name: Install Playwright browsers
       working-directory: ${{ inputs.working-directory }}
@@ -31,10 +32,11 @@ runs:
       run: yarn playwright install
 
     - name: Cache Playwright
-      uses: actions/cache/save@v4
+      uses: runs-on/cache/save@v5
       if: steps.restore-playwright-cache.outputs.cache-hit != 'true'
       with:
         path: ~/.cache/ms-playwright
         key: ${{ steps.set-playwright-cache-key.outputs.CACHE_KEY }}
       env:
         AWS_REGION: ${{ env.AWS_REGION || 'eu-west-1' }}
+        RUNS_ON_S3_BUCKET_CACHE: shared-islandis-github-actions-cache

--- a/.github/actions/setup-yarn/action.yml
+++ b/.github/actions/setup-yarn/action.yml
@@ -38,7 +38,7 @@ runs:
         echo "CYPRESS_CACHE_FOLDER=$CYPRESS_CACHE_FOLDER" | tee -a "$GITHUB_ENV"
         echo "cypress-cache=$CYPRESS_CACHE_FOLDER" | tee -a "$GITHUB_OUTPUT"
     - name: Cache Dependencies
-      uses: actions/cache@v4
+      uses: runs-on/cache@v5
       id: restore-cache
       with:
         path: |
@@ -48,6 +48,7 @@ runs:
         key: ${{ runner.os }}-deps-${{ steps.cache-paths.outputs.cypress-cache && 'cypress' || '' }}-${{ hashFiles(format('{0}/yarn.lock', inputs.working-directory)) }}-1-node_modules
       env:
         AWS_REGION: ${{ env.AWS_REGION || 'eu-west-1' }}
+        RUNS_ON_S3_BUCKET_CACHE: shared-islandis-github-actions-cache
 
     - name: Yarn install
       working-directory: ${{ inputs.working-directory }}


### PR DESCRIPTION
Replace actions/cache@v4 with runs-on/cache@v5 backed by shared-islandis-github-actions-cache S3 bucket via VPC Gateway endpoint.

- Eliminates NAT traffic for cache restore/save (~240-320 GB per burst)
- Unlimited cache size (vs GitHub's 10GB limit)
- Falls back to GitHub cache if S3 bucket env is unset
- Runner pods already have IAM access to the bucket via Pod Identity

# ...

Attach a link to issue if relevant

## What

Specify what you're trying to achieve

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Opus 4.6


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI dependency and browser caching to a new caching backend, improving build speed, cache reliability, and test environment setup.
  * Added environment configuration for the cache steps to standardize cache usage across workflows, reducing intermittent cache misses and stabilizing CI runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->