### PR TITLE
feat(web): Verdict list - Horizontal padding for filtermenu on mobile devices

### DIFF
--- a/apps/web/screens/Verdicts/VerdictsList.tsx
+++ b/apps/web/screens/Verdicts/VerdictsList.tsx
@@ -1827,7 +1827,7 @@ const VerdictsList: CustomScreen<VerdictsListProps> = (props) => {
                     onFilterClear={resetQueryState}
                     usePopoverDiscloureButtonStyling
                   >
-                    <Box paddingY={3}>
+                    <Box paddingX={[3, 3, 0]} paddingY={3}>
                       <Filters
                         selectedCourtLevel={mapCourtsToTopLevelCourt(
                           selectedCourts,


### PR DESCRIPTION
# Verdict list - Horizontal padding for filtermenu on mobile devices

## Before

<img width="544" height="457" alt="Screenshot 2026-06-19 at 13 10 20" src="https://github.com/user-attachments/assets/3be01eae-3329-4fa3-8fec-306340a02667" />

## After

<img width="556" height="487" alt="Screenshot 2026-06-19 at 13 11 15" src="https://github.com/user-attachments/assets/d6aff0bb-f579-4daa-b319-58aad7b5acc0" />


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [x] No AI tools were used in preparing this pull request
- [ ] AI tools were used in preparing this pull request
      Tools used:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved responsive layout spacing in the verdicts filter sidebar, adjusting padding to provide better visual balance and usability across mobile and desktop devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->