### PR TITLE
feat(native-app): if asset id is on wrong format, show error and skip request

### DIFF
--- a/apps/native/app/src/app/(auth)/(tabs)/more/assets/[id].tsx
+++ b/apps/native/app/src/app/(auth)/(tabs)/more/assets/[id].tsx
@@ -14,7 +14,7 @@ export default function AssetsDetailScreen() {
   }>()
   const intl = useIntl()
 
-  const isValidId = !!id && /^F?\d+$/.test(id)
+  const isValidId = !!id && /^F\d+$/.test(id)
 
   const { data, loading, networkStatus } = useGetAssetQuery({
     variables: { input: { assetId: id } },

--- a/apps/native/app/src/app/(auth)/(tabs)/more/assets/[id].tsx
+++ b/apps/native/app/src/app/(auth)/(tabs)/more/assets/[id].tsx
@@ -2,7 +2,7 @@ import { useIntl } from 'react-intl'
 import { ScrollView, View } from 'react-native'
 import { router, Stack, useLocalSearchParams } from 'expo-router'
 
-import { Divider, Input, InputRow, NavigationBarSheet } from '@/ui'
+import { Divider, Input, InputRow, NavigationBarSheet, Problem } from '@/ui'
 import { useGetAssetQuery } from '@/graphql/types/schema'
 import { testIDs } from '@/utils/test-ids'
 import { StackScreen } from '../../../../../components/stack-screen'
@@ -14,8 +14,11 @@ export default function AssetsDetailScreen() {
   }>()
   const intl = useIntl()
 
+  const isValidId = !!id && /^F?\d+$/.test(id)
+
   const { data, loading, networkStatus } = useGetAssetQuery({
     variables: { input: { assetId: id } },
+    skip: !isValidId,
   })
 
   const isLoading = loading && !data
@@ -31,124 +34,128 @@ export default function AssetsDetailScreen() {
         }}
         closeable
       />
-      <View>
-        <InputRow>
-          <Input
-            loading={isLoading}
-            label={intl.formatMessage({
-              id: 'assetsDetail.propertyNumber',
-            })}
-            value={id}
-            size="big"
-            noBorder
-            isCompact
-          />
-        </InputRow>
-        <InputRow>
-          <Input
-            loading={isLoading}
-            label={intl.formatMessage(
-              { id: 'assetsDetail.activeAppraisal' },
-              { activeYear: appraisal?.activeYear },
-            )}
-            value={
-              appraisal?.activeAppraisal
-                ? `${intl.formatNumber(appraisal.activeAppraisal)} kr.`
-                : '-'
-            }
-            size="big"
-            noBorder
-            isCompact
-          />
-          <Input
-            loading={isLoading}
-            label={intl.formatMessage(
-              { id: 'assetsDetail.plannedAppraisal' },
-              { plannedYear: appraisal?.plannedYear },
-            )}
-            value={
-              appraisal?.plannedAppraisal
-                ? `${intl.formatNumber(appraisal.plannedAppraisal)} kr.`
-                : '-'
-            }
-            size="big"
-            noBorder
-            isCompact
-          />
-        </InputRow>
+      {!isValidId ? (
+        <Problem withContainer />
+      ) : (
+        <View>
+          <InputRow>
+            <Input
+              loading={isLoading}
+              label={intl.formatMessage({
+                id: 'assetsDetail.propertyNumber',
+              })}
+              value={id}
+              size="big"
+              noBorder
+              isCompact
+            />
+          </InputRow>
+          <InputRow>
+            <Input
+              loading={isLoading}
+              label={intl.formatMessage(
+                { id: 'assetsDetail.activeAppraisal' },
+                { activeYear: appraisal?.activeYear },
+              )}
+              value={
+                appraisal?.activeAppraisal
+                  ? `${intl.formatNumber(appraisal.activeAppraisal)} kr.`
+                  : '-'
+              }
+              size="big"
+              noBorder
+              isCompact
+            />
+            <Input
+              loading={isLoading}
+              label={intl.formatMessage(
+                { id: 'assetsDetail.plannedAppraisal' },
+                { plannedYear: appraisal?.plannedYear },
+              )}
+              value={
+                appraisal?.plannedAppraisal
+                  ? `${intl.formatNumber(appraisal.plannedAppraisal)} kr.`
+                  : '-'
+              }
+              size="big"
+              noBorder
+              isCompact
+            />
+          </InputRow>
 
-        <Divider spacing={2} style={{ marginHorizontal: 16 }} />
+          <Divider spacing={2} style={{ marginHorizontal: 16 }} />
 
-        {(unitsOfUse?.unitsOfUse ?? []).map((unit, index) => (
-          <View key={`${unit?.propertyNumber}-${index}`}>
-            <InputRow>
-              <Input
-                loading={isLoading}
-                label={intl.formatMessage({
-                  id: 'assetsDetail.explanation',
-                })}
-                value={unit?.explanation}
-                noBorder
-                isCompact
-              />
-              <Input
-                loading={isLoading}
-                label={intl.formatMessage({
-                  id: 'assetsDetail.displaySize',
-                })}
-                value={`${unit?.displaySize} m²`}
-                noBorder
-                isCompact
-              />
-            </InputRow>
-
-            <InputRow>
-              <Input
-                loading={isLoading}
-                label={intl.formatMessage({
-                  id: 'assetsDetail.municipality',
-                })}
-                value={unit?.address?.municipality}
-                noBorder
-                isCompact
-              />
-              <Input
-                loading={isLoading}
-                label={intl.formatMessage({
-                  id: 'assetsDetail.postNumber',
-                })}
-                value={String(unit?.address?.postNumber ?? '-')}
-                noBorder
-                isCompact
-              />
-            </InputRow>
-
-            <InputRow>
-              {unit?.buildYearDisplay ? (
+          {(unitsOfUse?.unitsOfUse ?? []).map((unit, index) => (
+            <View key={`${unit?.propertyNumber}-${index}`}>
+              <InputRow>
                 <Input
                   loading={isLoading}
                   label={intl.formatMessage({
-                    id: 'assetsDetail.buildYearDisplay',
+                    id: 'assetsDetail.explanation',
                   })}
-                  value={unit?.buildYearDisplay}
+                  value={unit?.explanation}
                   noBorder
                   isCompact
                 />
-              ) : null}
-              <Input
-                loading={isLoading}
-                label={intl.formatMessage({ id: 'assetsDetail.marking' })}
-                value={unit?.marking}
-                noBorder
-                isCompact
-              />
-            </InputRow>
-            {index + 1 < (unitsOfUse?.unitsOfUse ?? []).length && (
-              <Divider spacing={2} style={{ marginHorizontal: 16 }} />
-            )}
-          </View>
-        ))}
-      </View>
+                <Input
+                  loading={isLoading}
+                  label={intl.formatMessage({
+                    id: 'assetsDetail.displaySize',
+                  })}
+                  value={`${unit?.displaySize} m²`}
+                  noBorder
+                  isCompact
+                />
+              </InputRow>
+
+              <InputRow>
+                <Input
+                  loading={isLoading}
+                  label={intl.formatMessage({
+                    id: 'assetsDetail.municipality',
+                  })}
+                  value={unit?.address?.municipality}
+                  noBorder
+                  isCompact
+                />
+                <Input
+                  loading={isLoading}
+                  label={intl.formatMessage({
+                    id: 'assetsDetail.postNumber',
+                  })}
+                  value={String(unit?.address?.postNumber ?? '-')}
+                  noBorder
+                  isCompact
+                />
+              </InputRow>
+
+              <InputRow>
+                {unit?.buildYearDisplay ? (
+                  <Input
+                    loading={isLoading}
+                    label={intl.formatMessage({
+                      id: 'assetsDetail.buildYearDisplay',
+                    })}
+                    value={unit?.buildYearDisplay}
+                    noBorder
+                    isCompact
+                  />
+                ) : null}
+                <Input
+                  loading={isLoading}
+                  label={intl.formatMessage({ id: 'assetsDetail.marking' })}
+                  value={unit?.marking}
+                  noBorder
+                  isCompact
+                />
+              </InputRow>
+              {index + 1 < (unitsOfUse?.unitsOfUse ?? []).length && (
+                <Divider spacing={2} style={{ marginHorizontal: 16 }} />
+              )}
+            </View>
+          ))}
+        </View>
+      )}
     </ScrollView>
   )
 }


### PR DESCRIPTION
## What

If asset id is on the wrong format, skip calling api and show error component.

## Why

Prevent calling the api with wrong data. 

## Screenshots / Gifs
If asset Id is on the wrong format this is what we show now:
<img width="446" height="941" alt="Screenshot 2026-06-09 at 11 30 42" src="https://github.com/user-attachments/assets/14e42e72-481b-4120-bf1c-0afc7eee7f8b" />


## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The asset details screen now includes validation for asset identifiers. When an invalid asset ID is accessed, the app displays an appropriate error message instead of attempting to load the asset, preventing broken or blank views. This improves reliability and user experience when navigating asset information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->