### PR TITLE
fix(web): Landspítali menu - Format the options we get from the backend service

### DIFF
--- a/apps/web/components/connected/LandspitaliMenu/LandspitaliMenu.tsx
+++ b/apps/web/components/connected/LandspitaliMenu/LandspitaliMenu.tsx
@@ -117,7 +117,19 @@ export const LandspitaliMenu = ({ slice: _slice }: LandspitaliMenuProps) => {
     WebLandspitaliMenuQueryVariables
   >(GET_LANDSPITALI_MENU, {
     onCompleted(a) {
-      setData(a)
+      setData({
+        ...a,
+        webLandspitaliMenu: {
+          ...a.webLandspitaliMenu,
+          meals: a.webLandspitaliMenu.meals.map((meal) => ({
+            ...meal,
+            courses: meal.courses.map((course) => ({
+              ...course,
+              optionName: course.optionName?.replace(' - ', ', '),
+            })),
+          })),
+        },
+      })
       setHasError(false)
       isLoading.current = false
     },

--- a/apps/web/components/connected/LandspitaliMenu/translation.strings.ts
+++ b/apps/web/components/connected/LandspitaliMenu/translation.strings.ts
@@ -31,28 +31,13 @@ export const m = defineMessages({
     defaultMessage: 'Hentar eldri kynslóðinni (A2)',
     description: 'Hentar eldri kynslóðinni (A2)',
   },
-  'A2 - hentar eldri kynslóðinni': {
-    id: 'web.landspitaliMenu:a2-hentar-eldri-kynslodinni',
-    defaultMessage: 'Hentar eldri kynslóðinni (A2)',
-    description: 'Hentar eldri kynslóðinni (A2)',
-  },
   A3: {
     id: 'web.landspitaliMenu:a3',
     defaultMessage: 'Grænmetisfæði (A3)',
     description: 'Grænmetisfæði (A3)',
   },
-  'A3 - grænmetisfæði': {
-    id: 'web.landspitaliMenu:a3-graenmetisfaedi',
-    defaultMessage: 'Grænmetisfæði (A3)',
-    description: 'Grænmetisfæði (A3)',
-  },
   A4: {
     id: 'web.landspitaliMenu:a4',
-    defaultMessage: 'Hentar börnum (A4)',
-    description: 'Hentar börnum (A4)',
-  },
-  'A4 - hentar börnum': {
-    id: 'web.landspitaliMenu:a4-hentar-bornum',
     defaultMessage: 'Hentar börnum (A4)',
     description: 'Hentar börnum (A4)',
   },


### PR DESCRIPTION
# Landspítali menu - Format the options we get from the backend service

We get "A4, ..." and "A4 - Hentar fyrir börn" from the backend service. That makes two tags appear in the frontend, so to make it appear as a single tag I've changed the formatting of the optionName to handle that issue.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [x] No AI tools were used in preparing this pull request
- [ ] AI tools were used in preparing this pull request
      Tools used:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the visual presentation of menu course options by enhancing how option names are formatted and displayed throughout the menu interface.

* **Refactor**
  * Simplified and consolidated menu translation strings by removing redundant message variants and streamlining the definition structure for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->