### PR TITLE
fix(web): Court agendas - Remove duplicates in schedule type options

### DIFF
--- a/libs/clients/verdicts/src/lib/verdicts-client.service.ts
+++ b/libs/clients/verdicts/src/lib/verdicts-client.service.ts
@@ -864,42 +864,35 @@ export class VerdictsClientService {
       ])
 
     const mapOfAll = new Map<string, { id: string; label: string }>()
+    const courtOfAppealMap = new Map<string, { id: string; label: string }>()
+    const districtCourtMap = new Map<string, { id: string; label: string }>()
 
-    const courtOfAppealSet = new Set<string>()
-    const courtOfAppealItems: Array<{ id: string; label: string }> = []
     if (courtOfAppealResponse.status === 'fulfilled')
       for (const scheduleType of courtOfAppealResponse.value.items ?? [])
         if (scheduleType.label && scheduleType.id !== undefined) {
-          const id = String(scheduleType.id)
-          const item = { id, label: scheduleType.label }
-          if (!mapOfAll.has(scheduleType.label)) {
-            mapOfAll.set(scheduleType.label, item)
+          const item = {
+            id: String(scheduleType.id),
+            label: scheduleType.label,
           }
-          if (!courtOfAppealSet.has(scheduleType.label)) {
-            courtOfAppealSet.add(scheduleType.label)
-            courtOfAppealItems.push(item)
-          }
+          courtOfAppealMap.set(scheduleType.label, item)
+          mapOfAll.set(scheduleType.label, item)
         }
 
-    const supremeCourtItems: Array<{ id: string; label: string }> = []
-
-    const districtCourtSet = new Set<string>()
-    const districtCourtItems: Array<{ id: string; label: string }> = []
     if (districtCourtResponse.status === 'fulfilled')
       for (const scheduleType of districtCourtResponse.value.items ?? [])
         if (scheduleType.label && scheduleType.id !== undefined) {
-          const id = String(scheduleType.id)
-          const item = { id, label: scheduleType.label }
-          if (!mapOfAll.has(scheduleType.label)) {
-            mapOfAll.set(scheduleType.label, item)
+          const item = {
+            id: String(scheduleType.id),
+            label: scheduleType.label,
           }
-          if (!districtCourtSet.has(scheduleType.label)) {
-            districtCourtSet.add(scheduleType.label)
-            districtCourtItems.push(item)
-          }
+          districtCourtMap.set(scheduleType.label, item)
+          mapOfAll.set(scheduleType.label, item)
         }
 
+    const courtOfAppealItems = Array.from(courtOfAppealMap.values())
     courtOfAppealItems.sort(sortAlpha('label'))
+
+    const districtCourtItems = Array.from(districtCourtMap.values())
     districtCourtItems.sort(sortAlpha('label'))
 
     const allItems = Array.from(mapOfAll.values())
@@ -910,7 +903,7 @@ export class VerdictsClientService {
         items: courtOfAppealItems,
       },
       supremeCourt: {
-        items: supremeCourtItems,
+        items: [],
       },
       districtCourt: {
         items: districtCourtItems,


### PR DESCRIPTION
# Court agendas - Remove duplicates in schedule type options

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code v2.1.165 - Sonnet 4.6


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected schedule types response to properly handle supreme court data.

* **Refactor**
  * Improved internal data collection and processing logic for schedule types aggregation across court categories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->