### PR TITLE
feat(hh-courses-application): Submit application to zendesk via custom objects

### DIFF
--- a/libs/application/template-api-modules/src/lib/modules/templates/hh/courses/constants.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/hh/courses/constants.ts
@@ -16,7 +16,19 @@ export const GET_COURSE_BY_ID_QUERY = `
           maxRegistrations
           chargeItemCode
           location
+          description
         }
+      }
+    }
+  }
+`
+
+export const GET_CHARGE_ITEM_CODES_BY_COURSE_ID_QUERY = `
+  query GetChargeItemCodesByCourseId($input: GetChargeItemCodesByCourseIdInput!) {
+    getChargeItemCodesByCourseId(input: $input) {
+      items {
+        code
+        priceAmount
       }
     }
   }
@@ -26,6 +38,12 @@ export const COURSE_LIST_PAGE_SLUG_MAP: Record<string, string> = {
   '6pkONOn80xzGTGij6qtjai': 'namskeid-fyrir-almenning',
   '147YftiWFQsBcbUFFe2rj1': 'namskeid-fyrir-fagfolk',
 }
+
+export const ZENDESK_CUSTOM_OBJECT_KEYS = {
+  course: 'hh_course',
+  courseInstance: 'hh_course_instance',
+  courseParticipant: 'hh_course_participant',
+} as const
 
 export const ZENDESK_TICKET_IDS = {
   brandId: 46016159517467,

--- a/libs/application/template-api-modules/src/lib/modules/templates/hh/courses/courses.service.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/hh/courses/courses.service.ts
@@ -492,19 +492,28 @@ export class CoursesService extends BaseTemplateApiService {
     participantList: ApplicationAnswers['participantList'],
     authorization: string,
   ): Promise<void> {
-    const chargeItemsResponse = await this.sharedTemplateApiService
-      .makeGraphqlQuery<{
-        getChargeItemCodesByCourseId: {
-          items: Array<{ code: string; priceAmount: number }>
-        }
-      }>(authorization, GET_CHARGE_ITEM_CODES_BY_COURSE_ID_QUERY, {
-        input: { courseId: course.id },
-      })
-      .then((r) => r.json())
+    let priceAmount: number | undefined
+    try {
+      const chargeItemsResponse = await this.sharedTemplateApiService
+        .makeGraphqlQuery<{
+          getChargeItemCodesByCourseId: {
+            items: Array<{ code: string; priceAmount: number }>
+          }
+        }>(authorization, GET_CHARGE_ITEM_CODES_BY_COURSE_ID_QUERY, {
+          input: { courseId: course.id },
+        })
+        .then((r) => r.json())
 
-    const priceAmount = chargeItemsResponse.data?.getChargeItemCodesByCourseId?.items?.find(
-      (item) => item.code === courseInstance.chargeItemCode,
-    )?.priceAmount
+      priceAmount =
+        chargeItemsResponse.data?.getChargeItemCodesByCourseId?.items?.find(
+          (item) => item.code === courseInstance.chargeItemCode,
+        )?.priceAmount
+    } catch (error) {
+      this.logger.error(
+        'Failed to fetch charge item codes for course, proceeding without price',
+        { error, courseId: course.id },
+      )
+    }
 
     const courseRecord = await this.zendeskService.upsertCustomObjectRecord(
       ZENDESK_CUSTOM_OBJECT_KEYS.course,

--- a/libs/application/template-api-modules/src/lib/modules/templates/hh/courses/courses.service.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/hh/courses/courses.service.ts
@@ -502,9 +502,10 @@ export class CoursesService extends BaseTemplateApiService {
       })
       .then((r) => r.json())
 
-    const priceAmount = chargeItemsResponse.data?.getChargeItemCodesByCourseId?.items?.find(
-      (item) => item.code === courseInstance.chargeItemCode,
-    )?.priceAmount
+    const priceAmount =
+      chargeItemsResponse.data?.getChargeItemCodesByCourseId?.items?.find(
+        (item) => item.code === courseInstance.chargeItemCode,
+      )?.priceAmount
 
     const courseRecord = await this.zendeskService.upsertCustomObjectRecord(
       ZENDESK_CUSTOM_OBJECT_KEYS.course,

--- a/libs/application/template-api-modules/src/lib/modules/templates/hh/courses/courses.service.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/hh/courses/courses.service.ts
@@ -19,7 +19,9 @@ import type { ApplicationAnswers } from './types'
 import { HHCoursesConfig } from './courses.config'
 import {
   COURSE_LIST_PAGE_SLUG_MAP,
+  GET_CHARGE_ITEM_CODES_BY_COURSE_ID_QUERY,
   GET_COURSE_BY_ID_QUERY,
+  ZENDESK_CUSTOM_OBJECT_KEYS,
   ZENDESK_TICKET_IDS,
 } from './constants'
 
@@ -153,6 +155,20 @@ export class CoursesService extends BaseTemplateApiService {
           },
         ],
       })
+
+      try {
+        await this.submitCustomObjects(
+          course,
+          courseInstance,
+          participantList,
+          auth.authorization,
+        )
+      } catch (error) {
+        this.logger.error(
+          'Failed to submit HH courses application to Zendesk custom objects',
+          { applicationId: application.id, error: error.message },
+        )
+      }
 
       return { success }
     } catch (error) {
@@ -379,6 +395,7 @@ export class CoursesService extends BaseTemplateApiService {
               maxRegistrations?: number
               chargeItemCode?: string | null
               location?: string | null
+              description?: string | null
             }[]
           }
         }
@@ -460,6 +477,71 @@ export class CoursesService extends BaseTemplateApiService {
     if (!slug) return null
 
     return `https://island.is/s/hh/${slug}/${courseId}`
