### PR TITLE
fix(native-app): refresh licenses in active locale after language switch

### DIFF
--- a/apps/native/app/src/graphql/client.ts
+++ b/apps/native/app/src/graphql/client.ts
@@ -96,6 +96,34 @@ const triggerCognitoReauth = ({
   }
 }
 
+// Tag each GenericUserLicense in the response with the locale used to fetch it.
+// Lets the cache key include the locale so entities for different locales don't
+// overwrite each other in normalised storage.
+const licenseLocaleTagLink = new ApolloLink((operation, forward) => {
+  const locale = (operation.variables as { locale?: string } | undefined)
+    ?.locale
+  return forward(operation).map((response) => {
+    const collection = response.data?.genericLicenseCollection
+    const licenses = collection?.licenses
+    if (!locale || !collection || !Array.isArray(licenses)) {
+      return response
+    }
+    return {
+      ...response,
+      data: {
+        ...response.data,
+        genericLicenseCollection: {
+          ...collection,
+          licenses: licenses.map((license: Record<string, unknown>) => ({
+            ...license,
+            __locale: locale,
+          })),
+        },
+      },
+    }
+  })
+})
+
 const errorLink = onError(({ graphQLErrors, networkError, operation }) => {
   if (graphQLErrors) {
     graphQLErrors.map((graphQLError) =>
@@ -216,28 +244,31 @@ const cache = new InMemoryCache({
     },
     // Custom cache key for GenericUserLicense.
     // The backend does not expose a single stable id, so we synthesise one from
-    // license.type and payload.metadata.licenseId. This must stay in sync with
-    // the fields selected in GenericUserLicenseFragment so list and detail
-    // queries for the same license share the same cache entry.
+    // license.type and payload.metadata.licenseId. We also append the locale
+    // (injected by licenseLocaleTagLink) so entities fetched in different
+    // locales don't overwrite each other.
     GenericUserLicense: {
       keyFields: (object) => {
         const licenseType = (object as GenericUserLicense).license?.type
         const licenseId = (object as GenericUserLicense).payload?.metadata
           ?.licenseId
+        const locale = (object as { __locale?: string }).__locale
 
-        if (licenseType && licenseId) {
-          // Composite key ensures no collisions between different license types
-          // that might share the same licenseId.
-          return `${licenseType}:${licenseId}`
+        const baseKey =
+          licenseType && licenseId
+            ? // Composite key ensures no collisions between different license types
+              // that might share the same licenseId.
+              `${licenseType}:${licenseId}`
+            : // Fallback when type is missing but licenseId is still unique enough.
+              licenseId ??
+              // Last resort – let Apollo fall back to its default normalisation.
+              defaultDataIdFromObject(object) ??
+              undefined
+
+        if (!baseKey) {
+          return undefined
         }
-
-        if (licenseId) {
-          // Fallback when type is missing but licenseId is still unique enough.
-          return licenseId
-        }
-
-        // Last resort – let Apollo fall back to its default normalisation.
-        return defaultDataIdFromObject(object) ?? undefined
+        return locale ? `${baseKey}:${locale}` : baseKey
       },
     },
   },
@@ -266,7 +297,13 @@ const initializeApolloClient = async () => {
   })
 
   return new ApolloClient({
-    link: ApolloLink.from([retryLink, errorLink, authLink, httpLink]),
+    link: ApolloLink.from([
+      retryLink,
+      errorLink,
+      authLink,
+      licenseLocaleTagLink,
+      httpLink,
+    ]),
     defaultOptions: {
       watchQuery: {
         fetchPolicy: 'cache-and-network',


### PR DESCRIPTION
- License cards stayed in the previously-fetched language after switching the app locale and returning to the wallet/home screen.
- Apollo's `cache-first` policy correctly served the cached `ListLicenses` result for the new locale, but the underlying `GenericUserLicense` entities were normalised only by `license.type + payload.metadata.licenseId` — so both locales shared one cache slot, and whichever locale was fetched last overwrote the other's text.
- An `ApolloLink` now stamps `__locale` onto each license in the response, and `GenericUserLicense.keyFields` includes that locale, giving each locale its own normalised entity. Switching to a new locale produces a clean cache miss → network fetch; switching back to a previously-fetched locale hits cache without re-fetching

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed locale-specific license caching to prevent display issues when switching between languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->