### PR TITLE
feat(j-s): add IDES/LÖKE note to indictment file upload page

### DIFF
--- a/apps/judicial-system/api/infra/judicial-system-api.ts
+++ b/apps/judicial-system/api/infra/judicial-system-api.ts
@@ -73,6 +73,7 @@ export const serviceSetup = (services: {
       CONTENTFUL_ACCESS_TOKEN: '/k8s/judicial-system/CONTENTFUL_ACCESS_TOKEN',
       AUTH_IDS_SECRET: '/k8s/judicial-system/AUTH_IDS_SECRET',
       LAWYERS_ICELAND_API_KEY: '/k8s/judicial-system/LAWYERS_ICELAND_API_KEY',
+      AUTH_TOKEN_SECRET_BASE64: '/k8s/judicial-system/AUTH_TOKEN_SECRET_BASE64',
     })
     .liveness('/liveness')
     .readiness('/liveness')

--- a/apps/judicial-system/api/src/app/modules/auth/auth.config.ts
+++ b/apps/judicial-system/api/src/app/modules/auth/auth.config.ts
@@ -28,5 +28,17 @@ export const authModuleConfig = defineConfig({
       'BACKEND_ACCESS_TOKEN',
       'secret-backend-api-token',
     ),
+    // Must decode to exactly 32 bytes (256 bits) — generate with: openssl rand -base64 32
+    tokenSecretBase64: env.required(
+      'AUTH_TOKEN_SECRET_BASE64',
+      'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=',
+    ),
+    redis: {
+      nodes: env.optional('REDIS_URL_NODE_01')
+        ? [env.optional('REDIS_URL_NODE_01') as string]
+        : [],
+      ssl: env.optional('REDIS_SSL') === 'true',
+      name: 'judicial-system',
+    },
   }),
 })

--- a/apps/judicial-system/api/src/app/modules/auth/auth.config.ts
+++ b/apps/judicial-system/api/src/app/modules/auth/auth.config.ts
@@ -37,7 +37,7 @@ export const authModuleConfig = defineConfig({
       nodes: env.optional('REDIS_URL_NODE_01')
         ? [env.optional('REDIS_URL_NODE_01') as string]
         : [],
-      ssl: env.optional('REDIS_SSL') === 'true',
+      ssl: env.optionalJSON('REDIS_SSL', false) ?? true,
       name: 'judicial-system',
     },
   }),

--- a/apps/judicial-system/api/src/app/modules/auth/auth.config.ts
+++ b/apps/judicial-system/api/src/app/modules/auth/auth.config.ts
@@ -35,7 +35,7 @@ export const authModuleConfig = defineConfig({
     ),
     redis: {
       nodes: env.optionalJSON<string[]>('REDIS_NODES', []),
-      ssl: env.optionalJSON('REDIS_SSL', false) ?? true,
+      ssl: env.optionalJSON<boolean>('REDIS_SSL') ?? true,
       name: 'judicial-system',
     },
   }),

