### PR TITLE
chore(j-s): add agent docs with codegen commands

### DIFF
--- a/apps/judicial-system/AGENTS.md
+++ b/apps/judicial-system/AGENTS.md
@@ -1,0 +1,21 @@
+# Judicial System — Agent Guide
+
+## Codegen
+
+Regenerate after changing GraphQL schema/resolvers, REST controllers/DTOs, or
+shared types in `@island.is/judicial-system/types`.
+
+| Project | Command | Output |
+|---|---|---|
+| backend | `yarn nx run judicial-system-backend:codegen/backend-schema` | `apps/judicial-system/backend/src/openapi.yaml` |
+| api | `yarn nx run judicial-system-api:codegen/backend-schema` | `apps/judicial-system/api/src/api.graphql` |
+| web | `yarn nx run judicial-system-web:codegen/frontend-client` | generated GraphQL client/types |
+
+Notes:
+- **message-handler has no codegen target** — nothing to run there.
+- `digital-mailbox-api` and `xrd-api` also expose `codegen/backend-schema` if you
+  touch their controllers.
+- Codegen type-checks/boots the app first, so it fails on any TypeScript error in
+  the project — fix compile errors before assuming codegen is broken.
+- To regenerate everything across the whole repo: `yarn codegen`.
+- Docs: https://docs.devland.is/repository/codegen

--- a/apps/judicial-system/AGENTS.md
+++ b/apps/judicial-system/AGENTS.md
@@ -5,13 +5,14 @@
 Regenerate after changing GraphQL schema/resolvers, REST controllers/DTOs, or
 shared types in `@island.is/judicial-system/types`.
 
-| Project | Command | Output |
-|---|---|---|
+| Project | Command                                                      | Output                                          |
+| ------- | ------------------------------------------------------------ | ----------------------------------------------- |
 | backend | `yarn nx run judicial-system-backend:codegen/backend-schema` | `apps/judicial-system/backend/src/openapi.yaml` |
-| api | `yarn nx run judicial-system-api:codegen/backend-schema` | `apps/judicial-system/api/src/api.graphql` |
-| web | `yarn nx run judicial-system-web:codegen/frontend-client` | generated GraphQL client/types |
+| api     | `yarn nx run judicial-system-api:codegen/backend-schema`     | `apps/judicial-system/api/src/api.graphql`      |
+| web     | `yarn nx run judicial-system-web:codegen/frontend-client`    | generated GraphQL client/types                  |
 
 Notes:
+
 - **message-handler has no codegen target** — nothing to run there.
 - `digital-mailbox-api` and `xrd-api` also expose `codegen/backend-schema` if you
   touch their controllers.

--- a/apps/judicial-system/CLAUDE.md
+++ b/apps/judicial-system/CLAUDE.md
@@ -1,0 +1,3 @@
+# Judicial System
+
+Guidance for this app lives in @AGENTS.md (shared with other AI tools).


### PR DESCRIPTION
## What
Adds `AGENTS.md` and `CLAUDE.md` under `apps/judicial-system/` documenting how to run codegen for the judicial-system projects.

- `AGENTS.md` is the single source of truth: codegen commands for `backend`, `api`, and `web`, plus notes that `message-handler` has no codegen target and that codegen type-checks the app first.
- `CLAUDE.md` is a one-line pointer that imports `@AGENTS.md`, so Claude Code and other AI tools (e.g. Cursor, which reads `AGENTS.md` natively) share one source with no duplication.

## Why
The exact nx codegen target names (`codegen/backend-schema` vs `codegen/frontend-client`) and the fact that `message-handler` has none are non-obvious and easy to get wrong. Documenting them in an auto-loaded location speeds up onboarding and keeps AI assistants accurate across both Claude Code and Cursor.

## Screenshots / Gifs
N/A — documentation only.

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code
- [ ] No AI tools were used in preparing this pull request

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added developer guidance for the Judicial System application, including how to run project code generation for backend, API, and web targets, notes on when and where generation applies, and pointers to additional internal development documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->