### PR TITLE
feat(j-s): preserve Word's 15 highlight colors exactly on paste

### DIFF
--- a/apps/judicial-system/web/src/components/TinyMCE/HighlightColorPicker.tsx
+++ b/apps/judicial-system/web/src/components/TinyMCE/HighlightColorPicker.tsx
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react'
 import { motion } from 'motion/react'
 
-import { HIGHLIGHT_COLORS } from './pasteNormalization'
+import { WORD_HIGHLIGHT_COLORS } from './pasteNormalization'
 import * as styles from './TinyMCE.css'
 
 const containerVariants = {
@@ -47,7 +47,7 @@ const HighlightColorPicker = forwardRef<HTMLDivElement, Props>(
       animate="visible"
       exit="exit"
     >
-      {HIGHLIGHT_COLORS.map(({ label, color }) => (
+      {WORD_HIGHLIGHT_COLORS.map(({ label, color }) => (
         <motion.button
           key={color}
           type="button"

--- a/apps/judicial-system/web/src/components/TinyMCE/TinyMCE.css.ts
+++ b/apps/judicial-system/web/src/components/TinyMCE/TinyMCE.css.ts
@@ -88,7 +88,8 @@ export const colorPicker = style({
   borderRadius: theme.border.radius.large,
   padding: theme.spacing[1],
   display: 'grid',
-  gridTemplateColumns: 'repeat(3, 1fr)',
+  // Word's 15 highlight colors plus the ✕ button fill a 4x4 grid exactly.
+  gridTemplateColumns: 'repeat(4, 1fr)',
   gap: 6,
   boxShadow: '0 4px 16px rgba(0,0,0,0.12)',
 })

--- a/apps/judicial-system/web/src/components/TinyMCE/TinyMCE.tsx
+++ b/apps/judicial-system/web/src/components/TinyMCE/TinyMCE.tsx
@@ -12,6 +12,7 @@ import {
   INDENT_STEP_PX,
   normalizePastedHighlights,
   normalizePastedIndentation,
+  WORD_HIGHLIGHT_COLORS,
 } from './pasteNormalization'
 import * as styles from './TinyMCE.css'
 
@@ -89,24 +90,29 @@ const TinyMCE = ({
     }
   }, [pickerOpen])
 
-  const handleNodeChange =
-    (editor: TinyMCEEditor) => (e: { element: Element }) => {
-      let node: HTMLElement | null = e.element as HTMLElement
-      while (node && node !== editor.getBody()) {
-        const bg: string = node.style?.backgroundColor ?? ''
-        if (bg && bg !== 'transparent') {
-          const match = HIGHLIGHT_COLORS.find(
-            ({ color }) => hexToRgb(color) === bg,
-          )
-          if (match) {
-            setSelectedColor(match.color)
-            return
-          }
+  const handleNodeChange = (editor: TinyMCEEditor) => (e: {
+    element: Element
+  }) => {
+    let node: HTMLElement | null = e.element as HTMLElement
+    while (node && node !== editor.getBody()) {
+      const bg: string = node.style?.backgroundColor ?? ''
+      if (bg && bg !== 'transparent') {
+        // Word highlight colors are preserved on paste without being part
+        // of the picker palette; they must still be tracked here so the
+        // picker's ✕ button can toggle them off.
+        const match = [
+          ...HIGHLIGHT_COLORS.map(({ color }) => color),
+          ...WORD_HIGHLIGHT_COLORS,
+        ].find((color) => hexToRgb(color) === bg)
+        if (match) {
+          setSelectedColor(match)
+          return
         }
-        node = node.parentElement
       }
-      setSelectedColor(null)
+      node = node.parentElement
     }
+    setSelectedColor(null)
+  }
 
   const setupHighlightButton = (editor: TinyMCEEditor) => {
     editor.ui.registry.addToggleButton('highlightcolor', {

--- a/apps/judicial-system/web/src/components/TinyMCE/TinyMCE.tsx
+++ b/apps/judicial-system/web/src/components/TinyMCE/TinyMCE.tsx
@@ -90,29 +90,28 @@ const TinyMCE = ({
     }
   }, [pickerOpen])
 
-  const handleNodeChange = (editor: TinyMCEEditor) => (e: {
-    element: Element
-  }) => {
-    let node: HTMLElement | null = e.element as HTMLElement
-    while (node && node !== editor.getBody()) {
-      const bg: string = node.style?.backgroundColor ?? ''
-      if (bg && bg !== 'transparent') {
-        // Word highlight colors are preserved on paste without being part
-        // of the picker palette; they must still be tracked here so the
-        // picker's ✕ button can toggle them off.
-        const match = [
-          ...HIGHLIGHT_COLORS.map(({ color }) => color),
-          ...WORD_HIGHLIGHT_COLORS,
-        ].find((color) => hexToRgb(color) === bg)
-        if (match) {
-          setSelectedColor(match)
-          return
+  const handleNodeChange =
+    (editor: TinyMCEEditor) => (e: { element: Element }) => {
+      let node: HTMLElement | null = e.element as HTMLElement
+      while (node && node !== editor.getBody()) {
+        const bg: string = node.style?.backgroundColor ?? ''
+        if (bg && bg !== 'transparent') {
+          // Word highlight colors are preserved on paste without being part
+          // of the picker palette; they must still be tracked here so the
+          // picker's ✕ button can toggle them off.
+          const match = [
+            ...HIGHLIGHT_COLORS.map(({ color }) => color),
+            ...WORD_HIGHLIGHT_COLORS,
+          ].find((color) => hexToRgb(color) === bg)
+          if (match) {
+            setSelectedColor(match)
+            return
+          }
         }
+        node = node.parentElement
       }
-      node = node.parentElement
+      setSelectedColor(null)
     }
-    setSelectedColor(null)
-  }
 
   const setupHighlightButton = (editor: TinyMCEEditor) => {
     editor.ui.registry.addToggleButton('highlightcolor', {

--- a/apps/judicial-system/web/src/components/TinyMCE/TinyMCE.tsx
+++ b/apps/judicial-system/web/src/components/TinyMCE/TinyMCE.tsx
@@ -8,7 +8,6 @@ import { ErrorMessage } from '@island.is/island-ui/core'
 import RequiredStar from '../RequiredStar/RequiredStar'
 import HighlightColorPicker from './HighlightColorPicker'
 import {
-  HIGHLIGHT_COLORS,
   INDENT_STEP_PX,
   normalizePastedHighlights,
   normalizePastedIndentation,
@@ -97,13 +96,9 @@ const TinyMCE = ({
     while (node && node !== editor.getBody()) {
       const bg: string = node.style?.backgroundColor ?? ''
       if (bg && bg !== 'transparent') {
-        // Word highlight colors are preserved on paste without being part
-        // of the picker palette; they must still be tracked here so the
-        // picker's ✕ button can toggle them off.
-        const match = [
-          ...HIGHLIGHT_COLORS.map(({ color }) => color),
-          ...WORD_HIGHLIGHT_COLORS,
-        ].find((color) => hexToRgb(color) === bg)
+        const match = WORD_HIGHLIGHT_COLORS.map(({ color }) => color).find(
+          (color) => hexToRgb(color) === bg,
+        )
         if (match) {
           setSelectedColor(match)
           return

--- a/apps/judicial-system/web/src/components/TinyMCE/pasteNormalization.spec.ts
+++ b/apps/judicial-system/web/src/components/TinyMCE/pasteNormalization.spec.ts
@@ -76,18 +76,71 @@ describe('findNearestHighlightColor', () => {
 })
 
 describe('normalizePastedHighlights', () => {
-  it('rewrites the Word "background" shorthand to a palette background-color', () => {
+  it('rewrites the Word "background" shorthand to a background-color', () => {
     // Word emits highlights as "background:yellow" — the shorthand, a keyword
     // color — after the paste plugin's Word filter has run.
     expect(
       normalizePastedHighlights('<span style="background:yellow">x</span>'),
-    ).toBe(`<span style="background-color: ${YELLOW};">x</span>`)
+    ).toBe('<span style="background-color: #ffff00;">x</span>')
   })
 
-  it('snaps a background-color hex value to the palette', () => {
+  it('preserves each of the 15 Word highlight colors exactly', () => {
+    // The CSS keyword Word emits for each of its 15 highlighter colors,
+    // paired with the canonical hex it must survive as.
+    const wordPalette: [string, string][] = [
+      ['yellow', '#ffff00'],
+      ['lime', '#00ff00'], // Bright Green
+      ['cyan', '#00ffff'],
+      ['magenta', '#ff00ff'],
+      ['blue', '#0000ff'], // Bright Blue
+      ['red', '#ff0000'],
+      ['navy', '#000080'], // Dark Blue
+      ['teal', '#008080'],
+      ['green', '#008000'], // Dark Green
+      ['purple', '#800080'], // Dark Violet
+      ['maroon', '#800000'], // Dark Red
+      ['olive', '#808000'], // Dark Yellow
+      ['silver', '#c0c0c0'], // Gray
+      ['gray', '#808080'], // Dark Gray
+      ['black', '#000000'],
+    ]
+    for (const [keyword, hex] of wordPalette) {
+      expect(
+        normalizePastedHighlights(
+          `<span style="background:${keyword}">x</span>`,
+        ),
+      ).toBe(`<span style="background-color: ${hex};">x</span>`)
+    }
+  })
+
+  it('preserves a Word highlight color given in rgb() form', () => {
     expect(
       normalizePastedHighlights(
-        '<span style="background-color: #ffff00;">x</span>',
+        '<span style="background-color: rgb(0, 128, 128);">x</span>',
+      ),
+    ).toBe('<span style="background-color: #008080;">x</span>')
+  })
+
+  it('preserves a black highlight instead of falling back to yellow', () => {
+    expect(
+      normalizePastedHighlights('<span style="background:black">x</span>'),
+    ).toBe('<span style="background-color: #000000;">x</span>')
+  })
+
+  it('maps "dark" keyword aliases onto the Word palette values', () => {
+    expect(
+      normalizePastedHighlights('<span style="background:darkred">x</span>'),
+    ).toBe('<span style="background-color: #800000;">x</span>')
+    expect(
+      normalizePastedHighlights('<span style="background:darkblue">x</span>'),
+    ).toBe('<span style="background-color: #000080;">x</span>')
+  })
+
+  it('snaps a color outside the Word palette to the editor palette', () => {
+    // Near-yellow but not an exact Word color → nearest editor swatch.
+    expect(
+      normalizePastedHighlights(
+        '<span style="background-color: #fffe10;">x</span>',
       ),
     ).toBe(`<span style="background-color: ${YELLOW};">x</span>`)
   })
@@ -115,7 +168,7 @@ describe('normalizePastedHighlights', () => {
     )
     expect(result).toContain('font-weight:bold')
     expect(result).toContain('font-style:italic')
-    expect(result).toContain(`background-color: ${YELLOW};`)
+    expect(result).toContain('background-color: #ffff00;')
   })
 
   it('does not change content without backgrounds', () => {

--- a/apps/judicial-system/web/src/components/TinyMCE/pasteNormalization.spec.ts
+++ b/apps/judicial-system/web/src/components/TinyMCE/pasteNormalization.spec.ts
@@ -1,13 +1,12 @@
 import {
   findNearestHighlightColor,
-  HIGHLIGHT_COLORS,
   normalizePastedHighlights,
   normalizePastedIndentation,
   parseCssColor,
+  WORD_HIGHLIGHT_COLORS,
 } from './pasteNormalization'
 
-const YELLOW = HIGHLIGHT_COLORS[0].color
-const BLUE = HIGHLIGHT_COLORS[1].color
+const YELLOW = WORD_HIGHLIGHT_COLORS[0].color
 
 describe('parseCssColor', () => {
   it('resolves Word highlighter color keywords', () => {
@@ -51,26 +50,20 @@ describe('parseCssColor', () => {
 
 describe('findNearestHighlightColor', () => {
   it('maps every palette color to itself', () => {
-    for (const { color } of HIGHLIGHT_COLORS) {
+    for (const { color } of WORD_HIGHLIGHT_COLORS) {
       expect(findNearestHighlightColor(color)).toBe(color)
     }
   })
 
   it('maps a palette color given in rgb() form to its hex value', () => {
-    const [r, g, b] = parseCssColor(BLUE) ?? []
-    expect(findNearestHighlightColor(`rgb(${r}, ${g}, ${b})`)).toBe(BLUE)
+    expect(findNearestHighlightColor('rgb(0, 128, 128)')).toBe('#008080')
   })
 
-  it('snaps Word yellow to the palette yellow', () => {
-    expect(findNearestHighlightColor('yellow')).toBe(YELLOW)
+  it('snaps a near-miss color to the nearest palette color', () => {
+    expect(findNearestHighlightColor('#fffe10')).toBe(YELLOW)
   })
 
-  it('falls back to the first palette color for distant colors', () => {
-    // Black is further than the snap threshold from every palette color.
-    expect(findNearestHighlightColor('black')).toBe(YELLOW)
-  })
-
-  it('falls back to the first palette color for unparseable input', () => {
+  it('falls back to yellow for unparseable input', () => {
     expect(findNearestHighlightColor('windowtext')).toBe(YELLOW)
   })
 })
@@ -136,8 +129,8 @@ describe('normalizePastedHighlights', () => {
     ).toBe('<span style="background-color: #000080;">x</span>')
   })
 
-  it('snaps a color outside the Word palette to the editor palette', () => {
-    // Near-yellow but not an exact Word color → nearest editor swatch.
+  it('snaps a color outside the Word palette to the nearest Word color', () => {
+    // Near-yellow but not an exact Word color → nearest palette swatch.
     expect(
       normalizePastedHighlights(
         '<span style="background-color: #fffe10;">x</span>',

--- a/apps/judicial-system/web/src/components/TinyMCE/pasteNormalization.ts
+++ b/apps/judicial-system/web/src/components/TinyMCE/pasteNormalization.ts
@@ -12,36 +12,64 @@ export const HIGHLIGHT_COLORS = [
   { label: 'Purple', color: theme.color.purple200 },
 ]
 
+// Word's text highlighter supports exactly 15 colors — the classic CSS named
+// palette minus white. A pasted highlight matching one of these is preserved
+// as-is; any other color is snapped to the editor palette as a backup. Word's
+// UI name is noted where it differs from the CSS keyword Word emits.
+export const WORD_HIGHLIGHT_COLORS = [
+  '#ffff00', // yellow
+  '#00ff00', // lime — Bright Green
+  '#00ffff', // cyan
+  '#ff00ff', // magenta
+  '#0000ff', // blue — Bright Blue
+  '#ff0000', // red
+  '#000080', // navy — Dark Blue
+  '#008080', // teal
+  '#008000', // green — Dark Green
+  '#800080', // purple — Dark Violet
+  '#800000', // maroon — Dark Red
+  '#808000', // olive — Dark Yellow
+  '#c0c0c0', // silver — Gray
+  '#808080', // gray — Dark Gray
+  '#000000', // black
+]
+
 // Word's text highlighter emits its palette as CSS color keywords (e.g.
-// "background:yellow;mso-highlight:yellow"), so we resolve those here. Only
-// real colors from the Word highlight palette are listed — keywords like
-// "transparent" or "windowtext" stay unresolvable and get stripped on paste.
+// "background:yellow;mso-highlight:yellow"), so we resolve those here. The
+// "dark"/"light" aliases are deliberately mapped onto the Word palette values
+// rather than their slightly different CSS counterparts — in pasted content
+// they can only mean the Word highlight. Keywords like "transparent", "white"
+// or "windowtext" stay unresolvable and get stripped on paste.
 const NAMED_COLORS: Record<string, [number, number, number]> = {
   yellow: [255, 255, 0],
   lime: [0, 255, 0],
   cyan: [0, 255, 255],
   aqua: [0, 255, 255],
+  turquoise: [0, 255, 255],
   magenta: [255, 0, 255],
   fuchsia: [255, 0, 255],
   blue: [0, 0, 255],
   red: [255, 0, 0],
   navy: [0, 0, 128],
-  darkblue: [0, 0, 139],
+  darkblue: [0, 0, 128],
   teal: [0, 128, 128],
-  darkcyan: [0, 139, 139],
+  darkcyan: [0, 128, 128],
   green: [0, 128, 0],
+  darkgreen: [0, 128, 0],
   purple: [128, 0, 128],
-  violet: [238, 130, 238],
+  violet: [128, 0, 128],
+  darkviolet: [128, 0, 128],
   maroon: [128, 0, 0],
-  darkred: [139, 0, 0],
+  darkred: [128, 0, 0],
   olive: [128, 128, 0],
+  darkyellow: [128, 128, 0],
+  silver: [192, 192, 192],
+  lightgray: [192, 192, 192],
+  lightgrey: [192, 192, 192],
   gray: [128, 128, 128],
   grey: [128, 128, 128],
-  silver: [192, 192, 192],
-  lightgray: [211, 211, 211],
-  lightgrey: [211, 211, 211],
-  darkgray: [169, 169, 169],
-  darkgrey: [169, 169, 169],
+  darkgray: [128, 128, 128],
+  darkgrey: [128, 128, 128],
   black: [0, 0, 0],
 }
 
@@ -97,17 +125,31 @@ export const findNearestHighlightColor = (cssColor: string): string => {
   return minDist <= HIGHLIGHT_DISTANCE_THRESHOLD ? nearest : fallback
 }
 
+const rgbToHex = ([r, g, b]: [number, number, number]): string =>
+  `#${[r, g, b].map((c) => c.toString(16).padStart(2, '0')).join('')}`
+
+// An exact Word highlight color is preserved as its canonical hex; any other
+// color falls back to snapping to the editor palette.
+export const normalizeHighlightColor = (cssColor: string): string => {
+  const rgb = parseCssColor(cssColor)
+  if (rgb) {
+    const hex = rgbToHex(rgb)
+    if (WORD_HIGHLIGHT_COLORS.includes(hex)) return hex
+  }
+  return findNearestHighlightColor(cssColor)
+}
+
 // Normalize pasted backgrounds to a known highlight color, and strip ones we
 // can't parse (e.g. Word's "transparent"), which would otherwise render as a
 // black rectangle in the PDF. Word emits highlights as the "background"
 // shorthand (retained via paste_retain_style_properties), which this rewrites
-// to a palette background-color.
+// to a background-color.
 export const normalizePastedHighlights = (html: string): string =>
   html.replace(
     /background(-color)?:\s*(#[0-9a-fA-F]{3,6}|rgba?\([^)]+\)|[a-zA-Z]+)\s*;?/g,
     (_match: string, _shorthand: string, color: string) =>
       parseCssColor(color)
-        ? `background-color: ${findNearestHighlightColor(color)};`
+        ? `background-color: ${normalizeHighlightColor(color)};`
         : '',
   )
 

--- a/apps/judicial-system/web/src/components/TinyMCE/pasteNormalization.ts
+++ b/apps/judicial-system/web/src/components/TinyMCE/pasteNormalization.ts
@@ -1,37 +1,25 @@
-import { theme } from '@island.is/island-ui/theme'
-
-// Single source of truth for the editor's highlight palette. HighlightColorPicker
-// renders these as swatches, and pasted backgrounds are snapped to the nearest
-// of these colors below. The backend PDF renderer draws whatever hex value is
-// stored, so every color here must be a 6-digit hex string.
-export const HIGHLIGHT_COLORS = [
-  { label: 'Yellow', color: theme.color.yellow400 },
-  { label: 'Blue', color: theme.color.blue100 },
-  { label: 'Mint', color: theme.color.mint200 },
-  { label: 'Rose', color: theme.color.roseTinted200 },
-  { label: 'Purple', color: theme.color.purple200 },
-]
-
-// Word's text highlighter supports exactly 15 colors — the classic CSS named
-// palette minus white. A pasted highlight matching one of these is preserved
-// as-is; any other color is snapped to the editor palette as a backup. Word's
-// UI name is noted where it differs from the CSS keyword Word emits.
+// The editor's highlight palette: exactly the 15 colors of Word's text
+// highlighter — the classic CSS named palette minus white. HighlightColorPicker
+// renders these as swatches, pasted backgrounds are snapped onto them (exact
+// Word colors survive unchanged), and the backend PDF renderer draws whatever
+// hex value is stored, so every color here must be a 6-digit hex string.
+// Labels are Word's UI names; the comments note the CSS keyword Word emits.
 export const WORD_HIGHLIGHT_COLORS = [
-  '#ffff00', // yellow
-  '#00ff00', // lime — Bright Green
-  '#00ffff', // cyan
-  '#ff00ff', // magenta
-  '#0000ff', // blue — Bright Blue
-  '#ff0000', // red
-  '#000080', // navy — Dark Blue
-  '#008080', // teal
-  '#008000', // green — Dark Green
-  '#800080', // purple — Dark Violet
-  '#800000', // maroon — Dark Red
-  '#808000', // olive — Dark Yellow
-  '#c0c0c0', // silver — Gray
-  '#808080', // gray — Dark Gray
-  '#000000', // black
+  { label: 'Yellow', color: '#ffff00' }, // yellow
+  { label: 'Bright Green', color: '#00ff00' }, // lime
+  { label: 'Cyan', color: '#00ffff' }, // cyan
+  { label: 'Magenta', color: '#ff00ff' }, // magenta
+  { label: 'Bright Blue', color: '#0000ff' }, // blue
+  { label: 'Red', color: '#ff0000' }, // red
+  { label: 'Dark Blue', color: '#000080' }, // navy
+  { label: 'Teal', color: '#008080' }, // teal
+  { label: 'Dark Green', color: '#008000' }, // green
+  { label: 'Dark Violet', color: '#800080' }, // purple
+  { label: 'Dark Red', color: '#800000' }, // maroon
+  { label: 'Dark Yellow', color: '#808000' }, // olive
+  { label: 'Gray', color: '#c0c0c0' }, // silver
+  { label: 'Dark Gray', color: '#808080' }, // gray
+  { label: 'Black', color: '#000000' }, // black
 ]
 
 // Word's text highlighter emits its palette as CSS color keywords (e.g.
@@ -101,15 +89,18 @@ export const parseCssColor = (
 
 const HIGHLIGHT_DISTANCE_THRESHOLD = 200
 
+// Snap a CSS color onto the palette: exact palette colors (e.g. re-pasted
+// editor content) map to themselves, anything else goes to the nearest
+// palette color, and colors we cannot resolve fall back to yellow.
 export const findNearestHighlightColor = (cssColor: string): string => {
-  const fallback = HIGHLIGHT_COLORS[0].color
+  const fallback = WORD_HIGHLIGHT_COLORS[0].color
   const rgb = parseCssColor(cssColor)
   if (!rgb) return fallback
 
   let minDist = Infinity
   let nearest = fallback
 
-  for (const { color } of HIGHLIGHT_COLORS) {
+  for (const { color } of WORD_HIGHLIGHT_COLORS) {
     const r = parseInt(color.slice(1, 3), 16)
     const g = parseInt(color.slice(3, 5), 16)
     const b = parseInt(color.slice(5, 7), 16)
@@ -125,20 +116,6 @@ export const findNearestHighlightColor = (cssColor: string): string => {
   return minDist <= HIGHLIGHT_DISTANCE_THRESHOLD ? nearest : fallback
 }
 
-const rgbToHex = ([r, g, b]: [number, number, number]): string =>
-  `#${[r, g, b].map((c) => c.toString(16).padStart(2, '0')).join('')}`
-
-// An exact Word highlight color is preserved as its canonical hex; any other
-// color falls back to snapping to the editor palette.
-export const normalizeHighlightColor = (cssColor: string): string => {
-  const rgb = parseCssColor(cssColor)
-  if (rgb) {
-    const hex = rgbToHex(rgb)
-    if (WORD_HIGHLIGHT_COLORS.includes(hex)) return hex
-  }
-  return findNearestHighlightColor(cssColor)
-}
-
 // Normalize pasted backgrounds to a known highlight color, and strip ones we
 // can't parse (e.g. Word's "transparent"), which would otherwise render as a
 // black rectangle in the PDF. Word emits highlights as the "background"
@@ -149,7 +126,7 @@ export const normalizePastedHighlights = (html: string): string =>
     /background(-color)?:\s*(#[0-9a-fA-F]{3,6}|rgba?\([^)]+\)|[a-zA-Z]+)\s*;?/g,
     (_match: string, _shorthand: string, color: string) =>
       parseCssColor(color)
-        ? `background-color: ${normalizeHighlightColor(color)};`
+        ? `background-color: ${findNearestHighlightColor(color)};`
         : '',
   )
 


### PR DESCRIPTION
## What

Replace the TinyMCE highlight feature's 5-color theme palette with Microsoft Word's 15 highlighter colors, end to end:

- **Picker:** the highlight color picker now shows exactly Word's 15 colors plus the remove (✕) button, in a 4×4 grid.
- **Paste:** a pasted Word highlight is preserved exactly. Word's highlighter palette is the classic CSS named palette minus white (Yellow `#FFFF00`, Bright Green `#00FF00`, Cyan `#00FFFF`, Magenta `#FF00FF`, Bright Blue `#0000FF`, Red `#FF0000`, Dark Blue `#000080`, Teal `#008080`, Dark Green `#008000`, Dark Violet `#800080`, Dark Red `#800000`, Dark Yellow `#808000`, Gray `#C0C0C0`, Dark Gray `#808080`, Black `#000000`).
- **Backup:** any pasted color that is not an exact Word color is snapped to the nearest of the 15 (`findNearestHighlightColor`), and unparseable values (`transparent`, `windowtext`, …) are stripped so they cannot render as black rectangles in the PDF.
- Keyword aliases (`darkblue`, `darkred`, `turquoise`, …) resolve to the Word palette values rather than their slightly different CSS counterparts.

## Why

Word documents pasted into court records use highlights to mark text; collapsing Word's 15 colors into 5 theme colors (with dark colors all falling back to yellow) loses the distinction between different highlight colors. Matching Word's palette exactly keeps pasted content faithful to the source document.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)