### PR TITLE
fix(application-templates): migrate Juni templates to national-registry v3

### DIFF
--- a/libs/application/templates/general-petition/src/dataProviders/index.ts
+++ b/libs/application/templates/general-petition/src/dataProviders/index.ts
@@ -1,1 +1,1 @@
-export { NationalRegistryUserApi } from '@island.is/application/types'
+export { NationalRegistryV3UserApi } from '@island.is/application/types'

--- a/libs/application/templates/general-petition/src/forms/form.ts
+++ b/libs/application/templates/general-petition/src/forms/form.ts
@@ -17,7 +17,7 @@ import {
   DefaultEvents,
   Form,
   FormModes,
-  NationalRegistryUserApi,
+  NationalRegistryV3UserApi,
   UserProfileApi,
 } from '@island.is/application/types'
 import { m } from '../lib/messages'
@@ -52,7 +52,7 @@ export const form: Form = buildForm({
           checkboxLabel: m.externalDataSectionCheckbox,
           dataProviders: [
             buildDataProviderItem({
-              provider: NationalRegistryUserApi,
+              provider: NationalRegistryV3UserApi,
               title: '',
               subTitle: '',
             }),

--- a/libs/application/templates/general-petition/src/lib/GeneralPetitionTemplate.ts
+++ b/libs/application/templates/general-petition/src/lib/GeneralPetitionTemplate.ts
@@ -7,7 +7,7 @@ import {
   Application,
   DefaultEvents,
   defineTemplateApi,
-  NationalRegistryUserApi,
+  NationalRegistryV3UserApi,
   UserProfileApi,
   ApplicationConfigurations,
 } from '@island.is/application/types'
@@ -94,7 +94,7 @@ const GeneralPetitionTemplate: ApplicationTemplate<
                 },
               ],
               write: 'all',
-              api: [NationalRegistryUserApi, UserProfileApi],
+              api: [NationalRegistryV3UserApi, UserProfileApi],
               delete: true,
             },
           ],

--- a/libs/application/templates/transport-authority/driving-instructor-registrations/src/dataProviders/index.ts
+++ b/libs/application/templates/transport-authority/driving-instructor-registrations/src/dataProviders/index.ts
@@ -1,4 +1,4 @@
 export {
-  NationalRegistryUserApi,
+  NationalRegistryV3UserApi,
   HasTeachingRightsApi,
 } from '@island.is/application/types'

--- a/libs/application/templates/transport-authority/driving-instructor-registrations/src/forms/instructorRegistrations.ts
+++ b/libs/application/templates/transport-authority/driving-instructor-registrations/src/forms/instructorRegistrations.ts
@@ -10,7 +10,7 @@ import {
   FormModes,
   GetTeacherRightsApi,
   HasTeachingRightsApi,
-  NationalRegistryUserApi,
+  NationalRegistryV3UserApi,
 } from '@island.is/application/types'
 import { TransportAuthorityLogo } from '@island.is/application/assets/institution-logos'
 import { m } from '../lib/messages'
@@ -38,7 +38,7 @@ export const getInstructorRegistrations = (allowBELicense = false): Form => {
                 subTitle: m.dataCollectionTeachersRightsSubtitle,
               }),
               buildDataProviderItem({
-                provider: NationalRegistryUserApi,
+                provider: NationalRegistryV3UserApi,
                 title: '',
                 subTitle: '',
               }),

--- a/libs/application/templates/transport-authority/driving-instructor-registrations/src/lib/InstructorRegistrationsTemplate.ts
+++ b/libs/application/templates/transport-authority/driving-instructor-registrations/src/lib/InstructorRegistrationsTemplate.ts
@@ -8,7 +8,7 @@ import {
   DefaultEvents,
   defineTemplateApi,
   HasTeachingRightsApi,
-  NationalRegistryUserApi,
+  NationalRegistryV3UserApi,
   GetTeacherRightsApi,
   ApplicationConfigurations,
 } from '@island.is/application/types'
@@ -81,7 +81,7 @@ const InstructorRegistrationsTemplate: ApplicationTemplate<
               ],
               api: [
                 HasTeachingRightsApi,
-                NationalRegistryUserApi,
+                NationalRegistryV3UserApi,
                 GetTeacherRightsApi,
               ],
               delete: true,
