### PR TITLE
fix(web): show content last reviewed on subpages under a parent subpage

### DIFF
--- a/apps/web/screens/queries/Organization.tsx
+++ b/apps/web/screens/queries/Organization.tsx
@@ -351,6 +351,8 @@ export const GET_ORGANIZATION_SUBPAGE_BY_ID_QUERY = gql`
         ...AllSlices
       }
       showTableOfContents
+      contentLastReviewed
+      showDateOfTheMostRecentReview
       sliceCustomRenderer
       sliceExtraText
       featuredImage {


### PR DESCRIPTION
## What

The **Content Last Reviewed** date ("Show date of the last review") renders on a standalone Organization Subpage, but not when the same subpage is linked under a **Parent Subpage**.

## Why

Both render paths use the same `SubPageContent` component, whose guard is `showDateOfTheMostRecentReview && contentLastReviewed`. But they fetch via different queries in `apps/web/screens/queries/Organization.tsx`:

- Standalone → `GET_ORGANIZATION_SUBPAGE_QUERY` — **selects** both fields.
- Under a parent subpage → `GET_ORGANIZATION_SUBPAGE_BY_ID_QUERY` — **was missing** both fields.

So on the nested path both fields came back `undefined`, the guard was false, and the review date silently never showed.

## Fix

Add `contentLastReviewed` and `showDateOfTheMostRecentReview` to `GET_ORGANIZATION_SUBPAGE_BY_ID_QUERY` to align it with the standalone query. Backend already resolves both fields (`getOrganizationSubpageById` returns the same `OrganizationSubpage` type) — no backend/schema/codegen change needed.

## Checklist

- [x] Frontend-only, single query change
- [x] Verified against a nested subpage with "Show date of the last review" enabled

Zendesk: 527932

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Organization subpages now include comprehensive review tracking information. The system captures the date when content was last reviewed and provides administrators with flexible controls to display or hide this review date. This improvement enhances transparency regarding content lifecycle and maintenance status across the platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->