### PR TITLE
fix(j-s): fix SearchModal width overflow across all screen sizes

### DIFF
--- a/apps/judicial-system/web/src/components/Modals/SearchModal/SearchModal.css.ts
+++ b/apps/judicial-system/web/src/components/Modals/SearchModal/SearchModal.css.ts
@@ -14,16 +14,10 @@ export const resultButton = style({
 })
 
 export const searchModal = style({
-  minWidth: '90vw',
+  width: '90vw',
   maxWidth: '634px',
   overflow: 'hidden',
   margin: `${theme.spacing[3]}px`,
-
-  '@media': {
-    [`screen and (min-width: ${theme.breakpoints.lg}px)`]: {
-      minWidth: '634px',
-    },
-  },
 })
 
 export const searchResultsContainer = style({

--- a/apps/judicial-system/web/src/components/Modals/SearchModal/SearchModal.css.ts
+++ b/apps/judicial-system/web/src/components/Modals/SearchModal/SearchModal.css.ts
@@ -14,8 +14,8 @@ export const resultButton = style({
 })
 
 export const searchModal = style({
-  width: '90vw',
-  maxWidth: '634px',
+  width: '634px',
+  maxWidth: `calc(90vw - ${theme.spacing[3] * 2}px)`,
   overflow: 'hidden',
   margin: `${theme.spacing[3]}px`,
 })

--- a/apps/judicial-system/web/src/components/Modals/SearchModal/SearchModal.tsx
+++ b/apps/judicial-system/web/src/components/Modals/SearchModal/SearchModal.tsx
@@ -240,7 +240,13 @@ const SearchModal: FC<Props> = ({ onClose }) => {
         <Text variant="h3" marginBottom={1}>
           Leit
         </Text>
-        <Box marginBottom={3} columnGap={1} display="flex" flexWrap="wrap">
+        <Box
+          marginBottom={3}
+          columnGap={1}
+          rowGap={1}
+          display="flex"
+          flexWrap="wrap"
+        >
           <Tag outlined disabled>
             Málsnúmer
           </Tag>


### PR DESCRIPTION
## What

Fix `SearchModal.css.ts` width constraints so the modal never overflows its container on any screen size.

## Why

The original CSS used `minWidth: 90vw` + `maxWidth: 634px`. When `90vw > 634px` (~705px+ viewports), CSS lets `minWidth` win over `maxWidth`, so the modal stretched to `90vw` regardless of the cap — overflowing on medium screens.

The fix uses `width: 634px` (desired size) + `maxWidth: calc(90vw - ${margin * 2})` so:
- On large screens: modal is 634px
- On small screens: modal shrinks to fit within 90vw, with the horizontal margins factored into the constraint so nothing overflows

## Screenshots / Gifs


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined the Search modal sizing to use a fixed base width (634px) while keeping it responsive via an updated `maxWidth` based on available viewport space. Removed the prior breakpoint override that adjusted minimum width, resulting in more predictable modal presentation across screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->