### PR TITLE
fix(samgongustofa): emphasize plate in vehicle picker + resolve selection by plate

### DIFF
--- a/libs/application/templates/transport-authority/transfer-of-vehicle-ownership/src/utils/getSelectedVehicle.spec.ts
+++ b/libs/application/templates/transport-authority/transfer-of-vehicle-ownership/src/utils/getSelectedVehicle.spec.ts
@@ -1,0 +1,101 @@
+import { getSelectedVehicle } from './getSelectedVehicle'
+
+const externalData = {
+  currentVehicleList: {
+    data: {
+      totalRecords: 2,
+      vehicles: [
+        {
+          permno: 'BAT90',
+          make: 'Toyota',
+          color: 'Black',
+          mileageReading: '1000',
+        },
+        {
+          permno: 'TM118',
+          make: 'Honda',
+          color: 'Red',
+          mileageReading: '2000',
+        },
+      ],
+    },
+  },
+} as Parameters<typeof getSelectedVehicle>[0]
+
+describe('getSelectedVehicle', () => {
+  it('uses selected plate before selected list index', () => {
+    const vehicle = getSelectedVehicle(externalData, {
+      pickVehicle: {
+        vehicle: '0',
+        plate: 'TM118',
+      },
+    })
+
+    expect(vehicle?.permno).toBe('TM118')
+    expect(vehicle?.make).toBe('Honda')
+  })
+
+  it('uses selected plate answers when the refreshed list no longer contains the selected vehicle', () => {
+    const vehicle = getSelectedVehicle(
+      {
+        currentVehicleList: {
+          data: {
+            totalRecords: 1,
+            vehicles: [
+              {
+                permno: 'BAT90',
+                make: 'Toyota',
+                color: 'Black',
+              },
+            ],
+          },
+        },
+      },
+      {
+        pickVehicle: {
+          vehicle: '0',
+          plate: 'TM118',
+          type: 'Honda',
+          color: 'Red',
+        },
+      },
+    )
+
+    expect(vehicle).toMatchObject({
+      permno: 'TM118',
+      make: 'Honda',
+      color: 'Red',
+    })
+  })
+
+  it('falls back to selected list index when selected plate is missing', () => {
+    const vehicle = getSelectedVehicle(externalData, {
+      pickVehicle: {
+        vehicle: '0',
+      },
+    })
+
+    expect(vehicle?.permno).toBe('BAT90')
+  })
+
+  it('normalizes vehicles found by plate to include permno and make', () => {
+    const vehicle = getSelectedVehicle(externalData, {
+      pickVehicle: {
+        findVehicle: true,
+        plate: 'SAT10',
+        type: 'Mazda',
+        color: 'Blue',
+      },
+      vehicleMileage: {
+        mileageReading: '3000',
+      },
+    })
+
+    expect(vehicle).toMatchObject({
+      permno: 'SAT10',
+      make: 'Mazda',
+      color: 'Blue',
+      mileageReading: '3000',
+    })
+  })
+})