@@ -89,7 +89,7 @@ const InstructorRegistrationsTemplate: ApplicationTemplate<
                 answers: ['approveExternalData'],
                 externalData: [
                   HasTeachingRightsApi.externalDataId,
-                  NationalRegistryUserApi.externalDataId,
+                  NationalRegistryV3UserApi.externalDataId,
                   GetTeacherRightsApi.externalDataId,
                 ],
               },

--- a/libs/application/templates/transport-authority/driving-school-confirmation/src/dataProviders/index.ts
+++ b/libs/application/templates/transport-authority/driving-school-confirmation/src/dataProviders/index.ts
@@ -1,4 +1,4 @@
 export {
   EmployeeApi,
-  NationalRegistryUserApi,
+  NationalRegistryV3UserApi,
 } from '@island.is/application/types'

--- a/libs/application/templates/transport-authority/driving-school-confirmation/src/forms/drivingSchoolConfirmation.ts
+++ b/libs/application/templates/transport-authority/driving-school-confirmation/src/forms/drivingSchoolConfirmation.ts
@@ -12,7 +12,7 @@ import {
   FormModes,
   DefaultEvents,
   EmployeeApi,
-  NationalRegistryUserApi,
+  NationalRegistryV3UserApi,
 } from '@island.is/application/types'
 import { TransportAuthorityLogo } from '@island.is/application/assets/institution-logos'
 import { m } from '../lib/messages'
@@ -36,7 +36,7 @@ export const getDrivingSchoolConfirmation = (): Form => {
             checkboxLabel: m.dataCollectionCheckboxLabel,
             dataProviders: [
               buildDataProviderItem({
-                provider: NationalRegistryUserApi,
+                provider: NationalRegistryV3UserApi,
                 title: '',
                 subTitle: '',
               }),

--- a/libs/application/templates/transport-authority/driving-school-confirmation/src/lib/DrivingSchoolConfirmationTemplate.ts
+++ b/libs/application/templates/transport-authority/driving-school-confirmation/src/lib/DrivingSchoolConfirmationTemplate.ts
@@ -8,7 +8,7 @@ import {
   DefaultEvents,
   defineTemplateApi,
   EmployeeApi,
-  NationalRegistryUserApi,
+  NationalRegistryV3UserApi,
   ApplicationConfigurations,
 } from '@island.is/application/types'
 import { Events, States, Roles } from './constants'
@@ -66,7 +66,7 @@ const DrivingSchoolConfirmationTemplate: ApplicationTemplate<
                 },
               ],
               write: 'all',
-              api: [EmployeeApi, NationalRegistryUserApi],
+              api: [EmployeeApi, NationalRegistryV3UserApi],
             },
           ],
         },


### PR DESCRIPTION
## What

Swap the National Registry data provider from **v2 → v3** (`NationalRegistryUserApi` → `NationalRegistryV3UserApi`) in three Juni-owned application templates:

- `general-petition`
- `transport-authority/driving-school-confirmation`
- `transport-authority/driving-instructor-registrations`

## Why

These templates still declared the **v2** provider, so they kept invoking the national-registry v2 client in production (surfacing as `Fetch (clients-national-registry-v2)` cache warnings in Datadog). The `shouldApplicationSystemUseNationalRegistryV3` flag is enabled in prod, so the v3 provider routes through `NationalRegistryV3Service` and uses v3.

The two provider definitions are identical except `namespace` — same `action` and `externalDataId: 'nationalRegistry'` — so `externalData.nationalRegistry` reads are unchanged, and the v3 individual type extends the v2 shape (backward compatible). No UI or backend changes required.

Follow-up (separate): `marriage-conditions` also hits v2 via `nationalRegistryXRoadService.getReligions()` for the religion code-list. That's not a provider swap — it needs a different source (e.g. Sýslumenn `getReligiousOrganizations`) and a product check on list contents, so it's tracked on its own.

## Screenshots / Gifs

N/A — no visible change; data-provider source swap only.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated National Registry API integration across multiple application templates (general petition, driving instructor registrations, and driving school confirmations) to use the latest version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->