### PR TITLE
feat(web): support content last reviewed on baby articles (sub articles)

### DIFF
--- a/apps/web/screens/Article/Article.tsx
+++ b/apps/web/screens/Article/Article.tsx
@@ -379,9 +379,13 @@ const ArticleScreen: Screen<ArticleProps> = ({
     return sub.slug.split('/').pop() === query.subSlug
   })
 
-  // When viewing a sub article (Baby Article) show its own "last reviewed"
-  // date; otherwise fall back to the main article's.
-  const reviewedContent = subArticle ?? article
+  // On a sub article (Baby Article) page, prefer the sub article's own "last
+  // reviewed" date when it has one; otherwise fall back to the main article's
+  // date so existing parent-level dates keep rendering (no regression).
+  const reviewedContent =
+    subArticle?.showDateOfTheMostRecentReview && subArticle.contentLastReviewed
+      ? subArticle
+      : article
 
   useContentfulId(article?.id ?? '', subArticle?.id)
 

--- a/apps/web/screens/Article/Article.tsx
+++ b/apps/web/screens/Article/Article.tsx
@@ -379,6 +379,10 @@ const ArticleScreen: Screen<ArticleProps> = ({
     return sub.slug.split('/').pop() === query.subSlug
   })
 
+  // When viewing a sub article (Baby Article) show its own "last reviewed"
+  // date; otherwise fall back to the main article's.
+  const reviewedContent = subArticle ?? article
+
   useContentfulId(article?.id ?? '', subArticle?.id)
 
   usePlausiblePageview(article?.organization?.[0]?.trackingDomain ?? undefined)
@@ -564,15 +568,15 @@ const ArticleScreen: Screen<ArticleProps> = ({
             activeLocale,
           )}
           <AppendedArticleComponents article={article} />
-          {article?.showDateOfTheMostRecentReview &&
-            article?.contentLastReviewed && (
+          {reviewedContent?.showDateOfTheMostRecentReview &&
+            reviewedContent?.contentLastReviewed && (
               <Box paddingTop={2}>
                 <Text variant="small">
                   {`${n(
                     'contentLastReviewedLabel',
                     activeLocale === 'is' ? 'Síðast uppfært' : 'Last updated',
                   )}: ${format(
-                    new Date(article.contentLastReviewed),
+                    new Date(reviewedContent.contentLastReviewed),
                     'do MMMM yyyy',
                   )}`}
                 </Text>

--- a/apps/web/screens/queries/Article.ts
+++ b/apps/web/screens/queries/Article.ts
@@ -140,6 +140,8 @@ export const GET_ARTICLE_QUERY = gql`
           ${nestedFields}
         }
         showTableOfContents
+        contentLastReviewed
+        showDateOfTheMostRecentReview
         stepper {
           id
           title

--- a/libs/cms/src/lib/generated/contentfulTypes.d.ts
+++ b/libs/cms/src/lib/generated/contentfulTypes.d.ts
@@ -4999,6 +4999,12 @@ export interface ISubArticleFields {
   /** Sign Language Video */
   signLanguageVideo?: IEmbeddedVideo | undefined
 
+  /** Content Last Reviewed */
+  contentLastReviewed?: string | undefined
+
+  /** Show date of the most recent review */
+  showDateOfTheMostRecentReview?: boolean | undefined
+
   /** Stepper */
   stepper?: IStepper | undefined
 }

--- a/libs/cms/src/lib/models/subArticle.model.ts
+++ b/libs/cms/src/lib/models/subArticle.model.ts
@@ -27,6 +27,12 @@ export class SubArticle {
   @Field({ nullable: true })
   showTableOfContents?: boolean
 
+  @Field({ nullable: true })
+  contentLastReviewed?: string
+
+  @Field({ nullable: true })
+  showDateOfTheMostRecentReview?: boolean
+
   @CacheField(() => EmbeddedVideo, { nullable: true })
   signLanguageVideo?: EmbeddedVideo | null
 
@@ -53,6 +59,8 @@ export const mapSubArticle = ({
     parent: fields.parent?.fields && mapArticleReference(fields.parent),
     body: fields.content ? mapDocument(fields.content, sys.id + ':body') : [],
     showTableOfContents: fields.showTableOfContents ?? false,
+    contentLastReviewed: fields.contentLastReviewed,
+    showDateOfTheMostRecentReview: fields.showDateOfTheMostRecentReview,
     signLanguageVideo: fields.signLanguageVideo
       ? mapEmbeddedVideo(fields.signLanguageVideo)
       : null,


### PR DESCRIPTION
# feat(web): support content last reviewed on baby articles (sub articles)

Follows #22884 (same review-date rollout).

## What

Extends the **Content last reviewed** field ("Show date of the last review") to **Baby Articles** (SubArticles) — the one content type that didn't support it. Article, Organization Subpage (incl. under a parent subpage, via #22884) and Project Subpage already do.

Across all layers:

- `subArticle.model.ts` — adds `contentLastReviewed` + `showDateOfTheMostRecentReview` to the CMS model and maps them.
- `Article.ts` — selects both fields in the `subArticles` selection of `getSingleArticle`.
- `Article.tsx` — renders the date for the active sub article, with a fallback to the parent article (see Behaviour). Same guard/label as the other types (date set **and** toggle on).
- The two fields have been added to the `subArticle` content type in Contentful (Date + Boolean, Article convention) — confirmed against the live content model.

The GraphQL generated files (`api.graphql`, `schema.ts`, `fragmentTypes.json`) are gitignored and regenerated in CI.

### Behaviour (review-date resolution on article pages)

| Page | Sub article has own review date | Shows |
| --- | --- | --- |
| Main article | – | Main article's date (unchanged) |
| Baby Article | yes | The Baby Article's own date (new) |
| Baby Article | no | Main article's date (**preserved fallback — no regression**) |

A naive `subArticle ?? article` would have hidden the parent's review date on every Baby Article page until each sub article got its own fields; the fallback keeps existing parent-level dates rendering.

## Why

Baby Articles were the only content type missing the review-date field — editors want to surface "last reviewed" on them too, consistent with the other types.

## Screenshots / Gifs

N/A — renders the existing "Síðast yfirfarið: &lt;date&gt;" line (same component/label as Article/OrgSubpage/Project) on Baby Article pages.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code (Claude Opus)
