### PR TITLE
fix(j-s): Allow reopening dismissed and cancelled indictment cases

### DIFF
--- a/apps/judicial-system/web/src/components/CaseInfo/CaseInfo.spec.tsx
+++ b/apps/judicial-system/web/src/components/CaseInfo/CaseInfo.spec.tsx
@@ -77,6 +77,7 @@ describe('CourtCaseInfo - reopen button visibility', () => {
   const completedIndictmentCase = {
     ...mockCase(CaseType.INDICTMENT),
     state: CaseState.COMPLETED,
+    indictmentRulingDecision: CaseIndictmentRulingDecision.RULING,
     indictmentCompletedDate: '2024-01-01',
     indictmentSentToPublicProsecutorDate: '2024-01-02',
   }
@@ -187,7 +188,7 @@ describe('CourtCaseInfo - reopen button visibility', () => {
     ).not.toBeInTheDocument()
   })
 
-  it('hides the reopen button when the case has not been sent to public prosecutor', () => {
+  it('hides the reopen button when a ruling case has not been sent to public prosecutor', () => {
     const notSentCase = {
       ...completedIndictmentCase,
       indictmentSentToPublicProsecutorDate: undefined,
@@ -198,5 +199,33 @@ describe('CourtCaseInfo - reopen button visibility', () => {
     expect(
       screen.queryByRole('button', { name: 'Enduropna mál' }),
     ).not.toBeInTheDocument()
+  })
+
+  it('shows the reopen button for a dismissed case even though it was never sent to public prosecutor', () => {
+    const dismissedCase = {
+      ...completedIndictmentCase,
+      indictmentRulingDecision: CaseIndictmentRulingDecision.DISMISSAL,
+      indictmentSentToPublicProsecutorDate: undefined,
+    }
+
+    renderComponent(UserRole.DISTRICT_COURT_JUDGE, dismissedCase)
+
+    expect(
+      screen.getByRole('button', { name: 'Enduropna mál' }),
+    ).toBeInTheDocument()
+  })
+
+  it('shows the reopen button for a cancelled case even though it was never sent to public prosecutor', () => {
+    const cancelledCase = {
+      ...completedIndictmentCase,
+      indictmentRulingDecision: CaseIndictmentRulingDecision.CANCELLATION,
+      indictmentSentToPublicProsecutorDate: undefined,
+    }
+
+    renderComponent(UserRole.DISTRICT_COURT_JUDGE, cancelledCase)
+
+    expect(
+      screen.getByRole('button', { name: 'Enduropna mál' }),
+    ).toBeInTheDocument()
   })
 })

--- a/apps/judicial-system/web/src/components/CaseInfo/CaseInfo.tsx
+++ b/apps/judicial-system/web/src/components/CaseInfo/CaseInfo.tsx
@@ -152,17 +152,28 @@ export const CourtCaseInfo: FC<Props> = ({ workingCase }) => {
   const [reopenReason, setReopenReason] = useState<string>('')
   const [isSubmitting, setIsSubmitting] = useState<boolean>(false)
 
+  // Rulings and fines go through a public prosecutor review step after completion
+  // ("Sakamál í frágangi"). They can only be reopened once they have actually been
+  // sent to the public prosecutor. Other completed decisions (e.g. dismissal or
+  // cancellation) have no such step and can be reopened as soon as they are completed.
+  const requiresPublicProsecutorReview =
+    workingCase.indictmentRulingDecision ===
+      CaseIndictmentRulingDecision.RULING ||
+    workingCase.indictmentRulingDecision === CaseIndictmentRulingDecision.FINE
+
+  const hasBeenSentToPublicProsecutor = Boolean(
+    workingCase.indictmentCompletedDate &&
+      workingCase.indictmentSentToPublicProsecutorDate &&
+      workingCase.indictmentSentToPublicProsecutorDate >
+        workingCase.indictmentCompletedDate,
+  )
+
   const canReopenCase =
     isDistrictCourtUser(user) &&
     !workingCase.mergeCase &&
     workingCase.indictmentRulingDecision !==
       CaseIndictmentRulingDecision.WITHDRAWAL &&
-    Boolean(
-      workingCase.indictmentCompletedDate &&
-        workingCase.indictmentSentToPublicProsecutorDate &&
-        workingCase.indictmentSentToPublicProsecutorDate >
-          workingCase.indictmentCompletedDate,
-    ) &&
+    (!requiresPublicProsecutorReview || hasBeenSentToPublicProsecutor) &&
     (!workingCase.appealCase ||
       workingCase.appealCase.appealState === AppealCaseState.COMPLETED ||
       workingCase.appealCase.appealState === AppealCaseState.WITHDRAWN)


### PR DESCRIPTION
## What
Scopes the reopen-button visibility guard in `CourtCaseInfo` so that **dismissed** (`DISMISSAL`) and **cancelled** (`CANCELLATION`) indictment cases can be reopened again.

Previously the button required the case to have been sent to the public prosecutor (`indictmentSentToPublicProsecutorDate`). Only `RULING` and `FINE` cases go through that public-prosecutor review step ("Sakamál í frágangi"); dismissed and cancelled cases complete without it, so the date is never set and their reopen button was hidden.

The "must be sent to the public prosecutor" condition is now only applied to decisions that actually go through that pipeline (`RULING`/`FINE`). Other completed decisions can be reopened as soon as they are completed, matching what the backend already allows.

Also updates the test mock to carry a realistic ruling decision and adds regression tests for the dismissed and cancelled paths.

## Why
Regression from #22661. That PR added the prosecutor-review requirement to stop users from reopening cases still in the completion pipeline, but it unintentionally hid the reopen button for dismissed and cancelled cases, which the backend still allows reopening. This restores the ability to reopen those cases.

## Screenshots / Gifs
Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code
- [ ] No AI tools were used in preparing this pull request

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the case reopen button visibility logic to distinguish between indictment ruling decision types. Cases marked as dismissed or cancelled can now be reopened as soon as they're completed, regardless of public prosecutor notification status. Cases with ruling or fine decisions continue to require public prosecutor review completion before reopening becomes available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->