### PR TITLE
fix(application-system): wrong date in historyLogs

### DIFF
--- a/libs/application/api/history/src/lib/historyBuilder.spec.ts
+++ b/libs/application/api/history/src/lib/historyBuilder.spec.ts
@@ -1,0 +1,315 @@
+// Mock the identity client before any imports trigger the module's dependency chain.
+// @island.is/clients/identity transitively loads @configcat/sdk, which is not
+// available in the test environment.
+jest.mock('@island.is/clients/identity', () => ({
+  IdentityClientService: class {
+    tryToGetNameFromNationalId = jest.fn().mockResolvedValue(undefined)
+  },
+}))
+
+import { Test } from '@nestjs/testing'
+import { HistoryBuilder } from './historyBuilder'
+import { History } from './history.model'
+import { IdentityClientService } from '@island.is/clients/identity'
+import { ApplicationTemplateHelper, coreHistoryMessages } from '@island.is/application/core'
+import {
+  Application,
+  ApplicationContext,
+  ApplicationStateSchema,
+  FormatMessage,
+} from '@island.is/application/types'
+import { EventObject } from 'xstate'
+
+type TemplateHelper = ApplicationTemplateHelper<
+  ApplicationContext,
+  ApplicationStateSchema<EventObject>,
+  EventObject
+>
+
+// Resolves MessageDescriptor to defaultMessage with basic {key} interpolation,
+// or returns plain strings as-is. Mirrors the minimum behaviour the builder relies on.
+const formatMessage: FormatMessage = (msg, values) => {
+  const template =
+    typeof msg === 'string'
+      ? msg
+      : typeof msg.defaultMessage === 'string'
+      ? msg.defaultMessage
+      : ''
+  return Object.entries(values ?? {}).reduce(
+    (str, [key, val]) => str.replace(`{${key}}`, String(val ?? '')),
+    template,
+  )
+}
+
+const makeEntry = (overrides: Partial<History> = {}): History =>
+  ({
+    id: 'uuid-1',
+    stateKey: 'draft',
+    exitEvent: 'SUBMIT',
+    exitTimestamp: new Date('2024-01-02T10:00:00Z'),
+    entryTimestamp: new Date('2024-01-01T10:00:00Z'),
+    application_id: 'app-id',
+    previousState: '',
+    exitEventSubjectNationalId: undefined,
+    exitEventActorNationalId: undefined,
+    ...overrides,
+  } as unknown as History)
+
+const makeApplication = (answersOverrides = {}): Application =>
+  ({ answers: { buyer: { nationalId: '1234567890' }, ...answersOverrides } } as unknown as Application)
+
+const SUBJECT_NATIONAL_ID = '1111111119'
+const ACTOR_NATIONAL_ID = '2222222229'
+
+describe('HistoryBuilder', () => {
+  let builder: HistoryBuilder
+  let identityService: jest.Mocked<Pick<IdentityClientService, 'tryToGetNameFromNationalId'>>
+  let templateHelper: jest.Mocked<Pick<TemplateHelper, 'getHistoryLog'>>
+
+  beforeEach(async () => {
+    const module = await Test.createTestingModule({
+      providers: [
+        HistoryBuilder,
+        {
+          provide: IdentityClientService,
+          useValue: {
+            tryToGetNameFromNationalId: jest.fn().mockResolvedValue(undefined),
+          },
+        },
+      ],
+    }).compile()
+
+    builder = module.get(HistoryBuilder)
+    identityService = module.get(IdentityClientService)
+    templateHelper = { getHistoryLog: jest.fn() }
+  })
+
+  const build = (entries: History[], application = makeApplication()) =>
+    builder.buildApplicationHistory(
+      entries,
+      formatMessage,
+      templateHelper as unknown as TemplateHelper,
+      application,
+      'applicant',
+      '0000000000',
+      false,
+    )
+
+  // --- Guard behaviour ---
+
+  it('skips entries with no exitEvent', async () => {
+    const result = await build([makeEntry({ exitEvent: undefined })])
+    expect(result).toHaveLength(0)
+    expect(templateHelper.getHistoryLog).not.toHaveBeenCalled()
+  })
+
+  it('skips entries with no exitTimestamp', async () => {
+    const result = await build([makeEntry({ exitTimestamp: undefined })])
+    expect(result).toHaveLength(0)
+    expect(templateHelper.getHistoryLog).not.toHaveBeenCalled()
+  })
+
+  it('skips entries where no historyLog is configured for the exitEvent', async () => {
+    templateHelper.getHistoryLog.mockReturnValue(undefined)
+    const result = await build([makeEntry()])
+    expect(result).toHaveLength(0)
+  })
+
+  // --- Static logMessage (mirrors DRAFT → SUBMIT in TransferOfVehicleOwnership) ---
+
+  it('returns a HistoryResponseDto with the correct date and log for a static MessageDescriptor', async () => {
+    templateHelper.getHistoryLog.mockReturnValue({
+      onEvent: 'SUBMIT',
+      logMessage: coreHistoryMessages.paymentStarted,
+    })
+    const exitTimestamp = new Date('2024-03-15T12:00:00Z')
+
+    const result = await build([makeEntry({ exitTimestamp })])
+
+    expect(result).toHaveLength(1)
+    expect(result[0].date).toEqual(exitTimestamp)
+    expect(result[0].log).toBe(coreHistoryMessages.paymentStarted.defaultMessage)
+    expect(result[0].subLog).toBeUndefined()
+  })
+
+  // --- Dynamic logMessage function (mirrors REVIEW → APPROVE/REJECT in TransferOfVehicleOwnership) ---
+
+  it('calls a logMessage function with the application and subjectNationalId', async () => {
+    const logMessageFn = jest.fn().mockReturnValue(coreHistoryMessages.applicationApprovedBy)
+    templateHelper.getHistoryLog.mockReturnValue({
+      onEvent: 'APPROVE',
+      logMessage: logMessageFn,
+    })
+
+    await build([makeEntry({
+      stateKey: 'review',
+      exitEvent: 'APPROVE',
+      exitEventSubjectNationalId: SUBJECT_NATIONAL_ID,
+    })])
+
+    expect(logMessageFn).toHaveBeenCalledWith(
+      expect.objectContaining({ answers: expect.anything() }),
+      SUBJECT_NATIONAL_ID,
+    )
+  })
+
+  it('uses the return value of a logMessage function as the log text', async () => {
+    templateHelper.getHistoryLog.mockReturnValue({
+      onEvent: 'APPROVE',
+      logMessage: () => coreHistoryMessages.applicationApprovedBy,
+    })
+
+    const result = await build([makeEntry({ stateKey: 'review', exitEvent: 'APPROVE' })])
+
+    expect(result[0].log).toBe(coreHistoryMessages.applicationApprovedBy.defaultMessage)
+  })
+
+  // --- includeSubjectAndActor ---
+
+  it('does not call the identity service when includeSubjectAndActor is false', async () => {
+    templateHelper.getHistoryLog.mockReturnValue({
+      onEvent: 'SUBMIT',
+      logMessage: coreHistoryMessages.paymentStarted,
+      includeSubjectAndActor: false,
+    })
+
+    await build([makeEntry({ exitEventSubjectNationalId: SUBJECT_NATIONAL_ID })])
+
+    expect(identityService.tryToGetNameFromNationalId).not.toHaveBeenCalled()
+  })
+
+  it('resolves subject name and sets subLog when includeSubjectAndActor is true', async () => {
+    identityService.tryToGetNameFromNationalId.mockResolvedValue('Jón Jónsson')
+    templateHelper.getHistoryLog.mockReturnValue({
+      onEvent: 'APPROVE',
+      logMessage: coreHistoryMessages.applicationApprovedBy,
+      includeSubjectAndActor: true,
+    })
+
+    const result = await build([makeEntry({
+      stateKey: 'review',
+      exitEvent: 'APPROVE',
+      exitEventSubjectNationalId: SUBJECT_NATIONAL_ID,
+    })])
+
+    expect(identityService.tryToGetNameFromNationalId).toHaveBeenCalledWith(SUBJECT_NATIONAL_ID)
+    expect(result[0].subLog).toContain('Jón Jónsson')
+  })
+
+  it('falls back to the nationalId as display name when the identity lookup returns undefined', async () => {
+    identityService.tryToGetNameFromNationalId.mockResolvedValue(undefined)
+    templateHelper.getHistoryLog.mockReturnValue({
+      onEvent: 'APPROVE',
+      logMessage: coreHistoryMessages.applicationApprovedBy,
+      includeSubjectAndActor: true,
+    })
+
+    const result = await build([makeEntry({
+      stateKey: 'review',
+      exitEvent: 'APPROVE',
+      exitEventSubjectNationalId: SUBJECT_NATIONAL_ID,
+    })])
+
+    expect(result[0].subLog).toContain(SUBJECT_NATIONAL_ID)
+  })
+
+  it('includes both subject and actor in subLog when they are different people', async () => {
+    identityService.tryToGetNameFromNationalId
+      .mockResolvedValueOnce('Jón Jónsson')   // subject
+      .mockResolvedValueOnce('María Sigurðardóttir') // actor
+    templateHelper.getHistoryLog.mockReturnValue({
+      onEvent: 'APPROVE',
+      logMessage: coreHistoryMessages.applicationApprovedBy,
+      includeSubjectAndActor: true,
+    })
+
+    const result = await build([makeEntry({
+      stateKey: 'review',
+      exitEvent: 'APPROVE',
+      exitEventSubjectNationalId: SUBJECT_NATIONAL_ID,
+      exitEventActorNationalId: ACTOR_NATIONAL_ID,
+    })])
+
+    expect(result[0].subLog).toContain('Jón Jónsson')
+    expect(result[0].subLog).toContain('María Sigurðardóttir')
+  })
+
+  it('uses the single-name format when subject and actor are the same person', async () => {
+    identityService.tryToGetNameFromNationalId.mockResolvedValue('Jón Jónsson')
+    templateHelper.getHistoryLog.mockReturnValue({
+      onEvent: 'APPROVE',
+      logMessage: coreHistoryMessages.applicationApprovedBy,
+      includeSubjectAndActor: true,
+    })
+
+    const result = await build([makeEntry({
+      stateKey: 'review',
+      exitEvent: 'APPROVE',
+      exitEventSubjectNationalId: SUBJECT_NATIONAL_ID,
+      exitEventActorNationalId: SUBJECT_NATIONAL_ID, // same person
+    })])
+
+    // byReviewer format — name appears once, not twice
+    expect(result[0].subLog).toBe(
+      coreHistoryMessages.byReviewer.defaultMessage.replace('{subject}', 'Jón Jónsson'),
+    )
+  })
+
+  it('calls an includeSubjectAndActor function with currentUserRole, nationalId, and isAdmin', async () => {
+    const includeSubjectAndActorFn = jest.fn().mockReturnValue(false)
+    templateHelper.getHistoryLog.mockReturnValue({
+      onEvent: 'APPROVE',
+      logMessage: coreHistoryMessages.applicationApprovedBy,
+      includeSubjectAndActor: includeSubjectAndActorFn,
+    })
+
+    await builder.buildApplicationHistory(
+      [makeEntry({ stateKey: 'review', exitEvent: 'APPROVE', exitEventSubjectNationalId: SUBJECT_NATIONAL_ID })],
+      formatMessage,
+      templateHelper as unknown as TemplateHelper,
+      makeApplication(),
+      'buyer',
+      '3333333339',
+      true,
+    )
+
+    expect(includeSubjectAndActorFn).toHaveBeenCalledWith('buyer', '3333333339', true)
+  })
+
+  it('does not set subLog when the includeSubjectAndActor function returns false', async () => {
+    templateHelper.getHistoryLog.mockReturnValue({
+      onEvent: 'APPROVE',
+      logMessage: coreHistoryMessages.applicationApprovedBy,
+      includeSubjectAndActor: () => false,
+    })
+
+    const result = await build([makeEntry({
+      stateKey: 'review',
+      exitEvent: 'APPROVE',
+      exitEventSubjectNationalId: SUBJECT_NATIONAL_ID,
+    })])
+
+    expect(identityService.tryToGetNameFromNationalId).not.toHaveBeenCalled()
+    expect(result[0].subLog).toBeUndefined()
+  })
+
+  // --- Sorting ---
+
+  it('returns entries sorted by exitTimestamp descending', async () => {
+    templateHelper.getHistoryLog.mockReturnValue({
+      onEvent: 'SUBMIT',
+      logMessage: coreHistoryMessages.paymentStarted,
+    })
+    const entries = [
+      makeEntry({ exitTimestamp: new Date('2024-01-01T00:00:00Z') }),
+      makeEntry({ exitTimestamp: new Date('2024-01-03T00:00:00Z') }),
+      makeEntry({ exitTimestamp: new Date('2024-01-02T00:00:00Z') }),
+    ]
+
+    const result = await build(entries)
+
+    expect(result[0].date).toEqual(new Date('2024-01-03T00:00:00Z'))
+    expect(result[1].date).toEqual(new Date('2024-01-02T00:00:00Z'))
+    expect(result[2].date).toEqual(new Date('2024-01-01T00:00:00Z'))
+  })
+})

