### PR TITLE
feat(my-pages-health): move location details to box

### DIFF
--- a/libs/portals/my-pages/health/src/lib/messages.ts
+++ b/libs/portals/my-pages/health/src/lib/messages.ts
@@ -809,6 +809,14 @@ export const messages = defineMessages({
     defaultMessage: 'Afgr. staður',
     id: 'sp.health:location',
   },
+  locationInstructions: {
+    defaultMessage: 'Leiðbeiningar um staðsetningu',
+    id: 'sp.health:location-instructions',
+  },
+  locationDetails: {
+    defaultMessage: 'Nánar um staðsetningu',
+    id: 'sp.health:location-details',
+  },
   LOTT: {
     defaultMessage: 'Lífeyrisþegi með óskerta tekjutryggingu',
     id: 'sp.health:lott',

--- a/libs/portals/my-pages/health/src/screens/Appointments/AppointmentDetail.tsx
+++ b/libs/portals/my-pages/health/src/screens/Appointments/AppointmentDetail.tsx
@@ -151,6 +151,38 @@ const AppointmentDetail = () => {
                     </Box>
                   </Box>
                 )}
+
+                {appointment.location?.organization && (
+                  <Box display="flex" alignItems="flexStart" columnGap={1}>
+                    <Box flexShrink={0}>
+                      <Icon
+                        icon="informationCircle"
+                        size="small"
+                        color="blue400"
+                        type="outline"
+                      />
+                    </Box>
+                    <Box
+                      display="flex"
+                      flexWrap="wrap"
+                      alignItems="center"
+                      columnGap={2}
+                    >
+                      <Text>
+                        {formatMessage(messages.locationInstructions)}
+                      </Text>
+                      {locationLink && (
+                        <LinkButton
+                          to={locationLink}
+                          text={formatMessage(messages.locationDetails)}
+                          variant="text"
+                          size="small"
+                          icon="open"
+                        />
+                      )}
+                    </Box>
+                  </Box>
+                )}
               </Stack>
             </Stack>
             <Box
@@ -166,8 +198,7 @@ const AppointmentDetail = () => {
           {((appointment.practitioners?.length ?? 0) > 0 ||
             appointment.instruction ||
             appointment.location?.phoneNumber ||
-            appointment.location?.openingHoursText ||
-            appointment.location?.organization) && (
+            appointment.location?.openingHoursText) && (
             <InfoLineStack
               label={formatMessage(messages.appointmentMoreInfo)}
               space={1}
@@ -198,23 +229,6 @@ const AppointmentDetail = () => {
                   loading={loading}
                   label={formatMessage(messages.openingHours)}
                   content={appointment.location.openingHoursText}
-                />
-              )}
-              {appointment.location?.organization && (
-                <InfoLine
-                  loading={loading}
-                  label={formatMessage(messages.organization)}
-                  content={appointment.location.organization}
-                  button={
-                    locationLink
-                      ? {
-                          type: 'link',
-                          to: locationLink,
-                          icon: 'open',
-                          label: formatMessage(messages.appointmentMoreInfo),
-                        }
-                      : undefined
-                  }
                 />
               )}
             </InfoLineStack>

--- a/libs/portals/my-pages/health/src/screens/Appointments/AppointmentDetail.tsx
+++ b/libs/portals/my-pages/health/src/screens/Appointments/AppointmentDetail.tsx
@@ -152,7 +152,7 @@ const AppointmentDetail = () => {
                   </Box>
                 )}
 
-                {appointment.location?.organization && (
+                {locationLink && (
                   <Box display="flex" alignItems="flexStart" columnGap={1}>
                     <Box flexShrink={0}>
                       <Icon
@@ -229,6 +229,13 @@ const AppointmentDetail = () => {
                   loading={loading}
                   label={formatMessage(messages.openingHours)}
                   content={appointment.location.openingHoursText}
+                />
+              )}
+              {appointment.location?.organization && (
+                <InfoLine
+                  loading={loading}
+                  label={formatMessage(messages.organization)}
+                  content={appointment.location.organization}
                 />
               )}
             </InfoLineStack>


### PR DESCRIPTION
## What

* Move info line about health appointment locations to box

## Why

* Requested by stakeholder

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [x] No AI tools were used in preparing this pull request
- [ ] AI tools were used in preparing this pull request
      Tools used:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “location instructions” and “additional location details” to the appointment details view when a location link is available.
  * Included an info icon and a quick access button to the location page.
* **UI Updates**
  * Adjusted the conditions for showing extra location information: organization-specific “more info” content was removed from the details stack, while opening-hours information remains.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->