### PR TITLE
fix(my-pages-health): add new UNKNOWN enum to status renewal dispaly

### DIFF
--- a/libs/api/domains/health-directorate/src/lib/mappers/medicineMapper.ts
+++ b/libs/api/domains/health-directorate/src/lib/mappers/medicineMapper.ts
@@ -55,8 +55,10 @@ export const mapPrescriptionRenewalStatus = (
       return PrescribedItemRenewalStatusEnum.Rejected
     case PrescriptionRenewalStatusDisplay.DISMISSED:
       return PrescribedItemRenewalStatusEnum.Dismissed
-    default:
+    case PrescriptionRenewalStatusDisplay.PENDING:
       return PrescribedItemRenewalStatusEnum.Pending
+    default:
+      return PrescribedItemRenewalStatusEnum.Unknown
   }
 }
 

--- a/libs/api/domains/health-directorate/src/lib/models/enums.ts
+++ b/libs/api/domains/health-directorate/src/lib/models/enums.ts
@@ -40,6 +40,7 @@ export enum PrescribedItemRenewalStatusEnum {
   Approved = 'approved',
   Rejected = 'rejected',
   Dismissed = 'dismissed',
+  Unknown = 'unknown',
 }
 
 registerEnumType(PrescribedItemRenewalStatusEnum, {

--- a/libs/clients/health-directorate/src/lib/clients/health/clientConfig.json
+++ b/libs/clients/health-directorate/src/lib/clients/health/clientConfig.json
@@ -3722,7 +3722,7 @@
       },
       "PrescriptionRenewalStatusDisplay": {
         "type": "string",
-        "enum": ["pending", "approved", "rejected", "dismissed"]
+        "enum": ["pending", "approved", "rejected", "dismissed", "unknown"]
       },
       "RenewalDto": {
         "type": "object",

--- a/libs/portals/my-pages/health/src/lib/messages.ts
+++ b/libs/portals/my-pages/health/src/lib/messages.ts
@@ -2624,6 +2624,10 @@ export const messages = defineMessages({
     defaultMessage: 'Hafnað',
     id: 'sp.health:renewal-status-rejected',
   },
+  renewalStatusUnknown: {
+    defaultMessage: 'Óþekkt',
+    id: 'sp.health:renewal-status-unknown',
+  },
   renewalSendTo: {
     defaultMessage: 'Sendist til',
     id: 'sp.health:renewal-send-to',

--- a/libs/portals/my-pages/health/src/screens/MedicinePrescriptions/components/PrescriptionsTable.tsx
+++ b/libs/portals/my-pages/health/src/screens/MedicinePrescriptions/components/PrescriptionsTable.tsx
@@ -22,6 +22,17 @@ import RenewPrescriptionModal from './RenewPrescriptionModal/RenewPrescriptionMo
 
 const STRING_MAX_LENGTH = 22
 
+const renewalStatusMessageMap: Record<
+  HealthDirectoratePrescriptionRenewalStatus,
+  keyof typeof messages
+> = {
+  [HealthDirectoratePrescriptionRenewalStatus.Approved]: 'renewalStatusApproved',
+  [HealthDirectoratePrescriptionRenewalStatus.Rejected]: 'renewalStatusRejected',
+  [HealthDirectoratePrescriptionRenewalStatus.Dismissed]: 'renewalStatusDismissed',
+  [HealthDirectoratePrescriptionRenewalStatus.Unknown]: 'renewalStatusUnknown',
+  [HealthDirectoratePrescriptionRenewalStatus.Pending]: 'renewalInProgress',
+}
+
 interface Props {
   data?: HealthDirectoratePrescription[]
   loading?: boolean
@@ -132,19 +143,9 @@ const PrescriptionsTable: React.FC<Props> = ({ data, loading }) => {
               lastNode: item?.renewalStatus
                 ? {
                     type: 'text' as const,
-                    label:
-                      item.renewalStatus ===
-                      HealthDirectoratePrescriptionRenewalStatus.Approved
-                        ? formatMessage(messages.renewalStatusApproved)
-                        : item.renewalStatus ===
-                          HealthDirectoratePrescriptionRenewalStatus.Rejected
-                        ? formatMessage(messages.renewalStatusRejected)
-                        : item.renewalStatus ===
-                          HealthDirectoratePrescriptionRenewalStatus.Dismissed
-                        ? formatMessage(messages.renewalStatusDismissed)
-                        : formatMessage(
-                            messages.medicineIsProcessedCertificate,
-                          ),
+                    label: formatMessage(
+                      messages[renewalStatusMessageMap[item.renewalStatus]],
+                    ),
                     text: item.renewResponseMessage ?? undefined,
                   }
                 : item?.isRenewable

--- a/libs/portals/my-pages/health/src/screens/MedicinePrescriptions/components/PrescriptionsTable.tsx
+++ b/libs/portals/my-pages/health/src/screens/MedicinePrescriptions/components/PrescriptionsTable.tsx
@@ -26,9 +26,12 @@ const renewalStatusMessageMap: Record<
   HealthDirectoratePrescriptionRenewalStatus,
   keyof typeof messages
 > = {
-  [HealthDirectoratePrescriptionRenewalStatus.Approved]: 'renewalStatusApproved',
-  [HealthDirectoratePrescriptionRenewalStatus.Rejected]: 'renewalStatusRejected',
-  [HealthDirectoratePrescriptionRenewalStatus.Dismissed]: 'renewalStatusDismissed',
+  [HealthDirectoratePrescriptionRenewalStatus.Approved]:
+    'renewalStatusApproved',
+  [HealthDirectoratePrescriptionRenewalStatus.Rejected]:
+    'renewalStatusRejected',
+  [HealthDirectoratePrescriptionRenewalStatus.Dismissed]:
+    'renewalStatusDismissed',
   [HealthDirectoratePrescriptionRenewalStatus.Unknown]: 'renewalStatusUnknown',
   [HealthDirectoratePrescriptionRenewalStatus.Pending]: 'renewalInProgress',
 }


### PR DESCRIPTION
## What

* New 'Unknown' status in client

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for displaying "Unknown" prescription renewal status in the medicines section.

* **Bug Fixes**
  * Fixed prescription renewal status handling to correctly display "Unknown" for unrecognized statuses instead of defaulting to "Pending".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->