### PR TITLE
fix(estate): return no signatories for officialDivision and estateWithoutAssets

### DIFF
--- a/libs/application/template-api-modules/src/lib/modules/templates/estate/estate.service.spec.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/estate/estate.service.spec.ts
@@ -1,0 +1,104 @@
+import { createApplication } from '@island.is/application/testing'
+import { ApplicationTypes } from '@island.is/application/types'
+import { createCurrentUser } from '@island.is/testing/fixtures'
+import {
+  SignatoryEstateTypes,
+  type SyslumennService,
+} from '@island.is/clients/syslumenn'
+import type { S3Service } from '@island.is/nest/aws'
+import type { Logger } from '@island.is/logging'
+
+import type { TemplateApiModuleActionProps } from '../../../types'
+import type { SharedTemplateApiService } from '../../shared'
+import { EstateTemplateService } from './estate.service'
+import { EstateTypes } from './consts'
+
+const mockLogger = {
+  info: jest.fn(),
+  error: jest.fn(),
+  warn: jest.fn(),
+  debug: jest.fn(),
+}
+
+const mockSyslumennService = {
+  getInheritanceReportSignatories: jest.fn(),
+}
+
+const createActionProps = (
+  selectedEstate: string,
+): TemplateApiModuleActionProps => ({
+  application: createApplication({
+    typeId: ApplicationTypes.ESTATE,
+    answers: {
+      selectedEstate,
+      estateInfoSelection: 'CASE-001',
+    },
+    externalData: {
+      syslumennOnEntry: {
+        data: {
+          estates: [
+            {
+              caseNumber: 'CASE-001',
+              nationalIdOfDeceased: '0101307789',
+            },
+          ],
+        },
+        date: new Date(),
+        status: 'success',
+      },
+    },
+  }),
+  auth: createCurrentUser({
+    nationalId: '0101301234',
+    scope: ['@island.is/applications:write'],
+  }),
+  currentUserLocale: 'is',
+})
+
+describe('EstateTemplateService', () => {
+  let service: EstateTemplateService
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    service = new EstateTemplateService(
+      mockLogger as unknown as Logger,
+      mockSyslumennService as unknown as SyslumennService,
+      {} as S3Service,
+      {} as SharedTemplateApiService,
+    )
+  })
+
+  describe('getSignatories', () => {
+    it.each([
+      EstateTypes.officialDivision,
+      EstateTypes.estateWithoutAssets,
+    ])('returns no signatories for %s without calling Syslumenn', async (type) => {
+      const result = await service.getSignatories(createActionProps(type))
+
+      expect(result).toEqual({ success: true, signatories: [] })
+      expect(
+        mockSyslumennService.getInheritanceReportSignatories,
+      ).not.toHaveBeenCalled()
+    })
+
+    it('fetches signatories from Syslumenn for estate division by heirs', async () => {
+      mockSyslumennService.getInheritanceReportSignatories.mockResolvedValue([
+        { name: 'Heir A', nationalId: '0101302209', signed: false },
+      ])
+
+      const result = await service.getSignatories(
+        createActionProps(EstateTypes.divisionOfEstateByHeirs),
+      )
+
+      expect(result).toEqual({
+        success: true,
+        signatories: [
+          { name: 'Heir A', nationalId: '0101302209', signed: false },
+        ],
+      })
+      expect(
+        mockSyslumennService.getInheritanceReportSignatories,
+      ).toHaveBeenCalledWith('0101307789', SignatoryEstateTypes.Einkaskipti)
+    })
+  })
+})

