### PR TITLE
fix: Download service health config

### DIFF
--- a/apps/download-service/src/app/app.module.ts
+++ b/apps/download-service/src/app/app.module.ts
@@ -63,10 +63,8 @@ import {
   RightsPortalClientModule,
 } from '@island.is/clients/icelandic-health-insurance/rights-portal'
 import {
-  HealthDirectorateClientModule,
-  HealthDirectorateClientConfig,
+  HealthDirectorateHealthModule,
   HealthDirectorateHealthClientConfig,
-  HealthDirectorateVaccinationsClientConfig,
 } from '@island.is/clients/health-directorate'
 import {
   DistrictCommissionersLicensesClientConfig,
@@ -114,7 +112,7 @@ import {
     UniversityCareersClientModule,
     MMSClientModule,
     RightsPortalClientModule,
-    HealthDirectorateClientModule,
+    HealthDirectorateHealthModule,
     FeatureFlagModule,
     HmsRentalAgreementClientModule,
     PrimarySchoolClientModule,
@@ -138,9 +136,7 @@ import {
         MMSClientConfig,
         DistrictCommissionersLicensesClientConfig,
         RightsPortalClientConfig,
-        HealthDirectorateClientConfig,
         HealthDirectorateHealthClientConfig,
-        HealthDirectorateVaccinationsClientConfig,
         DocumentClientConfig,
         FeatureFlagConfig,
         HmsRentalAgreementClientConfig,

--- a/libs/clients/health-directorate/src/index.ts
+++ b/libs/clients/health-directorate/src/index.ts
@@ -1,4 +1,5 @@
 export { HealthDirectorateClientModule } from './lib/healthDirectorateClient.module'
+export { HealthDirectorateHealthModule } from './lib/clients/health/health.module'
 export * from './lib/healthDirectorateClient.types'
 export * from './lib/clients/occupational-license/gen/fetch'
 export {

--- a/libs/portals/my-pages/health/src/screens/HealthConversations/HealthConversations.tsx
+++ b/libs/portals/my-pages/health/src/screens/HealthConversations/HealthConversations.tsx
@@ -143,6 +143,12 @@ const HealthConversations = () => {
           variant="primary"
           size="small"
         />
+        <LinkButton
+          to={HealthPaths.HealthConversationsNew}
+          text={formatMessage(messages.healthConversationsCreate)}
+          variant="primary"
+          size="small"
+        />
       </Box>
       <Box
         display="flex"


### PR DESCRIPTION
## What

Download service health config

## Why

We don't need the client and it has imports that aren't references

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [x] No AI tools were used in preparing this pull request
- [ ] AI tools were used in preparing this pull request
      Tools used:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted internal module registration for health-directorate integration in the download service.
* **Refactor**
  * Exposed an additional health-related module from the health-directorate client library to support integration.
* **Style**
  * Minor layout/formatting tweaks in the Health Conversations screen (no behavioral change).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->