### PR TITLE
fix(inheritance-report): make prefilled vehicle market value editable

### DIFF
--- a/libs/application/templates/inheritance-report/src/fields/EstateAndVehiclesRepeater/FieldComponent.tsx
+++ b/libs/application/templates/inheritance-report/src/fields/EstateAndVehiclesRepeater/FieldComponent.tsx
@@ -24,8 +24,13 @@ export const FieldComponent = ({
 }: FieldComponentProps) => {
   const { formatMessage } = useLocale()
 
-  // For initial/prefilled rows, only the share field is editable
-  const readOnly = isInitial && field.id !== 'share'
+  // For initial/prefilled rows, only the share field is editable.
+  // Vehicles are an exception: the market value at date of death
+  // (propertyValuation) can be corrected even for prefilled rows.
+  const isEditablePrefilledField =
+    field.id === 'share' ||
+    (assetKey === 'vehicles' && field.id === 'propertyValuation')
+  const readOnly = isInitial && !isEditablePrefilledField
 
   const defaultProps = {
     ...field,


### PR DESCRIPTION
Asana: https://app.asana.com/1/23849317865981/project/1204431115744096/task/1215660179112727

## What

On the **Farartæki (vehicles)** assets screen in the Inheritance report (Erfðafjárskýrsla – Dánarbú), make the prefilled **"Markaðsverðmæti á dánardegi"** (`propertyValuation`) input editable so users can correct the value at the date of death. Previously it was locked read-only.

## Why

The valuation is prefilled from the Sýslumenn lookup but the actual market value at the date of death often differs, and users had no way to correct it. The estate (dánarbú) template already allows this; the inheritance-report template did not.

## How

Single change in the shared `EstateAndVehiclesRepeater/FieldComponent.tsx`. Prefilled (`isInitial`) rows still lock every field except `share`; this also allows `propertyValuation`, **scoped to vehicles only** (`assetKey === 'vehicles'`). Real estate and all other asset types are unchanged.

- No schema change needed — `assetSchema` already requires a non-empty `propertyValuation` when the row is enabled, so clearing the field is still caught by validation.
- The screen total recalculates on edit (existing `onChange` → `calculateTotal`).

## Screenshots / Gifs

See the screenshot on the linked Asana task (the "Markaðsverðmæti á dánardegi" field on the vehicles screen).

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed read-only field restrictions in the estate and vehicles repeater. The property valuation field for vehicle assets is now editable in prefilled forms, while the share field remains editable as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->