### PR TITLE
fix(j-s): let civil claimant spokesperson view their own civil claim

### DIFF
--- a/apps/judicial-system/backend/src/app/modules/file/guards/civilClaimFileVisibility.ts
+++ b/apps/judicial-system/backend/src/app/modules/file/guards/civilClaimFileVisibility.ts
@@ -31,6 +31,16 @@ export const canDefenceUserViewCivilClaimCaseFile = (
     return true
   }
 
+  // The claimant's own confirmed spokesperson (lögmaður/réttargæslumaður) always
+  // has standing (aðild) to their own civil claim, so they may view it.
+  if (
+    claimant.hasSpokesperson &&
+    claimant.isSpokespersonConfirmed &&
+    claimant.spokespersonNationalId === defenderUserNationalId
+  ) {
+    return true
+  }
+
   return (
     args.defendants?.some(
       (defendant) =>

--- a/apps/judicial-system/backend/src/app/modules/file/guards/test/civilClaimFileVisibility.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/file/guards/test/civilClaimFileVisibility.spec.ts
@@ -155,6 +155,67 @@ describe('canDefenceUserViewCivilClaimCaseFile', () => {
     ).toBe(true)
   })
 
+  it('returns true when the requesting user is the claimant\'s own confirmed spokesperson', () => {
+    expect(
+      canDefenceUserViewCivilClaimCaseFile(defenderNationalId, {
+        ...baseArgs,
+        civilClaimants: [
+          {
+            id: claimantId,
+            policeCaseNumbers: ['007-2024'],
+            hasSpokesperson: true,
+            isSpokespersonConfirmed: true,
+            spokespersonNationalId: defenderNationalId,
+          } as CivilClaimant,
+        ],
+        defendants: [],
+      }),
+    ).toBe(true)
+  })
+
+  it('returns false when the user is the claimant\'s spokesperson but not confirmed', () => {
+    expect(
+      canDefenceUserViewCivilClaimCaseFile(defenderNationalId, {
+        ...baseArgs,
+        civilClaimants: [
+          {
+            id: claimantId,
+            policeCaseNumbers: ['007-2024'],
+            hasSpokesperson: true,
+            isSpokespersonConfirmed: false,
+            spokespersonNationalId: defenderNationalId,
+          } as CivilClaimant,
+        ],
+        defendants: [],
+      }),
+    ).toBe(false)
+  })
+
+  it('returns false when the user is the confirmed spokesperson of a different claimant', () => {
+    expect(
+      canDefenceUserViewCivilClaimCaseFile(defenderNationalId, {
+        ...baseArgs,
+        civilClaimants: [
+          {
+            id: claimantId,
+            policeCaseNumbers: ['007-2024'],
+            hasSpokesperson: true,
+            isSpokespersonConfirmed: true,
+            spokespersonNationalId: '9999999999',
+          } as CivilClaimant,
+          {
+            id: 'other-claimant',
+            policeCaseNumbers: ['008-2024'],
+            hasSpokesperson: true,
+            isSpokespersonConfirmed: true,
+            spokespersonNationalId: defenderNationalId,
+          } as CivilClaimant,
+        ],
+        defendants: [],
+      }),
+    ).toBe(false)
+  })
+
   it('returns true when any of multiple defendants matches', () => {
     expect(
       canDefenceUserViewCivilClaimCaseFile(defenderNationalId, {

--- a/apps/judicial-system/backend/src/app/modules/file/guards/test/civilClaimFileVisibility.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/file/guards/test/civilClaimFileVisibility.spec.ts
@@ -155,7 +155,7 @@ describe('canDefenceUserViewCivilClaimCaseFile', () => {
     ).toBe(true)
   })
 
-  it('returns true when the requesting user is the claimant\'s own confirmed spokesperson', () => {
+  it("returns true when the requesting user is the claimant's own confirmed spokesperson", () => {
     expect(
       canDefenceUserViewCivilClaimCaseFile(defenderNationalId, {
         ...baseArgs,
@@ -173,7 +173,7 @@ describe('canDefenceUserViewCivilClaimCaseFile', () => {
     ).toBe(true)
   })
 
-  it('returns false when the user is the claimant\'s spokesperson but not confirmed', () => {
+  it("returns false when the user is the claimant's spokesperson but not confirmed", () => {
     expect(
       canDefenceUserViewCivilClaimCaseFile(defenderNationalId, {
         ...baseArgs,


### PR DESCRIPTION
## What

Let a civil claimant's confirmed spokesperson (lögmaður/réttargæslumaður) view the civil claim (bótakrafa) they have standing to.

Defence-side parties who represent a civil claimant could not see the civil claim once it was scoped to police case numbers (introduced in #22544 "Multiple defendants – Civil claim"). The final visibility gate `canDefenceUserViewCivilClaimCaseFile` derived `CIVIL_CLAIM` access **solely** from the `defendants` array, so the claimant's own confirmed spokesperson — who is not a defender — was always denied, even though they already pass the category gate.

This adds one branch: the claimant's **own confirmed spokesperson** (`isSpokespersonConfirmed` + national-id match on that specific claimant) may view the claim. The existing defender (verjandi) police-case scoping is unchanged.

## Why

> Verjendur/lögmenn/réttargælsumenn eiga að sjá bótakröfu hafi þeir aðild að henni. Í dag sjá þeir ekki bótakröfu.

The parties with standing to a civil claim must be able to see it; today the claimant's spokesperson cannot.

## Screenshots / Gifs

N/A — backend access-control change only.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Defence representatives who are confirmed as claimant spokespersons can now access relevant civil claim case files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
