### PR TITLE
fix(starfatorg): show job category on new API cards and add api=old override

### DIFF
--- a/apps/web/screens/IcelandicGovernmentInstitutionVacancies/IcelandicGovernmentInstitutionVacanciesList.tsx
+++ b/apps/web/screens/IcelandicGovernmentInstitutionVacancies/IcelandicGovernmentInstitutionVacanciesList.tsx
@@ -95,11 +95,18 @@ interface IcelandicGovernmentInstitutionVacanciesListProps {
   namespace: Record<string, string>
   fetchErrorOccurred?: boolean | null
   useNewApiOverride?: boolean
+  useOldApiOverride?: boolean
 }
 
 const IcelandicGovernmentInstitutionVacanciesList: Screen<
   IcelandicGovernmentInstitutionVacanciesListProps
-> = ({ vacancies, namespace, fetchErrorOccurred, useNewApiOverride }) => {
+> = ({
+  vacancies,
+  namespace,
+  fetchErrorOccurred,
+  useNewApiOverride,
+  useOldApiOverride,
+}) => {
   const { query, replace, isReady } = useRouter()
   const n = useNamespace(namespace)
   const { linkResolver } = useLinkResolver()
@@ -156,14 +163,10 @@ const IcelandicGovernmentInstitutionVacanciesList: Screen<
     let shouldBeShown = searchTermMatches
 
     if (parameters.fieldOfWork.length > 0) {
-      // The new API populates the "Störf" filter from the jobCategory field
-      const fieldOfWorkValue = useNewApiOverride
-        ? vacancy.jobCategory
-        : vacancy.fieldOfWork
       shouldBeShown = Boolean(
         shouldBeShown &&
-          fieldOfWorkValue &&
-          parameters.fieldOfWork.includes(fieldOfWorkValue),
+          vacancy.fieldOfWork &&
+          parameters.fieldOfWork.includes(vacancy.fieldOfWork),
       )
     }
 
@@ -190,12 +193,8 @@ const IcelandicGovernmentInstitutionVacanciesList: Screen<
   })
 
   const fieldOfWorkOptions = useMemo(
-    () =>
-      mapVacanciesField(
-        vacancies,
-        useNewApiOverride ? 'jobCategory' : 'fieldOfWork',
-      ),
-    [vacancies, useNewApiOverride],
+    () => mapVacanciesField(vacancies, 'fieldOfWork'),
+    [vacancies],
   )
 
   const locationOptions = useMemo(
@@ -337,7 +336,9 @@ const IcelandicGovernmentInstitutionVacanciesList: Screen<
           label: n('viewDetails', 'Skoða nánar'),
           href: `${
             linkResolver('vacancydetails', [vacancy.id?.toString() || '']).href
-          }${useNewApiOverride ? '?api=new' : ''}`,
+          }${
+            useNewApiOverride ? '?api=new' : useOldApiOverride ? '?api=old' : ''
+          }`,
         },
         tags,
         detailLines,
@@ -832,6 +833,7 @@ IcelandicGovernmentInstitutionVacanciesList.getProps = async ({
   query,
 }) => {
   const useNewApiOverride = query?.api === 'new' ? true : undefined
+  const useOldApiOverride = query?.api === 'old' ? true : undefined
   const namespaceResponse = await apolloClient.query<
     GetNamespaceQuery,
     GetNamespaceQueryVariables
@@ -857,6 +859,7 @@ IcelandicGovernmentInstitutionVacanciesList.getProps = async ({
     variables: {
       input: {
         ...(useNewApiOverride && { useNewApiOverride }),
+        ...(useOldApiOverride && { useOldApiOverride }),
       },
     },
   })
@@ -869,6 +872,7 @@ IcelandicGovernmentInstitutionVacanciesList.getProps = async ({
     namespace,
     fetchErrorOccurred,
     useNewApiOverride,
+    useOldApiOverride,
   }
 }
 

--- a/apps/web/screens/IcelandicGovernmentInstitutionVacancies/IcelandicGovernmentInstitutionVacancyDetails.tsx
+++ b/apps/web/screens/IcelandicGovernmentInstitutionVacancies/IcelandicGovernmentInstitutionVacancyDetails.tsx
@@ -366,6 +366,7 @@ IcelandicGovernmentInstitutionVacancyDetails.getProps = async ({
   }
 
   const useNewApiOverride = query?.api === 'new' ? true : undefined
+  const useOldApiOverride = query?.api === 'old' ? true : undefined
 
   const [vacancyResponse, namespaceResponse] = await Promise.all([
     apolloClient.query<
@@ -377,6 +378,7 @@ IcelandicGovernmentInstitutionVacancyDetails.getProps = async ({
         input: {
           id: query.id as string,
           ...(useNewApiOverride && { useNewApiOverride }),
+          ...(useOldApiOverride && { useOldApiOverride }),
         },
       },
     }),

--- a/apps/web/screens/queries/IcelandicGovernmentInstitutionVacancies.ts
+++ b/apps/web/screens/queries/IcelandicGovernmentInstitutionVacancies.ts
@@ -9,7 +9,6 @@ export const GET_ICELANDIC_GOVERNMENT_INSTITUTION_VACANCIES = gql`
       vacancies {
         id
         fieldOfWork
-        jobCategory
         title
         intro
         applicationDeadlineFrom

--- a/libs/api/domains/icelandic-government-institution-vacancies/src/lib/dto/icelandicGovernmentInstitutionVacancies.input.ts
+++ b/libs/api/domains/icelandic-government-institution-vacancies/src/lib/dto/icelandicGovernmentInstitutionVacancies.input.ts
@@ -11,4 +11,7 @@ export class IcelandicGovernmentInstitutionVacanciesInput {
 
   @Field(() => Boolean, { nullable: true })
   useNewApiOverride?: boolean
+
+  @Field(() => Boolean, { nullable: true })
+  useOldApiOverride?: boolean
 }

--- a/libs/api/domains/icelandic-government-institution-vacancies/src/lib/dto/icelandicGovernmentInstitutionVacancyById.input.ts
+++ b/libs/api/domains/icelandic-government-institution-vacancies/src/lib/dto/icelandicGovernmentInstitutionVacancyById.input.ts
@@ -11,4 +11,7 @@ export class IcelandicGovernmentInstitutionVacancyByIdInput {
 
   @Field(() => Boolean, { nullable: true })
   useNewApiOverride?: boolean
+
+  @Field(() => Boolean, { nullable: true })
+  useOldApiOverride?: boolean
 }

--- a/libs/api/domains/icelandic-government-institution-vacancies/src/lib/icelandic-government-institution-vacancies.resolver.spec.ts
+++ b/libs/api/domains/icelandic-government-institution-vacancies/src/lib/icelandic-government-institution-vacancies.resolver.spec.ts
@@ -200,4 +200,54 @@ describe('IcelandicGovernmentInstitutionVacanciesResolver', () => {
     })
     expect(mockXRoadApi.vacanciesVacancyIdGet).not.toHaveBeenCalled()
   })
