### PR TITLE
fix(native-app): Fix apply link for missing passports

### DIFF
--- a/apps/native/app/src/ui/lib/card/license-list-card.tsx
+++ b/apps/native/app/src/ui/lib/card/license-list-card.tsx
@@ -51,9 +51,9 @@ const ContentContainer = styled.View`
   align-items: center;
 `
 
-const Trailing = styled.View`
+const Trailing = styled.View<{ hasLink?: boolean }>`
   flex-shrink: 0;
-  width: 24px;
+  width: ${({ hasLink }) => (hasLink ? 'auto' : '24px')};
   align-items: center;
   justify-content: center;
   margin-left: ${({ theme }) => theme.spacing[1]}px;
@@ -272,7 +272,7 @@ export function LicenseListCard({
             )}
           </Content>
         </TextContent>
-        <Trailing>
+        <Trailing hasLink={!!props.link}>
           {props.link ? (
             props.link
           ) : (


### PR DESCRIPTION
## What

Fix apply text for link when passport is missing

## Screenshots / Gifs
Before:
<img width="430" height="275" alt="Screenshot 2026-06-12 at 14 26 42" src="https://github.com/user-attachments/assets/7fdc48e5-e51c-40d1-aa78-53278fff84f9" />


After:

<img width="410" height="236" alt="Screenshot 2026-06-12 at 14 26 22" src="https://github.com/user-attachments/assets/2937272a-2f96-4b1e-907e-4712e8511de4" />

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved layout of the license list card by making the right-side container width adjust dynamically based on content presence, ensuring proper spacing and visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->