### PR TITLE
fix(island-ui): Tooltip inside Input component doesn't open when clicked

### DIFF
--- a/libs/island-ui/core/src/lib/Input/Input.tsx
+++ b/libs/island-ui/core/src/lib/Input/Input.tsx
@@ -90,6 +90,11 @@ export const Input = forwardRef(
       ? backgroundColor.map(mapBlue)
       : mapBlue(backgroundColor as InputBackgroundColor)
 
+    const handleTooltipClick = (e: React.MouseEvent<HTMLDivElement>) => {
+      e.stopPropagation() // Prevent event from bubbling up to the input field (which would cause the tooltip to not open since the input would be focused)
+      e.preventDefault() // Prevent default browser behaviour that focuses input on label click
+    }
+
     return (
       <div>
         {/* If size is xs then the label is above the input box */}
@@ -113,13 +118,16 @@ export const Input = forwardRef(
               </span>
             )}
             {tooltip && (
-              <Box marginLeft={1} display="inlineBlock">
+              <Box
+                marginLeft={1}
+                display="inlineBlock"
+                onClick={handleTooltipClick}
+              >
                 <Tooltip text={tooltip} />
               </Box>
             )}
           </label>
         )}
-
         <Box
           background={containerBackground as UseBoxStylesProps['background']}
           className={styles.container({
@@ -161,7 +169,11 @@ export const Input = forwardRef(
                   </span>
                 )}
                 {tooltip && (
-                  <Box marginLeft={1} display="inlineBlock">
+                  <Box
+                    marginLeft={1}
+                    display="inlineBlock"
+                    onClick={handleTooltipClick}
+                  >
                     <Tooltip text={tooltip} />
                   </Box>
                 )}


### PR DESCRIPTION
# Tooltip inside Input component doesn't open when clicked

On mobile, when clicking on the tooltip icon inside an Input, the tooltip would not open up and the input element would get focus. So essentially there is no way currently to see text inside a tooltip on mobile devices.

1. Stop the tooltip click event from propagating upwards (otherwise the input component gets focused)
2. Prevent the default browser behaviour so the label click doesn't cause the input to be focused

<img width="335" height="341" alt="Screenshot 2026-06-19 at 10 27 01" src="https://github.com/user-attachments/assets/32e67ae6-d5a6-45e4-9c99-1541b38ae394" />

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [x] No AI tools were used in preparing this pull request
- [ ] AI tools were used in preparing this pull request
      Tools used:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Fixed Input component tooltip interaction—clicking tooltips no longer triggers unintended input focus behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->