### PR TITLE
fix(web): set Reply-To from custom email field on CMS forms

### DIFF
--- a/apps/web/components/Form/Form.tsx
+++ b/apps/web/components/Form/Form.tsx
@@ -671,12 +671,21 @@ export const Form = ({ form }: FormProps) => {
           ),
         }
         setData(_data)
+        // The built-in email field drives Reply-To via data['email']. If a form
+        // collects the sender's email in a custom email field instead, fall back
+        // to the first valid one so replies reach the sender, not the from-address.
+        const senderEmail = isValidEmail.test(data['email'] ?? '')
+          ? data['email']
+          : form.fields
+              .filter((field) => field.type === FormFieldType.EMAIL)
+              .map((field) => data[getUniqueFormFieldValue(field)])
+              .find((email) => isValidEmail.test(email ?? '')) ?? ''
         submit({
           variables: {
             input: {
               id: form.id,
               name: data['name'] ?? '',
-              email: data['email'] ?? '',
+              email: senderEmail,
               message: formatBody(_data),
               // eslint-disable-next-line @typescript-eslint/ban-ts-comment
               // @ts-ignore make web strict


### PR DESCRIPTION
## What

CMS/Contentful forms (`apps/web/components/Form`) send the submitter's email as `input.email`, which the communications backend uses to set the email's **Reply-To** header. The frontend only populated `input.email` from the form's **built-in** email field. When a form instead collects the sender's email via a **custom** email field, `input.email` went out empty, so the relayed email had no usable `Reply-To`. Institutions replying from their mail/case systems then replied to the `island@island.is` *From* address rather than the actual sender.

## Change

In the form submit handler, when the built-in email value is missing/invalid, fall back to the first **valid** custom email-type field on the form (guarded by `isValidEmail`):

```ts
const senderEmail = isValidEmail.test(data['email'] ?? '')
  ? data['email']
  : form.fields
      .filter((field) => field.type === FormFieldType.EMAIL)
      .map((field) => data[getUniqueFormFieldValue(field)])
      .find((email) => isValidEmail.test(email ?? '')) ?? ''
```

- Backend/API unchanged — it already maps `input.email` -> `Reply-To`.
- `From` still stays the Ísland.is address (required for SPF/DKIM); only `Reply-To` is affected.
- Fixes the whole class of such forms without relying on every Contentful editor enabling the built-in email field.

## Why

Reported via Zendesk by an institution unable to reply to applicants who submitted through an island.is form. Caveat: assumes the first valid email field is the sender's address — true for typical forms; worth a glance if any form collects an unrelated third-party email before the applicant's own.

## Screenshots / Gifs

N/A — affects the email's `Reply-To` header, no UI change.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code
