### PR TITLE
feat(web): Add translations for Landspítali menu course titles

### DIFF
--- a/apps/web/components/connected/LandspitaliMenu/translation.strings.ts
+++ b/apps/web/components/connected/LandspitaliMenu/translation.strings.ts
@@ -132,4 +132,14 @@ export const m = defineMessages({
     defaultMessage: 'Kvöldverður',
     description: 'Kvöldverður',
   },
+  'Mellanmál em': {
+    id: 'web.landspitaliMenu:mellanmal-em',
+    defaultMessage: 'Millimál',
+    description: 'Millimál',
+  },
+  Kvællsmál: {
+    id: 'web.landspitaliMenu:kvallsmal',
+    defaultMessage: 'Kvöldsnarl',
+    description: 'Kvöldsnarl',
+  },
 })


### PR DESCRIPTION
# Add translations for Landspítali menu course titles

Web service is returning this jibberish, we need to override it via translations

<img width="457" height="832" alt="Screenshot 2026-06-10 at 10 34 25" src="https://github.com/user-attachments/assets/48eef99c-6153-48b0-b1d6-446f45b57d12" />


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [x] No AI tools were used in preparing this pull request
- [ ] AI tools were used in preparing this pull request
      Tools used:
