### PR TITLE
feat(j-s): Show police digital case files on request case files screen

### DIFF
--- a/apps/judicial-system/web/src/routes/Prosecutor/components/CaseFiles/CaseFiles.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/components/CaseFiles/CaseFiles.tsx
@@ -28,11 +28,15 @@ import {
   ProsecutorCaseInfo,
   SectionHeading,
 } from '@island.is/judicial-system-web/src/components'
-import { CaseOrigin } from '@island.is/judicial-system-web/src/graphql/schema'
+import {
+  CaseOrigin,
+  PoliceDigitalCaseFile,
+} from '@island.is/judicial-system-web/src/graphql/schema'
 import {
   TUploadFile,
   useDebouncedInput,
   useFileList,
+  usePoliceDigitalCaseFile,
   useS3Upload,
   useUploadFiles,
 } from '@island.is/judicial-system-web/src/utils/hooks'
@@ -44,6 +48,7 @@ import {
   PoliceCaseFiles,
   PoliceCaseFilesData,
 } from '../../components'
+import { PoliceDigitalCaseFilesList } from '../PoliceCaseFiles/PoliceDigitalCaseFiles'
 import { usePoliceCaseFilesQuery } from './policeCaseFiles.generated'
 import { caseFiles as strings } from './CaseFiles.strings'
 
@@ -82,6 +87,13 @@ export const CaseFiles = () => {
   const { onOpenFile } = useFileList({
     caseId: workingCase.id,
   })
+
+  const {
+    digitalCaseFiles,
+    digitalCaseFilesLoading,
+    digitalCaseFilesError,
+    deletePoliceDigitalCaseFile,
+  } = usePoliceDigitalCaseFile()
 
   const caseFilesComments = useDebouncedInput('caseFilesComments', [])
 
@@ -224,6 +236,21 @@ export const CaseFiles = () => {
               policeCaseFileList={policeCaseFileList}
               policeCaseFiles={policeCaseFiles}
             />
+            {((digitalCaseFiles && digitalCaseFiles.length > 0) ||
+              digitalCaseFilesError) && (
+              <PoliceDigitalCaseFilesList
+                digitalCaseFiles={digitalCaseFiles ?? []}
+                onRemove={(file: PoliceDigitalCaseFile) => {
+                  deletePoliceDigitalCaseFile(file.id)
+                }}
+                isLoading={digitalCaseFilesLoading}
+                errorMessage={
+                  digitalCaseFilesError
+                    ? 'Ekki tókst að sækja rafræn skjöl í LÖKE.'
+                    : undefined
+                }
+              />
+            )}
           </section>
           <section>
             <SectionHeading


### PR DESCRIPTION
## What
Renders the `PoliceDigitalCaseFilesList` component (digital LÖKE files — "Hljóð- og myndupptökur") on the *Rannsóknargögn* (case files) screen for request cases (restriction & investigation), beneath the existing police case files list.

## Why
Digital case files from LÖKE were already surfaced on the indictment police case files route, but not on the request case files screen. This brings parity so prosecutors can see (and remove) the case's digital recordings while working on request cases.

## Screenshots / Gifs
<img width="882" height="766" alt="Screenshot 2026-06-10 at 10 49 30" src="https://github.com/user-attachments/assets/8392cc07-79eb-4843-ae7c-8f8047f31580" />


## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code
- [ ] No AI tools were used in preparing this pull request

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Digital case files are now displayed within the CaseFiles interface when available for the working case
  * Users can remove digital case files directly from the interface
  * Loading and error states are handled gracefully during operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->