### PR TITLE
fix(j-s): prevent table header text from wrapping

### DIFF
--- a/apps/judicial-system/web/src/components/Table/Table.css.ts
+++ b/apps/judicial-system/web/src/components/Table/Table.css.ts
@@ -30,6 +30,7 @@ export const tableRowContainer = style({
 
 export const th = style({
   padding: `${theme.spacing[2]}px ${theme.spacing[3]}px`,
+  whiteSpace: 'nowrap',
 })
 
 export const smallContainer = style({

--- a/apps/judicial-system/web/src/routes/Admin/Users/Users.css.ts
+++ b/apps/judicial-system/web/src/routes/Admin/Users/Users.css.ts
@@ -1,4 +1,4 @@
-import { style } from '@vanilla-extract/css'
+import { globalStyle, style } from '@vanilla-extract/css'
 
 import { theme } from '@island.is/island-ui/theme'
 
@@ -36,4 +36,8 @@ export const userManagementContainer = style({
   gridTemplateColumns: '.6fr auto',
   justifyContent: 'center',
   padding: '48px 0',
+})
+
+globalStyle(`${thead} th`, {
+  whiteSpace: 'nowrap',
 })


### PR DESCRIPTION
## What

Add `whiteSpace: 'nowrap'` to table header (`th`) styles so header text never breaks across lines.

## Why

Table headers in case list tables could wrap at spaces when columns were narrow, breaking the visual layout. Headers should always stay on a single line.

## Changes

- `Table.css.ts` — added `whiteSpace: 'nowrap'` to the shared `th` style class, covering all tables that use it: main case list (`Table`), backend-driven case table (`GenericTable`), case file table (`CaseFileTable`), and non-sortable header wrapper (`TableHeaderText`)
- `Users.css.ts` — added a `globalStyle` targeting `th` inside the admin user table's `thead`, since that table uses a separate CSS scope

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved table header layout to prevent text wrapping, ensuring headers display on a single line for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->