### PR TITLE
fix(j-s): redirect after losing case access in ChangeProsecutorModal

### DIFF
--- a/apps/judicial-system/web/src/components/Modals/ChangeProsecutorModal/ChangeProsecutorModal.tsx
+++ b/apps/judicial-system/web/src/components/Modals/ChangeProsecutorModal/ChangeProsecutorModal.tsx
@@ -1,10 +1,13 @@
 import React, { FC, useContext, useState } from 'react'
+import { useRouter } from 'next/router'
 
+import { getStandardUserDashboardRoute } from '@island.is/judicial-system/consts'
 import { isRequestCase } from '@island.is/judicial-system/types'
 import {
   FormContext,
   Modal,
   ProsecutorSelection,
+  UserContext,
 } from '@island.is/judicial-system-web/src/components'
 import { useCase } from '@island.is/judicial-system-web/src/utils/hooks'
 
@@ -16,6 +19,8 @@ const ChangeProsecutorModal: FC<Props> = (props) => {
   const { onClose } = props
   const { updateCase } = useCase()
   const { refreshCase, workingCase } = useContext(FormContext)
+  const { user } = useContext(UserContext)
+  const router = useRouter()
 
   const [menuIsOpen, setMenuIsOpen] = useState<boolean>(false)
   const [prosecutorsCount, setProsecutorsCount] = useState<number>(0)
@@ -58,7 +63,18 @@ const ChangeProsecutorModal: FC<Props> = (props) => {
           await updateCase(workingCase.id, {
             prosecutorId: selectedProsecutorId,
           })
-          refreshCase()
+
+          const userWouldLoseAccess =
+            workingCase.isHeightenedSecurityLevel &&
+            user?.id !== workingCase.creatingProsecutor?.id &&
+            user?.id !== selectedProsecutorId
+
+          if (userWouldLoseAccess) {
+            router.push(getStandardUserDashboardRoute(user))
+          } else {
+            refreshCase()
+          }
+
           onClose()
         },
       }}


### PR DESCRIPTION
## What
In `ChangeProsecutorModal`, detect when the current user would lose access to the case after reassigning the prosecutor on a heightened-security R-case, and redirect them to the standard dashboard instead of calling `refreshCase()`.

A user loses access when all of the following hold:
- the case has `isHeightenedSecurityLevel`
- the user is not the `creatingProsecutor`
- the user is not the newly selected prosecutor

In that case we `router.push(getStandardUserDashboardRoute(user))`; otherwise the existing `refreshCase()` behaviour is preserved. `onClose()` runs in both paths.

## Why
On heightened-security restriction/investigation cases, only the creating prosecutor and the currently assigned prosecutor can access the case. When a non-creating prosecutor reassigned the case to someone else via `ChangeProsecutorModal`, they immediately lost backend access. The unconditional `refreshCase()` then re-fetched the case, got null/403, and rendered a "Mál fannst ekki" alert banner with a manual link to the dashboard — an abrupt experience. This mirrors the existing redirect already done in `ProsecutorSectionHeightenedSecurity`.

## Screenshots / Gifs
Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code
- [ ] No AI tools were used in preparing this pull request

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced security controls for prosecutor assignment in sensitive cases. When a prosecutor is changed for a heightened security case, users who are neither the case creator nor the newly assigned prosecutor will no longer remain on the case—they're redirected to their dashboard to maintain proper access restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->