### PR TITLE
fix(as): Block next button while uploading to ensure correct answer population

### DIFF
--- a/libs/application/ui-components/src/utilities/FileUploadController/index.tsx
+++ b/libs/application/ui-components/src/utilities/FileUploadController/index.tsx
@@ -4,7 +4,11 @@ import { useMutation, useQuery } from '@apollo/client'
 import { FileRejection } from 'react-dropzone'
 
 import { getValueViaPath, coreErrorMessages } from '@island.is/application/core'
-import { Application } from '@island.is/application/types'
+import {
+  Application,
+  SetFieldLoadingState,
+  SetSubmitButtonDisabled,
+} from '@island.is/application/types'
 import {
   InputFileUploadDeprecated,
   UploadFileDeprecated,
@@ -84,6 +88,8 @@ interface FileUploadControllerProps {
   readonly totalMaxSize?: number
   readonly maxFileCount?: number
   readonly forImageUpload?: boolean
+  readonly setFieldLoadingState?: SetFieldLoadingState
+  readonly setSubmitButtonDisabled?: SetSubmitButtonDisabled
 }
 
 export const FileUploadController = ({
@@ -101,6 +107,8 @@ export const FileUploadController = ({
   maxFileCount = Number.MAX_SAFE_INTEGER, // Default to no limit
   forImageUpload,
   onRemove,
+  setFieldLoadingState,
+  setSubmitButtonDisabled,
 }: FileUploadControllerProps) => {
   const { formatMessage } = useLocale()
   const { clearErrors, setValue } = useFormContext()
@@ -127,6 +135,8 @@ export const FileUploadController = ({
     initialUploadFiles?.length ?? 0,
   )
 
+  const uploadingCount = state.filter((f) => f.status === 'uploading').length
+
   useEffect(() => {
     const onlyUploadedFiles = state.filter(
       (f: UploadFileDeprecated) => f.key && f.status === 'done',
@@ -137,6 +147,12 @@ export const FileUploadController = ({
 
     setValue(id, uploadAnswer)
   }, [state, id, setValue])
+
+  useEffect(() => {
+    const isUploading = uploadingCount > 0
+    setFieldLoadingState?.(isUploading)
+    setSubmitButtonDisabled?.(isUploading)
+  }, [uploadingCount, setFieldLoadingState, setSubmitButtonDisabled])
 
   const isFreeOfMalware = async (fileKey: string): Promise<boolean> => {
     const { data } = await fileUploadMalwareStatus({ filename: fileKey })

--- a/libs/application/ui-fields/src/lib/FieldsRepeaterFormField/FieldsRepeaterFormField.tsx
+++ b/libs/application/ui-fields/src/lib/FieldsRepeaterFormField/FieldsRepeaterFormField.tsx
@@ -36,6 +36,8 @@ export const FieldsRepeaterFormField = ({
   field: data,
   showFieldName,
   error,
+  setFieldLoadingState,
+  setSubmitButtonDisabled,
 }: Props) => {
   const {
     id,
@@ -152,6 +154,8 @@ export const FieldsRepeaterFormField = ({
           dataId={id}
           index={index}
           values={values}
+          setFieldLoadingState={setFieldLoadingState}
+          setSubmitButtonDisabled={setSubmitButtonDisabled}
         />
       ))}
     </GridRow>

--- a/libs/application/ui-fields/src/lib/FieldsRepeaterFormField/FieldsRepeaterItem.tsx
+++ b/libs/application/ui-fields/src/lib/FieldsRepeaterFormField/FieldsRepeaterItem.tsx
@@ -20,6 +20,8 @@ import {
   RepeaterOptionValue,
   VehiclePermnoWithInfoField,
   StaticText,
+  SetFieldLoadingState,
+  SetSubmitButtonDisabled,
 } from '@island.is/application/types'
 import { GridColumn, Text } from '@island.is/island-ui/core'
 import { useLocale } from '@island.is/localization'
@@ -50,6 +52,8 @@ interface ItemFieldProps {
   dataId: string
   index: number
   values: Array<Record<string, string>>
+  setFieldLoadingState?: SetFieldLoadingState
+  setSubmitButtonDisabled?: SetSubmitButtonDisabled
 }
 
 const componentMapper = {
@@ -69,6 +73,8 @@ export const Item = ({
   dataId,
   index,
   values,
+  setFieldLoadingState,
+  setSubmitButtonDisabled,
 }: ItemFieldProps) => {
   const { formatMessage, lang } = useLocale()
   const { setValue, getValues, control, clearErrors } = useFormContext()
@@ -564,6 +570,8 @@ export const Item = ({
                 }
               : {})}
             {...(component === 'input' ? { suffix: suffixVal } : {})}
+            setFieldLoadingState={setFieldLoadingState}
+            setSubmitButtonDisabled={setSubmitButtonDisabled}
           />
         )}
     </GridColumn>

--- a/libs/application/ui-fields/src/lib/FileUploadFormField/FileUploadFormField.tsx
+++ b/libs/application/ui-fields/src/lib/FileUploadFormField/FileUploadFormField.tsx
@@ -16,6 +16,8 @@ export const FileUploadFormField = ({
   answerQuestions,
   field,
   error,
+  setFieldLoadingState,
+  setSubmitButtonDisabled,
 }: Props) => {
   const {
     id,
@@ -87,6 +89,8 @@ export const FileUploadFormField = ({
           maxFileCount={maxFileCount}
           forImageUpload={forImageUpload}
           onRemove={onFileRemoveWhenInAnswers}
+          setFieldLoadingState={setFieldLoadingState}
+          setSubmitButtonDisabled={setSubmitButtonDisabled}
         />
       </Box>
     </Box>

--- a/libs/application/ui-fields/src/lib/TableRepeaterFormField/TableRepeaterFormField.tsx
+++ b/libs/application/ui-fields/src/lib/TableRepeaterFormField/TableRepeaterFormField.tsx
@@ -51,6 +51,8 @@ type TableRepeaterForm = Record<string, TableRepeaterRow[]>
 export const TableRepeaterFormField: FC<Props> = ({
   application,
   setBeforeSubmitCallback,
+  setFieldLoadingState,
+  setSubmitButtonDisabled,
   field: data,
   showFieldName,
   error,
@@ -414,6 +416,8 @@ export const TableRepeaterFormField: FC<Props> = ({
                     dataId={data.id}
                     activeIndex={activeIndex}
                     values={values}
+                    setFieldLoadingState={setFieldLoadingState}
+                    setSubmitButtonDisabled={setSubmitButtonDisabled}
                   />
                 ))}
               </GridRow>

--- a/libs/application/ui-fields/src/lib/TableRepeaterFormField/TableRepeaterItem.tsx
+++ b/libs/application/ui-fields/src/lib/TableRepeaterFormField/TableRepeaterItem.tsx
@@ -9,6 +9,8 @@ import {
 import {
   AlertMessageField,
   Application,
+  SetFieldLoadingState,
+  SetSubmitButtonDisabled,
   AsyncSelectField,
   DescriptionField,
   FieldComponents,
@@ -52,6 +54,8 @@ interface ItemFieldProps {
   dataId: string
   activeIndex: number
   values: Array<Record<string, string>>
+  setFieldLoadingState?: SetFieldLoadingState
+  setSubmitButtonDisabled?: SetSubmitButtonDisabled
 }
 
 const componentMapper = {
@@ -72,6 +76,8 @@ export const Item = ({
   dataId,
   activeIndex,
   values,
+  setFieldLoadingState,
+  setSubmitButtonDisabled,
 }: ItemFieldProps) => {
   const { formatMessage, lang } = useLocale()
   const { setValue, getValues, control, clearErrors } = useFormContext()
@@ -531,6 +537,8 @@ export const Item = ({
             ...fileUploadProps,
           }}
           showFieldName={true}
+          setFieldLoadingState={setFieldLoadingState}
+          setSubmitButtonDisabled={setSubmitButtonDisabled}
         />
       )}
       {!(component === 'selectAsync' && selectAsyncProps) &&


### PR DESCRIPTION

# ...

Attach a link to issue if relevant

## What

Prevent users from leaving a page before uploads have finished

## Why

If a user leaves a screen before an upload is finished the file gets added to the attachments object but not the answers object potentially causing unforeseen consequences.

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Cursor
