### PR TITLE
fix(web): Apollo id caching fix

### DIFF
--- a/apps/web/screens/queries/SecondarySchoolStudies.ts
+++ b/apps/web/screens/queries/SecondarySchoolStudies.ts
@@ -139,7 +139,7 @@ export const GET_SECONDARY_SCHOOL_PROGRAMME_BY_ID_QUERY = gql`
         coreSubjectGroups {
           title
           subjects {
-            id
+            subjectId
             name
             level1
             level2
@@ -153,7 +153,7 @@ export const GET_SECONDARY_SCHOOL_PROGRAMME_BY_ID_QUERY = gql`
           packages {
             title
             subjects {
-              id
+              subjectId
               name
               level1
               level2
@@ -166,7 +166,7 @@ export const GET_SECONDARY_SCHOOL_PROGRAMME_BY_ID_QUERY = gql`
         subjectChoiceGroups {
           requiredCredits
           subjects {
-            id
+            subjectId
             name
             level1
             level2

--- a/libs/api/domains/secondary-school/src/lib/graphql/models/programmeStructure.ts
+++ b/libs/api/domains/secondary-school/src/lib/graphql/models/programmeStructure.ts
@@ -3,7 +3,7 @@ import { Field, Int, ObjectType } from '@nestjs/graphql'
 @ObjectType('SecondarySchoolSubjectStructure')
 export class SecondarySchoolSubjectStructure {
   @Field(() => String, { nullable: true })
-  id?: string | null
+  subjectId?: string | null
 
   @Field(() => String, { nullable: true })
   name?: string | null

--- a/libs/api/domains/secondary-school/src/lib/secondarySchool.service.ts
+++ b/libs/api/domains/secondary-school/src/lib/secondarySchool.service.ts
@@ -36,6 +36,41 @@ export class SecondarySchoolApi {
   }
 
   async getProgrammeById(id: string): Promise<SecondarySchoolProgrammeDetail> {
-    return this.secondarySchoolPublicClient.getProgrammeById(id)
+    const programme = await this.secondarySchoolPublicClient.getProgrammeById(
+      id,
+    )
+
+    const mapSubjects = (subjects?: { id?: string | null }[] | null) =>
+      subjects?.map(({ id: subjectId, ...rest }) => ({
+        ...rest,
+        subjectId,
+      }))
+
+    return {
+      ...programme,
+      programmeStructure: programme.programmeStructure
+        ? {
+            coreSubjectGroups:
+              programme.programmeStructure.coreSubjectGroups?.map((g) => ({
+                ...g,
+                subjects: mapSubjects(g.subjects),
+              })),
+            packageChoices: programme.programmeStructure.packageChoices?.map(
+              (c) => ({
+                ...c,
+                packages: c.packages?.map((p) => ({
+                  ...p,
+                  subjects: mapSubjects(p.subjects),
+                })),
+              }),
+            ),
+            subjectChoiceGroups:
+              programme.programmeStructure.subjectChoiceGroups?.map((g) => ({
+                ...g,
+                subjects: mapSubjects(g.subjects),
+              })),
+          }
+        : undefined,
+    }
   }
 }


### PR DESCRIPTION
Subject have the same id and having the name "id" makes apollo cache them and return the same object everytime

Attach a link to issue if relevant

## What

Specify what you're trying to achieve

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [X] AI tools were used in preparing this pull request
      Tools used: Copilot (Claude Opus 4.6)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized subject identifier field naming from `id` to `subjectId` across secondary school programme data structures (core subjects, package choices, and subject choice groups) for improved consistency and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->