### PR TITLE
fix(application-system): submit sailor pension under its own type to TR

### DIFF
--- a/libs/application/template-api-modules/src/lib/modules/templates/social-insurance-administration/social-insurance-administration-utils.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/social-insurance-administration/social-insurance-administration-utils.ts
@@ -867,7 +867,7 @@ export const getOAPApplicationType = (
     return ApplicationType.HALF_OLD_AGE_PENSION
   }
 
-  // Sailor pension is submitted under its own type so TR applies the
+  // Sailor pension is submitted under its own type so TR can apply the
   // seamen age rule instead of the general old-age minimum.
   if (applicationType === ApplicationType.SAILOR_PENSION) {
     return ApplicationType.SAILOR_PENSION

--- a/libs/application/template-api-modules/src/lib/modules/templates/social-insurance-administration/social-insurance-administration-utils.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/social-insurance-administration/social-insurance-administration-utils.ts
@@ -857,14 +857,22 @@ export const getMonthNumber = (monthName: string): number => {
 
 export const getOAPApplicationType = (
   application: Application,
-): ApplicationType.OLD_AGE_PENSION | ApplicationType.HALF_OLD_AGE_PENSION => {
+):
+  | ApplicationType.OLD_AGE_PENSION
+  | ApplicationType.HALF_OLD_AGE_PENSION
+  | ApplicationType.SAILOR_PENSION => {
   const { applicationType } = getOAPApplicationAnswers(application.answers)
 
   if (applicationType === ApplicationType.HALF_OLD_AGE_PENSION) {
     return ApplicationType.HALF_OLD_AGE_PENSION
   }
 
-  // Sailors pension and Old age pension is the same application type
+  // Sailor pension is submitted under its own type so TR applies the
+  // seamen age rule instead of the general old-age minimum.
+  if (applicationType === ApplicationType.SAILOR_PENSION) {
+    return ApplicationType.SAILOR_PENSION
+  }
+
   return ApplicationType.OLD_AGE_PENSION
 }
 

--- a/libs/application/template-api-modules/src/lib/modules/templates/social-insurance-administration/social-insurance-administration.service.spec.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/social-insurance-administration/social-insurance-administration.service.spec.ts
@@ -23,9 +23,10 @@ const mockConfig = {
 
 describe('SocialInsuranceAdministrationService', () => {
   let socialInsuranceAdministrationService: SocialInsuranceAdministrationService
+  let module: TestingModule
 
   beforeEach(async () => {
-    const module: TestingModule = await Test.createTestingModule({
+    module = await Test.createTestingModule({
       providers: [
         SocialInsuranceAdministrationService,
         {
@@ -125,6 +126,65 @@ describe('SocialInsuranceAdministrationService', () => {
     })
 
     expect(result).toMatchObject({ applicationLineId: '0' })
+  })
+
+  it('should send sailor pension under its own application type', async () => {
+    const auth = createCurrentUser()
+    const oldAgePensionService = module.get(
+      SocialInsuranceAdministrationOldAgePensionService,
+    )
+    const sendSpy = jest.spyOn(
+      oldAgePensionService,
+      'sendOldAgePensionApplication',
+    )
+
+    const application = createApplication({
+      externalData: {
+        socialInsuranceAdministrationApplicant: {
+          data: {
+            bankAccount: {
+              bank: '2222',
+              ledger: '00',
+              accountNumber: '123456',
+            },
+          },
+          date: new Date('2021-06-10T11:31:02.641Z'),
+          status: 'success',
+        },
+      },
+      answers: {
+        applicationType: { option: 'sailorPension' },
+        paymentInfo: {
+          bank: { ledger: '00', bankNumber: '2222', accountNumber: '123456' },
+          iban: '',
+          swift: '',
+          taxLevel: '2',
+          bankAccountType: 'icelandic',
+          personalAllowance: 'no',
+        },
+        'period.year': '2023',
+      },
+      typeId: ApplicationTypes.OLD_AGE_PENSION,
+    })
+
+    jest
+      .spyOn(socialInsuranceAdministrationService, 'getPdf')
+      .mockImplementation(jest.fn())
+
+    await socialInsuranceAdministrationService.sendApplication({
+      application,
+      auth,
+      currentUserLocale: 'is',
+    })
+
+    // Regression guard (Zendesk 528088): sailor pension must be sent as
+    // 'sailorPension', not collapsed into 'oldAgePension' — TR keys the
+    // seamen age rule off this type at submit.
+    expect(sendSpy).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      'sailorPension',
+    )
   })
 
   it('should send household supplement application', async () => {

--- a/libs/application/template-api-modules/src/lib/modules/templates/social-insurance-administration/social-insurance-administration.service.spec.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/social-insurance-administration/social-insurance-administration.service.spec.ts
@@ -178,8 +178,8 @@ describe('SocialInsuranceAdministrationService', () => {
     })
 
     // Regression guard (Zendesk 528088): sailor pension must be sent as
-    // 'sailorPension', not collapsed into 'oldAgePension' — TR keys the
-    // seamen age rule off this type at submit.
+    // 'sailorPension', not collapsed into 'oldAgePension' — so TR can key
+    // the seamen age rule off this type at submit.
     expect(sendSpy).toHaveBeenCalledWith(
       expect.anything(),
       expect.anything(),

--- a/libs/clients/social-insurance-administration/src/lib/constants.ts
+++ b/libs/clients/social-insurance-administration/src/lib/constants.ts
@@ -4,7 +4,9 @@ export const MEDICAL_AND_REHABILITATION_PAYMENTS_SLUG =
   'medicalandrehabilitationpayments'
 export const OLD_AGE_PENSION_APPLICATION_SLUG = 'oldagepension'
 export const HALF_OLD_AGE_PENSION_APPLICATION_SLUG = 'halfoldagepension'
+export const SAILOR_PENSION_APPLICATION_SLUG = 'sailorpension'
 export const OAP_APPLICATION_TYPES = {
   oldAgePension: OLD_AGE_PENSION_APPLICATION_SLUG,
   halfOldAgePension: HALF_OLD_AGE_PENSION_APPLICATION_SLUG,
+  sailorPension: SAILOR_PENSION_APPLICATION_SLUG,
 } as const

--- a/libs/clients/social-insurance-administration/src/lib/types.ts
+++ b/libs/clients/social-insurance-administration/src/lib/types.ts
@@ -1,1 +1,4 @@
-export type OldAgePensionApplicationType = 'halfOldAgePension' | 'oldAgePension'
+export type OldAgePensionApplicationType =
+  | 'halfOldAgePension'
+  | 'oldAgePension'
+  | 'sailorPension'


### PR DESCRIPTION
## What

Submit the **sailor old-age pension** (ellilífeyrir sjómanna) to TR under its own `sailorpension` type instead of collapsing it into `oldagepension`.

## Why

Reported via Zendesk 528088 / TR Jira SMARI-134. A seaman applying for ellilífeyrir sjómanna got the generic **"Eitthvað fór úrskeiðis"** on submit (only on prod, only for the seamen variant).

Root cause (confirmed in prod Datadog logs + the failing application record): we label the same applicant two different ways to TR.

| Step | Type sent | TR age rule | Seaman aged 60–64.5 |
|------|-----------|-------------|---------------------|
| Eligibility precheck (`getIsEligible`) | `sailorpension` | from 60 | ✅ passes → fills out form |
| Submit (`getOAPApplicationType`) | `oldagepension` | 64.5 | ❌ rejected |

TR's 400 (`User not eligible for application type 'oldagepension': Applicant is younger than 64.5`) is hidden behind the generic error screen.

## Change

- `getOAPApplicationType` returns `SAILOR_PENSION` instead of collapsing it into `OLD_AGE_PENSION`.
- Client maps `sailorPension → 'sailorpension'` (`OAP_APPLICATION_TYPES`, `OldAgePensionApplicationType`).
- Regression test asserting a sailor application is sent with the `'sailorPension'` type.

Regular and half old-age pension are unaffected.

## ⚠️ Do not merge yet

Blocked on **TR confirming the V2 submit endpoint accepts `sailorpension`**. Their OpenAPI spec types `applicationType` as a free-form string with no sailor type documented, though their eligibility endpoint already honours `sailorpension` in practice. Question is out to TR (Ólafur). If TR instead chooses to relax the V2 `oldagepension` age check for seamen, this PR can be dropped.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code (Opus 4.8)

## Remaining gates

- [ ] TR confirms V2 submit accepts `sailorpension`
- [ ] Tested on dev with a seaman under 64.5