### PR TITLE
fix(j-s): Show "sækjandi" in change prosecutor modal for R-cases

### DIFF
--- a/apps/judicial-system/web/src/components/Modals/ChangeProsecutorModal/ChangeProsecutorModal.tsx
+++ b/apps/judicial-system/web/src/components/Modals/ChangeProsecutorModal/ChangeProsecutorModal.tsx
@@ -1,6 +1,6 @@
 import React, { FC, useContext, useState } from 'react'
 
-import { isRestrictionCase } from '@island.is/judicial-system/types'
+import { isRequestCase } from '@island.is/judicial-system/types'
 import {
   FormContext,
   Modal,
@@ -20,13 +20,13 @@ const ChangeProsecutorModal: FC<Props> = (props) => {
   const [menuIsOpen, setMenuIsOpen] = useState<boolean>(false)
   const [prosecutorsCount, setProsecutorsCount] = useState<number>(0)
   const [selectedProsecutorId, setSelectedProsecutorId] = useState<string>()
-  const title = isRestrictionCase(workingCase.type)
+  const title = isRequestCase(workingCase.type)
     ? 'Breyta um sækjanda'
     : 'Breyta um ákæranda'
-  const text = isRestrictionCase(workingCase.type)
+  const text = isRequestCase(workingCase.type)
     ? 'Nýr sækjandi mun verða skráður sem sækjandi í málinu og fá tilkynningar er það varðar.'
     : 'Nýr ákærandi mun verða skráður sem ákærandi í málinu og fá tilkynningar er það varðar.'
-  const placeholder = isRestrictionCase(workingCase.type)
+  const placeholder = isRequestCase(workingCase.type)
     ? 'Veldu sækjanda til að taka við málinu'
     : 'Veldu ákæranda til að taka við málinu'
 


### PR DESCRIPTION
## What
The change-prosecutor modal (`ChangeProsecutorModal`) is shared between request cases (R-cases) and indictment cases (S-cases). It previously gated its wording on `isRestrictionCase`, which only matches restriction case types — a subset of R-cases. As a result, **investigation cases (also R-cases) fell through to the `else` branch and incorrectly showed the indictment wording "Breyta um ákæranda"**.

This switches the predicate to `isRequestCase` (restriction + investigation), so the modal title (and the matching body text and placeholder) reads "Breyta um sækjanda" for all R-cases, while S-cases (indictment) keep "Breyta um ákæranda".

## Why
R-cases use the term "sækjandi" and S-cases use "ákærandi". Investigation R-cases were wrongly displaying the indictment terminology.

## Screenshots / Gifs
Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code
- [ ] No AI tools were used in preparing this pull request

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed prosecutor change modal to display appropriate case-specific wording and messaging based on case type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->