--- a/libs/application/template-api-modules/src/lib/modules/templates/estate/estate.service.spec.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/estate/estate.service.spec.ts
@@ -69,17 +69,17 @@ describe('EstateTemplateService', () => {
   })
 
   describe('getSignatories', () => {
-    it.each([
-      EstateTypes.officialDivision,
-      EstateTypes.estateWithoutAssets,
-    ])('returns no signatories for %s without calling Syslumenn', async (type) => {
-      const result = await service.getSignatories(createActionProps(type))
+    it.each([EstateTypes.officialDivision, EstateTypes.estateWithoutAssets])(
+      'returns no signatories for %s without calling Syslumenn',
+      async (type) => {
+        const result = await service.getSignatories(createActionProps(type))
 
-      expect(result).toEqual({ success: true, signatories: [] })
-      expect(
-        mockSyslumennService.getInheritanceReportSignatories,
-      ).not.toHaveBeenCalled()
-    })
+        expect(result).toEqual({ success: true, signatories: [] })
+        expect(
+          mockSyslumennService.getInheritanceReportSignatories,
+        ).not.toHaveBeenCalled()
+      },
+    )
 
     it('fetches signatories from Syslumenn for estate division by heirs', async () => {
       mockSyslumennService.getInheritanceReportSignatories.mockResolvedValue([

--- a/libs/application/template-api-modules/src/lib/modules/templates/estate/estate.service.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/estate/estate.service.ts
@@ -424,6 +424,19 @@ export class EstateTemplateService extends BaseTemplateApiService {
 
   async getSignatories({ application }: TemplateApiModuleActionProps) {
     const answers = application.answers as unknown as EstateSchema
+    if (
+      answers.selectedEstate === EstateTypes.officialDivision ||
+      answers.selectedEstate === EstateTypes.estateWithoutAssets
+    ) {
+      this.logger.info(
+        '[estate]: Skipping getSignatories API for estate type without signatories',
+        { selectedEstate: answers.selectedEstate },
+      )
+      return {
+        success: true,
+        signatories: [],
+      }
+    }
 
     const syslumennData = application.externalData?.syslumennOnEntry?.data as
       | { estates: Array<EstateInfo> }
@@ -472,8 +485,6 @@ export class EstateTemplateService extends BaseTemplateApiService {
     const estateTypeMap: Record<string, SignatoryEstateTypes> = {
       [EstateTypes.divisionOfEstateByHeirs]: SignatoryEstateTypes.Einkaskipti,
       [EstateTypes.permitForUndividedEstate]: SignatoryEstateTypes.OskiptBu,
-      [EstateTypes.officialDivision]: SignatoryEstateTypes.OpinberSkipti,
-      [EstateTypes.estateWithoutAssets]: SignatoryEstateTypes.Eignaleysi,
     }
 
     const estateType = estateTypeMap[selectedEstate]


### PR DESCRIPTION
# Fix estate no-signer completion redirect

Attach a link to issue if relevant

N/A

## What

Fix estate application completion for settlement types that have no signers.

- `getSignatories()` now returns a successful empty signer list for:
  - `officialDivision`
  - `estateWithoutAssets`
- Those flows no longer call the Syslumenn signatory endpoint.
- Added focused API-module tests proving no-signer estate types skip Syslumenn and signer-required estate types still fetch signatories.

## Why

No-signer estate applications were still redirecting to the `Undirritun` page after submission.

The previous state-machine fix depended on `getSignatories` succeeding with `signatories: []`. In dev logs for commit `f0699e9282`, the Syslumenn signatory lookup failed for no-signer estate types with `jsonValue.map is not a function`. That left `getSignatories.data.success !== true`, so the state machine treated signatures as incomplete and routed to `signing`.

Short-circuiting no-signer estate types at the API action produces the expected persisted result: `success: true` and `signatories: []`, allowing the existing state transition to go directly to `done`.

## Screenshots / Gifs

N/A — backend/state-machine behavior fix covered by tests.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: OpenAI Codex in the Oh My Pi coding harness

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Skip signatory processing for official-division and estates-without-assets: returns success with empty signatories and logs the skip; retain correct signatory retrieval for other estate types.

* **Tests**
  * Added unit tests covering skipped cases and verifying external signatory lookup and returned signatory shape for division-by-heirs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->