### PR TITLE
fix(energy-funds): pass required clientPersidno to BasicVehicleInformation

### DIFF
--- a/libs/api/domains/energy-funds/src/lib/energyFunds.service.ts
+++ b/libs/api/domains/energy-funds/src/lib/energyFunds.service.ts
@@ -67,7 +67,10 @@ export class EnergyFundsService {
 
     const basicVehicle = await this.vehiclesApiWithAuth(
       auth,
-    ).basicVehicleInformationGet({ permno: permno })
+    ).basicVehicleInformationGet({
+      clientPersidno: auth.nationalId,
+      permno: permno,
+    })
 
     if (!result || !result.data || result.data.length === 0 || !basicVehicle) {
       throw Error(

--- a/libs/application/template-api-modules/src/lib/modules/templates/energy-funds/energy-funds.service.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/energy-funds/energy-funds.service.ts
@@ -175,28 +175,30 @@ export class EnergyFundsService extends BaseTemplateApiService {
       : currentVehicleList?.vehicles?.find(
           (x) => x.permno === applicationAnswers.selectVehicle.plate,
         ) || undefined
+    let vehicleApiDetails
     try {
-      const vehicleApiDetails = await this.vehiclesApiWithAuth(
+      vehicleApiDetails = await this.vehiclesApiWithAuth(
         auth,
       ).basicVehicleInformationGet({
+        clientPersidno: auth.nationalId,
         vin: currentvehicleDetails?.vin || '',
       })
-      if (
-        !vehicleApiDetails.owners?.find((x) => x.persidno === auth.nationalId)
-      ) {
-        throw new TemplateApiError(
-          {
-            title: coreErrorMessages.vehicleNotOwner,
-            summary: coreErrorMessages.vehicleNotOwner,
-          },
-          400,
-        )
-      }
     } catch (error) {
+      this.logger.error('Failed to fetch vehicle information on submit', error)
       throw new TemplateApiError(
         {
           title: coreErrorMessages.applicationSubmitFailed,
           summary: coreErrorMessages.applicationSubmitFailed,
+        },
+        400,
+      )
+    }
+
+    if (!vehicleApiDetails.owners?.find((x) => x.persidno === auth.nationalId)) {
+      throw new TemplateApiError(
+        {
+          title: coreErrorMessages.vehicleNotOwner,
+          summary: coreErrorMessages.vehicleNotOwner,
         },
         400,
       )

--- a/libs/application/template-api-modules/src/lib/modules/templates/energy-funds/energy-funds.service.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/energy-funds/energy-funds.service.ts
@@ -194,7 +194,9 @@ export class EnergyFundsService extends BaseTemplateApiService {
       )
     }
 
-    if (!vehicleApiDetails.owners?.find((x) => x.persidno === auth.nationalId)) {
+    if (
+      !vehicleApiDetails.owners?.find((x) => x.persidno === auth.nationalId)
+    ) {
       throw new TemplateApiError(
         {
           title: coreErrorMessages.vehicleNotOwner,


### PR DESCRIPTION
Samgöngustofa's Mitt-Svaedi-V1/BasicVehicleInformation endpoint now requires clientPersidno; omitting it returns HTTP 400, which broke all electric-vehicle grant (rafbílastyrkur) submissions with the generic "Sending umsóknar mistókst" error.

- Add clientPersidno: auth.nationalId to both basicVehicleInformationGet call sites (submit handler + getVehicleDetailsWithGrant).
- Scope the submit-handler try/catch to only the fetch and log the underlying error, so the vehicleNotOwner check and real failures are no longer masked as a generic submit error.

[Attach a link to issue if relevant](https://digitaliceland.zendesk.com/agent/tickets/521626)

<img width="692" height="313" alt="image" src="https://github.com/user-attachments/assets/1cffe8d6-fab5-4220-80b3-8dbcc9bc37fb" />

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved vehicle ownership validation to give clearer errors when submitting applications for vehicles not owned by the user.
  * Enhanced vehicle details lookup by validating and matching an additional personal identifier to reduce mismatches.
  * Refined error handling to preserve specific “not owner” errors and provide better logging for troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->