### PR TITLE
fix(j-s): Loading state on correct buttons

### DIFF
--- a/apps/judicial-system/web/src/routes/Court/InvestigationCase/HearingArrangements/HearingArrangements.tsx
+++ b/apps/judicial-system/web/src/routes/Court/InvestigationCase/HearingArrangements/HearingArrangements.tsx
@@ -13,7 +13,7 @@ import {
   DISTRICT_COURT_INVESTIGATION_CASE_RULING_ROUTE,
 } from '@island.is/judicial-system/consts'
 import { isDistrictCourtUser } from '@island.is/judicial-system/types'
-import { titles } from '@island.is/judicial-system-web/messages'
+import { errors, titles } from '@island.is/judicial-system-web/messages'
 import {
   ArraignmentAlert,
   BlueBox,
@@ -48,6 +48,11 @@ import { isCourtHearingArrangementsStepValidIC } from '@island.is/judicial-syste
 
 import { icHearingArrangements as m } from './HearingArrangements.strings'
 
+enum ModalButtonLoading {
+  PRIMARY = 'PRIMARY',
+  SECONDARY = 'SECONDARY',
+}
+
 const HearingArrangements = () => {
   const {
     workingCase,
@@ -59,8 +64,12 @@ const HearingArrangements = () => {
   const { user } = useContext(UserContext)
 
   const { formatMessage } = useIntl()
-  const { setAndSendCaseToServer, sendNotification, isSendingNotification } =
-    useCase()
+  const {
+    setAndSendCaseToServer,
+    sendNotification,
+    isSendingNotification,
+    sendNotificationError,
+  } = useCase()
   const {
     courtDate,
     courtDateHasChanged,
@@ -70,6 +79,8 @@ const HearingArrangements = () => {
   } = useCourtArrangements(workingCase, setWorkingCase, 'arraignmentDate')
 
   const [navigateTo, setNavigateTo] = useState<keyof stepValidationsType>()
+  const [modalButtonLoading, setModalButtonLoading] =
+    useState<ModalButtonLoading>()
   const [checkedRadio, setCheckedRadio] = useState<SessionArrangements>()
 
   const initialize = useCallback(() => {
@@ -359,6 +370,8 @@ const HearingArrangements = () => {
           primaryButton={{
             text: formatMessage(m.modal.primaryButtonText),
             onClick: async () => {
+              setModalButtonLoading(ModalButtonLoading.PRIMARY)
+
               const notificationSent = await sendNotification(
                 workingCase.id,
                 TrackedNotificationType.COURT_DATE,
@@ -368,14 +381,18 @@ const HearingArrangements = () => {
                 router.push(`${navigateTo}/${workingCase.id}`)
               }
             },
-            isLoading: isSendingNotification,
+            isLoading:
+              isSendingNotification &&
+              modalButtonLoading === ModalButtonLoading.PRIMARY,
           }}
           secondaryButton={{
             text: formatMessage(m.modal.secondaryButtonText, {
               courtDateHasChanged,
             }),
-            onClick: () => {
-              sendNotification(
+            onClick: async () => {
+              setModalButtonLoading(ModalButtonLoading.SECONDARY)
+
+              await sendNotification(
                 workingCase.id,
                 TrackedNotificationType.COURT_DATE,
                 true,
@@ -383,7 +400,15 @@ const HearingArrangements = () => {
 
               router.push(`${navigateTo}/${workingCase.id}`)
             },
+            isLoading:
+              isSendingNotification &&
+              modalButtonLoading === ModalButtonLoading.SECONDARY,
           }}
+          errorMessage={
+            sendNotificationError
+              ? formatMessage(errors.sendNotification)
+              : undefined
+          }
         />
       )}
     </PageLayout>

--- a/apps/judicial-system/web/src/routes/Court/InvestigationCase/HearingArrangements/HearingArrangements.tsx
+++ b/apps/judicial-system/web/src/routes/Court/InvestigationCase/HearingArrangements/HearingArrangements.tsx
@@ -83,6 +83,11 @@ const HearingArrangements = () => {
     useState<ModalButtonLoading>()
   const [checkedRadio, setCheckedRadio] = useState<SessionArrangements>()
 
+  const handleCloseModal = () => {
+    setNavigateTo(undefined)
+    setModalButtonLoading(undefined)
+  }
+
   const initialize = useCallback(() => {
     if (!workingCase.arraignmentDate && workingCase.requestedCourtDate) {
       setWorkingCase((theCase) => ({
@@ -358,6 +363,7 @@ const HearingArrangements = () => {
       {navigateTo !== undefined && (
         <Modal
           title={formatMessage(m.modal.heading)}
+          onClose={handleCloseModal}
           text={formatMessage(
             workingCase.sessionArrangements === SessionArrangements.ALL_PRESENT
               ? m.modal.allPresentText
@@ -405,7 +411,7 @@ const HearingArrangements = () => {
               modalButtonLoading === ModalButtonLoading.SECONDARY,
           }}
           errorMessage={
-            sendNotificationError
+            modalButtonLoading && sendNotificationError
               ? formatMessage(errors.sendNotification)
               : undefined
           }


### PR DESCRIPTION
[Asana](https://app.asana.com/1/203394141643832/project/1212657017130395/task/1215580168101886?focus=true)
## What

track which button was clicked, set loading state only on the one clicked

## Why

So the wrong button doesn't get a loading state.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Cursor


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error message visibility when notification sending fails.
  * Refined confirmation modal behavior to show per-button loading feedback (primary vs. secondary) and reset state when the modal closes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->