### PR TITLE
fix(form-system): organizationNationalId in notification

### DIFF
--- a/apps/form-system/web/src/components/Footer/Footer.tsx
+++ b/apps/form-system/web/src/components/Footer/Footer.tsx
@@ -215,6 +215,7 @@ export const Footer = ({ externalDataAgreement }: Props) => {
             input: {
               applicationId: state.application.id,
               nationalId: '',
+              organizationNationalId: state.application.organizationNationalId,
               slug: state.application.slug,
               isTest: state.application.isTest,
               command: NotificationCommands.VALIDATE,

--- a/apps/form-system/web/src/components/Footer/Footer.tsx
+++ b/apps/form-system/web/src/components/Footer/Footer.tsx
@@ -215,7 +215,8 @@ export const Footer = ({ externalDataAgreement }: Props) => {
             input: {
               applicationId: state.application.id,
               nationalId: '',
-              organizationNationalId: state.application.organizationNationalId,
+              organizationNationalId:
+                state.application.organizationNationalId ?? '',
               slug: state.application.slug,
               isTest: state.application.isTest,
               command: NotificationCommands.VALIDATE,

--- a/apps/services/form-system/src/app/modules/applications/applications.service.ts
+++ b/apps/services/form-system/src/app/modules/applications/applications.service.ts
@@ -1289,7 +1289,6 @@ export class ApplicationsService {
     const nationalId = user.actor?.nationalId || user.nationalId
 
     notificationDto.nationalId = nationalId
-    notificationDto.organizationNationalId = form.organizationNationalId
 
     if (!notificationDto.screenDto) {
       throw new BadRequestException(

--- a/apps/services/form-system/src/app/modules/applications/models/dto/notification.dto.ts
+++ b/apps/services/form-system/src/app/modules/applications/models/dto/notification.dto.ts
@@ -26,9 +26,8 @@ export class NotificationDto {
   @IsString()
   @Type(() => String)
   @Expose()
-  @ApiPropertyOptional()
-  @IsOptional()
-  organizationNationalId?: string
+  @ApiProperty()
+  organizationNationalId!: string
 
   @Type(() => String)
   @IsString()

--- a/apps/services/form-system/src/app/modules/services/service.manager.ts
+++ b/apps/services/form-system/src/app/modules/services/service.manager.ts
@@ -44,6 +44,7 @@ export class ServiceManager {
       const notificationDto = {
         applicationId: applicationDto.id ?? '',
         nationalId: applicationDto.nationalId ?? '',
+        organizationNationalId: applicationDto.organizationNationalId ?? '',
         slug: applicationDto.slug ?? '',
         isTest: applicationDto.isTest ?? false,
         command: NotificationCommands.SUBMIT,

--- a/libs/api/domains/form-system/src/dto/notification.input.ts
+++ b/libs/api/domains/form-system/src/dto/notification.input.ts
@@ -10,6 +10,9 @@ export class NotificationInput {
   nationalId!: string
 
   @Field(() => String, { nullable: false })
+  organizationNationalId!: string
+
+  @Field(() => String, { nullable: false })
   slug!: string
 
   @Field(() => Boolean, { nullable: false })


### PR DESCRIPTION
# ...

Attach a link to issue if relevant

## What

Specify what you're trying to achieve

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [x] No AI tools were used in preparing this pull request
- [ ] AI tools were used in preparing this pull request
      Tools used:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
* Improved organization national ID handling for form validation notifications. The organization national ID is now consistently treated as required and is included in notification payloads sent to external validation and downstream notification services, ensuring the correct organization context is maintained throughout the workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->