+
+  it('forces the new list API via override even when the feature flag is disabled', async () => {
+    featureFlagClient.getValue.mockResolvedValue(false)
+
+    await request(app.getHttpServer()).get('/graphql').query({
+      query:
+        '{ icelandicGovernmentInstitutionVacancies(input: { useNewApiOverride: true }) { vacancies { id } } }',
+    })
+
+    expect(mockElfurApi.v1VacancyGetVacancyListGet).toHaveBeenCalledTimes(1)
+    expect(mockXRoadApi.vacanciesGet).not.toHaveBeenCalled()
+  })
+
+  it('forces the xroad list API via override even when the feature flag is enabled', async () => {
+    featureFlagClient.getValue.mockResolvedValue(true)
+
+    await request(app.getHttpServer()).get('/graphql').query({
+      query:
+        '{ icelandicGovernmentInstitutionVacancies(input: { useOldApiOverride: true }) { vacancies { id } } }',
+    })
+
+    expect(mockXRoadApi.vacanciesGet).toHaveBeenCalledTimes(1)
+    expect(mockElfurApi.v1VacancyGetVacancyListGet).not.toHaveBeenCalled()
+  })
+
+  it('lets the old API override win when both overrides are set', async () => {
+    featureFlagClient.getValue.mockResolvedValue(true)
+
+    await request(app.getHttpServer()).get('/graphql').query({
+      query:
+        '{ icelandicGovernmentInstitutionVacancies(input: { useNewApiOverride: true, useOldApiOverride: true }) { vacancies { id } } }',
+    })
+
+    expect(mockXRoadApi.vacanciesGet).toHaveBeenCalledTimes(1)
+    expect(mockElfurApi.v1VacancyGetVacancyListGet).not.toHaveBeenCalled()
+  })
+
+  it('forces the xroad detail API via override even when the feature flag is enabled', async () => {
+    featureFlagClient.getValue.mockResolvedValue(true)
+
+    await request(app.getHttpServer()).get('/graphql').query({
+      query:
+        '{ icelandicGovernmentInstitutionVacancyById(input: { id: "123", useOldApiOverride: true }) { vacancy { id } } }',
+    })
+
+    expect(mockXRoadApi.vacanciesVacancyIdGet).toHaveBeenCalledWith(
+      expect.objectContaining({ vacancyId: 123 }),
+    )
+    expect(mockElfurApi.v1VacancyGetVacancyGet).not.toHaveBeenCalled()
+  })
 })

