### PR TITLE
fix(j-s): use padded date format instead of locale short date

### DIFF
--- a/apps/judicial-system/api/.eslintrc.json
+++ b/apps/judicial-system/api/.eslintrc.json
@@ -2,6 +2,13 @@
   "extends": "../../../.eslintrc.json",
   "rules": {
     "eqeqeq": ["error", "always"],
+    "no-restricted-syntax": [
+      "error",
+      {
+        "selector": "CallExpression[callee.name=/^format(Date)?$/] > Literal[value=/^Pp?$/]",
+        "message": "Do not use the date-fns short date token 'P'/'Pp' — the Icelandic locale renders it as 'd.MM.y' (unpadded day, padded month, e.g. \"5.05.2025\"). Use an explicit padded format like 'dd.MM.y' or 'dd.MM.y HH:mm'."
+      }
+    ],
     "simple-import-sort/imports": [
       "error",
       {

--- a/apps/judicial-system/backend/.eslintrc.json
+++ b/apps/judicial-system/backend/.eslintrc.json
@@ -2,6 +2,13 @@
   "extends": "../../../.eslintrc.json",
   "rules": {
     "eqeqeq": ["error", "always"],
+    "no-restricted-syntax": [
+      "error",
+      {
+        "selector": "CallExpression[callee.name=/^format(Date)?$/] > Literal[value=/^Pp?$/]",
+        "message": "Do not use the date-fns short date token 'P'/'Pp' — the Icelandic locale renders it as 'd.MM.y' (unpadded day, padded month, e.g. \"5.05.2025\"). Use an explicit padded format like 'dd.MM.y' or 'dd.MM.y HH:mm'."
+      }
+    ],
     "simple-import-sort/imports": [
       "error",
       {

--- a/apps/judicial-system/backend/src/app/formatters/generatedPdfs/subpoenaServiceCertificatePdf.ts
+++ b/apps/judicial-system/backend/src/app/formatters/generatedPdfs/subpoenaServiceCertificatePdf.ts
@@ -172,7 +172,7 @@ export const createSubpoenaServiceCertificate = (
     doc,
     `${
       subpoena.arraignmentDate
-        ? formatDate(new Date(subpoena.arraignmentDate), 'Pp')
+        ? formatDate(new Date(subpoena.arraignmentDate), 'dd.MM.y HH:mm')
         : 'Ekki skráð'
     }`,
     'Times-Roman',

--- a/apps/judicial-system/backend/src/app/modules/event/event.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/event/event.service.ts
@@ -160,7 +160,7 @@ export class EventService {
               formatDate(
                 DateLog.courtDate(theCase.dateLogs)?.date ??
                   DateLog.arraignmentDate(theCase.dateLogs)?.date,
-                'Pp',
+                'dd.MM.y HH:mm',
               ) ?? 'er ekki skráð'
             }`
           : ''
@@ -390,7 +390,7 @@ export class EventService {
         extraInfo = `courtDate: ${formatDate(
           DateLog.courtDate(theCase.dateLogs)?.date ??
             DateLog.arraignmentDate(theCase.dateLogs)?.date,
-          'Pp',
+          'dd.MM.y HH:mm',
         )}`
         break
       default:

--- a/apps/judicial-system/backend/src/app/modules/verdict/internalVerdict.controller.ts
+++ b/apps/judicial-system/backend/src/app/modules/verdict/internalVerdict.controller.ts
@@ -244,7 +244,9 @@ export class InternalVerdictController {
 
       this.eventService.postEvent('VERDICT_SERVICE_STATUS', theCase, false, {
         Staða: getVerdictServiceStatusText(updatedVerdict.serviceStatus),
-        Birt: formatDate(updatedVerdict.serviceDate, 'Pp') ?? 'ekki skráð',
+        Birt:
+          formatDate(updatedVerdict.serviceDate, 'dd.MM.y HH:mm') ??
+          'ekki skráð',
       })
     }
 

--- a/apps/judicial-system/digital-mailbox-api/.eslintrc.json
+++ b/apps/judicial-system/digital-mailbox-api/.eslintrc.json
@@ -2,6 +2,13 @@
   "extends": "../../../.eslintrc.json",
   "rules": {
     "eqeqeq": ["error", "always"],
+    "no-restricted-syntax": [
+      "error",
+      {
+        "selector": "CallExpression[callee.name=/^format(Date)?$/] > Literal[value=/^Pp?$/]",
+        "message": "Do not use the date-fns short date token 'P'/'Pp' — the Icelandic locale renders it as 'd.MM.y' (unpadded day, padded month, e.g. \"5.05.2025\"). Use an explicit padded format like 'dd.MM.y' or 'dd.MM.y HH:mm'."
+      }
+    ],
     "simple-import-sort/imports": [
       "error",
       {

--- a/apps/judicial-system/message-handler/.eslintrc.json
+++ b/apps/judicial-system/message-handler/.eslintrc.json
@@ -3,6 +3,13 @@
   "ignorePatterns": ["!**/*"],
   "rules": {
     "eqeqeq": ["error", "always"],
+    "no-restricted-syntax": [
+      "error",
+      {
+        "selector": "CallExpression[callee.name=/^format(Date)?$/] > Literal[value=/^Pp?$/]",
+        "message": "Do not use the date-fns short date token 'P'/'Pp' — the Icelandic locale renders it as 'd.MM.y' (unpadded day, padded month, e.g. \"5.05.2025\"). Use an explicit padded format like 'dd.MM.y' or 'dd.MM.y HH:mm'."
+      }
+    ],
     "simple-import-sort/imports": [
       "error",
       {

--- a/apps/judicial-system/scheduler/.eslintrc.json
+++ b/apps/judicial-system/scheduler/.eslintrc.json
@@ -3,6 +3,13 @@
   "ignorePatterns": ["!**/*"],
   "rules": {
     "eqeqeq": ["error", "always"],
+    "no-restricted-syntax": [
+      "error",
+      {
+        "selector": "CallExpression[callee.name=/^format(Date)?$/] > Literal[value=/^Pp?$/]",
+        "message": "Do not use the date-fns short date token 'P'/'Pp' — the Icelandic locale renders it as 'd.MM.y' (unpadded day, padded month, e.g. \"5.05.2025\"). Use an explicit padded format like 'dd.MM.y' or 'dd.MM.y HH:mm'."
+      }
+    ],
     "simple-import-sort/imports": [
       "error",
       {

--- a/apps/judicial-system/web/.eslintrc.json
+++ b/apps/judicial-system/web/.eslintrc.json
@@ -7,6 +7,13 @@
   "ignorePatterns": ["!**/*", "/src/graphql/schema.tsx"],
   "rules": {
     "eqeqeq": ["error", "always"],
+    "no-restricted-syntax": [
+      "error",
+      {
+        "selector": "CallExpression[callee.name=/^format(Date)?$/] > Literal[value=/^Pp?$/]",
+        "message": "Do not use the date-fns short date token 'P'/'Pp' — the Icelandic locale renders it as 'd.MM.y' (unpadded day, padded month, e.g. \"5.05.2025\"). Use an explicit padded format like 'dd.MM.y' or 'dd.MM.y HH:mm'."
+      }
+    ],
     "@nx/enforce-module-boundaries": [
       "error",
       {

--- a/apps/judicial-system/web/src/components/InfoCard/DefendantInfo/DefendantInfo.tsx
+++ b/apps/judicial-system/web/src/components/InfoCard/DefendantInfo/DefendantInfo.tsx
@@ -222,7 +222,7 @@ export const DefendantInfo: FC<DefendantInfoProps> = (props) => {
               : 'Niðurfellt'
           } ${formatDate(
             defendant.indictmentCancelledOrDismissedState.time,
-            'P',
+            'dd.MM.y',
           )}`}</Text>
         )}
         {displayOpenCaseReference && (

--- a/apps/judicial-system/web/src/components/InfoCard/useInfoCardItems.tsx
+++ b/apps/judicial-system/web/src/components/InfoCard/useInfoCardItems.tsx
@@ -146,7 +146,7 @@ const useInfoCardItems = () => {
           <Text>
             {formatDate(
               defendant.indictmentCancelledOrDismissedState?.time,
-              'P',
+              'dd.MM.y',
             )}
           </Text>
         </div>,

--- a/apps/judicial-system/web/src/components/ServiceAnnouncement/ServiceAnnouncements.tsx
+++ b/apps/judicial-system/web/src/components/ServiceAnnouncement/ServiceAnnouncements.tsx
@@ -43,7 +43,7 @@ const mapServiceStatusMessages = (
       return [
         `${subpoena.servedBy ? subpoena.servedBy : ''}${
           subpoena.serviceDate
-            ? ` - ${formatDate(subpoena.serviceDate, 'Pp')}`
+            ? ` - ${formatDate(subpoena.serviceDate, 'dd.MM.y HH:mm')}`
             : ''
         }`,
         formatMessage(strings.servedToDefender, {
@@ -55,7 +55,7 @@ const mapServiceStatusMessages = (
       return [
         formatMessage(strings.servedToElectronically, {
           date: subpoena.serviceDate
-            ? formatDate(subpoena.serviceDate, 'Pp')
+            ? formatDate(subpoena.serviceDate, 'dd.MM.y HH:mm')
             : '',
         }),
       ]
@@ -64,7 +64,7 @@ const mapServiceStatusMessages = (
       return [
         `${subpoena.servedBy ? subpoena.servedBy : ''}${
           subpoena.serviceDate
-            ? ` - ${formatDate(subpoena.serviceDate, 'Pp')}`
+            ? ` - ${formatDate(subpoena.serviceDate, 'dd.MM.y HH:mm')}`
             : ''
         }`,
         subpoena.comment,
@@ -74,7 +74,9 @@ const mapServiceStatusMessages = (
     default:
       return [
         formatMessage(strings.subpoenaCreated, {
-          date: subpoena.created ? formatDate(subpoena.created, 'Pp') : '',
+          date: subpoena.created
+            ? formatDate(subpoena.created, 'dd.MM.y HH:mm')
+            : '',
         }),
       ]
   }

--- a/apps/judicial-system/web/src/routes/Admin/MessageSuspension/MessageSuspension.tsx
+++ b/apps/judicial-system/web/src/routes/Admin/MessageSuspension/MessageSuspension.tsx
@@ -162,7 +162,8 @@ export const MessageSuspension = () => {
               {suspension.suspended && suspension.modified && (
                 <Text variant="small" color="dark400">
                   {`Frestað ${
-                    formatDate(suspension.modified, 'Pp') ?? 'á óþekktum tíma'
+                    formatDate(suspension.modified, 'dd.MM.y HH:mm') ??
+                    'á óþekktum tíma'
                   } af ${
                     formatNationalId(suspension.modifiedBy) ||
                     'óþekktum notanda'

--- a/apps/judicial-system/web/src/routes/Defender/IndictmentCase/IndictmentOverview.tsx
+++ b/apps/judicial-system/web/src/routes/Defender/IndictmentCase/IndictmentOverview.tsx
@@ -80,7 +80,7 @@ const ServiceAnnouncement: FC<ServiceAnnouncementProps> = (props) => {
         ? 'Rafrænt pósthólf island.is'
         : servedBy
 
-    return [processServer, formatDate(serviceDate, 'Pp')]
+    return [processServer, formatDate(serviceDate, 'dd.MM.y HH:mm')]
       .filter(Boolean)
       .join(', ')
   }

--- a/apps/judicial-system/xrd-api/.eslintrc.json
+++ b/apps/judicial-system/xrd-api/.eslintrc.json
@@ -2,6 +2,13 @@
   "extends": "../../../.eslintrc.json",
   "rules": {
     "eqeqeq": ["error", "always"],
+    "no-restricted-syntax": [
+      "error",
+      {
+        "selector": "CallExpression[callee.name=/^format(Date)?$/] > Literal[value=/^Pp?$/]",
+        "message": "Do not use the date-fns short date token 'P'/'Pp' — the Icelandic locale renders it as 'd.MM.y' (unpadded day, padded month, e.g. \"5.05.2025\"). Use an explicit padded format like 'dd.MM.y' or 'dd.MM.y HH:mm'."
+      }
+    ],
     "simple-import-sort/imports": [
       "error",
       {

--- a/libs/judicial-system/formatters/.eslintrc.json
+++ b/libs/judicial-system/formatters/.eslintrc.json
@@ -2,6 +2,13 @@
   "extends": "../../../.eslintrc.json",
   "rules": {
     "eqeqeq": ["error", "always"],
+    "no-restricted-syntax": [
+      "error",
+      {
+        "selector": "CallExpression[callee.name=/^format(Date)?$/] > Literal[value=/^Pp?$/]",
+        "message": "Do not use the date-fns short date token 'P'/'Pp' — the Icelandic locale renders it as 'd.MM.y' (unpadded day, padded month, e.g. \"5.05.2025\"). Use an explicit padded format like 'dd.MM.y' or 'dd.MM.y HH:mm'."
+      }
+    ],
     "simple-import-sort/imports": [
       "error",
       {


### PR DESCRIPTION
# Use padded date format instead of date-fns locale short date

## What

The date-fns Icelandic locale renders the short date token (`'P'` / `'Pp'`) as `d.MM.y` — an **unpadded day** but **zero-padded month** (e.g. `5.05.2025`). This change:

- Switches all 12 callsites from `'P'` / `'Pp'` to an explicit padded format (`'dd.MM.y'` / `'dd.MM.y HH:mm'`), preserving output structure but padding the day (e.g. `05.05.2025`).
- Adds a `no-restricted-syntax` ESLint rule to all 8 judicial-system projects to block reintroducing the short date token.

Affected source files:
- `web/.../ServiceAnnouncement/ServiceAnnouncements.tsx` (4 callsites)
- `web/.../Admin/MessageSuspension/MessageSuspension.tsx`
- `web/.../Defender/IndictmentCase/IndictmentOverview.tsx`
- `web/.../InfoCard/useInfoCardItems.tsx`
- `web/.../InfoCard/DefendantInfo/DefendantInfo.tsx`
- `backend/.../verdict/internalVerdict.controller.ts`
- `backend/.../formatters/generatedPdfs/subpoenaServiceCertificatePdf.ts`
- `backend/.../modules/event/event.service.ts` (2 callsites)

## Why

The inconsistent `5.05.2025` format (unpadded day, padded month) looks like a bug to users. The root cause is the locale's `short` format definition, so every `P`-short-date usage was affected. The lint rule prevents regressions.

## Screenshots / Gifs

N/A — formatting change only (`5.05.2025 09:07` → `05.05.2025 09:07`).

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Code Quality**
  * Added linting rules to enforce consistent date formatting across the application, preventing use of ambiguous short date tokens that render incorrectly for the Icelandic locale.

* **Bug Fixes**
  * Updated date display formatting throughout the app to use explicit, padded date formats (e.g., `dd.MM.y` or `dd.MM.y HH:mm`), ensuring consistent and reliable date rendering across all judicial system interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->