### PR TITLE
fix(estate): match opt-in YES constant when emailing copy to parties

### DIFF
--- a/libs/application/template-api-modules/src/lib/modules/templates/estate/estate.service.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/estate/estate.service.ts
@@ -15,6 +15,10 @@ import { infer as zinfer } from 'zod'
 import {
   estateSchema,
   nationalIdsMatch,
+  // estate's checkbox/schema write its local YES ('Yes'); the opt-in guard
+  // below must compare against that value, not core YES ('yes'), otherwise
+  // the copy-email path never fires.
+  YES,
 } from '@island.is/application/templates/estate'
 import {
   estateTransformer,
@@ -26,11 +30,7 @@ import {
 import { BaseTemplateApiService } from '../../base-template-api.service'
 import { ApplicationTypes } from '@island.is/application/types'
 import { TemplateApiError } from '@island.is/nest/problem'
-import {
-  coreErrorMessages,
-  getValueViaPath,
-  YES,
-} from '@island.is/application/core'
+import { coreErrorMessages, getValueViaPath } from '@island.is/application/core'
 import {
   ApplicationAttachments,
   AttachmentPaths,

--- a/libs/application/templates/estate/src/index.ts
+++ b/libs/application/templates/estate/src/index.ts
@@ -7,3 +7,4 @@ export const getFields = () => import('./fields/')
 export default EstateTemplate
 export { estateSchema }
 export { nationalIdsMatch } from './lib/utils/helpers'
+export { YES } from './lib/constants'


### PR DESCRIPTION
## What

The send-copy opt-in checkbox and dataSchema write estate's local YES ('Yes'), but sendApplicationCopyToParties guarded on core YES ('yes'). ['Yes'].includes('yes') is always false, so the copy email silently never sent: the action returned {sent:false, recipients:0} before any logging or send (confirmed in prod for opted-in apps).

Export YES from the estate package and have the service compare against it, matching the value the form actually stores. Inheritance report is unaffected (it uses core YES consistently throughout).

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the application copy email opt-in feature for estate applications to correctly recognize and honor user selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->