+  }
+
+  private async submitCustomObjects(
+    course: { id: string; title: string },
+    courseInstance: {
+      id: string
+      displayedTitle?: string | null
+      startDate: string
+      startDateTimeDuration?: { startTime?: string; endTime?: string }
+      description?: string | null
+      chargeItemCode?: string | null
+    },
+    participantList: ApplicationAnswers['participantList'],
+    authorization: string,
+  ): Promise<void> {
+    const chargeItemsResponse = await this.sharedTemplateApiService
+      .makeGraphqlQuery<{
+        getChargeItemCodesByCourseId: {
+          items: Array<{ code: string; priceAmount: number }>
+        }
+      }>(authorization, GET_CHARGE_ITEM_CODES_BY_COURSE_ID_QUERY, {
+        input: { courseId: course.id },
+      })
+      .then((r) => r.json())
+
+    const priceAmount = chargeItemsResponse.data?.getChargeItemCodesByCourseId?.items?.find(
+      (item) => item.code === courseInstance.chargeItemCode,
+    )?.priceAmount
+
+    const courseRecord = await this.zendeskService.upsertCustomObjectRecord(
+      ZENDESK_CUSTOM_OBJECT_KEYS.course,
+      { name: course.title, external_id: course.id },
+    )
+
+    const instanceRecord = await this.zendeskService.upsertCustomObjectRecord(
+      ZENDESK_CUSTOM_OBJECT_KEYS.courseInstance,
+      {
+        name: courseInstance.displayedTitle ?? course.title,
+        external_id: courseInstance.id,
+        custom_object_fields: {
+          upphafsdagsetning: courseInstance.startDate.split('T')[0],
+          upphafstímasetning:
+            courseInstance.startDateTimeDuration?.startTime ?? '',
+          lýsing: courseInstance.description ?? '',
+          verð_per_skráningu: priceAmount?.toString() ?? '',
+          course: courseRecord.id,
+        },
+      },
+    )
+
+    if (participantList.length === 0) return
+
+    await this.zendeskService.runCustomObjectJob(
+      ZENDESK_CUSTOM_OBJECT_KEYS.courseParticipant,
+      'create_or_update_by_external_id',
+      participantList.map((p) => ({
+        name: p.nationalIdWithName.name,
+        external_id: `${courseInstance.id}-${p.nationalIdWithName.nationalId}`,
+        custom_object_fields: {
+          kennitala: p.nationalIdWithName.nationalId,
+          email: p.nationalIdWithName.email,
+          course_instance: instanceRecord.id,
+        },
+      })),
+    )
   }
 
   private async formatApplicationMessage(

--- a/libs/clients/zendesk/src/lib/zendesk.service.ts
+++ b/libs/clients/zendesk/src/lib/zendesk.service.ts
@@ -302,7 +302,11 @@ export class ZendeskService {
     const body = JSON.stringify({ custom_object_record: record })
     try {
       const response = await axios.patch(
-        `${this.api}/custom_objects/${objectKey}/records?external_id=${encodeURIComponent(record.external_id)}`,
+        `${
+          this.api
+        }/custom_objects/${objectKey}/records?external_id=${encodeURIComponent(
+          record.external_id,
+        )}`,
         body,
         this.params,
       )

--- a/libs/clients/zendesk/src/lib/zendesk.service.ts
+++ b/libs/clients/zendesk/src/lib/zendesk.service.ts
@@ -375,8 +375,10 @@ export class ZendeskService {
     }
 
     if (jobStatus.results) {
-      const failed = jobStatus.results.filter(
-        (r) => r.status === 'failed' || r.errors,
+      const failed = jobStatus.results.filter((r) =>
+        r.status === 'failed' || Array.isArray(r.errors)
+          ? (r.errors as unknown[]).length > 0
+          : Boolean(r.errors),
       )
       if (failed.length > 0) {
         throw new Error(

--- a/libs/clients/zendesk/src/lib/zendesk.service.ts
+++ b/libs/clients/zendesk/src/lib/zendesk.service.ts
@@ -52,6 +52,31 @@ export type User = {
   id: number
 }
 
+export type CustomObjectRecord = {
+  id: string
+  name: string
+  external_id: string
+  custom_object_fields?: Record<string, unknown>
+}
+
+export type CustomObjectJobItem = {
+  name: string
+  external_id: string
+  custom_object_fields?: Record<string, unknown>
+}
+
+type CustomObjectJobStatus = {
+  id: string
+  url?: string
+  status: 'queued' | 'working' | 'completed' | 'failed' | 'aborted'
+  results?: Array<{
+    id?: string
+    external_id?: string
+    status?: string
+    errors?: unknown
+  }>
+}
+
 export type Ticket = {
   id: string
   status: TicketStatus | string
@@ -268,5 +293,92 @@ export class ZendeskService {
     }
 
     return true
+  }
+
+  async upsertCustomObjectRecord(
+    objectKey: string,
+    record: CustomObjectJobItem,
+  ): Promise<CustomObjectRecord> {
+    const body = JSON.stringify({ custom_object_record: record })
+    try {
+      const response = await axios.patch(
+        `${this.api}/custom_objects/${objectKey}/records?external_id=${encodeURIComponent(record.external_id)}`,
+        body,
+        this.params,
+      )
+      return response.data.custom_object_record
+    } catch (e) {
+      const errMsg = 'Failed to upsert Zendesk custom object record'
+      const description = e.response?.data?.description ?? e.message
+      this.logger.error(errMsg, { message: description })
+      throw new Error(`${errMsg}: ${description}`)
+    }
+  }
+
+  async runCustomObjectJob(
+    objectKey: string,
+    action: 'create_or_update_by_external_id',
+    items: CustomObjectJobItem[],
+  ): Promise<void> {
+    const body = JSON.stringify({ job: { action, items } })
+
+    let jobStatus: CustomObjectJobStatus
+    try {
+      const response = await axios.post(
+        `${this.api}/custom_objects/${objectKey}/records/jobs`,
+        body,
+        this.params,
+      )
+      jobStatus = response.data.job_status ?? response.data
+    } catch (e) {
+      const errMsg = 'Failed to create Zendesk custom object job'
+      const description = e.response?.data?.description ?? e.message
+      this.logger.error(errMsg, { message: description })
+      throw new Error(`${errMsg}: ${description}`)
+    }
+
+    const MAX_POLL_ATTEMPTS = 10
+    const POLL_INTERVAL_MS = 1000
+
+    for (let attempt = 0; attempt < MAX_POLL_ATTEMPTS; attempt++) {
+      if (jobStatus.status === 'completed') break
+      if (jobStatus.status === 'failed' || jobStatus.status === 'aborted') {
+        throw new Error(
+          `Zendesk custom object job ${jobStatus.status}: ${jobStatus.id}`,
+        )
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS))
+
+      try {
+        const pollUrl =
+          jobStatus.url ??
+          `${this.api}/custom_objects/${objectKey}/records/jobs/${jobStatus.id}`
+        const response = await axios.get(pollUrl, this.params)
+        jobStatus = response.data.job_status ?? response.data
+      } catch (e) {
+        const errMsg = 'Failed to poll Zendesk custom object job status'
+        const description = e.response?.data?.description ?? e.message
+        this.logger.error(errMsg, { message: description })
+        throw new Error(`${errMsg}: ${description}`)
+      }
+    }
+
+    if (jobStatus.status !== 'completed') {
+      throw new Error(
+        `Zendesk custom object job did not complete in time: ${jobStatus.id}`,
+      )
+    }
+
+    if (jobStatus.results) {
+      const failed = jobStatus.results.filter(
+        (r) => r.status === 'failed' || r.errors,
+      )
+      if (failed.length > 0) {
+        throw new Error(
+          `${failed.length} Zendesk custom object job item(s) failed`,
+        )
+      }
+    }
   }
 }


### PR DESCRIPTION
# Submit application to zendesk via custom objects

The idea is that we will stop relying on Zendesk tickets and instead use custom objects. This PR includes just the addition that now we also write to custom objects in Zendesk

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code v2.1.173 - Sonnet 4.6


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Course instance descriptions are now included in course details.
  * Course data is synchronized to external ticketing/custom-object systems, including course and participant records.
  * Charge item codes and price amounts are now automatically retrieved and associated with course instances to support billing/registration.
* **Bug Fixes**
  * Improved submission flow resilience: ticket submission remains successful even if supplementary custom-object updates encounter errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->