### PR TITLE
feat(j-s): add IDES/LÖKE note to indictment file upload page

### DIFF
--- a/apps/judicial-system/web/src/routes/Shared/AddFiles/AddFiles.spec.tsx
+++ b/apps/judicial-system/web/src/routes/Shared/AddFiles/AddFiles.spec.tsx
@@ -1,0 +1,60 @@
+import { render, screen, waitFor } from '@testing-library/react'
+
+import {
+  CaseType,
+  UserRole,
+} from '@island.is/judicial-system-web/src/graphql/schema'
+import { mockCase } from '@island.is/judicial-system-web/src/utils/mocks'
+import {
+  ApolloProviderWrapper,
+  FormContextWrapper,
+  IntlProviderWrapper,
+  UserContextWrapper,
+} from '@island.is/judicial-system-web/src/utils/testHelpers'
+
+import AddFiles from './AddFiles'
+
+jest.mock('next/router', () => ({
+  useRouter() {
+    return {
+      pathname: '',
+      query: {
+        id: 'test_id',
+      },
+    }
+  },
+}))
+
+const renderWithRole = (userRole: UserRole) =>
+  render(
+    <IntlProviderWrapper>
+      <ApolloProviderWrapper>
+        <UserContextWrapper userRole={userRole}>
+          <FormContextWrapper theCase={mockCase(CaseType.INDICTMENT)}>
+            <AddFiles />
+          </FormContextWrapper>
+        </UserContextWrapper>
+      </ApolloProviderWrapper>
+    </IntlProviderWrapper>,
+  )
+
+describe('AddFiles', () => {
+  it('should show the IDES/LÖKE note for prosecution users', async () => {
+    renderWithRole(UserRole.PROSECUTOR)
+
+    expect(await screen.findByText(/IDES\/LÖKE/)).toBeInTheDocument()
+  })
+
+  it('should not show the IDES/LÖKE note for defence users', async () => {
+    renderWithRole(UserRole.DEFENDER)
+
+    // The base instruction always renders, confirming the page mounted...
+    expect(
+      await screen.findByText(/Gögnin verða að hafa lýsandi skráarheiti\./),
+    ).toBeInTheDocument()
+    // ...but the prosecution-only note must not be present.
+    await waitFor(() => {
+      expect(screen.queryByText(/IDES\/LÖKE/)).not.toBeInTheDocument()
+    })
+  })
+})

--- a/apps/judicial-system/web/src/routes/Shared/AddFiles/AddFiles.strings.ts
+++ b/apps/judicial-system/web/src/routes/Shared/AddFiles/AddFiles.strings.ts
@@ -12,12 +12,6 @@ export const strings = {
     description:
       'Notaður sem titill í Innsending gagna til dómsins hluta á Gögn síðu í ákærum.',
   },
-  uploadFilesDescription: {
-    id: 'judicial.system.core:add_files.upload_files_description',
-    defaultMessage: 'Gögnin verða að hafa lýsandi skráarheiti.',
-    description:
-      'Notaður sem texti í Innsending gagna til dómsins hluta á Gögn síðu í ákærum.',
-  },
   uploadFilesRepresentativeSelectionTitle: {
     id: 'judicial.system.core:add_files.upload_files_representative_selection_title',
     defaultMessage: 'Hver lagði skjölin fram?',

--- a/apps/judicial-system/web/src/routes/Shared/AddFiles/AddFiles.tsx
+++ b/apps/judicial-system/web/src/routes/Shared/AddFiles/AddFiles.tsx
@@ -11,6 +11,7 @@ import {
 import {
   isDefenceUser,
   isDistrictCourtUser,
+  isProsecutionUser,
 } from '@island.is/judicial-system/types'
 import { titles } from '@island.is/judicial-system-web/messages'
 import {
@@ -232,7 +233,11 @@ const AddFiles: FC = () => {
         {CaseInfo}
         <SectionHeading
           title={formatMessage(strings.uploadFilesHeading)}
-          description={formatMessage(strings.uploadFilesDescription)}
+          description={`Gögnin verða að hafa lýsandi skráarheiti.${
+            isProsecutionUser(user)
+              ? ' Athugið að viðbótar rafræn gögn eru send til dómstóla í gegnum IDES/LÖKE gluggann.'
+              : ''
+          }`}
         />
         <UploadFiles
           files={uploadFiles}


### PR DESCRIPTION
## What
On the indictment "Gögn" (supplementary documents / viðbótargögn) upload page, the description text under the upload heading now reads:

- All users: "Gögnin verða að hafa lýsandi skráarheiti."
- Prosecution users additionally: "Athugið að viðbótar rafræn gögn eru send til dómstóla í gegnum IDES/LÖKE gluggann."

The text is now a hardcoded inline string instead of a react-intl message, and the unused `uploadFilesDescription` message was removed from `AddFiles.strings.ts`.

## Why
Prosecutors need a reminder that supplementary electronic data is sent to the courts through the IDES/LÖKE window. The note is only relevant to prosecution users, so it is gated to that role while other users (defence, district court) continue to see the original instruction only.

## Screenshots / Gifs
Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code
- [ ] No AI tools were used in preparing this pull request

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced file upload interface with role-specific information. Prosecutors now receive additional details about electronic data transmission to courts via IDES/LÖKE during file uploads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->