### PR TITLE
fix(native-app): fix 2 way bugs

### DIFF
--- a/apps/native/app/src/app/(auth)/(tabs)/inbox/[id]/communications.tsx
+++ b/apps/native/app/src/app/(auth)/(tabs)/inbox/[id]/communications.tsx
@@ -14,6 +14,8 @@ import {
 import { router, useLocalSearchParams } from 'expo-router'
 import styled, { useTheme } from 'styled-components/native'
 
+import { useApolloClient } from '@apollo/client'
+
 import { StackScreen } from '@/components/stack-screen'
 import { DocumentComment, useGetDocumentQuery } from '@/graphql/types/schema'
 import { useDateTimeFormatter } from '@/hooks/use-date-time-formatter'
@@ -70,12 +72,29 @@ export default function DocumentCommunicationsScreen() {
   const flatListRef = useRef<Animated.FlatList>(null)
   const scrollY = useRef(new Animated.Value(0)).current
 
+  const client = useApolloClient()
+
   const docRes = useGetDocumentQuery({
     variables: {
       input: {
         id: documentId,
       },
       locale,
+    },
+    // The document detail screen marks the doc as opened in the local cache
+    // (see use-document.ts). This query's network response would overwrite
+    // that back to whatever the server has (still `opened: false` — there's
+    // no read-mutation yet), so re-assert it here.
+    onCompleted: (data) => {
+      const cacheId = client.cache.identify({
+        __typename: 'DocumentV2',
+        id: data.documentV2?.id,
+      })
+      if (!cacheId) return
+      client.cache.modify({
+        id: cacheId,
+        fields: { opened: () => true },
+      })
     },
   })
 

--- a/apps/native/app/src/app/(auth)/(tabs)/inbox/[id]/reply.tsx
+++ b/apps/native/app/src/app/(auth)/(tabs)/inbox/[id]/reply.tsx
@@ -206,6 +206,8 @@ export default function DocumentReplyScreen() {
                   })}
                   autoFocus
                   multiline
+                  numberOfLines={3}
+                  inputStyle={{ minHeight: 60 }}
                 />
               </Row>
             </KeyboardAvoidingView>

--- a/apps/native/app/src/ui/lib/text-field/text-field.tsx
+++ b/apps/native/app/src/ui/lib/text-field/text-field.tsx
@@ -1,8 +1,10 @@
 import React, { useRef } from 'react'
 import {
   ActivityIndicator,
+  StyleProp,
   TextInput,
   TextInputProps,
+  TextStyle,
   View,
 } from 'react-native'
 import styled, { css, useTheme } from 'styled-components/native'
@@ -77,6 +79,7 @@ interface TextFieldProps extends TIProps {
   disabled?: boolean
   loading?: boolean
   errorMessage?: string
+  inputStyle?: StyleProp<TextStyle>
 }
 
 export const TextField = ({
@@ -84,6 +87,7 @@ export const TextField = ({
   onChange,
   value,
   style,
+  inputStyle,
   disabled = false,
   loading = false,
   errorMessage,
@@ -107,6 +111,7 @@ export const TextField = ({
             ref={inputRef}
             readOnly={readOnly}
             {...rest}
+            style={inputStyle}
           />
         </View>
         {loading && (


### PR DESCRIPTION
## What

A few 2 way communications fixes.
* Input is now default 3 lines big instead of 1.
* Make sure document does not get back to unread state when going back from looking at communications.
* I also added an error message if sending a reply fails but did that in another [PR](https://github.com/island-is/island.is/pull/22960) since I needed a toast to show the error and that is implemented in that PR.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reply text field now displays multiple lines with customizable height for better composition experience
  * TextField component now supports custom input styling options

* **Bug Fixes**
  * Document opened state is now properly tracked and cached to prevent state inconsistencies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->