--- a/libs/application/templates/transport-authority/transfer-of-vehicle-ownership/src/utils/getSelectedVehicle.ts
+++ b/libs/application/templates/transport-authority/transfer-of-vehicle-ownership/src/utils/getSelectedVehicle.ts
@@ -6,6 +6,22 @@ export const getSelectedVehicle = (
   externalData: ExternalData,
   answers: FormValue,
 ): VehiclesCurrentVehicle | undefined => {
+  const selectedPlate = getValueViaPath(
+    answers,
+    'pickVehicle.plate',
+    '',
+  ) as string
+  const selectedType = getValueViaPath(
+    answers,
+    'pickVehicle.type',
+    '',
+  ) as string
+  const mileageReading = getValueViaPath(
+    answers,
+    'vehicleMileage.mileageReading',
+    '',
+  ) as string
+
   if (
     getValueViaPath<boolean | undefined>(answers, 'pickVehicle.findVehicle')
   ) {
@@ -13,12 +29,43 @@ export const getSelectedVehicle = (
       answers,
       'pickVehicle',
     ) as VehiclesCurrentVehicle
-    return vehicle
+
+    return {
+      ...vehicle,
+      permno: vehicle?.permno ?? selectedPlate,
+      make: vehicle?.make ?? selectedType,
+      mileageReading: mileageReading || vehicle?.mileageReading,
+    }
   }
 
   const currentVehicleList =
     (externalData?.currentVehicleList?.data as CurrentVehiclesAndRecords) ??
     undefined
+
+  const selectedVehicle = currentVehicleList?.vehicles?.find(
+    (vehicle) => vehicle.permno === selectedPlate,
+  )
+
+  if (selectedVehicle) {
+    return {
+      ...selectedVehicle,
+      mileageReading: mileageReading || selectedVehicle.mileageReading,
+    }
+  }
+
+  if (selectedPlate) {
+    const vehicle = getValueViaPath(
+      answers,
+      'pickVehicle',
+    ) as VehiclesCurrentVehicle
+
+    return {
+      ...vehicle,
+      permno: vehicle?.permno ?? selectedPlate,
+      make: vehicle?.make ?? selectedType,
+      mileageReading: mileageReading || vehicle?.mileageReading,
+    }
+  }
 
   const vehicleIndex = getValueViaPath(
     answers,
@@ -26,22 +73,16 @@ export const getSelectedVehicle = (
     '',
   ) as string
 
-  const mileageReading = getValueViaPath(
-    answers,
-    'vehicleMileage.mileageReading',
-    '',
-  ) as string
-
   const index = parseInt(vehicleIndex, 10)
 
   const vehicle = currentVehicleList?.vehicles?.[index]
 
-  if (vehicle && !Object.isFrozen(vehicle)) {
-    currentVehicleList.vehicles[index] = {
+  if (vehicle) {
+    return {
       ...vehicle,
-      mileageReading: mileageReading,
+      mileageReading: mileageReading || vehicle.mileageReading,
     }
   }
 
-  return currentVehicleList?.vehicles?.[index]
+  return undefined
 }

--- a/libs/application/ui-fields/src/lib/VehicleRadioFormField/VehicleRadioFormField.tsx
+++ b/libs/application/ui-fields/src/lib/VehicleRadioFormField/VehicleRadioFormField.tsx
@@ -96,13 +96,26 @@ export const VehicleRadioFormField: FC<React.PropsWithChildren<Props>> = ({
         value: `${index}`,
         label: (
           <Box display="flex" flexDirection="column">
-            <Box>
-              <Text variant="default" color={disabled ? 'dark200' : 'dark400'}>
-                {vehicle.make}
-              </Text>
-              <Text variant="small" color={disabled ? 'dark200' : 'dark400'}>
-                {vehicle.color} - {vehicle.permno}
-              </Text>
+            <Box
+              display="flex"
+              flexDirection="row"
+              alignItems="center"
+              justifyContent="spaceBetween"
+            >
+              <Box>
+                <Text
+                  variant="default"
+                  color={disabled ? 'dark200' : 'dark400'}
+                >
+                  {vehicle.make}
+                </Text>
+                <Text variant="small" color={disabled ? 'dark200' : 'dark400'}>
+                  {vehicle.color}
+                </Text>
+              </Box>
+              <Tag variant="blue" disabled>
+                {vehicle.permno}
+              </Tag>
             </Box>
             {disabled && (
               <Box marginTop={2}>

--- a/libs/application/ui-fields/src/lib/VehicleSelectFormField/VehicleSelectFormField.tsx
+++ b/libs/application/ui-fields/src/lib/VehicleSelectFormField/VehicleSelectFormField.tsx
@@ -191,7 +191,10 @@ export const VehicleSelectFormField: FC<React.PropsWithChildren<Props>> = ({
     for (const [index, vehicle] of vehicles.entries()) {
       options.push({
         value: index.toString(),
-        label: `${vehicle.make} - ${vehicle.permno}` || '',
+        label:
+          [vehicle.make, vehicle.color, vehicle.permno]
+            .filter(Boolean)
+            .join(' - ') || '',
       })
     }
 


### PR DESCRIPTION
## What

Two related changes to the vehicle-ownership transfer flow, from investigating ticket 526847 ("wrong vehicle" reports):

1. **Make the plate prominent in the vehicle picker.** In the radio list the plate shows as a badge instead of small grey text after the colour; the dropdown option label includes the colour. Shared components, so this applies to all vehicle pickers.
2. **Resolve the selected vehicle by plate, not list index** (hardening). `getSelectedVehicle` keys on `pickVehicle.plate`, falling back to saved answers, then the index, only when no plate is stored.

## Why

Investigation (prod data + SGS request logs) **ruled out several code mechanisms**: there was a single SGS fetch per application (no re-order window), no filtering of the list, and the intended vehicles were selectable. What remains is a clear **usability risk** — the affected owners had multiple vehicles of the **same make and colour** (e.g. three Polaris Sportsman; two Chevrolet Captiva), distinguished in the list only by a small grey plate. **(1)** makes the plate the obvious differentiator.

We have **not reproduced** the original "always lands on the wrong car" behaviour, so this is **not claimed as a confirmed root cause**. But (1) directly attacks the one thing that's demonstrably hard here, and **(2)** removes a genuine stale-index fragility regardless (submission was already plate-keyed, so it only ever affected what could be displayed).

## Tests

Unit tests for `getSelectedVehicle`: plate precedence over the index, the saved-answers fallback, and the find-by-plate path.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective
- [x] Formatting passes locally with my changes
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code, Codex
