### PR TITLE
fix(ids-admin): api scope users syncing issues

### DIFF
--- a/libs/api/domains/auth-admin/src/lib/scope/models/scope-environment.model.ts
+++ b/libs/api/domains/auth-admin/src/lib/scope/models/scope-environment.model.ts
@@ -94,6 +94,9 @@ export class ScopeEnvironment {
   @Field(() => [String], { defaultValue: [] })
   tagIds!: string[]
 
+  @Field(() => [String], { defaultValue: [] })
+  userNationalIds!: string[]
+
   @Field(() => Date, { nullable: true })
   modified?: Date
 }

--- a/libs/api/domains/auth-admin/src/lib/scope/scope.service.spec.ts
+++ b/libs/api/domains/auth-admin/src/lib/scope/scope.service.spec.ts
@@ -96,6 +96,9 @@ const createMockAdminApi = (
   meScopeClientsControllerFindAllRaw: jest
     .fn()
     .mockResolvedValue(createMockApiResponse([])),
+  meScopeUsersControllerFindUsersByScopeRaw: jest
+    .fn()
+    .mockResolvedValue(createMockApiResponse([])),
 })
 
 const mockAdminDevApi = createMockAdminApi(
@@ -246,6 +249,7 @@ describe('ScopeService', () => {
             isAccessControlled: false,
             categoryIds: [],
             tagIds: [],
+            userNationalIds: [],
           })),
         }),
       )
@@ -288,7 +292,12 @@ describe('ScopeService', () => {
       const environments = Object.entries(groupedScopes)
         .map(([_, scopes]) => scopes)
         .flat()
-        .map((env) => ({ ...env, categoryIds: [], tagIds: [] }))
+        .map((env) => ({
+          ...env,
+          categoryIds: [],
+          tagIds: [],
+          userNationalIds: [],
+        }))
 
       // Act
       const scopeResponses = await scopeService.getScope(currentUser, {

--- a/libs/api/domains/auth-admin/src/lib/scope/scope.service.ts
+++ b/libs/api/domains/auth-admin/src/lib/scope/scope.service.ts
@@ -187,6 +187,7 @@ export class ScopeService extends MultiEnvironmentService {
           environment: environments[index],
           categoryIds: scope.categoryIds ?? [],
           tagIds: scope.tagIds ?? [],
+          userNationalIds: [],
         }),
         prefixErrorMessage: `Failed to update scope ${scopeName}`,
       },
@@ -246,6 +247,7 @@ export class ScopeService extends MultiEnvironmentService {
       environment: targetEnvironment,
       categoryIds: newScope.categoryIds ?? [],
       tagIds: newScope.tagIds ?? [],
+      userNationalIds: [],
     }
   }
 
@@ -281,6 +283,7 @@ export class ScopeService extends MultiEnvironmentService {
                 environment: targetEnvironments[index],
                 categoryIds: scope.categoryIds ?? [],
                 tagIds: scope.tagIds ?? [],
+                userNationalIds: [],
               } as ScopeEnvironment),
           ),
         prefixErrorMessage: `Failed to get scopes by tenantId ${tenantId}`,
