### PR TITLE
fix(island-ui): make Select search match Icelandic ð and þ

### DIFF
--- a/libs/island-ui/core/src/lib/Select/Select.tsx
+++ b/libs/island-ui/core/src/lib/Select/Select.tsx
@@ -2,8 +2,10 @@ import React from 'react'
 import cn from 'classnames'
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore make web strict
-import ReactSelect, { createFilter, GroupBase } from 'react-select'
+import ReactSelect, { GroupBase } from 'react-select'
 import CreatableReactSelect from 'react-select/creatable'
+
+import { createIcelandicFilter } from './icelandicFilter'
 
 import {
   Option,
@@ -108,7 +110,7 @@ export const Select = <
         formatCreateLabel={() => currentValue}
         createOptionPosition="first"
         onInputChange={(inputValue) => setCurrentValue(inputValue)}
-        filterOption={createFilter(filterConfig)}
+        filterOption={createIcelandicFilter(filterConfig)}
         components={{
           Control,
           Input,
@@ -173,7 +175,7 @@ export const Select = <
         size={size}
         required={required}
         formatGroupLabel={formatGroupLabel}
-        filterOption={createFilter(filterConfig)}
+        filterOption={createIcelandicFilter(filterConfig)}
         hideSelectedOptions={hideSelectedOptions}
         components={{
           Control,

--- a/libs/island-ui/core/src/lib/Select/icelandicFilter.spec.ts
+++ b/libs/island-ui/core/src/lib/Select/icelandicFilter.spec.ts
@@ -1,0 +1,36 @@
+import {
+  createIcelandicFilter,
+  normalizeIcelandicLetters,
+} from './icelandicFilter'
+
+describe('normalizeIcelandicLetters', () => {
+  it('maps eth and thorn to plain ASCII', () => {
+    expect(normalizeIcelandicLetters('Guðrún')).toBe('Gudrún')
+    expect(normalizeIcelandicLetters('Þuríður')).toBe('Thurídur')
+    expect(normalizeIcelandicLetters('þök')).toBe('thök')
+  })
+
+  it('leaves other characters untouched', () => {
+    expect(normalizeIcelandicLetters('Þórsdóttir')).toBe('Thórsdóttir')
+  })
+})
+
+describe('createIcelandicFilter', () => {
+  const filter = createIcelandicFilter()
+  const option = {
+    label: 'Guðrún Þórsdóttir',
+    value: 'teacher-1',
+    data: {},
+  } as Parameters<typeof filter>[0]
+
+  it.each<[string, boolean]>([
+    ['Guð', true],
+    ['Guðrún', true], // typed with eth
+    ['Gudrun', true], // typed with plain ASCII — the bug this fixes
+    ['Þórs', true], // typed with thorn
+    ['Thorsdottir', true], // thorn as "th", plus ó→o handled by react-select
+    ['Jón', false],
+  ])('matches input %p -> %p', (input, expected) => {
+    expect(filter(option, input)).toBe(expected)
+  })
+})

--- a/libs/island-ui/core/src/lib/Select/icelandicFilter.ts
+++ b/libs/island-ui/core/src/lib/Select/icelandicFilter.ts
@@ -1,0 +1,40 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore make web strict
+import { createFilter } from 'react-select'
+
+type FilterConfig = Parameters<typeof createFilter>[0]
+
+/**
+ * react-select's accent-insensitive search (`ignoreAccents`) strips most Latin
+ * diacritics — e.g. ö→o, á→a — but its lookup table does NOT include the
+ * Icelandic letters ð (eth) and þ (thorn). As a result, typing "Sigurdur"
+ * never matches "Sigurður". We normalise those two letters on both the option
+ * text and the typed input so Icelandic names stay searchable when typed with
+ * plain ASCII letters.
+ */
+export const normalizeIcelandicLetters = (value: string): string =>
+  String(value ?? '')
+    .replace(/Ð/g, 'D')
+    .replace(/ð/g, 'd')
+    .replace(/Þ/g, 'Th')
+    .replace(/þ/g, 'th')
+
+/**
+ * Drop-in replacement for react-select's `createFilter` that additionally
+ * handles ð/þ. Honours any caller-provided `filterConfig` (matchFrom,
+ * ignoreCase, stringify, …) — it only pre-normalises the eth/thorn letters.
+ */
+export const createIcelandicFilter = (
+  filterConfig?: FilterConfig,
+): ReturnType<typeof createFilter> => {
+  const filterOption = createFilter(filterConfig)
+  return (option: Parameters<typeof filterOption>[0], rawInput: string) =>
+    filterOption(
+      {
+        ...option,
+        label: normalizeIcelandicLetters(option.label),
+        value: normalizeIcelandicLetters(option.value),
+      },
+      rawInput ? normalizeIcelandicLetters(rawInput) : rawInput,
+    )
+}


### PR DESCRIPTION
## What

Make the island-ui `Select` search match options whose text contains the Icelandic letters `ð` (eth) and `þ` (thorn).

react-select's accent-insensitive filter (`ignoreAccents`) strips most Latin diacritics — `ö→o`, `á→a` — but its lookup table does **not** include `ð`/`þ`. So typing `Gudrun` (with a plain `d`) never matched an option labelled `Guðrún`, even though it was in the list.

This adds a small Icelandic-aware filter (`createIcelandicFilter`) that normalises `ð→d` and `þ→th` on **both** the option text and the typed input before delegating to react-select's `createFilter`. Any caller-provided `filterConfig` is still honoured.

## Why

`Select` is searchable platform-wide. When users typed a name containing `ð`/`þ` using plain ASCII letters (the natural keyboard input), the matching option was filtered out and they concluded it was missing. This came up with the driving-instructor dropdown but affects every searchable `Select`.

## Screenshots / Gifs

Behavioural change in search filtering — covered by unit tests (`icelandicFilter.spec.ts`):

| Type | Before | After |
| --- | --- | --- |
| `Gudrun` → option `Guðrún Þórsdóttir` | no match | ✅ match |
| `Thorsdottir` → `Guðrún Þórsdóttir` | no match | ✅ match |
| `Guðrún` (with ð) | ✅ match | ✅ match |

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Select component now supports Icelandic character filtering. Type ASCII equivalents to match options containing Icelandic characters.

* **Tests**
  * Added comprehensive test coverage for Icelandic character filtering functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->