### PR TITLE
fix(my-pages-health): stringified null in answer

### DIFF
--- a/libs/api/domains/questionnaires/src/lib/questionnaires.service.ts
+++ b/libs/api/domains/questionnaires/src/lib/questionnaires.service.ts
@@ -336,7 +336,7 @@ export class QuestionnairesService {
                             ? formatMessage(m.yes)
                             : formatMessage(m.no),
                         ]
-                      } else {
+                      } else if (reply.answer != null) {
                         // StringReplyDto, NumberReplyDto, DateReplyDto
                         values = [String(reply.answer)]
                       }


### PR DESCRIPTION
## What

* Dont stringify if null in reply

## Why

It ain't right

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Corrected questionnaire answer handling to properly validate answer values, ensuring accurate processing of questionnaire responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->