--- a/libs/api/domains/icelandic-government-institution-vacancies/src/lib/icelandic-government-institution-vacancies.resolver.ts
+++ b/libs/api/domains/icelandic-government-institution-vacancies/src/lib/icelandic-government-institution-vacancies.resolver.ts
@@ -132,14 +132,16 @@ export class IcelandicGovernmentInstitutionVacanciesResolver {
     input: IcelandicGovernmentInstitutionVacanciesInput,
     user?: FeatureFlagUser,
   ) {
-    // Check override, then feature flag, to determine which client to use
+    // Check overrides, then feature flag, to determine which client to use.
+    // An explicit old-API override always wins, forcing the X-Road API.
     const useNewApi =
-      input.useNewApiOverride === true ||
-      (await this.featureFlagClient.getValue(
-        Features.useNewVacancyApi,
-        false,
-        user,
-      ))
+      input.useOldApiOverride !== true &&
+      (input.useNewApiOverride === true ||
+        (await this.featureFlagClient.getValue(
+          Features.useNewVacancyApi,
+          false,
+          user,
+        )))
 
     let errorOccurred = false
     let mappedVacancies
@@ -203,6 +205,9 @@ export class IcelandicGovernmentInstitutionVacanciesResolver {
         await mapIcelandicGovernmentInstitutionVacanciesFromElfur(vacancies)
     } else {
       // Use old X-Road API
+      if (input.useOldApiOverride) {
+        this.logger.info('Using X-Road API via override for vacancy list')
+      }
       let vacancies: DefaultApiVacanciesListItem[] = []
 
       try {
@@ -351,15 +356,18 @@ export class IcelandicGovernmentInstitutionVacanciesResolver {
     language?: VacancyLanguageEnum,
     user?: FeatureFlagUser,
     useNewApiOverride?: boolean,
+    useOldApiOverride?: boolean,
   ) {
-    // Check override, then feature flag, to determine which client to use
+    // Check overrides, then feature flag, to determine which client to use.
+    // An explicit old-API override always wins, forcing the X-Road API.
     const useNewApi =
-      useNewApiOverride === true ||
-      (await this.featureFlagClient.getValue(
-        Features.useNewVacancyApi,
-        false,
-        user,
-      ))
+      useOldApiOverride !== true &&
+      (useNewApiOverride === true ||
+        (await this.featureFlagClient.getValue(
+          Features.useNewVacancyApi,
+          false,
+          user,
+        )))
 
     let vacancy
 
@@ -407,6 +415,11 @@ export class IcelandicGovernmentInstitutionVacanciesResolver {
       }
     } else {
       // Use old X-Road API
+      if (useOldApiOverride) {
+        this.logger.info('Using X-Road API via override for vacancy detail', {
+          vacancyId: id,
+        })
+      }
       const numericId = Number(id)
       if (isNaN(numericId)) {
         return { vacancy: null }
@@ -495,17 +508,21 @@ export class IcelandicGovernmentInstitutionVacanciesResolver {
         input.language,
         featureFlagUser,
         input.useNewApiOverride,
+        input.useOldApiOverride,
       )
     }
 
-    // If no prefix is present then we determine what service to call depending on the feature flag and id format
+    // If no prefix is present then we determine what service to call depending
+    // on the overrides, feature flag and id format. An explicit old-API
+    // override always wins, forcing the X-Road API.
     const useNewApi =
-      input.useNewApiOverride === true ||
-      (await this.featureFlagClient.getValue(
-        Features.useNewVacancyApi,
-        false,
-        featureFlagUser,
-      ))
+      input.useOldApiOverride !== true &&
+      (input.useNewApiOverride === true ||
+        (await this.featureFlagClient.getValue(
+          Features.useNewVacancyApi,
+          false,
+          featureFlagUser,
+        )))
 
     if (useNewApi) {
       // New API: first try CMS, then external service
@@ -516,6 +533,7 @@ export class IcelandicGovernmentInstitutionVacanciesResolver {
           input.language,
           featureFlagUser,
           input.useNewApiOverride,
+          input.useOldApiOverride,
         )
       }
       return vacancyFromCms
@@ -530,6 +548,7 @@ export class IcelandicGovernmentInstitutionVacanciesResolver {
         input.language,
         featureFlagUser,
         input.useNewApiOverride,
+        input.useOldApiOverride,
       )
     }
   }

--- a/libs/api/domains/icelandic-government-institution-vacancies/src/lib/models/icelandicGovernmentInstitutionVacancy.model.ts
+++ b/libs/api/domains/icelandic-government-institution-vacancies/src/lib/models/icelandicGovernmentInstitutionVacancy.model.ts
@@ -23,9 +23,6 @@ class IcelandicGovernmentInstitutionVacancyListItemBase {
   fieldOfWork?: string
 
   @Field({ nullable: true })
-  jobCategory?: string
-
-  @Field({ nullable: true })
   title?: string
 
   @Field({ nullable: true })

--- a/libs/api/domains/icelandic-government-institution-vacancies/src/lib/utils.spec.ts
+++ b/libs/api/domains/icelandic-government-institution-vacancies/src/lib/utils.spec.ts
@@ -114,7 +114,7 @@ describe('sortVacancyList', () => {
 })
 
 describe('mapIcelandicGovernmentInstitutionVacanciesFromElfur', () => {
-  it('should map jobCategory (starfssvid) separately from fieldOfWork (job title)', async () => {
+  it('should map jobCategory into fieldOfWork to match the old X-Road API', async () => {
     const result = await mapIcelandicGovernmentInstitutionVacanciesFromElfur([
       {
         vacancyID: '1',
@@ -125,11 +125,13 @@ describe('mapIcelandicGovernmentInstitutionVacanciesFromElfur', () => {
     ])
 
     expect(result).toHaveLength(1)
-    expect(result[0].fieldOfWork).toBe('Hjúkrunarfræðingur')
-    expect(result[0].jobCategory).toBe('Heilbrigðisþjónusta')
+    // fieldOfWork carries the category (the card eyebrow), consistent with the
+    // old API. The job title is not surfaced as a separate field.
+    expect(result[0].fieldOfWork).toBe('Heilbrigðisþjónusta')
+    expect(result[0].title).toBe('Hjúkrunarfræðingur óskast')
   })
 
-  it('should leave jobCategory undefined when the API omits it', async () => {
+  it('should leave fieldOfWork undefined when the API omits jobCategory', async () => {
     const result = await mapIcelandicGovernmentInstitutionVacanciesFromElfur([
       {
         vacancyID: '1',
@@ -138,6 +140,6 @@ describe('mapIcelandicGovernmentInstitutionVacanciesFromElfur', () => {
       },
     ])
 
-    expect(result[0].jobCategory).toBeUndefined()
+    expect(result[0].fieldOfWork).toBeUndefined()
   })
 })

--- a/libs/api/domains/icelandic-government-institution-vacancies/src/lib/utils.ts
+++ b/libs/api/domains/icelandic-government-institution-vacancies/src/lib/utils.ts
@@ -142,8 +142,7 @@ export const mapIcelandicGovernmentInstitutionVacanciesFromElfur = async (
       applicationDeadlineFrom: formatDate(item.publishDate),
       applicationDeadlineTo: formatDate(item.openTo),
       intro: '',
-      fieldOfWork: item.jobTitle ?? undefined,
-      jobCategory: item.jobCategory ?? undefined,
+      fieldOfWork: item.jobCategory ?? undefined,
       institutionName: item.orgName ?? undefined,
       institutionReferenceIdentifier: (() => {
         const orgNrStr =
@@ -262,8 +261,7 @@ export const mapIcelandicGovernmentInstitutionVacancyByIdResponseFromElfur =
       applicationDeadlineFrom: formatDate(vacancy.publishDate),
       applicationDeadlineTo: formatDate(vacancy.openTo),
       intro,
-      fieldOfWork: vacancy.jobTitle ?? undefined,
-      jobCategory: vacancy.jobCategory ?? undefined,
+      fieldOfWork: vacancy.jobCategory ?? undefined,
       institutionName: vacancy.orgName ?? undefined,
       institutionReferenceIdentifier: (() => {
         const orgNrStr =


### PR DESCRIPTION

## What

Hotfix in: 

* fix(starfatorg): show job category on new API cards and add api=old override

The new (Elfur) vacancy API mapped the job title into `fieldOfWork`, so the job card header displayed the title instead of the category shown by the old X-Road API. Normalize the Elfur mappers to place the category in `fieldOfWork` so the UI renders identically regardless of which external API serves the data, and remove the now-redundant `jobCategory` field along with the API-specific branches in the vacancy list filter.

Specify what you're trying to achieve

## Why

This needs to go out on release so the feature flag for the new elfur API can be lifted tomorrow 

## Screenshots / Gifs

n/a

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [x] No AI tools were used in preparing this pull request
- [ ] AI tools were used in preparing this pull request
      Tools used:
