### PR TITLE
fix(native-app): Update link for medicine delegation

### DIFF
--- a/apps/native/app/src/components/health-tabs/medicine-delegation-tab.tsx
+++ b/apps/native/app/src/components/health-tabs/medicine-delegation-tab.tsx
@@ -131,7 +131,11 @@ export function MedicineDelegationTab({ initial }: { initial?: boolean }) {
         <HeaderActions>
           <ReadMoreButton
             accessibilityRole="button"
-            onPress={() => openBrowser('https://island.is/s/landlaeknir/frett')}
+            onPress={() =>
+              openBrowser(
+                'https://island.is/heilbrigdisthjonusta-yfir-landamaeri',
+              )
+            }
           >
             <Typography
               variant="eyebrow"


### PR DESCRIPTION
Was pointing to https://island.is/s/landlaeknir/frett like mínar síður instead of correct link.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [x] No AI tools were used in preparing this pull request
- [ ] AI tools were used in preparing this pull request
      Tools used:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the "Read more" link in the medicine delegation section to reference the correct health service information resource.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->