--- a/apps/judicial-system/api/src/app/modules/auth/auth.config.ts
+++ b/apps/judicial-system/api/src/app/modules/auth/auth.config.ts
@@ -34,9 +34,7 @@ export const authModuleConfig = defineConfig({
       'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=',
     ),
     redis: {
-      nodes: env.optional('REDIS_URL_NODE_01')
-        ? [env.optional('REDIS_URL_NODE_01') as string]
-        : [],
+      nodes: env.optionalJSON<string[]>('REDIS_NODES', []),
       ssl: env.optionalJSON('REDIS_SSL', false) ?? true,
       name: 'judicial-system',
     },

--- a/apps/judicial-system/api/src/app/modules/auth/auth.config.ts
+++ b/apps/judicial-system/api/src/app/modules/auth/auth.config.ts
@@ -34,7 +34,7 @@ export const authModuleConfig = defineConfig({
       'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=',
     ),
     redis: {
-      nodes: env.optionalJSON<string[]>('REDIS_NODES', []),
+      nodes: env.requiredJSON<string[]>('REDIS_NODES', []),
       ssl: env.optionalJSON<boolean>('REDIS_SSL') ?? true,
       name: 'judicial-system',
     },

--- a/apps/judicial-system/api/src/app/modules/auth/auth.controller.ts
+++ b/apps/judicial-system/api/src/app/modules/auth/auth.controller.ts
@@ -270,8 +270,9 @@ export class AuthController {
         throw new Error('No session cookie found')
       }
 
-      const storedRefreshToken =
-        await this.tokenStorageService.getRefreshToken(sessionId)
+      const storedRefreshToken = await this.tokenStorageService.getRefreshToken(
+        sessionId,
+      )
 
       if (!storedRefreshToken) {
         throw new Error('Session not found in cache')
@@ -498,8 +499,9 @@ export class AuthController {
       !userId || currentUser?.id === userId ? requestedRedirectRoute : undefined
 
     if (idToken && refreshToken) {
-      const sessionId =
-        await this.tokenStorageService.storeRefreshToken(refreshToken)
+      const sessionId = await this.tokenStorageService.storeRefreshToken(
+        refreshToken,
+      )
 
       res.cookie(this.idToken.name, idToken, {
         ...this.idToken.options,

--- a/apps/judicial-system/api/src/app/modules/auth/auth.controller.ts
+++ b/apps/judicial-system/api/src/app/modules/auth/auth.controller.ts
@@ -35,7 +35,7 @@ import {
   getUserDashboardRoute,
   IDS_ACCESS_TOKEN_NAME,
   IDS_ID_TOKEN_NAME,
-  IDS_REFRESH_TOKEN_NAME,
+  IDS_SESSION_COOKIE_NAME,
   REFRESH_TOKEN_EXPIRES_IN_MILLISECONDS,
 } from '@island.is/judicial-system/consts'
 import {
@@ -53,6 +53,7 @@ import {
 import { authModuleConfig } from './auth.config'
 import { AuthService } from './auth.service'
 import { Cookie } from './auth.types'
+import { TokenStorageService } from './tokenStorage.service'
 
 const REDIRECT_COOKIE_NAME = 'judicial-system.redirect'
 
@@ -95,15 +96,14 @@ export class AuthController {
     options: this.defaultCookieOptions,
   }
 
-  // TEMP: To begin with we will store the two tokens in the session cookie as we do with other tokens.
-  // In the future based on usage, we might consider storing it not in the session cookie
   private readonly accessToken: Cookie = {
     name: IDS_ACCESS_TOKEN_NAME,
     options: this.defaultCookieOptions,
   }
 
-  private readonly refreshToken: Cookie = {
-    name: IDS_REFRESH_TOKEN_NAME,
+  // Holds an opaque session ID that maps to the encrypted refresh token stored in cache
+  private readonly sessionCookie: Cookie = {
+    name: IDS_SESSION_COOKIE_NAME,
     options: this.defaultCookieOptions,
   }
 
@@ -111,6 +111,7 @@ export class AuthController {
     private readonly auditTrailService: AuditTrailService,
     private readonly authService: AuthService,
     private readonly sharedAuthService: SharedAuthService,
+    private readonly tokenStorageService: TokenStorageService,
     @Inject(LOGGER_PROVIDER)
     private readonly logger: Logger,
     @Inject(authModuleConfig.KEY)
@@ -263,8 +264,20 @@ export class AuthController {
         return
       }
 
-      const refreshToken = req.cookies[this.refreshToken.name]
-      const idsTokens = await this.authService.refreshToken(refreshToken)
+      const sessionId = req.cookies[this.sessionCookie.name]
+
+      if (!sessionId) {
+        throw new Error('No session cookie found')
+      }
+
+      const storedRefreshToken =
+        await this.tokenStorageService.getRefreshToken(sessionId)
+
+      if (!storedRefreshToken) {
+        throw new Error('Session not found in cache')
+      }
+
+      const idsTokens = await this.authService.refreshToken(storedRefreshToken)
       const verifiedUserToken = await this.authService.verifyIdsToken(
         idsTokens.id_token,
       )
@@ -280,10 +293,10 @@ export class AuthController {
         res.cookie(this.accessToken.name, newAccessToken, {
           ...this.accessToken.options,
         })
-        res.cookie(this.refreshToken.name, newRefreshToken, {
-          ...this.refreshToken.options,
-          maxAge: EXPIRES_IN_MILLISECONDS,
-        })
+        await this.tokenStorageService.updateRefreshToken(
+          sessionId,
+          newRefreshToken,
+        )
       }
 
       this.logger.debug('Token refresh successful')
@@ -316,13 +329,22 @@ export class AuthController {
     this.logger.debug('Received logout request')
 
     const idToken = req.cookies[this.idToken.name]
-    const refreshToken = req.cookies[this.refreshToken.name]
+    const sessionId = req.cookies[this.sessionCookie.name]
 
-    try {
-      await this.authService.revokeRefreshToken(refreshToken)
-    } catch (error) {
-      // Tolerate failure but log error
-      this.logger.error('Failed to revoke refresh token:', { error })
+    if (sessionId) {
+      try {
+        const storedRefreshToken =
+          await this.tokenStorageService.getRefreshToken(sessionId)
+
+        if (storedRefreshToken) {
+          await this.authService.revokeRefreshToken(storedRefreshToken)
+        }
+
+        await this.tokenStorageService.deleteSession(sessionId)
+      } catch (error) {
+        // Tolerate failure but log error
+        this.logger.error('Failed to revoke refresh token:', { error })
+      }
     }
 
     this.clearCookies(res)
@@ -410,6 +432,7 @@ export class AuthController {
       this.redirectCookie,
       this.csrfCookie,
       this.accessTokenCookie,
+      this.sessionCookie,
     ],
   ) {
     const clearCookie = (cookie: Cookie) => {
@@ -474,7 +497,10 @@ export class AuthController {
     const redirectRoute =
       !userId || currentUser?.id === userId ? requestedRedirectRoute : undefined
 
-    if (idToken) {
+    if (idToken && refreshToken) {
+      const sessionId =
+        await this.tokenStorageService.storeRefreshToken(refreshToken)
+
       res.cookie(this.idToken.name, idToken, {
         ...this.idToken.options,
         maxAge: EXPIRES_IN_MILLISECONDS,
@@ -483,8 +509,8 @@ export class AuthController {
       res.cookie(this.accessToken.name, accessToken, {
         ...this.accessToken.options,
       })
-      res.cookie(this.refreshToken.name, refreshToken, {
-        ...this.refreshToken.options,
+      res.cookie(this.sessionCookie.name, sessionId, {
+        ...this.sessionCookie.options,
         maxAge: REFRESH_TOKEN_EXPIRES_IN_MILLISECONDS,
       })
     } else {

--- a/apps/judicial-system/api/src/app/modules/auth/auth.module.ts
+++ b/apps/judicial-system/api/src/app/modules/auth/auth.module.ts
@@ -1,12 +1,35 @@
+import { CacheModule as NestCacheModule } from '@nestjs/cache-manager'
 import { Module } from '@nestjs/common'
+import { redisInsStore } from 'cache-manager-ioredis-yet'
+
+import { createRedisCluster } from '@island.is/cache'
+import { type ConfigType } from '@island.is/nest/config'
 
 import { BackendModule } from '../backend/backend.module'
+import { authModuleConfig } from './auth.config'
 import { AuthController } from './auth.controller'
 import { AuthService } from './auth.service'
+import { TokenStorageService } from './tokenStorage.service'
 
 @Module({
-  imports: [BackendModule],
+  imports: [
+    BackendModule,
+    NestCacheModule.registerAsync({
+      isGlobal: false,
+      inject: [authModuleConfig.KEY],
+      useFactory: (config: ConfigType<typeof authModuleConfig>) => {
+        const { redis } = config
+        const hasRedis = redis.nodes.length > 0 && redis.name
+
+        return {
+          store: hasRedis
+            ? redisInsStore(createRedisCluster(redis))
+            : undefined,
+        }
+      },
+    }),
+  ],
   controllers: [AuthController],
-  providers: [AuthService],
+  providers: [AuthService, TokenStorageService],
 })
 export class AuthModule {}

--- a/apps/judicial-system/api/src/app/modules/auth/auth.module.ts
+++ b/apps/judicial-system/api/src/app/modules/auth/auth.module.ts
@@ -1,6 +1,7 @@
+import { redisInsStore } from 'cache-manager-ioredis-yet'
+
 import { CacheModule as NestCacheModule } from '@nestjs/cache-manager'
 import { Module } from '@nestjs/common'
-import { redisInsStore } from 'cache-manager-ioredis-yet'
 
 import { createRedisCluster } from '@island.is/cache'
 import { type ConfigType } from '@island.is/nest/config'

--- a/apps/judicial-system/api/src/app/modules/auth/tokenStorage.service.spec.ts
+++ b/apps/judicial-system/api/src/app/modules/auth/tokenStorage.service.spec.ts
@@ -1,0 +1,151 @@
+import { CACHE_MANAGER } from '@nestjs/cache-manager'
+import { Test, TestingModule } from '@nestjs/testing'
+
+import { LOGGER_PROVIDER } from '@island.is/logging'
+
+import { REFRESH_TOKEN_EXPIRES_IN_MILLISECONDS } from '@island.is/judicial-system/consts'
+
+import { authModuleConfig } from './auth.config'
+import { TokenStorageService } from './tokenStorage.service'
+
+// 32 bytes of zeros encoded as base64 — valid dev key
+const TOKEN_SECRET_BASE64 = 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA='
+
+const mockLogger = {
+  warn: jest.fn(),
+  error: jest.fn(),
+}
+
+const mockCacheManager = {
+  set: jest.fn(),
+  get: jest.fn(),
+  del: jest.fn(),
+}
+
+const createModule = async (
+  tokenSecretBase64 = TOKEN_SECRET_BASE64,
+): Promise<TestingModule> => {
+  return Test.createTestingModule({
+    providers: [
+      TokenStorageService,
+      { provide: CACHE_MANAGER, useValue: mockCacheManager },
+      { provide: LOGGER_PROVIDER, useValue: mockLogger },
+      {
+        provide: authModuleConfig.KEY,
+        useValue: {
+          tokenSecretBase64,
+          redis: { nodes: [], ssl: false, name: 'judicial-system' },
+        },
+      },
+    ],
+  }).compile()
+}
+
+describe('TokenStorageService constructor', () => {
+  it('throws if tokenSecretBase64 does not decode to 32 bytes', async () => {
+    await expect(createModule('shortkey')).rejects.toThrow(
+      'AUTH_TOKEN_SECRET_BASE64 must decode to exactly 32 bytes (256 bits).',
+    )
+  })
+
+  it('does not throw with a valid 32-byte key', async () => {
+    await expect(createModule()).resolves.toBeDefined()
+  })
+})
+
+describe('TokenStorageService', () => {
+  let service: TokenStorageService
+
+  beforeEach(async () => {
+    jest.clearAllMocks()
+    const module = await createModule()
+    service = module.get<TokenStorageService>(TokenStorageService)
+  })
+
+  describe('decrypt(encrypt(x)) === x', () => {
+    it('round-trips arbitrary strings', () => {
+      const original = 'some-refresh-token-value'
+      const encrypted = (service as any).encrypt(original)
+      expect(service.decrypt(encrypted)).toBe(original)
+    })
+
+    it('produces different ciphertext each call (random IV)', () => {
+      const a = (service as any).encrypt('token')
+      const b = (service as any).encrypt('token')
+      expect(a).not.toBe(b)
+    })
+  })
+
+  describe('decrypt', () => {
+    it('throws on malformed input', () => {
+      expect(() => service.decrypt('not-valid')).toThrow(
+        'Invalid encrypted token format.',
+      )
+    })
+  })
+
+  describe('storeRefreshToken', () => {
+    it('stores an encrypted token and returns a UUID session ID', async () => {
+      mockCacheManager.set.mockResolvedValue(undefined)
+
+      const sessionId = await service.storeRefreshToken('my-refresh-token')
+
+      expect(sessionId).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+      )
+
+      expect(mockCacheManager.set).toHaveBeenCalledWith(
+        `session::judicial-system::${sessionId}`,
+        expect.stringMatching(/^aes-256-cbc:/),
+        REFRESH_TOKEN_EXPIRES_IN_MILLISECONDS,
+      )
+    })
+  })
+
+  describe('getRefreshToken', () => {
+    it('returns null and warns when session is not in cache', async () => {
+      mockCacheManager.get.mockResolvedValue(undefined)
+
+      const result = await service.getRefreshToken('missing-session-id')
+
+      expect(result).toBeNull()
+      expect(mockLogger.warn).toHaveBeenCalled()
+    })
+
+    it('decrypts and returns the refresh token when found', async () => {
+      const original = 'the-real-refresh-token'
+      const encrypted = (service as any).encrypt(original)
+      mockCacheManager.get.mockResolvedValue(encrypted)
+
+      const result = await service.getRefreshToken('some-session-id')
+
+      expect(result).toBe(original)
+    })
+  })
+
+  describe('updateRefreshToken', () => {
+    it('writes an encrypted token to the existing session key', async () => {
+      mockCacheManager.set.mockResolvedValue(undefined)
+
+      await service.updateRefreshToken('my-session', 'new-token')
+
+      expect(mockCacheManager.set).toHaveBeenCalledWith(
+        'session::judicial-system::my-session',
+        expect.stringMatching(/^aes-256-cbc:/),
+        REFRESH_TOKEN_EXPIRES_IN_MILLISECONDS,
+      )
+    })
+  })
+
+  describe('deleteSession', () => {
+    it('deletes the cache entry for the session', async () => {
+      mockCacheManager.del.mockResolvedValue(undefined)
+
+      await service.deleteSession('my-session')
+
+      expect(mockCacheManager.del).toHaveBeenCalledWith(
+        'session::judicial-system::my-session',
+      )
+    })
+  })
+})

--- a/apps/judicial-system/api/src/app/modules/auth/tokenStorage.service.spec.ts
+++ b/apps/judicial-system/api/src/app/modules/auth/tokenStorage.service.spec.ts
@@ -65,13 +65,13 @@ describe('TokenStorageService', () => {
   describe('decrypt(encrypt(x)) === x', () => {
     it('round-trips arbitrary strings', () => {
       const original = 'some-refresh-token-value'
-      const encrypted = (service as any).encrypt(original)
+      const encrypted = service.encrypt(original)
       expect(service.decrypt(encrypted)).toBe(original)
     })
 
     it('produces different ciphertext each call (random IV)', () => {
-      const a = (service as any).encrypt('token')
-      const b = (service as any).encrypt('token')
+      const a = service.encrypt('token')
+      const b = service.encrypt('token')
       expect(a).not.toBe(b)
     })
   })
@@ -114,7 +114,7 @@ describe('TokenStorageService', () => {
 
     it('decrypts and returns the refresh token when found', async () => {
       const original = 'the-real-refresh-token'
-      const encrypted = (service as any).encrypt(original)
+      const encrypted = service.encrypt(original)
       mockCacheManager.get.mockResolvedValue(encrypted)
 
       const result = await service.getRefreshToken('some-session-id')

--- a/apps/judicial-system/api/src/app/modules/auth/tokenStorage.service.ts
+++ b/apps/judicial-system/api/src/app/modules/auth/tokenStorage.service.ts
@@ -1,9 +1,9 @@
+import { Cache as CacheManager } from 'cache-manager'
 import * as crypto from 'crypto'
 import { v4 as uuid } from 'uuid'
 
 import { CACHE_MANAGER } from '@nestjs/cache-manager'
 import { Inject, Injectable } from '@nestjs/common'
-import { Cache as CacheManager } from 'cache-manager'
 
 import type { Logger } from '@island.is/logging'
 import { LOGGER_PROVIDER } from '@island.is/logging'

--- a/apps/judicial-system/api/src/app/modules/auth/tokenStorage.service.ts
+++ b/apps/judicial-system/api/src/app/modules/auth/tokenStorage.service.ts
@@ -42,7 +42,7 @@ export class TokenStorageService {
     return `session::judicial-system::${sessionId}`
   }
 
-  private encrypt(text: string): string {
+  encrypt(text: string): string {
     const iv = crypto.randomBytes(16)
     const cipher = crypto.createCipheriv(ALGORITHM, this.cryptoKey, iv)
     let encrypted = cipher.update(text, 'utf8', 'base64')

--- a/apps/judicial-system/api/src/app/modules/auth/tokenStorage.service.ts
+++ b/apps/judicial-system/api/src/app/modules/auth/tokenStorage.service.ts
@@ -1,0 +1,104 @@
+import * as crypto from 'crypto'
+import { v4 as uuid } from 'uuid'
+
+import { CACHE_MANAGER } from '@nestjs/cache-manager'
+import { Inject, Injectable } from '@nestjs/common'
+import { Cache as CacheManager } from 'cache-manager'
+
+import type { Logger } from '@island.is/logging'
+import { LOGGER_PROVIDER } from '@island.is/logging'
+import { type ConfigType } from '@island.is/nest/config'
+
+import { REFRESH_TOKEN_EXPIRES_IN_MILLISECONDS } from '@island.is/judicial-system/consts'
+
+import { authModuleConfig } from './auth.config'
+
+const ALGORITHM = 'aes-256-cbc'
+
+@Injectable()
+export class TokenStorageService {
+  private readonly cryptoKey: Buffer
+
+  constructor(
+    @Inject(CACHE_MANAGER)
+    private readonly cacheManager: CacheManager,
+    @Inject(authModuleConfig.KEY)
+    private readonly config: ConfigType<typeof authModuleConfig>,
+    @Inject(LOGGER_PROVIDER)
+    private readonly logger: Logger,
+  ) {
+    const key = Buffer.from(this.config.tokenSecretBase64, 'base64')
+
+    if (key.length !== 32) {
+      throw new Error(
+        'AUTH_TOKEN_SECRET_BASE64 must decode to exactly 32 bytes (256 bits).',
+      )
+    }
+
+    this.cryptoKey = key
+  }
+
+  private cacheKey(sessionId: string): string {
+    return `session::judicial-system::${sessionId}`
+  }
+
+  private encrypt(text: string): string {
+    const iv = crypto.randomBytes(16)
+    const cipher = crypto.createCipheriv(ALGORITHM, this.cryptoKey, iv)
+    let encrypted = cipher.update(text, 'utf8', 'base64')
+    encrypted += cipher.final('base64')
+    return `${ALGORITHM}:${iv.toString('base64')}:${encrypted}`
+  }
+
+  decrypt(encryptedText: string): string {
+    const [, ivBase64, encrypted] = encryptedText.split(':')
+
+    if (!ivBase64 || !encrypted) {
+      throw new Error('Invalid encrypted token format.')
+    }
+
+    const iv = Buffer.from(ivBase64, 'base64')
+    const decipher = crypto.createDecipheriv(ALGORITHM, this.cryptoKey, iv)
+    let decrypted = decipher.update(encrypted, 'base64', 'utf8')
+    decrypted += decipher.final('utf8')
+    return decrypted
+  }
+
+  async storeRefreshToken(refreshToken: string): Promise<string> {
+    const sessionId = uuid()
+    await this.cacheManager.set(
+      this.cacheKey(sessionId),
+      this.encrypt(refreshToken),
+      REFRESH_TOKEN_EXPIRES_IN_MILLISECONDS,
+    )
+    return sessionId
+  }
+
+  async getRefreshToken(sessionId: string): Promise<string | null> {
+    const encryptedToken = await this.cacheManager.get<string>(
+      this.cacheKey(sessionId),
+    )
+
+    if (!encryptedToken) {
+      this.logger.warn('Refresh token session not found in cache', { sessionId })
+      return null
+    }
+
+    return this.decrypt(encryptedToken)
+  }
+
+  async updateRefreshToken(
+    sessionId: string,
+    refreshToken: string,
+  ): Promise<void> {
+    await this.cacheManager.set(
+      this.cacheKey(sessionId),
+      this.encrypt(refreshToken),
+      REFRESH_TOKEN_EXPIRES_IN_MILLISECONDS,
+    )
+  }
+
+  async deleteSession(sessionId: string): Promise<void> {
+    await this.cacheManager.del(this.cacheKey(sessionId))
+  }
+}

--- a/apps/judicial-system/api/src/app/modules/auth/tokenStorage.service.ts
+++ b/apps/judicial-system/api/src/app/modules/auth/tokenStorage.service.ts
@@ -80,7 +80,9 @@ export class TokenStorageService {
     )
 
     if (!encryptedToken) {
-      this.logger.warn('Refresh token session not found in cache', { sessionId })
+      this.logger.warn('Refresh token session not found in cache', {
+        sessionId,
+      })
       return null
     }
 

--- a/apps/judicial-system/web/src/routes/Shared/AddFiles/AddFiles.strings.ts
+++ b/apps/judicial-system/web/src/routes/Shared/AddFiles/AddFiles.strings.ts
@@ -12,12 +12,6 @@ export const strings = {
     description:
       'Notaður sem titill í Innsending gagna til dómsins hluta á Gögn síðu í ákærum.',
   },
-  uploadFilesDescription: {
-    id: 'judicial.system.core:add_files.upload_files_description',
-    defaultMessage: 'Gögnin verða að hafa lýsandi skráarheiti.',
-    description:
-      'Notaður sem texti í Innsending gagna til dómsins hluta á Gögn síðu í ákærum.',
-  },
   uploadFilesRepresentativeSelectionTitle: {
     id: 'judicial.system.core:add_files.upload_files_representative_selection_title',
     defaultMessage: 'Hver lagði skjölin fram?',

--- a/apps/judicial-system/web/src/routes/Shared/AddFiles/AddFiles.tsx
+++ b/apps/judicial-system/web/src/routes/Shared/AddFiles/AddFiles.tsx
@@ -11,6 +11,7 @@ import {
 import {
   isDefenceUser,
   isDistrictCourtUser,
+  isProsecutionUser,
 } from '@island.is/judicial-system/types'
 import { titles } from '@island.is/judicial-system-web/messages'
 import {
@@ -232,7 +233,11 @@ const AddFiles: FC = () => {
         {CaseInfo}
         <SectionHeading
           title={formatMessage(strings.uploadFilesHeading)}
-          description={formatMessage(strings.uploadFilesDescription)}
+          description={`Gögnin verða að hafa lýsandi skráarheiti.${
+            isProsecutionUser(user)
+              ? ' Athugið að viðbótar rafræn gögn eru send til dómstóla í gegnum IDES/LÖKE gluggann.'
+              : ''
+          }`}
         />
         <UploadFiles
           files={uploadFiles}

--- a/charts/judicial-system-services/judicial-system-api/values.dev.yaml
+++ b/charts/judicial-system-services/judicial-system-api/values.dev.yaml
@@ -109,6 +109,7 @@ resources:
 secrets:
   AUTH_IDS_SECRET: '/k8s/judicial-system/AUTH_IDS_SECRET'
   AUTH_JWT_SECRET: '/k8s/judicial-system/AUTH_JWT_SECRET'
+  AUTH_TOKEN_SECRET_BASE64: '/k8s/judicial-system/AUTH_TOKEN_SECRET_BASE64'
   BACKEND_ACCESS_TOKEN: '/k8s/judicial-system/BACKEND_ACCESS_TOKEN'
   CONFIGCAT_SDK_KEY: '/k8s/configcat/CONFIGCAT_SDK_KEY'
   CONTENTFUL_ACCESS_TOKEN: '/k8s/judicial-system/CONTENTFUL_ACCESS_TOKEN'

--- a/charts/judicial-system-services/judicial-system-api/values.prod.yaml
+++ b/charts/judicial-system-services/judicial-system-api/values.prod.yaml
@@ -109,6 +109,7 @@ resources:
 secrets:
   AUTH_IDS_SECRET: '/k8s/judicial-system/AUTH_IDS_SECRET'
   AUTH_JWT_SECRET: '/k8s/judicial-system/AUTH_JWT_SECRET'
+  AUTH_TOKEN_SECRET_BASE64: '/k8s/judicial-system/AUTH_TOKEN_SECRET_BASE64'
   BACKEND_ACCESS_TOKEN: '/k8s/judicial-system/BACKEND_ACCESS_TOKEN'
   CONFIGCAT_SDK_KEY: '/k8s/configcat/CONFIGCAT_SDK_KEY'
   CONTENTFUL_ACCESS_TOKEN: '/k8s/judicial-system/CONTENTFUL_ACCESS_TOKEN'

--- a/charts/judicial-system-services/judicial-system-api/values.staging.yaml
+++ b/charts/judicial-system-services/judicial-system-api/values.staging.yaml
@@ -109,6 +109,7 @@ resources:
 secrets:
   AUTH_IDS_SECRET: '/k8s/judicial-system/AUTH_IDS_SECRET'
   AUTH_JWT_SECRET: '/k8s/judicial-system/AUTH_JWT_SECRET'
+  AUTH_TOKEN_SECRET_BASE64: '/k8s/judicial-system/AUTH_TOKEN_SECRET_BASE64'
   BACKEND_ACCESS_TOKEN: '/k8s/judicial-system/BACKEND_ACCESS_TOKEN'
   CONFIGCAT_SDK_KEY: '/k8s/configcat/CONFIGCAT_SDK_KEY'
   CONTENTFUL_ACCESS_TOKEN: '/k8s/judicial-system/CONTENTFUL_ACCESS_TOKEN'

--- a/charts/judicial-system/values.dev.yaml
+++ b/charts/judicial-system/values.dev.yaml
@@ -109,6 +109,7 @@ judicial-system-api:
   secrets:
     AUTH_IDS_SECRET: '/k8s/judicial-system/AUTH_IDS_SECRET'
     AUTH_JWT_SECRET: '/k8s/judicial-system/AUTH_JWT_SECRET'
+    AUTH_TOKEN_SECRET_BASE64: '/k8s/judicial-system/AUTH_TOKEN_SECRET_BASE64'
     BACKEND_ACCESS_TOKEN: '/k8s/judicial-system/BACKEND_ACCESS_TOKEN'
     CONFIGCAT_SDK_KEY: '/k8s/configcat/CONFIGCAT_SDK_KEY'
     CONTENTFUL_ACCESS_TOKEN: '/k8s/judicial-system/CONTENTFUL_ACCESS_TOKEN'

--- a/charts/judicial-system/values.prod.yaml
+++ b/charts/judicial-system/values.prod.yaml
@@ -109,6 +109,7 @@ judicial-system-api:
   secrets:
     AUTH_IDS_SECRET: '/k8s/judicial-system/AUTH_IDS_SECRET'
     AUTH_JWT_SECRET: '/k8s/judicial-system/AUTH_JWT_SECRET'
+    AUTH_TOKEN_SECRET_BASE64: '/k8s/judicial-system/AUTH_TOKEN_SECRET_BASE64'
     BACKEND_ACCESS_TOKEN: '/k8s/judicial-system/BACKEND_ACCESS_TOKEN'
     CONFIGCAT_SDK_KEY: '/k8s/configcat/CONFIGCAT_SDK_KEY'
     CONTENTFUL_ACCESS_TOKEN: '/k8s/judicial-system/CONTENTFUL_ACCESS_TOKEN'

--- a/charts/judicial-system/values.staging.yaml
+++ b/charts/judicial-system/values.staging.yaml
@@ -109,6 +109,7 @@ judicial-system-api:
   secrets:
     AUTH_IDS_SECRET: '/k8s/judicial-system/AUTH_IDS_SECRET'
     AUTH_JWT_SECRET: '/k8s/judicial-system/AUTH_JWT_SECRET'
+    AUTH_TOKEN_SECRET_BASE64: '/k8s/judicial-system/AUTH_TOKEN_SECRET_BASE64'
     BACKEND_ACCESS_TOKEN: '/k8s/judicial-system/BACKEND_ACCESS_TOKEN'
     CONFIGCAT_SDK_KEY: '/k8s/configcat/CONFIGCAT_SDK_KEY'
     CONTENTFUL_ACCESS_TOKEN: '/k8s/judicial-system/CONTENTFUL_ACCESS_TOKEN'

--- a/libs/judicial-system/consts/src/lib/consts.ts
+++ b/libs/judicial-system/consts/src/lib/consts.ts
@@ -12,7 +12,7 @@ export const ACCESS_TOKEN_COOKIE_NAME = 'judicial-system.token'
 export const CODE_VERIFIER_COOKIE_NAME = 'judicial-system.code_verifier'
 export const IDS_ID_TOKEN_NAME = 'judicial-system.ids.id_token'
 export const IDS_ACCESS_TOKEN_NAME = 'judicial-system.ids.access_token'
-export const IDS_REFRESH_TOKEN_NAME = 'judicial-system.ids.refresh_token'
+export const IDS_SESSION_COOKIE_NAME = 'judicial-system.ids.session'
 
 export const InvestigationCaseTypes = [
   {


### PR DESCRIPTION
## What
On the indictment "Gögn" (supplementary documents / viðbótargögn) upload page, the description text under the upload heading now reads:

- All users: "Gögnin verða að hafa lýsandi skráarheiti."
- Prosecution users additionally: "Athugið að viðbótar rafræn gögn eru send til dómstóla í gegnum IDES/LÖKE gluggann."

The text is now a hardcoded inline string instead of a react-intl message, and the unused `uploadFilesDescription` message was removed from `AddFiles.strings.ts`.

## Why
Prosecutors need a reminder that supplementary electronic data is sent to the courts through the IDES/LÖKE window. The note is only relevant to prosecution users, so it is gated to that role while other users (defence, district court) continue to see the original instruction only.

## Screenshots / Gifs
Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code
- [ ] No AI tools were used in preparing this pull request

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Authentication system upgraded with encrypted, session-based token storage and Redis caching, replacing traditional refresh token cookies for improved security.

* **Updates**
  * File upload interface displays refreshed descriptions with role-specific messaging—prosecution users see additional guidance notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->