### PR TITLE
fix(j-s): keep uploaded file preview openable after rename

### DIFF
--- a/apps/judicial-system/web/src/components/UploadFiles/UploadFiles.tsx
+++ b/apps/judicial-system/web/src/components/UploadFiles/UploadFiles.tsx
@@ -1,4 +1,11 @@
-import { Dispatch, FC, SetStateAction, useCallback, useEffect } from 'react'
+import {
+  Dispatch,
+  FC,
+  SetStateAction,
+  useCallback,
+  useEffect,
+  useRef,
+} from 'react'
 import { useDropzone } from 'react-dropzone'
 import { useIntl } from 'react-intl'
 
@@ -56,16 +63,21 @@ const UploadFiles: FC<Props> = (props) => {
     onDrop,
   })
 
+  // Keep the latest files in a ref so the unmount cleanup can revoke their
+  // object URLs without re-running (and revoking) on every `files` change.
+  const filesRef = useRef(files)
+  filesRef.current = files
+
   useEffect(() => {
     return () => {
       // Cleanup object URLs when component unmounts
-      files.forEach((file) => {
+      filesRef.current.forEach((file) => {
         if (file.previewUrl) {
           URL.revokeObjectURL(file.previewUrl)
         }
       })
     }
-  }, [files])
+  }, [])
 
   return (
     <div

--- a/apps/judicial-system/web/src/components/UploadFiles/UploadFiles.tsx
+++ b/apps/judicial-system/web/src/components/UploadFiles/UploadFiles.tsx
@@ -63,14 +63,27 @@ const UploadFiles: FC<Props> = (props) => {
     onDrop,
   })
 
-  // Keep the latest files in a ref so the unmount cleanup can revoke their
-  // object URLs without re-running (and revoking) on every `files` change.
+  // Keep the previous `files` in a ref so we can revoke the object URLs of
+  // files that have been removed, without revoking URLs that are still in use
+  // (e.g. after a rename, which keeps the same previewUrl).
   const filesRef = useRef(files)
-  filesRef.current = files
+
+  useEffect(() => {
+    const currentUrls = new Set(files.map((file) => file.previewUrl))
+
+    // Revoke object URLs for files that are no longer present
+    filesRef.current.forEach((file) => {
+      if (file.previewUrl && !currentUrls.has(file.previewUrl)) {
+        URL.revokeObjectURL(file.previewUrl)
+      }
+    })
+
+    filesRef.current = files
+  }, [files])
 
   useEffect(() => {
     return () => {
-      // Cleanup object URLs when component unmounts
+      // Cleanup remaining object URLs when component unmounts
       filesRef.current.forEach((file) => {
         if (file.previewUrl) {
           URL.revokeObjectURL(file.previewUrl)


### PR DESCRIPTION
## What
Fixes a bug in the `UploadFiles` component where editing a file's name or display date made the file no longer openable (`ERR_FILE_NOT_FOUND`).

The cleanup effect that revokes blob preview URLs depended on `[files]`, so its cleanup ran on **every** change to `files` — not just on unmount. Renaming a file produced a new `files` array, which triggered the effect to revoke the blob URLs while the component was still mounted, leaving the file object pointing at a dead `previewUrl`.

The fix keeps the latest `files` in a ref and changes the effect dependency array to `[]`, so the URLs are revoked only once, at unmount.

## Why
Users could open uploaded case files, but as soon as they edited the file name or display date, opening the file failed with "Your file couldn't be accessed — It may have been moved, edited or deleted. ERR_FILE_NOT_FOUND". This restores the ability to open edited files while preserving the original memory-leak cleanup on unmount.

## Screenshots / Gifs
Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code
- [ ] No AI tools were used in preparing this pull request

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of file preview URLs to ensure object URLs are revoked promptly when files change and on component unmount, reducing potential memory leaks and stale previews.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->