### PR TITLE
fix(marriage-conditions): return to spouse_confirm on payment abort

### DIFF
--- a/libs/application/templates/marriage-conditions/src/lib/MarriageConditionsTemplate.ts
+++ b/libs/application/templates/marriage-conditions/src/lib/MarriageConditionsTemplate.ts
@@ -227,6 +227,11 @@ const MarriageConditionsTemplate: ApplicationTemplate<
 
           return paymentCodes.flat()
         },
+        // A cancelled payment must return to SPOUSE_CONFIRM (where the spouse has a
+        // form), not buildPaymentState's default 'draft' — DRAFT has no
+        // ASSIGNED_SPOUSE role, so the assigned spouse would be stranded on an
+        // endless loading screen with no form to render.
+        abortTarget: States.SPOUSE_CONFIRM,
         submitTarget: States.DONE,
       }),
       [States.DONE]: {


### PR DESCRIPTION
## What

Cancelling/aborting the payment step in marriage-conditions sent the application back to `draft` — `buildPaymentState`'s default `abortTarget` is `'draft'` (`paymentStateBuilder.ts:129`) and this template didn't override it. But the spouse stays in `assignees`, and the `DRAFT` state defines **no form for the `ASSIGNED_SPOUSE` role** (only `APPLICANT`). So when the assigned spouse opens the application afterwards, no form resolves for the (state=`draft`, role=`ASSIGNED_SPOUSE`) combination and the page **hangs on the loading spinner indefinitely** — no exception is thrown, which is why nothing surfaced in server logs. The applicant is unaffected (maps to `APPLICANT`, opens the draft fine).

This sets `abortTarget: States.SPOUSE_CONFIRM`, so a cancelled payment returns to `SPOUSE_CONFIRM` — where the spouse has a form and can retry payment.

## Why

Reported via Zendesk: an assigned spouse stuck on an endless loading screen when opening their in-progress application, in multiple browsers. Root cause traced through prod logs and the application DB. **40 production applications are currently stranded** in `draft` + assignee, each locking its spouse out the same way.

## Note

This prevents *new* occurrences. The 40 already-stranded applications need a separate one-off data fix (advance `draft` -> `spouse_confirm`); that is intentionally **not** part of this PR.

## Screenshots / Gifs

N/A — backend state-machine change only.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code
