### PR TITLE
fix(my-pages): Health questionnaires key collision

### DIFF
--- a/libs/api/domains/questionnaires/src/lib/transform-mappers/display.mappers.spec.ts
+++ b/libs/api/domains/questionnaires/src/lib/transform-mappers/display.mappers.spec.ts
@@ -361,8 +361,8 @@ describe('display mappers', () => {
       expect(section?.questions).toHaveLength(1)
 
       const question = section?.questions?.[0]
-      expect(question?.id).toBe('group-1__bool-q1')
-      expect(question?.originalId).toBe('bool-q1')
+      expect(question?.id).toBe('bool-q1')
+      expect(question?.sectionId).toBe('group-1')
       expect(question?.label).toBe('Are you OK?')
       expect(question?.answerOptions.type).toBe(AnswerOptionType.radio)
 
@@ -468,10 +468,10 @@ describe('display mappers', () => {
 
       const section = mapped.sections?.[0]
       const dependentQuestion = section?.questions?.find(
-        (q) => q.id === 'group-1__q2',
+        (q) => q.id === 'q2',
       )
 
-      // q2 should depend on q1 via triggers (dependsOn uses original IDs, not namespaced)
+      // q2 should depend on q1 via triggers
       expect(dependentQuestion?.dependsOn).toEqual(['q1'])
       expect(dependentQuestion?.visibilityConditions).toBeDefined()
       expect(dependentQuestion?.visibilityConditions?.[0].questionId).toBe('q1')

--- a/libs/api/domains/questionnaires/src/lib/transform-mappers/display.mappers.spec.ts
+++ b/libs/api/domains/questionnaires/src/lib/transform-mappers/display.mappers.spec.ts
@@ -467,9 +467,7 @@ describe('display mappers', () => {
       const mapped = mapElQuestionnaireForm(elDetail, formatMessage)
 
       const section = mapped.sections?.[0]
-      const dependentQuestion = section?.questions?.find(
-        (q) => q.id === 'q2',
-      )
+      const dependentQuestion = section?.questions?.find((q) => q.id === 'q2')
 
       // q2 should depend on q1 via triggers
       expect(dependentQuestion?.dependsOn).toEqual(['q1'])

--- a/libs/api/domains/questionnaires/src/lib/transform-mappers/el/display/mapQuestion.ts
+++ b/libs/api/domains/questionnaires/src/lib/transform-mappers/el/display/mapQuestion.ts
@@ -18,8 +18,6 @@ export const mapItemToQuestion = (
   const answerType = mapAnswerOptionType(item.type, item)
   const triggerDeps = mapTriggers(allQuestions, triggers, item.id)
 
-  const uniqueId = item.id
-
   // Handle options based on question type
   let options: Array<{ label: string; value: string; id: string }> | undefined
 
@@ -39,7 +37,7 @@ export const mapItemToQuestion = (
   }
 
   const answerOptions = {
-    id: uniqueId,
+    id: item.id,
     type: answerType,
     label: undefined,
     options,
@@ -78,7 +76,7 @@ export const mapItemToQuestion = (
   }
 
   return {
-    id: uniqueId,
+    id: item.id,
     sectionId: groupId,
     label: item.label,
     htmlLabel: item.htmlLabel,

--- a/libs/api/domains/questionnaires/src/lib/transform-mappers/el/display/mapQuestion.ts
+++ b/libs/api/domains/questionnaires/src/lib/transform-mappers/el/display/mapQuestion.ts
@@ -18,8 +18,7 @@ export const mapItemToQuestion = (
   const answerType = mapAnswerOptionType(item.type, item)
   const triggerDeps = mapTriggers(allQuestions, triggers, item.id)
 
-  // Create unique ID by combining group and item IDs to avoid collisions
-  const uniqueId = groupId ? `${groupId}__${item.id}` : item.id
+  const uniqueId = item.id
 
   // Handle options based on question type
   let options: Array<{ label: string; value: string; id: string }> | undefined
@@ -41,7 +40,6 @@ export const mapItemToQuestion = (
 
   const answerOptions = {
     id: uniqueId,
-    originalId: item.id, // Keep original ID for submission
     type: answerType,
     label: undefined,
     options,
@@ -81,7 +79,7 @@ export const mapItemToQuestion = (
 
   return {
     id: uniqueId,
-    originalId: item.id, // Keep original ID for submission
+    sectionId: groupId,
     label: item.label,
     htmlLabel: item.htmlLabel,
     sublabel: item.hint,

--- a/libs/api/domains/questionnaires/src/lib/transform-mappers/el/display/mapQuestion.ts
+++ b/libs/api/domains/questionnaires/src/lib/transform-mappers/el/display/mapQuestion.ts
@@ -77,7 +77,7 @@ export const mapItemToQuestion = (
 
   return {
     id: item.id,
-    sectionId: groupId,
+    sectionId: groupId ?? '',
     label: item.label,
     htmlLabel: item.htmlLabel,
     sublabel: item.hint,

--- a/libs/api/domains/questionnaires/src/models/question.model.ts
+++ b/libs/api/domains/questionnaires/src/models/question.model.ts
@@ -91,9 +91,6 @@ export class AnswerOption {
   @Field({ nullable: true })
   value?: string
 
-  @Field({ nullable: true })
-  originalId?: string
-
   @Field(() => AnswerOptionType)
   type!: AnswerOptionType
 
@@ -140,7 +137,7 @@ export class Question {
   id!: string
 
   @Field({ nullable: true })
-  originalId?: string
+  sectionId?: string
 
   @Field()
   label!: string

--- a/libs/portals/my-pages/core/src/components/Questionnaires/GenericQuestionnaire.tsx
+++ b/libs/portals/my-pages/core/src/components/Questionnaires/GenericQuestionnaire.tsx
@@ -104,6 +104,22 @@ export const GenericQuestionnaire: FC<GenericQuestionnaireProps> = ({
     }
   }, [questionnaire.sections, calculateFormulaCallback, initialAnswers])
 
+  // Build a derived answers map keyed by originalId for visibility condition lookups.
+  // EL visibilityConditions reference question.originalId (e.g. "5770") but answers are
+  // stored keyed by the full compound question.id (e.g. "group_1__5770").
+  // LSH questions have no originalId (id is already the raw id), so fall back to q.id.
+  const originalIdAnswers = useMemo(() => {
+    const allQuestions =
+      questionnaire.sections?.flatMap((s) => s.questions ?? []) ?? []
+    return allQuestions.reduce<{ [key: string]: QuestionAnswer }>((acc, q) => {
+      const key = q.originalId ?? q.id
+      if (answers[q.id]) {
+        acc[key] = answers[q.id]
+      }
+      return acc
+    }, {})
+  }, [answers, questionnaire.sections])
+
   // Process sections into visible questions with section-aware filtering
   const processedSections = useMemo(() => {
     if (!questionnaire.sections?.length) return []
@@ -111,7 +127,7 @@ export const GenericQuestionnaire: FC<GenericQuestionnaireProps> = ({
     return questionnaire.sections
       .filter((section) => {
         // First check if the section itself is visible based on its conditions
-        return isSectionVisible(section, answers)
+        return isSectionVisible(section, originalIdAnswers)
       })
       .map((section) => {
         if (!section.questions?.length) return { ...section, questions: [] }
@@ -125,7 +141,7 @@ export const GenericQuestionnaire: FC<GenericQuestionnaireProps> = ({
           ) {
             return isQuestionVisibleWithStructuredConditions(
               question.visibilityConditions,
-              answers,
+              originalIdAnswers,
             )
           }
 
@@ -136,7 +152,7 @@ export const GenericQuestionnaire: FC<GenericQuestionnaireProps> = ({
         return { ...section, questions: filteredQuestions }
       })
       .filter((section) => section.questions?.length > 0)
-  }, [questionnaire.sections, answers])
+  }, [questionnaire.sections, originalIdAnswers])
 
   // Get all visible questions for backwards compatibility
   const visibleQuestions = useMemo(() => {

--- a/libs/portals/my-pages/core/src/components/Questionnaires/GenericQuestionnaire.tsx
+++ b/libs/portals/my-pages/core/src/components/Questionnaires/GenericQuestionnaire.tsx
@@ -104,31 +104,12 @@ export const GenericQuestionnaire: FC<GenericQuestionnaireProps> = ({
     }
   }, [questionnaire.sections, calculateFormulaCallback, initialAnswers])
 
-  // Build a derived answers map keyed by originalId for visibility condition lookups.
-  // EL visibilityConditions reference question.originalId (e.g. "5770") but answers are
-  // stored keyed by the full compound question.id (e.g. "group_1__5770").
-  // LSH questions have no originalId (id is already the raw id), so fall back to q.id.
-  const originalIdAnswers = useMemo(() => {
-    const allQuestions =
-      questionnaire.sections?.flatMap((s) => s.questions ?? []) ?? []
-    return allQuestions.reduce<{ [key: string]: QuestionAnswer }>((acc, q) => {
-      const key = q.originalId ?? q.id
-      if (answers[q.id]) {
-        acc[key] = answers[q.id]
-      }
-      return acc
-    }, {})
-  }, [answers, questionnaire.sections])
-
   // Process sections into visible questions with section-aware filtering
   const processedSections = useMemo(() => {
     if (!questionnaire.sections?.length) return []
 
     return questionnaire.sections
-      .filter((section) => {
-        // First check if the section itself is visible based on its conditions
-        return isSectionVisible(section, originalIdAnswers)
-      })
+      .filter((section) => isSectionVisible(section, answers))
       .map((section) => {
         if (!section.questions?.length) return { ...section, questions: [] }
 
@@ -141,18 +122,17 @@ export const GenericQuestionnaire: FC<GenericQuestionnaireProps> = ({
           ) {
             return isQuestionVisibleWithStructuredConditions(
               question.visibilityConditions,
-              originalIdAnswers,
+              answers,
             )
           }
 
-          // Questions without visibility conditions are visible by default
           return true
         })
 
         return { ...section, questions: filteredQuestions }
       })
       .filter((section) => section.questions?.length > 0)
-  }, [questionnaire.sections, originalIdAnswers])
+  }, [questionnaire.sections, answers])
 
   // Get all visible questions for backwards compatibility
   const visibleQuestions = useMemo(() => {

--- a/libs/portals/my-pages/graphql/src/lib/client.ts
+++ b/libs/portals/my-pages/graphql/src/lib/client.ts
@@ -47,6 +47,11 @@ export const client = new ApolloClient({
       AuthDelegationsGroupedByIdentity: {
         keyFields: ['nationalId', 'type'],
       },
+      // Health Questionnaire Question: composite key because
+      // questions from different sections can share the same id
+      QuestionnaireQuestion: {
+        keyFields: ['id', 'sectionId'],
+      },
       Query: {
         fields: {
           authDelegations: {

--- a/libs/portals/my-pages/health/src/screens/Questionnaires/AnswerQuestionnaire.tsx
+++ b/libs/portals/my-pages/health/src/screens/Questionnaires/AnswerQuestionnaire.tsx
@@ -65,9 +65,13 @@ const AnswerQuestionnaire: FC = () => {
   const initialAnswers = useMemo(() => {
     if (!questionnaire?.draftAnswers?.length) return undefined
 
+    // Build maps from originalId (or id) → compound question.id and → label
+    const originalIdToCompoundId: { [key: string]: string } = {}
     const questionLabels: { [key: string]: string } = {}
     questionnaire.sections?.forEach((section) => {
       section.questions?.forEach((q) => {
+        const key = q.originalId ?? q.id
+        originalIdToCompoundId[key] = q.id
         questionLabels[q.id] = q.label
       })
     })
@@ -78,11 +82,16 @@ const AnswerQuestionnaire: FC = () => {
           return acc
         }
 
+        // Map originalId back to compound question.id so answers align with
+        // the key-space GenericQuestionnaire uses internally
+        const compoundId =
+          originalIdToCompoundId[draft.questionId] ?? draft.questionId
+
         return {
           ...acc,
-          [draft.questionId]: {
-            questionId: draft.questionId,
-            question: questionLabels[draft.questionId] ?? '',
+          [compoundId]: {
+            questionId: compoundId,
+            question: questionLabels[compoundId] ?? '',
             type: draft.type,
             answers: draft.answers.map((a) => ({
               label: a.label ?? undefined,
@@ -120,8 +129,20 @@ const AnswerQuestionnaire: FC = () => {
       return
     }
 
+    // For EL questionnaires, answers are keyed by compound question.id
+    // (e.g. "group_1__3143") but the backend expects originalId ("3143").
+    // Build a lookup so we send the correct entryId.
+    const idToOriginalId: { [key: string]: string } = {}
+    data?.questionnairesDetail?.sections?.forEach((section) => {
+      section.questions?.forEach((q) => {
+        if (q.originalId) {
+          idToOriginalId[q.id] = q.originalId
+        }
+      })
+    })
+
     const entries = Object.entries(answers).map(([questionId, answer]) => ({
-      entryId: questionId,
+      entryId: idToOriginalId[questionId] ?? questionId,
       type: answer.type,
       answers: answer.answers.map((a) => ({
         label: a.label,

--- a/libs/portals/my-pages/health/src/screens/Questionnaires/AnswerQuestionnaire.tsx
+++ b/libs/portals/my-pages/health/src/screens/Questionnaires/AnswerQuestionnaire.tsx
@@ -62,36 +62,29 @@ const AnswerQuestionnaire: FC = () => {
     )
   }
 
-  const initialAnswers = useMemo(() => {
-    if (!questionnaire?.draftAnswers?.length) return undefined
-
-    // Build maps from originalId (or id) → compound question.id and → label
-    const originalIdToCompoundId: { [key: string]: string } = {}
-    const questionLabels: { [key: string]: string } = {}
-    questionnaire.sections?.forEach((section) => {
+  const questionLabels = useMemo(() => {
+    const labels: { [key: string]: string } = {}
+    questionnaire?.sections?.forEach((section) => {
       section.questions?.forEach((q) => {
-        const key = q.originalId ?? q.id
-        originalIdToCompoundId[key] = q.id
-        questionLabels[q.id] = q.label
+        labels[q.id] = q.label
       })
     })
+    return labels
+  }, [questionnaire?.sections])
+
+  const initialAnswers = useMemo(() => {
+    if (!questionnaire?.draftAnswers?.length) return undefined
 
     return questionnaire.draftAnswers.reduce<{ [key: string]: QuestionAnswer }>(
       (acc, draft) => {
         if (!isValidQuestionnaireAnswerType(draft.type)) {
           return acc
         }
-
-        // Map originalId back to compound question.id so answers align with
-        // the key-space GenericQuestionnaire uses internally
-        const compoundId =
-          originalIdToCompoundId[draft.questionId] ?? draft.questionId
-
         return {
           ...acc,
-          [compoundId]: {
-            questionId: compoundId,
-            question: questionLabels[compoundId] ?? '',
+          [draft.questionId]: {
+            questionId: draft.questionId,
+            question: questionLabels[draft.questionId] ?? '',
             type: draft.type,
             answers: draft.answers.map((a) => ({
               label: a.label ?? undefined,
@@ -102,7 +95,7 @@ const AnswerQuestionnaire: FC = () => {
       },
       {},
     )
-  }, [questionnaire?.draftAnswers, questionnaire?.sections])
+  }, [questionnaire?.draftAnswers, questionLabels])
 
   if (!id) {
     return (
@@ -129,20 +122,8 @@ const AnswerQuestionnaire: FC = () => {
       return
     }
 
-    // For EL questionnaires, answers are keyed by compound question.id
-    // (e.g. "group_1__3143") but the backend expects originalId ("3143").
-    // Build a lookup so we send the correct entryId.
-    const idToOriginalId: { [key: string]: string } = {}
-    data?.questionnairesDetail?.sections?.forEach((section) => {
-      section.questions?.forEach((q) => {
-        if (q.originalId) {
-          idToOriginalId[q.id] = q.originalId
-        }
-      })
-    })
-
     const entries = Object.entries(answers).map(([questionId, answer]) => ({
-      entryId: idToOriginalId[questionId] ?? questionId,
+      entryId: questionId,
       type: answer.type,
       answers: answer.answers.map((a) => ({
         label: a.label,

--- a/libs/portals/my-pages/health/src/screens/Questionnaires/questionnaires.graphql
+++ b/libs/portals/my-pages/health/src/screens/Questionnaires/questionnaires.graphql
@@ -58,7 +58,7 @@ fragment AnswerOptions on QuestionnaireAnswerOption {
 fragment QuestionDetail on QuestionnaireQuestion {
   __typename
   id
-  originalId
+  sectionId
   label
   sublabel
   htmlLabel


### PR DESCRIPTION
## What

Fix bug in EL questionnaires caused by older key collision fix

## Why

The current key collision handling created a new originalId that was not being used in the frontend so certain answers weren't getting triggered correctly and drafts and submissions were behaving strangely. By using key fields instead we remove the need for the frontend to juggle 2 separate id's. 

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed question identification and caching so questions with the same id in different sections no longer conflict; answers and visibility now map to the correct section.
  * Removed redundant identifier payloads to simplify question/option data returned.

* **Refactor**
  * Simplified section/question visibility processing and improved initial-answer loading logic for more reliable rendering.

* **Tests**
  * Updated tests to reflect new identification and visibility behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->