### PR TITLE
chore(contentful-role-permissions): Add lifeEventPage as default editable content type

### DIFF
--- a/apps/tools/contentful-role-permissions/constants/index.ts
+++ b/apps/tools/contentful-role-permissions/constants/index.ts
@@ -69,7 +69,6 @@ export const DEFAULT_EDITABLE_ENTRY_TYPE_IDS = [
   'manualChapter',
   'featured',
   'lifeEventPage',
-  'sectionWithImage',
 ]
 
 export const DEFAULT_READ_ONLY_ENTRY_IDS = [

--- a/apps/tools/contentful-role-permissions/constants/index.ts
+++ b/apps/tools/contentful-role-permissions/constants/index.ts
@@ -68,6 +68,8 @@ export const DEFAULT_EDITABLE_ENTRY_TYPE_IDS = [
   'manual',
   'manualChapter',
   'featured',
+  'lifeEventPage',
+  'sectionWithImage',
 ]
 
 export const DEFAULT_READ_ONLY_ENTRY_IDS = [


### PR DESCRIPTION
# Add lifeEventPage as default editable content type

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [x] No AI tools were used in preparing this pull request
- [ ] AI tools were used in preparing this pull request
      Tools used:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the life event page content type in the role permissions system.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->