### PR TITLE
fix(marriage-conditions): restore religion list via national-registry (revert #22896)

### DIFF
--- a/libs/application/template-api-modules/src/lib/modules/templates/marriage-conditions-submission/marriage-conditions-submission.module.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/marriage-conditions-submission/marriage-conditions-submission.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common'
 import { SyslumennClientModule } from '@island.is/clients/syslumenn'
 import { MarriageConditionsSubmissionService } from './marriage-conditions-submission.service'
 import { SharedTemplateAPIModule } from '../../shared'
+import { NationalRegistryXRoadModule } from '@island.is/api/domains/national-registry-x-road'
 import { NationalRegistryV3Module } from '../../shared/api/national-registry-v3/national-registry-v3.module'
 
 @Module({
@@ -9,6 +10,7 @@ import { NationalRegistryV3Module } from '../../shared/api/national-registry-v3/
     SyslumennClientModule,
     SharedTemplateAPIModule,
     NationalRegistryV3Module,
+    NationalRegistryXRoadModule,
   ],
   providers: [MarriageConditionsSubmissionService],
   exports: [MarriageConditionsSubmissionService],

--- a/libs/application/template-api-modules/src/lib/modules/templates/marriage-conditions-submission/marriage-conditions-submission.service.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/marriage-conditions-submission/marriage-conditions-submission.service.ts
@@ -16,8 +16,8 @@ import {
 } from '@island.is/application/templates/marriage-conditions/types'
 import { BaseTemplateApiService } from '../../base-template-api.service'
 import { ApplicationTypes } from '@island.is/application/types'
+import { NationalRegistryXRoadService } from '@island.is/api/domains/national-registry-x-road'
 import { NationalRegistryV3Service } from '../../shared/api/national-registry-v3/national-registry-v3.service'
-import { sortAlpha } from '@island.is/shared/utils'
 import { TemplateApiError } from '@island.is/nest/problem'
 import {
   coreErrorMessages,
@@ -32,6 +32,7 @@ export class MarriageConditionsSubmissionService extends BaseTemplateApiService 
     private readonly sharedTemplateAPIService: SharedTemplateApiService,
     private readonly syslumennService: SyslumennService,
     private readonly nationalRegistryV3Service: NationalRegistryV3Service,
+    private readonly nationalRegistryXRoadService: NationalRegistryXRoadService,
   ) {
     super(ApplicationTypes.MARRIAGE_CONDITIONS)
   }
@@ -88,9 +89,7 @@ export class MarriageConditionsSubmissionService extends BaseTemplateApiService 
   }
 
   async religionCodes() {
-    const organizations =
-      await this.syslumennService.getReligiousOrganizations()
-    return organizations.map(({ name }) => ({ name })).sort(sortAlpha('name'))
+    return await this.nationalRegistryXRoadService.getReligions()
   }
 
   private handleReturn(maritalStatus: string) {

--- a/libs/application/templates/marriage-conditions/src/lib/constants.ts
+++ b/libs/application/templates/marriage-conditions/src/lib/constants.ts
@@ -36,6 +36,7 @@ export type DistrictCommissionerAgencies = {
 
 export type Religion = {
   name: string
+  code: string
 }
 
 export const twoDays = 24 * 3600 * 1000 * 2


### PR DESCRIPTION
## What

Revert #22896. `religionCodes()` returns to `nationalRegistryXRoadService.getReligions()` (re-adds the NatReg X-Road module + injection and the `Religion.code` field).

## Why

In production the Sýslumenn `TrufelogOgLifsskodunarfelog` endpoint returns `401 "Notandi hefur ekki aðgang"` for the `application-system-api` integration account, so the (hidden) `religions` data provider fails and blocks the whole data-collection step with **"Ekki tókst að sækja gögn"** — users can't get past Gagnaöflun.

The same account is authorized for other Sýslumenn resources (e.g. `KannaKonnunarvottord`), and the public religion list works via the `api`-gateway account, so this is a per-resource permission gap on the prod application-system account — not a code defect. Reverting unblocks users now; #22896 can be re-applied once Sýslumenn grants that account access to the resource.

## Screenshots / Gifs

N/A — no UI change; restores the previously working data source.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated religion data retrieval for marriage conditions to use the National Registry X-Road service.
  * Extended religion data structure to include code information alongside name field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->