### PR TITLE
fix(driving-license): fetch driving-instructor list live instead of a frozen snapshot

### DIFF
--- a/libs/application/templates/driving-license/src/forms/draft/subSectionApplicantInfo.ts
+++ b/libs/application/templates/driving-license/src/forms/draft/subSectionApplicantInfo.ts
@@ -2,12 +2,13 @@ import {
   buildDescriptionField,
   buildMultiField,
   buildKeyValueField,
-  buildSelectField,
+  buildAsyncSelectField,
   buildDividerField,
   buildTextField,
   buildSubSection,
   buildPhoneField,
   getValueViaPath,
+  coreErrorMessages,
 } from '@island.is/application/core'
 import {
   Application,
@@ -22,6 +23,7 @@ import {
   B_FULL,
   B_ADVANCED,
 } from '../../lib/constants'
+import { GET_DRIVING_LICENSE_TEACHERS } from '../../graphql/teachersQuery'
 
 export const subSectionApplicantInfo = buildSubSection({
   id: 'infoStep',
@@ -112,22 +114,33 @@ export const subSectionApplicantInfo = buildSubSection({
             answers.applicationFor !== B_FULL_RENEWAL_65 &&
             answers.applicationFor !== B_FULL,
         }),
-        buildSelectField({
+        buildAsyncSelectField({
           id: 'drivingInstructor',
           title: m.drivingInstructor,
+          loadingError: coreErrorMessages.failedDataProvider,
+          isSearchable: true,
           condition: (answers) =>
             answers.applicationFor !== B_FULL_RENEWAL_65 &&
             answers.applicationFor !== B_FULL,
           required: true,
-          options: ({
-            externalData: {
-              teachers: { data },
-            },
-          }) => {
-            return (data as TeacherV4[]).map(({ name, nationalId }) => ({
-              value: nationalId,
-              label: `${name} (${nationalId.substring(0, 6)})`,
-            }))
+          // Fetch the instructor list live so a newly-registered instructor
+          // shows up (and de-licensed ones drop off) without the user having
+          // to start a new application. The list used to be read from the
+          // snapshot frozen into external data when the application was created.
+          loadOptions: async ({ apolloClient }) => {
+            const { data } = await apolloClient.query<{
+              drivingLicenseTeachersV4: TeacherV4[]
+            }>({
+              query: GET_DRIVING_LICENSE_TEACHERS,
+              fetchPolicy: 'network-only',
+            })
+
+            return (data?.drivingLicenseTeachersV4 ?? []).map(
+              ({ name, nationalId }) => ({
+                value: nationalId,
+                label: `${name} (${nationalId.substring(0, 6)})`,
+              }),
+            )
           },
         }),
       ],

--- a/libs/application/templates/driving-license/src/forms/draft/subSectionSummary.ts
+++ b/libs/application/templates/driving-license/src/forms/draft/subSectionSummary.ts
@@ -113,21 +113,35 @@ export const subSectionSummary = buildSubSection({
           label: m.overviewTeacher,
           width: 'half',
           condition: isApplicationForCondition(B_TEMP),
-          value: ({
-            externalData: {
-              drivingAssessment,
-              teachers: { data },
-            },
-            answers,
-          }) => {
+          value: ({ externalData, answers }) => {
             if (answers.applicationFor === B_TEMP) {
-              const teacher = (data as TeacherV4[])?.find(
-                ({ nationalId }) =>
-                  getValueViaPath(answers, 'drivingInstructor') === nationalId,
+              const selectedNationalId = getValueViaPath<string>(
+                answers,
+                'drivingInstructor',
               )
-              return teacher?.name ?? ''
+              const teachers =
+                getValueViaPath<TeacherV4[]>(
+                  externalData,
+                  'teachers.data',
+                  [],
+                ) ?? []
+              const teacher = teachers.find(
+                ({ nationalId }) => nationalId === selectedNationalId,
+              )
+              // Fall back to the kennitala if the chosen instructor isn't in
+              // the (snapshot) list — e.g. an instructor registered after this
+              // application was created, now selectable via the live dropdown.
+              return (
+                teacher?.name ??
+                (selectedNationalId ? formatNationalId(selectedNationalId) : '')
+              )
             }
-            return (drivingAssessment.data as StudentAssessment).teacherName
+            return (
+              getValueViaPath<StudentAssessment>(
+                externalData,
+                'drivingAssessment.data',
+              )?.teacherName ?? ''
+            )
           },
         }),
         // Health cert section — old "bring along" checkbox flow.

--- a/libs/application/templates/driving-license/src/forms/draft/subSectionSummary.ts
+++ b/libs/application/templates/driving-license/src/forms/draft/subSectionSummary.ts
@@ -107,14 +107,17 @@ export const subSectionSummary = buildSubSection({
             (nationalRegistry.data as NationalRegistryUser).address?.city,
         }),
         buildDividerField({
-          condition: isApplicationForCondition(B_TEMP),
+          condition: isApplicationForCondition([B_TEMP, BE]),
         }),
         buildKeyValueField({
           label: m.overviewTeacher,
           width: 'half',
-          condition: isApplicationForCondition(B_TEMP),
+          condition: isApplicationForCondition([B_TEMP, BE]),
           value: ({ externalData, answers }) => {
-            if (answers.applicationFor === B_TEMP) {
+            if (
+              answers.applicationFor === B_TEMP ||
+              answers.applicationFor === BE
+            ) {
               const selectedNationalId = getValueViaPath<string>(
                 answers,
                 'drivingInstructor',

--- a/libs/application/templates/driving-license/src/graphql/teachersQuery.ts
+++ b/libs/application/templates/driving-license/src/graphql/teachersQuery.ts
@@ -1,0 +1,13 @@
+import { gql } from '@apollo/client'
+
+// Fetches the current list of driving instructors live (instead of relying on
+// the snapshot frozen into external data when the application was created), so
+// newly-registered instructors show up and de-licensed ones drop off.
+export const GET_DRIVING_LICENSE_TEACHERS = gql`
+  query DrivingLicenseTeachers {
+    drivingLicenseTeachersV4 {
+      name
+      nationalId
+    }
+  }
+`

--- a/libs/application/templates/transport-authority/driving-license-book-update-instructor/src/forms/DrivingLicenseBookUpdateInstructorForm/informationSection.ts
+++ b/libs/application/templates/transport-authority/driving-license-book-update-instructor/src/forms/DrivingLicenseBookUpdateInstructorForm/informationSection.ts
@@ -3,14 +3,16 @@ import {
   buildDescriptionField,
   buildMultiField,
   buildSection,
-  buildSelectField,
+  buildAsyncSelectField,
   buildSubmitField,
   buildTextField,
   getValueViaPath,
+  coreErrorMessages,
 } from '@island.is/application/core'
 import { information } from '../../lib/messages'
 import kennitala from 'kennitala'
 import { DefaultEvents } from '@island.is/application/types'
+import { GET_DRIVING_LICENSE_TEACHERS } from '../../graphql/teachersQuery'
 
 export const informationSection = buildSection({
   id: 'informationSection',
@@ -50,25 +52,31 @@ export const informationSection = buildSection({
           titleVariant: 'h5',
           space: 3,
         }),
-        buildSelectField({
+        buildAsyncSelectField({
           id: 'newInstructor.nationalId',
           title: information.labels.newInstructor.selectSubLabel,
-          disabled: false,
+          loadingError: coreErrorMessages.failedDataProvider,
+          isSearchable: true,
           required: true,
-          options: (application) => {
-            const teachers = getValueViaPath(
-              application.externalData,
-              'teachers.data',
-              [],
-            ) as TeacherV4[]
-
+          // Fetch the instructor list live so a newly-registered instructor
+          // shows up (and de-licensed ones drop off) without the user having
+          // to start a new application. The list used to be read from the
+          // snapshot frozen into external data when the application was created.
+          loadOptions: async ({ application, apolloClient }) => {
             const currentInstructorNationalId = getValueViaPath(
               application.externalData,
               'currentInstructor.data.nationalId',
               undefined,
             ) as string | undefined | null
 
-            return teachers
+            const { data } = await apolloClient.query<{
+              drivingLicenseTeachersV4: TeacherV4[]
+            }>({
+              query: GET_DRIVING_LICENSE_TEACHERS,
+              fetchPolicy: 'network-only',
+            })
+
+            return (data?.drivingLicenseTeachersV4 ?? [])
               .filter(
                 ({ nationalId }) => nationalId !== currentInstructorNationalId,
               )

--- a/libs/application/templates/transport-authority/driving-license-book-update-instructor/src/graphql/teachersQuery.ts
+++ b/libs/application/templates/transport-authority/driving-license-book-update-instructor/src/graphql/teachersQuery.ts
@@ -1,0 +1,13 @@
+import { gql } from '@apollo/client'
+
+// Fetches the current list of driving instructors live (instead of relying on
+// the snapshot frozen into external data when the application was created), so
+// newly-registered instructors show up and de-licensed ones drop off.
+export const GET_DRIVING_LICENSE_TEACHERS = gql`
+  query DrivingLicenseBookUpdateInstructorTeachers {
+    drivingLicenseTeachersV4 {
+      name
+      nationalId
+    }
+  }
+`


### PR DESCRIPTION
## What

Make the driving-instructor dropdowns fetch the current instructor list **live** instead of reading a snapshot frozen into external data when the application was created.

Affected templates:
- `driving-license` — temporary licence / learner flow (`subSectionApplicantInfo.ts`)
- `driving-license-book-update-instructor` — change instructor (`informationSection.ts`)

Both use `buildAsyncSelectField` with the existing `drivingLicenseTeachersV4` query (`fetchPolicy: 'network-only'`). The change-instructor form keeps its "exclude the student's current instructor" filter.

The B-temp **overview** resolves the chosen instructor's name with a safe `getValueViaPath` lookup, falling back to the kennitala when the instructor isn't in the prerequisites snapshot (e.g. one registered after the application was created, now selectable via the live dropdown). The `TeachersApi` prerequisites provider is retained — the overview still uses it to resolve the name.

Also: the **BE** flow collects an instructor exactly like B-temp but didn't show it on the overview — the overview now displays the selected instructor for BE too (same name lookup).

## Why

The instructor list was fetched once when the application was created and never refreshed. A driving instructor who registered **after** a student created their application never appeared in that student's dropdown — and waiting didn't help, because the application kept using the data fetched at creation time. The only workaround was to start a new application. The inverse is also wrong: a de-licensed instructor keeps showing in older applications. Fetching the list live fixes both directions.

> Companion PR (#22978) makes the shared `Select` search match Icelandic `ð`/`þ`; together the instructor dropdowns become both current and properly searchable.

## Screenshots / Gifs

n/a — data-source change; the dropdown UI is unchanged.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Driving instructor selection now dynamically loads the current, live instructor list (searchable and on-demand), so newly registered instructors appear immediately and de-licensed instructors no longer show up.
* **Bug Fixes**
  * Updated teacher information display logic so the correct teacher name/formatting is shown for additional application types, including improved fallback behavior when no matching teacher is found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->