@@ -348,12 +351,39 @@ export class ScopeService extends MultiEnvironmentService {
    * Gets a specific scope by scope name for all available environments
    */
   async getScope(user: User, input: ScopeInput): Promise<Scope | null> {
-    const scopeSettledPromises = await Promise.allSettled(
-      environments.map((environment) =>
-        this.makeRequest(user, environment, (api) =>
-          api.meScopesControllerFindByTenantIdAndScopeNameRaw(input),
+    const [scopeSettledPromises, scopeUsersSettledPromises] = await Promise.all(
+      [
+        Promise.allSettled(
+          environments.map((environment) =>
+            this.makeRequest(user, environment, (api) =>
+              api.meScopesControllerFindByTenantIdAndScopeNameRaw(input),
+            ),
+          ),
         ),
-      ),
+        Promise.allSettled(
+          environments.map((environment) =>
+            this.makeRequest(user, environment, (api) =>
+              api.meScopeUsersControllerFindUsersByScopeRaw({
+                tenantId: input.tenantId,
+                scopeName: input.scopeName,
+              }),
+            ),
+          ),
+        ),
+      ],
+    )
+
+    const userNationalIdsByEnvIndex = scopeUsersSettledPromises.map(
+      (resp, index) => {
+        if (resp.status === 'fulfilled') {
+          return (resp.value ?? []).map((u) => u.nationalId)
+        }
+        this.logger.error(
+          `Failed to get scope users for ${input.scopeName} in environment ${environments[index]}`,
+          resp.reason,
+        )
+        return []
+      },
     )
 
     const environmentsScopes = this.handleSettledPromises(
@@ -364,6 +394,7 @@ export class ScopeService extends MultiEnvironmentService {
           environment: environments[index],
           categoryIds: scope.categoryIds ?? [],
           tagIds: scope.tagIds ?? [],
+          userNationalIds: userNationalIdsByEnvIndex[index],
         }),
         prefixErrorMessage: `Failed to get scope ${input.scopeName}`,
       },
@@ -498,6 +529,7 @@ export class ScopeService extends MultiEnvironmentService {
       {
         mapper: (_value, index) => targetEnvironments[index],
         prefixErrorMessage: `Failed to update scope users for ${input.scopeName}`,
+        voidResponse: true,
       },
     )
 

--- a/libs/api/domains/auth-admin/src/lib/shared/services/multi-environment.service.ts
+++ b/libs/api/domains/auth-admin/src/lib/shared/services/multi-environment.service.ts
@@ -145,7 +145,7 @@ export abstract class MultiEnvironmentService {
 
   /**
    * Like {@link handleSettledPromises} but also collects per-environment
-   * failures and returns them alongside the successful results
+   * failures and returns them alongside the successful results.
    */
   public handleSettledPromisesWithFailures<T, K>(
     settledPromises: PromiseSettledResult<T | undefined | null>[],
@@ -153,9 +153,11 @@ export abstract class MultiEnvironmentService {
     {
       mapper,
       prefixErrorMessage,
+      voidResponse = false,
     }: {
       mapper: (value: PromiseFulfilledResult<T>['value'], index: number) => K
       prefixErrorMessage?: string
+      voidResponse?: boolean
     },
   ): { values: K[]; failures: EnvironmentFailure[] } {
     const values: K[] = []
@@ -165,6 +167,12 @@ export abstract class MultiEnvironmentService {
       const environment = requestedEnvs[index]
       if (resp.status === 'fulfilled' && resp.value) {
         values.push(mapper(resp.value, index))
+      } else if (
+        resp.status === 'fulfilled' &&
+        voidResponse &&
+        this.isEnvironmentConfigured(environment)
+      ) {
+        values.push(mapper(resp.value as T, index))
       } else if (resp.status === 'fulfilled') {
         // makeRequest resolves to null/undefined when the env's API client
         // is not configured, or when the upstream returned an empty body.

--- a/libs/clients/auth/admin-api/src/lib/auth-admin-api-client.config.ts
+++ b/libs/clients/auth/admin-api/src/lib/auth-admin-api-client.config.ts
@@ -20,7 +20,6 @@ export const AuthAdminApiClientConfig = defineConfig({
     return {
       basePaths: env.requiredJSON('AUTH_ADMIN_API_PATHS', {
         development: 'http://localhost:6333/backend',
-        staging: 'https://identity-server.dev01.devland.is/backend',
       }),
       basePath: env.required(
         'AUTH_ADMIN_API_PATH',

--- a/libs/clients/auth/admin-api/src/lib/auth-admin-api-client.config.ts
+++ b/libs/clients/auth/admin-api/src/lib/auth-admin-api-client.config.ts
@@ -20,6 +20,7 @@ export const AuthAdminApiClientConfig = defineConfig({
     return {
       basePaths: env.requiredJSON('AUTH_ADMIN_API_PATHS', {
         development: 'http://localhost:6333/backend',
+        staging: 'https://identity-server.dev01.devland.is/backend',
       }),
       basePath: env.required(
         'AUTH_ADMIN_API_PATH',

--- a/libs/portals/admin/ids-admin/src/screens/Permission/EditPermission.action.ts
+++ b/libs/portals/admin/ids-admin/src/screens/Permission/EditPermission.action.ts
@@ -18,6 +18,11 @@ import {
   UpdateScopeUsersMutation,
   UpdateScopeUsersMutationVariables,
 } from './components/PermissionAccessControl.generated'
+import {
+  AuthAdminScopeDocument,
+  AuthAdminScopeQuery,
+  AuthAdminScopeQueryVariables,
+} from './Permission.generated'
 import { getIntent } from '../../utils/getIntent'
 import {
   MergedFormDataSchema,
@@ -127,7 +132,76 @@ export const editPermissionAction: WrappedActionFn =
         (addedScopeUserNationalIds && addedScopeUserNationalIds.length > 0) ||
         (removedScopeUserNationalIds && removedScopeUserNationalIds.length > 0)
 
-      if (intent === PermissionFormTypes.ACCESS_CONTROL && hasUserChanges) {
+      if (
+        intent === PermissionFormTypes.ACCESS_CONTROL &&
+        sync &&
+        syncEnvironments &&
+        syncEnvironments.length > 0
+      ) {
+        // Sync users from the source (current) environment to the target
+        // environments. Refetch with network-only so deltas are computed
+        // against the authoritative current state — the Apollo cache may
+        // be stale (e.g., unsaved dropdown edits, recent writes elsewhere).
+        const freshScope = await client.query<
+          AuthAdminScopeQuery,
+          AuthAdminScopeQueryVariables
+        >({
+          query: AuthAdminScopeDocument,
+          variables: { input: { tenantId, scopeName } },
+          fetchPolicy: 'network-only',
+        })
+
+        const envs = freshScope.data?.authAdminScope?.environments ?? []
+        const sourceUserIds =
+          envs.find((e) => e.environment === environment)?.userNationalIds ?? []
+
+        for (const targetEnv of syncEnvironments) {
+          const targetUserIds =
+            envs.find((e) => e.environment === targetEnv)?.userNationalIds ?? []
+          const added = sourceUserIds.filter(
+            (id) => !targetUserIds.includes(id),
+          )
+          const removed = targetUserIds.filter(
+            (id) => !sourceUserIds.includes(id),
+          )
+
+          if (added.length === 0 && removed.length === 0) continue
+
+          const syncResult = await client.mutate<
+            UpdateScopeUsersMutation,
+            UpdateScopeUsersMutationVariables
+          >({
+            mutation: UpdateScopeUsersDocument,
+            variables: {
+              input: {
+                tenantId,
+                scopeName,
+                addedNationalIds: added,
+                removedNationalIds: removed,
+                environments: [targetEnv],
+              },
+            },
+          })
+
+          if (syncResult.errors?.length) {
+            const transportMessage = syncResult.errors
+              .map((e) => e.message)
+              .join('; ')
+            failedEnvironments.push({
+              environment: targetEnv,
+              message: `Syncing scope users failed: ${transportMessage}`,
+            })
+          } else {
+            const userFailures =
+              syncResult.data?.updateAuthAdminScopeUsers.failedEnvironments ??
+              []
+            failedEnvironments.push(...userFailures)
+          }
+        }
+      } else if (
+        intent === PermissionFormTypes.ACCESS_CONTROL &&
+        hasUserChanges
+      ) {
         const updateUsersResult = await client.mutate<
           UpdateScopeUsersMutation,
           UpdateScopeUsersMutationVariables

--- a/libs/portals/admin/ids-admin/src/screens/Permission/Permission.graphql
+++ b/libs/portals/admin/ids-admin/src/screens/Permission/Permission.graphql
@@ -45,6 +45,7 @@ query AuthAdminScope($input: ScopeInput!) {
     modified
     environments {
       ...AuthAdminScopeEnvironmentFragment
+      userNationalIds
     }
     defaultEnvironment {
       environment

--- a/libs/portals/admin/ids-admin/src/screens/Permission/components/PermissionAccessControl.tsx
+++ b/libs/portals/admin/ids-admin/src/screens/Permission/components/PermissionAccessControl.tsx
@@ -187,6 +187,7 @@ export const PermissionAccessControl = () => {
         'isAccessControlled',
         'grantToAuthenticatedUser',
         'automaticDelegationGrant',
+        'userNationalIds',
       ])}
       customValidation={customValidation}
     >


### PR DESCRIPTION
## What

- Fix spurious "Failed in environment" toast on access-control user updates. The upstream PATCH endpoint returns 204 No Content; handleSettledPromisesWithFailures was treating that as a failure. Added an opt-in voidResponse flag to the helper and used it in updateScopeUsers so 204s for configured environments are classified as success. 
- Make the Access control sync badge reflect scope users. Added a userNationalIds field to AuthAdminScopeEnvironment (populated in getScope via a parallel per-env fetch), exposed it in the AuthAdminScope query (kept out of the shared fragment to avoid the patch-mutation response  clobbering it in the Apollo cache), and included it in the checkEnvironmentsSync field list on the Access control card. 
- Wire up "Sync settings (from this environment)" for users. The existing sync flow only patched scope config; the user list never followed. Added a per-target-env delta branch in editPermissionAction: refetch AuthAdminScope with network-only, diff each target env's userNationalIds against the source, and dispatch updateAuthAdminScopeUsers per target with that env's specific add/remove. 
- Refetch fresh state for sync. Sync reads scope user lists via client.query({ fetchPolicy: 'network-only' }) rather than readQuery, so stale cache can't cause a silent no-op with a misleading success toast.


## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for managing user national IDs within permission scopes.
  * Enabled syncing of user national IDs across multiple environments during permission updates.

* **Improvements**
  * Enhanced environment synchronization to properly track and detect changes to user national ID lists.
  * Updated backend configuration for improved staging environment connectivity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->