### PR TITLE
fix(native-app): app lock fixes

### DIFF
--- a/apps/native/app/src/app/(auth)/(modals)/update-app.tsx
+++ b/apps/native/app/src/app/(auth)/(modals)/update-app.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react'
 import { useIntl, FormattedMessage } from 'react-intl'
 import {
+  AppState,
   View,
   Image,
   Linking,
@@ -15,6 +16,10 @@ import { Button, Typography } from '@/ui'
 import logo from '@/assets/logo/logo-64w.png'
 import illustrationSrc from '@/assets/illustrations/digital-services-m1-dots.png'
 import { isIos } from '@/utils/devices'
+import {
+  clearLockScreenSuppression,
+  suppressLockScreen,
+} from '@/stores/auth-store'
 import { preferencesStore } from '@/stores/preferences-store'
 
 const Text = styled.View<{ isSmallDevice: boolean }>`
@@ -58,6 +63,25 @@ export default function UpdateAppScreen() {
     }
     const sub = BackHandler.addEventListener('hardwareBackPress', () => true)
     return () => sub.remove()
+  }, [closable])
+
+  // Suppress the app lock — its dismissAll would pop this wall and let the
+  // user bypass the required update (version check only runs on home tab
+  // mount). Refresh on each foreground to outlast the 15-min cap.
+  useEffect(() => {
+    if (closable) {
+      return
+    }
+    suppressLockScreen()
+    const sub = AppState.addEventListener('change', (next) => {
+      if (next === 'active') {
+        suppressLockScreen()
+      }
+    })
+    return () => {
+      sub.remove()
+      clearLockScreenSuppression()
+    }
   }, [closable])
 
   return (

--- a/apps/native/app/src/components/app-lock/app-lock.tsx
+++ b/apps/native/app/src/components/app-lock/app-lock.tsx
@@ -3,7 +3,7 @@ import {
   authenticateAsync,
   AuthenticationType,
 } from 'expo-local-authentication'
-import { useRouter, useSegments } from 'expo-router'
+import { useGlobalSearchParams, useRouter, useSegments } from 'expo-router'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useIntl } from 'react-intl'
 import {
@@ -104,19 +104,32 @@ function useShouldShowLock() {
 export function AppLock() {
   const router = useRouter()
   const segments = useSegments()
+  const params = useGlobalSearchParams<{ closable?: string }>()
   const shouldShow = useShouldShowLock()
   const inModal = segments.includes('(modals)' as never)
+  // The forced-update wall (update-app modal with closable=false) MUST stay
+  // up — the version check in (tabs)/index/index.tsx only runs once on mount,
+  // so dismissing the wall would let the user bypass a required update.
+  const onUnclosableUpdate =
+    segments.includes('update-app' as never) && params.closable === 'false'
+
   const [renderable, setRenderable] = useState(shouldShow)
   const opacity = useSharedValue(shouldShow ? 1 : 0)
 
   // Dismiss any stack-presented modal so the lock overlay isn't visually
   // covered by a native formSheet on iOS. Scoped to (modals)/* so regular
-  // stack pushes (e.g. inbox document) aren't popped.
+  // stack pushes (e.g. inbox document) aren't popped, and skipped for the
+  // forced-update wall (see above).
   useEffect(() => {
-    if (shouldShow && inModal && router.canDismiss()) {
+    if (
+      shouldShow &&
+      inModal &&
+      !onUnclosableUpdate &&
+      router.canDismiss()
+    ) {
       router.dismissAll()
     }
-  }, [shouldShow, inModal, router])
+  }, [shouldShow, inModal, onUnclosableUpdate, router])
 
   // Instant show; fade out on unlock. Re-lock mid-fade snaps back to 1.
   useEffect(() => {

--- a/apps/native/app/src/components/app-lock/app-lock.tsx
+++ b/apps/native/app/src/components/app-lock/app-lock.tsx
@@ -3,7 +3,7 @@ import {
   authenticateAsync,
   AuthenticationType,
 } from 'expo-local-authentication'
-import { useGlobalSearchParams, useRouter, useSegments } from 'expo-router'
+import { useRouter, useSegments } from 'expo-router'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useIntl } from 'react-intl'
 import {
@@ -104,32 +104,21 @@ function useShouldShowLock() {
 export function AppLock() {
   const router = useRouter()
   const segments = useSegments()
-  const params = useGlobalSearchParams<{ closable?: string }>()
   const shouldShow = useShouldShowLock()
   const inModal = segments.includes('(modals)' as never)
-  // The forced-update wall (update-app modal with closable=false) MUST stay
-  // up — the version check in (tabs)/index/index.tsx only runs once on mount,
-  // so dismissing the wall would let the user bypass a required update.
-  const onUnclosableUpdate =
-    segments.includes('update-app' as never) && params.closable === 'false'
-
   const [renderable, setRenderable] = useState(shouldShow)
   const opacity = useSharedValue(shouldShow ? 1 : 0)
 
   // Dismiss any stack-presented modal so the lock overlay isn't visually
   // covered by a native formSheet on iOS. Scoped to (modals)/* so regular
-  // stack pushes (e.g. inbox document) aren't popped, and skipped for the
-  // forced-update wall (see above).
+  // stack pushes (e.g. inbox document) aren't popped. Screens that must
+  // never be dismissed (e.g. the forced-update wall) opt out by calling
+  // suppressLockScreen() so shouldShow returns false here.
   useEffect(() => {
-    if (
-      shouldShow &&
-      inModal &&
-      !onUnclosableUpdate &&
-      router.canDismiss()
-    ) {
+    if (shouldShow && inModal && router.canDismiss()) {
       router.dismissAll()
     }
-  }, [shouldShow, inModal, onUnclosableUpdate, router])
+  }, [shouldShow, inModal, router])
 
   // Instant show; fade out on unlock. Re-lock mid-fade snaps back to 1.
   useEffect(() => {

--- a/apps/native/app/src/components/app-lock/app-lock.tsx
+++ b/apps/native/app/src/components/app-lock/app-lock.tsx
@@ -3,7 +3,7 @@ import {
   authenticateAsync,
   AuthenticationType,
 } from 'expo-local-authentication'
-import { useRouter } from 'expo-router'
+import { useRouter, useSegments } from 'expo-router'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useIntl } from 'react-intl'
 import {
@@ -104,18 +104,21 @@ function useShouldShowLock() {
 
 export function AppLock() {
   const router = useRouter()
+  const segments = useSegments()
   const shouldShow = useShouldShowLock()
   const [renderable, setRenderable] = useState(shouldShow)
   const opacity = useSharedValue(shouldShow ? 1 : 0)
 
   // Dismiss any stack-presented modals before showing the lock.
   // Without this, iOS layers our RN <Modal> beneath an
-  // already-presented formSheet.
+  // already-presented formSheet. Scoped to (modals)/* so regular
+  // stack pushes (e.g. inbox document detail) aren't popped.
+  const inModal = segments.includes('(modals)' as never)
   useEffect(() => {
-    if (shouldShow && router.canDismiss()) {
+    if (shouldShow && inModal && router.canDismiss()) {
       router.dismissAll()
     }
-  }, [shouldShow, router])
+  }, [shouldShow, inModal, router])
 
   // Instant show; fade out on unlock. Re-lock mid-fade snaps back to 1.
   useEffect(() => {

--- a/apps/native/app/src/components/app-lock/app-lock.tsx
+++ b/apps/native/app/src/components/app-lock/app-lock.tsx
@@ -10,7 +10,6 @@ import {
   AppState,
   BackHandler,
   Image,
-  Modal,
   SafeAreaView,
   StyleSheet,
   View,
@@ -106,14 +105,13 @@ export function AppLock() {
   const router = useRouter()
   const segments = useSegments()
   const shouldShow = useShouldShowLock()
+  const inModal = segments.includes('(modals)' as never)
   const [renderable, setRenderable] = useState(shouldShow)
   const opacity = useSharedValue(shouldShow ? 1 : 0)
 
-  // Dismiss any stack-presented modals before showing the lock.
-  // Without this, iOS layers our RN <Modal> beneath an
-  // already-presented formSheet. Scoped to (modals)/* so regular
-  // stack pushes (e.g. inbox document detail) aren't popped.
-  const inModal = segments.includes('(modals)' as never)
+  // Dismiss any stack-presented modal so the lock overlay isn't visually
+  // covered by a native formSheet on iOS. Scoped to (modals)/* so regular
+  // stack pushes (e.g. inbox document) aren't popped.
   useEffect(() => {
     if (shouldShow && inModal && router.canDismiss()) {
       router.dismissAll()
@@ -282,67 +280,67 @@ function AppLockContent({
   const animatedStyle = useAnimatedStyle(() => ({ opacity: opacity.value }))
 
   return (
-    <Modal
-      visible
-      transparent
-      animationType="none"
-      statusBarTranslucent
-      onRequestClose={() => undefined}
+    <View
+      style={[StyleSheet.absoluteFill, styles.overlay]}
+      pointerEvents={fading ? 'none' : 'auto'}
     >
-      <View
-        style={StyleSheet.absoluteFill}
-        pointerEvents={fading ? 'none' : 'auto'}
-      >
-        <Host style={animatedStyle} testID={testIDs.SCREEN_APP_LOCK}>
-          <SafeAreaView>
-            <View
-              style={{
-                justifyContent: 'center',
-                alignItems: 'center',
-                paddingTop: 50,
-                paddingBottom: 20,
-                maxHeight: 200,
-                flex: 1,
-              }}
-            >
-              <Image
-                source={require('../../assets/logo/logo-64w.png')}
-                resizeMode="contain"
-                style={{ width: 45, height: 45, marginBottom: 20 }}
-              />
-              <Title>{intl.formatMessage({ id: 'applock.title' })}</Title>
-              <Subtitle>
-                {pinTries > 0
-                  ? `${attemptsLeft} ${intl.formatMessage({
-                      id:
-                        attemptsLeft === 1
-                          ? 'applock.attempt'
-                          : 'applock.attempts',
-                    })}`
-                  : ''}
-              </Subtitle>
-            </View>
-            <Center>
-              <VisualizedPinCode
-                code={code}
-                invalid={invalidCode}
-                maxChars={MAX_PIN_CHARS}
-              />
-              <View style={{ height: 32 }} />
-              <PinKeypad
-                onInput={onPinInput}
-                onBackPress={onBackPress}
-                onFaceIdPress={onFaceIdPress}
-                back={code.length > 0}
-                biometricType={
-                  useBiometrics ? biometricType ?? 'faceid' : undefined
-                }
-              />
-              <View style={{ height: 64 }} />
-            </Center>
-          </SafeAreaView>
-        </Host>
-      </View>
-    </Modal>
+      <Host style={animatedStyle} testID={testIDs.SCREEN_APP_LOCK}>
+        <SafeAreaView>
+          <View
+            style={{
+              justifyContent: 'center',
+              alignItems: 'center',
+              paddingTop: 50,
+              paddingBottom: 20,
+              maxHeight: 200,
+              flex: 1,
+            }}
+          >
+            <Image
+              source={require('../../assets/logo/logo-64w.png')}
+              resizeMode="contain"
+              style={{ width: 45, height: 45, marginBottom: 20 }}
+            />
+            <Title>{intl.formatMessage({ id: 'applock.title' })}</Title>
+            <Subtitle>
+              {pinTries > 0
+                ? `${attemptsLeft} ${intl.formatMessage({
+                    id:
+                      attemptsLeft === 1
+                        ? 'applock.attempt'
+                        : 'applock.attempts',
+                  })}`
+                : ''}
+            </Subtitle>
+          </View>
+          <Center>
+            <VisualizedPinCode
+              code={code}
+              invalid={invalidCode}
+              maxChars={MAX_PIN_CHARS}
+            />
+            <View style={{ height: 32 }} />
+            <PinKeypad
+              onInput={onPinInput}
+              onBackPress={onBackPress}
+              onFaceIdPress={onFaceIdPress}
+              back={code.length > 0}
+              biometricType={
+                useBiometrics ? biometricType ?? 'faceid' : undefined
+              }
+            />
+            <View style={{ height: 64 }} />
+          </Center>
+        </SafeAreaView>
+      </Host>
+    </View>
   )
 }
+
+// Force the lock onto the top of the in-tree z-order. Stack screens render
+// in tree order, but a high zIndex guards against unexpected restacking on
+// Android. (Native iOS formSheets still float above the RN root — those are
+// dismissed via router.dismissAll above.)
+const styles = StyleSheet.create({
+  overlay: { zIndex: 9999, elevation: 9999 },
+})


### PR DESCRIPTION
## What

Make sure to only dismiss modals when app lock opens (Necessary so modals will not render above the lock screen). 
Also add increased z-index and elevation to make sure app lock is on top on android.

Add special case for update app screen if `closable: false` since that screen is a modal on iOS but should not be closable.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced app lock behavior during foreground transitions to properly suppress and re-apply lock when needed
  * Improved app lock screen rendering in modal contexts to ensure correct dismissal behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->