### PR TITLE
fix(j-s): preserve newlines in indictment court record entries pdf

### DIFF
--- a/apps/judicial-system/backend/src/app/formatters/indictmentCourtRecordPdf.ts
+++ b/apps/judicial-system/backend/src/app/formatters/indictmentCourtRecordPdf.ts
@@ -27,7 +27,7 @@ import {
   addNormalCenteredText,
   addNormalText,
   addNumberedList,
-  addRichText,
+  // addRichText,
   Confirmation,
   drawConfirmation,
   setLineGap,
@@ -317,10 +317,12 @@ export const createIndictmentCourtRecordPdf = (
     }
 
     addEmptyLines(doc, 2)
-    addRichText(
-      doc,
-      courtSession.entries ?? '<p>Engar bókanir voru skráðar.</p>',
-    )
+    // TODO: uncomment when TinyMCE feature flag is lifted
+    // addRichText(
+    //   doc,
+    //   courtSession.entries ?? '<p>Engar bókanir voru skráðar.</p>',
+    // )
+    addNormalText(doc, courtSession.entries ?? 'Engar bókanir voru skráðar.')
 
     if (courtSession.rulingType !== CourtSessionRulingType.NONE) {
       addEmptyLines(doc)


### PR DESCRIPTION
## What
Render court session entries in the indictment court record PDF with `addNormalText` instead of `addRichText` while the TinyMCE feature flag is still off. A TODO is left to restore `addRichText` once the flag is lifted.

## Why
The entries field is currently a plain textarea (TinyMCE flag off), so its value is stored as plain text with literal `\n` newlines. `addRichText` parses its input as HTML and collapses raw whitespace — including `\n` — into single spaces (only `<br>`/`<p>` count as breaks), so newlines were lost in the PDF. PDFKit's `doc.text` (used by `addNormalText`) honors `\n` as hard line breaks, so plain-text entries now keep their formatting.

## Screenshots / Gifs
Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code
- [ ] No AI tools were used in preparing this pull request

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Court session entries in indictment court record PDFs now display as plain text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->