### PR TITLE
fix(contentful-apps): allow non-admins to link existing subpages on parent subpage

### DIFF
--- a/apps/contentful-apps/pages/fields/organization-parent-subpage-pages-field.tsx
+++ b/apps/contentful-apps/pages/fields/organization-parent-subpage-pages-field.tsx
@@ -42,7 +42,10 @@ const OrganizationParentSubpagePagesField = () => {
       parameters={{
         instance: {
           showCreateEntityAction: true,
-          showLinkEntityAction: sdk.user.spaceMembership.admin,
+          // Link-existing is enforced by the entry picker (read) and the
+          // back-reference update below (update), both scoped by the editor's
+          // tag-based role policy. No need to gate the action on space admin.
+          showLinkEntityAction: true,
         },
       }}
       onAction={async (action) => {
@@ -106,21 +109,29 @@ const OrganizationParentSubpagePagesField = () => {
 
             if (entries.length > 0) {
               const selectedEntry = entries[0]
-              const entry = await cma.entry.get({
-                entryId: selectedEntry.sys.id,
-              })
-              entry.fields.organizationParentSubpage = {
-                [DEFAULT_LOCALE]: {
-                  sys: { id: sdk.entry.getSys().id, linkType: 'Entry' },
-                },
+              try {
+                const entry = await cma.entry.get({
+                  entryId: selectedEntry.sys.id,
+                })
+                entry.fields.organizationParentSubpage = {
+                  [DEFAULT_LOCALE]: {
+                    sys: { id: sdk.entry.getSys().id, linkType: 'Entry' },
+                  },
+                }
+                await cma.entry.update(
+                  {
+                    entryId: entry.sys.id,
+                  },
+                  entry,
+                )
+                props.onLinkedExisting(entries)
+              } catch (error) {
+                sdk.notifier.warning(
+                  error instanceof Error
+                    ? error.message
+                    : 'Subpage could not be linked. You might not have permission to edit it.',
+                )
               }
-              await cma.entry.update(
-                {
-                  entryId: entry.sys.id,
-                },
-                entry,
-              )
-              props.onLinkedExisting(entries)
             }
           }}
           onCreate={(contentTypeId) => {


### PR DESCRIPTION
## What

On the **Organization Parent Subpage** `Pages` field, the custom Contentful field app gated the **"Add existing content"** action (`showLinkEntityAction`) on space-admin membership. Regular organization editors therefore only ever saw **"New Content"** and could not link existing subpages.

This change:
- Always shows **"Add existing content"** (`showLinkEntityAction: true`).
- Wraps the back-reference update in a `try/catch` so a permission miss surfaces a friendly notifier instead of throwing.

## Why

Editors reported (Zendesk #531202) that they can only create new subpages, not link existing ones, under a Parent Subpage.

The admin gate has been present since the field app was first created (#18478) and was not a deliberate restriction — the fragile re-parenting case it implicitly guarded is now handled by the existing `onLinkExisting` safety checks (#22262, #22446).

Enforcement now lives where it belongs: both the entry picker (**read**) and the back-reference update (**update**) are scoped by the editor's tag-based Contentful role policy, so a non-admin can only see and link subpages within their own organization.

⚠️ **Scope:** this enables link-existing for editors across **all** organizations, which is the requested behaviour — flagging it for owner confirmation.

## Screenshots / Gifs

N/A — this changes a Contentful field-app behaviour that's only observable in the Contentful UI after the app is deployed.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Linking of existing entries is now always available in organization parent subpage management.

* **Bug Fixes**
  * Improved error handling for linking operations with clearer user feedback when issues occur during the linking process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->