--- a/libs/application/api/history/src/lib/historyBuilder.spec.ts
+++ b/libs/application/api/history/src/lib/historyBuilder.spec.ts
@@ -29,7 +29,6 @@ type TemplateHelper = ApplicationTemplateHelper<
   EventObject
 >
 
-
 const makeEntry = (overrides: Partial<History> = {}): History =>
   ({
     id: 'uuid-1',
@@ -61,7 +60,9 @@ describe('HistoryBuilder', () => {
   let templateHelper: jest.Mocked<Pick<TemplateHelper, 'getHistoryLog'>>
 
   beforeEach(async () => {
-    formatMessage = jest.fn<string, Parameters<FormatMessage>>().mockReturnValue('')
+    formatMessage = jest
+      .fn<string, Parameters<FormatMessage>>()
+      .mockReturnValue('')
     const module = await Test.createTestingModule({
       providers: [
         HistoryBuilder,

--- a/libs/application/api/history/src/lib/historyBuilder.spec.ts
+++ b/libs/application/api/history/src/lib/historyBuilder.spec.ts
@@ -11,7 +11,10 @@ import { Test } from '@nestjs/testing'
 import { HistoryBuilder } from './historyBuilder'
 import { History } from './history.model'
 import { IdentityClientService } from '@island.is/clients/identity'
-import { ApplicationTemplateHelper, coreHistoryMessages } from '@island.is/application/core'
+import {
+  ApplicationTemplateHelper,
+  coreHistoryMessages,
+} from '@island.is/application/core'
 import {
   Application,
   ApplicationContext,
@@ -56,14 +59,18 @@ const makeEntry = (overrides: Partial<History> = {}): History =>
   } as unknown as History)
 
 const makeApplication = (answersOverrides = {}): Application =>
-  ({ answers: { buyer: { nationalId: '1234567890' }, ...answersOverrides } } as unknown as Application)
+  ({
+    answers: { buyer: { nationalId: '1234567890' }, ...answersOverrides },
+  } as unknown as Application)
 
 const SUBJECT_NATIONAL_ID = '1111111119'
 const ACTOR_NATIONAL_ID = '2222222229'
 
 describe('HistoryBuilder', () => {
   let builder: HistoryBuilder
-  let identityService: jest.Mocked<Pick<IdentityClientService, 'tryToGetNameFromNationalId'>>
+  let identityService: jest.Mocked<
+    Pick<IdentityClientService, 'tryToGetNameFromNationalId'>
+  >
   let templateHelper: jest.Mocked<Pick<TemplateHelper, 'getHistoryLog'>>
 
   beforeEach(async () => {
@@ -128,24 +135,30 @@ describe('HistoryBuilder', () => {
 
     expect(result).toHaveLength(1)
     expect(result[0].date).toEqual(exitTimestamp)
-    expect(result[0].log).toBe(coreHistoryMessages.paymentStarted.defaultMessage)
+    expect(result[0].log).toBe(
+      coreHistoryMessages.paymentStarted.defaultMessage,
+    )
     expect(result[0].subLog).toBeUndefined()
   })
 
   // --- Dynamic logMessage function (mirrors REVIEW → APPROVE/REJECT in TransferOfVehicleOwnership) ---
 
   it('calls a logMessage function with the application and subjectNationalId', async () => {
-    const logMessageFn = jest.fn().mockReturnValue(coreHistoryMessages.applicationApprovedBy)
+    const logMessageFn = jest
+      .fn()
+      .mockReturnValue(coreHistoryMessages.applicationApprovedBy)
     templateHelper.getHistoryLog.mockReturnValue({
       onEvent: 'APPROVE',
       logMessage: logMessageFn,
     })
 
-    await build([makeEntry({
-      stateKey: 'review',
-      exitEvent: 'APPROVE',
-      exitEventSubjectNationalId: SUBJECT_NATIONAL_ID,
-    })])
+    await build([
+      makeEntry({
+        stateKey: 'review',
+        exitEvent: 'APPROVE',
+        exitEventSubjectNationalId: SUBJECT_NATIONAL_ID,
+      }),
+    ])
 
     expect(logMessageFn).toHaveBeenCalledWith(
       expect.objectContaining({ answers: expect.anything() }),
@@ -159,9 +172,13 @@ describe('HistoryBuilder', () => {
       logMessage: () => coreHistoryMessages.applicationApprovedBy,
     })
 
-    const result = await build([makeEntry({ stateKey: 'review', exitEvent: 'APPROVE' })])
+    const result = await build([
+      makeEntry({ stateKey: 'review', exitEvent: 'APPROVE' }),
+    ])
 
-    expect(result[0].log).toBe(coreHistoryMessages.applicationApprovedBy.defaultMessage)
+    expect(result[0].log).toBe(
+      coreHistoryMessages.applicationApprovedBy.defaultMessage,
+    )
   })
 
   // --- includeSubjectAndActor ---
@@ -173,7 +190,9 @@ describe('HistoryBuilder', () => {
       includeSubjectAndActor: false,
     })
 
-    await build([makeEntry({ exitEventSubjectNationalId: SUBJECT_NATIONAL_ID })])
+    await build([
+      makeEntry({ exitEventSubjectNationalId: SUBJECT_NATIONAL_ID }),
+    ])
 
     expect(identityService.tryToGetNameFromNationalId).not.toHaveBeenCalled()
   })
@@ -186,13 +205,17 @@ describe('HistoryBuilder', () => {
       includeSubjectAndActor: true,
     })
 
-    const result = await build([makeEntry({
-      stateKey: 'review',
-      exitEvent: 'APPROVE',
-      exitEventSubjectNationalId: SUBJECT_NATIONAL_ID,
-    })])
+    const result = await build([
+      makeEntry({
+        stateKey: 'review',
+        exitEvent: 'APPROVE',
+        exitEventSubjectNationalId: SUBJECT_NATIONAL_ID,
+      }),
+    ])
 
-    expect(identityService.tryToGetNameFromNationalId).toHaveBeenCalledWith(SUBJECT_NATIONAL_ID)
+    expect(identityService.tryToGetNameFromNationalId).toHaveBeenCalledWith(
+      SUBJECT_NATIONAL_ID,
+    )
     expect(result[0].subLog).toContain('Jón Jónsson')
   })
 
@@ -204,18 +227,20 @@ describe('HistoryBuilder', () => {
       includeSubjectAndActor: true,
     })
 
-    const result = await build([makeEntry({
-      stateKey: 'review',
-      exitEvent: 'APPROVE',
-      exitEventSubjectNationalId: SUBJECT_NATIONAL_ID,
-    })])
+    const result = await build([
+      makeEntry({
+        stateKey: 'review',
+        exitEvent: 'APPROVE',
+        exitEventSubjectNationalId: SUBJECT_NATIONAL_ID,
+      }),
+    ])
 
     expect(result[0].subLog).toContain(SUBJECT_NATIONAL_ID)
   })
 
   it('includes both subject and actor in subLog when they are different people', async () => {
     identityService.tryToGetNameFromNationalId
-      .mockResolvedValueOnce('Jón Jónsson')   // subject
+      .mockResolvedValueOnce('Jón Jónsson') // subject
       .mockResolvedValueOnce('María Sigurðardóttir') // actor
     templateHelper.getHistoryLog.mockReturnValue({
       onEvent: 'APPROVE',
@@ -223,12 +248,14 @@ describe('HistoryBuilder', () => {
       includeSubjectAndActor: true,
     })
 
-    const result = await build([makeEntry({
-      stateKey: 'review',
-      exitEvent: 'APPROVE',
-      exitEventSubjectNationalId: SUBJECT_NATIONAL_ID,
-      exitEventActorNationalId: ACTOR_NATIONAL_ID,
-    })])
+    const result = await build([
+      makeEntry({
+        stateKey: 'review',
+        exitEvent: 'APPROVE',
+        exitEventSubjectNationalId: SUBJECT_NATIONAL_ID,
+        exitEventActorNationalId: ACTOR_NATIONAL_ID,
+      }),
+    ])
 
     expect(result[0].subLog).toContain('Jón Jónsson')
     expect(result[0].subLog).toContain('María Sigurðardóttir')
@@ -242,16 +269,21 @@ describe('HistoryBuilder', () => {
       includeSubjectAndActor: true,
     })
 
-    const result = await build([makeEntry({
-      stateKey: 'review',
-      exitEvent: 'APPROVE',
-      exitEventSubjectNationalId: SUBJECT_NATIONAL_ID,
-      exitEventActorNationalId: SUBJECT_NATIONAL_ID, // same person
-    })])
+    const result = await build([
+      makeEntry({
+        stateKey: 'review',
+        exitEvent: 'APPROVE',
+        exitEventSubjectNationalId: SUBJECT_NATIONAL_ID,
+        exitEventActorNationalId: SUBJECT_NATIONAL_ID, // same person
+      }),
+    ])
 
     // byReviewer format — name appears once, not twice
     expect(result[0].subLog).toBe(
-      coreHistoryMessages.byReviewer.defaultMessage.replace('{subject}', 'Jón Jónsson'),
+      coreHistoryMessages.byReviewer.defaultMessage.replace(
+        '{subject}',
+        'Jón Jónsson',
+      ),
     )
   })
 
@@ -264,7 +296,13 @@ describe('HistoryBuilder', () => {
     })
 
     await builder.buildApplicationHistory(
-      [makeEntry({ stateKey: 'review', exitEvent: 'APPROVE', exitEventSubjectNationalId: SUBJECT_NATIONAL_ID })],
+      [
+        makeEntry({
+          stateKey: 'review',
+          exitEvent: 'APPROVE',
+          exitEventSubjectNationalId: SUBJECT_NATIONAL_ID,
+        }),
+      ],
       formatMessage,
       templateHelper as unknown as TemplateHelper,
       makeApplication(),
@@ -273,7 +311,11 @@ describe('HistoryBuilder', () => {
       true,
     )
 
-    expect(includeSubjectAndActorFn).toHaveBeenCalledWith('buyer', '3333333339', true)
+    expect(includeSubjectAndActorFn).toHaveBeenCalledWith(
+      'buyer',
+      '3333333339',
+      true,
+    )
   })
 
   it('does not set subLog when the includeSubjectAndActor function returns false', async () => {
@@ -283,11 +325,13 @@ describe('HistoryBuilder', () => {
       includeSubjectAndActor: () => false,
     })
 
-    const result = await build([makeEntry({
-      stateKey: 'review',
-      exitEvent: 'APPROVE',
-      exitEventSubjectNationalId: SUBJECT_NATIONAL_ID,
-    })])
+    const result = await build([
+      makeEntry({
+        stateKey: 'review',
+        exitEvent: 'APPROVE',
+        exitEventSubjectNationalId: SUBJECT_NATIONAL_ID,
+      }),
+    ])
 
     expect(identityService.tryToGetNameFromNationalId).not.toHaveBeenCalled()
     expect(result[0].subLog).toBeUndefined()

--- a/libs/application/api/history/src/lib/historyBuilder.spec.ts
+++ b/libs/application/api/history/src/lib/historyBuilder.spec.ts
@@ -29,18 +29,6 @@ type TemplateHelper = ApplicationTemplateHelper<
   EventObject
 >
 
-const makeFormatMessageImpl = (): FormatMessage => (msg, values) => {
-  const template =
-    typeof msg === 'string'
-      ? msg
-      : typeof msg.defaultMessage === 'string'
-      ? msg.defaultMessage
-      : ''
-  return Object.entries(values ?? {}).reduce(
-    (str, [key, val]) => str.replace(`{${key}}`, String(val ?? '')),
-    template,
-  )
-}
 
 const makeEntry = (overrides: Partial<History> = {}): History =>
   ({
@@ -73,9 +61,7 @@ describe('HistoryBuilder', () => {
   let templateHelper: jest.Mocked<Pick<TemplateHelper, 'getHistoryLog'>>
 
   beforeEach(async () => {
-    formatMessage = jest
-      .fn<string, Parameters<FormatMessage>>()
-      .mockImplementation(makeFormatMessageImpl())
+    formatMessage = jest.fn<string, Parameters<FormatMessage>>().mockReturnValue('')
     const module = await Test.createTestingModule({
       providers: [
         HistoryBuilder,

--- a/libs/application/api/history/src/lib/historyBuilder.spec.ts
+++ b/libs/application/api/history/src/lib/historyBuilder.spec.ts
@@ -51,6 +51,8 @@ const makeApplication = (answersOverrides = {}): Application =>
 
 const SUBJECT_NATIONAL_ID = '1111111119'
 const ACTOR_NATIONAL_ID = '2222222229'
+const SUBJECT_NAME = 'Jón Jónsson'
+const ACTOR_NAME = 'María Sigurðardóttir'
 
 describe('HistoryBuilder', () => {
   let builder: HistoryBuilder
@@ -188,7 +190,7 @@ describe('HistoryBuilder', () => {
   })
 
   it('resolves subject name and sets subLog when includeSubjectAndActor is true', async () => {
-    identityService.tryToGetNameFromNationalId.mockResolvedValue('Jón Jónsson')
+    identityService.tryToGetNameFromNationalId.mockResolvedValue(SUBJECT_NAME)
     templateHelper.getHistoryLog.mockReturnValue({
       onEvent: 'APPROVE',
       logMessage: coreHistoryMessages.applicationApprovedBy,
@@ -207,7 +209,7 @@ describe('HistoryBuilder', () => {
       SUBJECT_NATIONAL_ID,
     )
     expect(formatMessage).toHaveBeenCalledWith(coreHistoryMessages.byReviewer, {
-      subject: 'Jón Jónsson',
+      subject: SUBJECT_NAME,
     })
   })
 
@@ -234,8 +236,8 @@ describe('HistoryBuilder', () => {
 
   it('includes both subject and actor in subLog when they are different people', async () => {
     identityService.tryToGetNameFromNationalId
-      .mockResolvedValueOnce('Jón Jónsson') // subject
-      .mockResolvedValueOnce('María Sigurðardóttir') // actor
+      .mockResolvedValueOnce(SUBJECT_NAME) // subject
+      .mockResolvedValueOnce(ACTOR_NAME) // actor
     templateHelper.getHistoryLog.mockReturnValue({
       onEvent: 'APPROVE',
       logMessage: coreHistoryMessages.applicationApprovedBy,
@@ -253,12 +255,12 @@ describe('HistoryBuilder', () => {
 
     expect(formatMessage).toHaveBeenCalledWith(
       coreHistoryMessages.byReviewerWithActor,
-      { subject: 'Jón Jónsson', actor: 'María Sigurðardóttir' },
+      { subject: SUBJECT_NAME, actor: ACTOR_NAME },
     )
   })
 
   it('uses the single-name format when subject and actor are the same person', async () => {
-    identityService.tryToGetNameFromNationalId.mockResolvedValue('Jón Jónsson')
+    identityService.tryToGetNameFromNationalId.mockResolvedValue(SUBJECT_NAME)
     templateHelper.getHistoryLog.mockReturnValue({
       onEvent: 'APPROVE',
       logMessage: coreHistoryMessages.applicationApprovedBy,
@@ -276,7 +278,7 @@ describe('HistoryBuilder', () => {
 
     // byReviewer format — name appears once, not twice
     expect(formatMessage).toHaveBeenCalledWith(coreHistoryMessages.byReviewer, {
-      subject: 'Jón Jónsson',
+      subject: SUBJECT_NAME,
     })
   })
 

--- a/libs/application/api/history/src/lib/historyBuilder.spec.ts
+++ b/libs/application/api/history/src/lib/historyBuilder.spec.ts
@@ -29,9 +29,7 @@ type TemplateHelper = ApplicationTemplateHelper<
   EventObject
 >
 
-// Resolves MessageDescriptor to defaultMessage with basic {key} interpolation,
-// or returns plain strings as-is. Mirrors the minimum behaviour the builder relies on.
-const formatMessage: FormatMessage = (msg, values) => {
+const makeFormatMessageImpl = (): FormatMessage => (msg, values) => {
   const template =
     typeof msg === 'string'
       ? msg
@@ -68,12 +66,16 @@ const ACTOR_NATIONAL_ID = '2222222229'
 
 describe('HistoryBuilder', () => {
   let builder: HistoryBuilder
+  let formatMessage: jest.MockedFunction<FormatMessage>
   let identityService: jest.Mocked<
     Pick<IdentityClientService, 'tryToGetNameFromNationalId'>
   >
   let templateHelper: jest.Mocked<Pick<TemplateHelper, 'getHistoryLog'>>
 
   beforeEach(async () => {
+    formatMessage = jest
+      .fn<string, Parameters<FormatMessage>>()
+      .mockImplementation(makeFormatMessageImpl())
     const module = await Test.createTestingModule({
       providers: [
         HistoryBuilder,
@@ -135,8 +137,9 @@ describe('HistoryBuilder', () => {
 
     expect(result).toHaveLength(1)
     expect(result[0].date).toEqual(exitTimestamp)
-    expect(result[0].log).toBe(
-      coreHistoryMessages.paymentStarted.defaultMessage,
+    expect(formatMessage).toHaveBeenCalledWith(
+      coreHistoryMessages.paymentStarted,
+      undefined,
     )
     expect(result[0].subLog).toBeUndefined()
   })
@@ -176,8 +179,9 @@ describe('HistoryBuilder', () => {
       makeEntry({ stateKey: 'review', exitEvent: 'APPROVE' }),
     ])
 
-    expect(result[0].log).toBe(
-      coreHistoryMessages.applicationApprovedBy.defaultMessage,
+    expect(formatMessage).toHaveBeenCalledWith(
+      coreHistoryMessages.applicationApprovedBy,
+      undefined,
     )
   })
 
@@ -216,7 +220,9 @@ describe('HistoryBuilder', () => {
     expect(identityService.tryToGetNameFromNationalId).toHaveBeenCalledWith(
       SUBJECT_NATIONAL_ID,
     )
-    expect(result[0].subLog).toContain('Jón Jónsson')
+    expect(formatMessage).toHaveBeenCalledWith(coreHistoryMessages.byReviewer, {
+      subject: 'Jón Jónsson',
+    })
   })
 
   it('falls back to the nationalId as display name when the identity lookup returns undefined', async () => {
@@ -235,7 +241,9 @@ describe('HistoryBuilder', () => {
       }),
     ])
 
-    expect(result[0].subLog).toContain(SUBJECT_NATIONAL_ID)
+    expect(formatMessage).toHaveBeenCalledWith(coreHistoryMessages.byReviewer, {
+      subject: SUBJECT_NATIONAL_ID,
+    })
   })
 
   it('includes both subject and actor in subLog when they are different people', async () => {
@@ -257,8 +265,10 @@ describe('HistoryBuilder', () => {
       }),
     ])
 
-    expect(result[0].subLog).toContain('Jón Jónsson')
-    expect(result[0].subLog).toContain('María Sigurðardóttir')
+    expect(formatMessage).toHaveBeenCalledWith(
+      coreHistoryMessages.byReviewerWithActor,
+      { subject: 'Jón Jónsson', actor: 'María Sigurðardóttir' },
+    )
   })
 
   it('uses the single-name format when subject and actor are the same person', async () => {
@@ -279,12 +289,9 @@ describe('HistoryBuilder', () => {
     ])
 
     // byReviewer format — name appears once, not twice
-    expect(result[0].subLog).toBe(
-      coreHistoryMessages.byReviewer.defaultMessage.replace(
-        '{subject}',
-        'Jón Jónsson',
-      ),
-    )
+    expect(formatMessage).toHaveBeenCalledWith(coreHistoryMessages.byReviewer, {
+      subject: 'Jón Jónsson',
+    })
   })
 
   it('calls an includeSubjectAndActor function with currentUserRole, nationalId, and isAdmin', async () => {

--- a/libs/application/api/history/src/lib/historyBuilder.ts
+++ b/libs/application/api/history/src/lib/historyBuilder.ts
@@ -30,18 +30,18 @@ export class HistoryBuilder {
     currentUserNationalId: string,
     isAdmin: boolean,
   ): Promise<HistoryResponseDto[] | []> {
-    const result = []
+    const result: HistoryResponseDto[] = []
 
     for (const entry of history) {
       const {
-        entryTimestamp,
         stateKey,
         exitEvent,
+        exitTimestamp,
         exitEventSubjectNationalId: subjectNationalId,
         exitEventActorNationalId: actorNationalId,
       } = entry
 
-      if (!exitEvent) continue
+      if (!exitEvent || !exitTimestamp) continue
 
       const historyLog = templateHelper.getHistoryLog(stateKey, exitEvent)
 
@@ -95,7 +95,7 @@ export class HistoryBuilder {
 
         result.push(
           new HistoryResponseDto(
-            entryTimestamp,
+            exitTimestamp,
             message,
             formatMessage,
             subjectAndActorText,

--- a/libs/application/api/history/src/lib/historyBuilder.ts
+++ b/libs/application/api/history/src/lib/historyBuilder.ts
@@ -29,7 +29,7 @@ export class HistoryBuilder {
     currentUserRole: string,
     currentUserNationalId: string,
     isAdmin: boolean,
-  ): Promise<HistoryResponseDto[] | []> {
+  ): Promise<HistoryResponseDto[]> {
     const result: HistoryResponseDto[] = []
 
     for (const entry of history) {

--- a/libs/application/templates/examples/example-common-actions/src/lib/template.ts
+++ b/libs/application/templates/examples/example-common-actions/src/lib/template.ts
@@ -54,7 +54,7 @@ const template: ApplicationTemplate<
             historyLogs: [
               {
                 onEvent: DefaultEvents.SUBMIT,
-                logMessage: 'Eitthvað message prerequsites',
+                logMessage: 'Umsókn úr prerequisites',
               },
             ],
           },
@@ -107,7 +107,7 @@ const template: ApplicationTemplate<
             historyLogs: [
               {
                 onEvent: DefaultEvents.SUBMIT,
-                logMessage: 'Eitthvað message draft',
+                logMessage: 'Umsókn úr draft',
               },
             ],
             tag: {
@@ -146,12 +146,6 @@ const template: ApplicationTemplate<
           actionCard: {
             title: 'Test titill completed.',
             description: 'Test title completed',
-            historyLogs: [
-              {
-                onEvent: DefaultEvents.SUBMIT,
-                logMessage: 'Eitthvað message completed',
-              },
-            ],
           },
           lifecycle: DefaultStateLifeCycle,
 

--- a/libs/application/types/src/lib/StateMachine.ts
+++ b/libs/application/types/src/lib/StateMachine.ts
@@ -131,7 +131,7 @@ export interface ApplicationStateMeta<
     /**
      * Configures which messages should be displayed to the user when presenting the
      * application's history.
-     * Each `HistoryEventMessage` object maps a state exitEvent to its corresponding user-friendly log message.
+     * Each `HistoryEventMessage` object maps a state's `exitEvent` to its corresponding user-friendly log message.
      * The `historyLogs` field can either be an array of `HistoryEventMessage` objects
      * or a single `HistoryEventMessage` object.
      */

--- a/libs/application/types/src/lib/StateMachine.ts
+++ b/libs/application/types/src/lib/StateMachine.ts
@@ -131,7 +131,7 @@ export interface ApplicationStateMeta<
     /**
      * Configures which messages should be displayed to the user when presenting the
      * application's history.
-     * Each `HistoryEventMessage` object maps an event to its corresponding user-friendly log message.
+     * Each `HistoryEventMessage` object maps a state exitEvent to its corresponding user-friendly log message.
      * The `historyLogs` field can either be an array of `HistoryEventMessage` objects
      * or a single `HistoryEventMessage` object.
      */


### PR DESCRIPTION
# ...

We were using entryTimestamp to decide the date for entries in historyLog but all messages are intended for the exit event which is also used to determine which message gets selected. Changed to using exitTimestamp instead.

To reduce risk of existing messages referencing the entry action I asked Claude to compile a list of all historyLogs and their corresponding messages. The only ones that reference the entry action were from an example template which I updated. The full list can be found here https://app.notion.com/p/History-Logs-Summary-37a5a76701d680ec8e09fbc32d14ee63

## What

Specify what you're trying to achieve

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests for application history building: guards for missing exit data, static & dynamic message formatting, identity-resolution behavior, include-subject/actor logic (including functional toggle), and sorting by exit time.

* **Bug Fixes**
  * History entries now rely on exit timestamps and skip incomplete exit entries for correct timeline ordering.

* **Documentation**
  * Clarified history event-to-message mapping in state machine docs.

* **Chores**
  * Updated example template history log text (Icelandic) and removed a redundant completed-state history log.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->