### PR TITLE
fix(my-pages): tabs on mobile screens

### DIFF
--- a/libs/portals/my-pages/core/src/components/TabNavigation/TabBar.css.ts
+++ b/libs/portals/my-pages/core/src/components/TabNavigation/TabBar.css.ts
@@ -4,13 +4,6 @@ import { style } from '@vanilla-extract/css'
 export const tabBar = style({
   display: 'inline-flex',
   background: theme.color.blue100,
-  '@media': {
-    [`screen and (max-width: ${theme.breakpoints.md}px)`]: {
-      height: 0,
-      overflow: 'hidden',
-      display: 'none',
-    },
-  },
 })
 
 export const alternativeTabDivider = style({

--- a/libs/portals/my-pages/core/src/components/TabNavigation/TabNavigation.tsx
+++ b/libs/portals/my-pages/core/src/components/TabNavigation/TabNavigation.tsx
@@ -59,22 +59,28 @@ export const TabNavigation: React.FC<Props> = ({ items, pathname, label }) => {
     activePath.serviceProviderTooltip
 
   const isMobile = width < theme.breakpoints.md
+  const hasMoreThan2Items = items.length > 2
+
+  // If it's mobile and there are more than 2 items, we show a select instead of the tab bar
+  const showSelect = isMobile && hasMoreThan2Items
 
   return (
     <>
-      <TabBar
-        aria-label={label}
-        tabs={items?.map((item, index) => {
-          const active = item.path === activePath.path
-          return {
-            id: `tab-item-${index}`,
-            active: active,
-            onClick: () => tabChangeHandler(item.path),
-            name: formatMessage(item.name),
-          }
-        })}
-      />
-      {activePath.path && isMobile && (
+      {!showSelect && (
+        <TabBar
+          aria-label={label}
+          tabs={items?.map((item, index) => {
+            const active = item.path === activePath.path
+            return {
+              id: `tab-item-${index}`,
+              active: active,
+              onClick: () => tabChangeHandler(item.path),
+              name: formatMessage(item.name),
+            }
+          })}
+        />
+      )}
+      {activePath.path && showSelect && (
         <Box className={styles.select}>
           <Select
             size="xs"
@@ -118,7 +124,7 @@ export const TabNavigation: React.FC<Props> = ({ items, pathname, label }) => {
                       }) ?? []
                     }
                   />
-                  {activePath.children && activePath.name && isMobile && (
+                  {activePath.children && activePath.name && showSelect && (
                     <Box className={styles.select}>
                       <Select
                         size="sm"
@@ -156,7 +162,7 @@ export const TabNavigation: React.FC<Props> = ({ items, pathname, label }) => {
             )}
             {activePath?.displayServiceProviderLogo &&
               serviceProvider &&
-              !isMobile && (
+              !showSelect && (
                 <TabNavigationInstitutionPanel
                   serviceProvider={serviceProvider}
                   tooltipText={tooltipText}

--- a/libs/portals/my-pages/education/src/screens/PrimarySchool/PrimarySchoolOverview/PrimarySchoolOverview.tsx
+++ b/libs/portals/my-pages/education/src/screens/PrimarySchool/PrimarySchoolOverview/PrimarySchoolOverview.tsx
@@ -41,11 +41,6 @@ export const PrimarySchoolOverview = () => {
       {!loading && !error && student && (
         <InfoLineStack label={formatMessage(m.baseInfo)}>
           <InfoLine
-            label={psm.studentLabel}
-            content={student.name ?? undefined}
-            loading={loading}
-          />
-          <InfoLine
             label={psm.schoolLabel}
             content={student.schoolName ?? undefined}
             loading={loading}

--- a/libs/portals/my-pages/education/src/screens/PrimarySchool/PrimarySchoolStudent/PrimarySchoolStudentWrapper.tsx
+++ b/libs/portals/my-pages/education/src/screens/PrimarySchool/PrimarySchoolStudent/PrimarySchoolStudentWrapper.tsx
@@ -57,7 +57,7 @@ export const PrimarySchoolStudentWrapper = ({
         <>
           <Hidden print>
             <TabNavigation
-              label={formatMessage(psm.studentLabel)}
+              label={formatMessage(m.menu)}
               pathname={location.pathname}
               items={[
                 {


### PR DESCRIPTION
# My pages - Primary school overview tabs

## What

Change tabs navigation to always show tabs if only two tabs, even on mobile screens.
Also, remove name from list as it's not in the design and the name is also the title of the page


## Screenshots / Gifs
<img width="453" height="849" alt="Screenshot 2026-06-08 at 14 50 02" src="https://github.com/user-attachments/assets/76f050c8-574d-40b0-95b1-27dcc5e7f343" />


## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [x] No AI tools were used in preparing this pull request
- [ ] AI tools were used in preparing this pull request
      Tools used:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **UI Updates**
  * Improved mobile responsiveness of tab navigation with enhanced layout behavior on smaller screens
  * Simplified primary school overview display by refining information presentation
  * Updated label terminology for consistency throughout student records and printable views

<!-- end of auto-generated comment: release notes by coderabbit.ai -->