### PR TITLE
fix(j-s): reset Svipting and Útivistardómur on indictment reopen

### DIFF
--- a/apps/judicial-system/backend/src/app/modules/case/case.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/case/case.service.ts
@@ -1859,6 +1859,7 @@ export class CaseService {
               isSentToPrisonAdmin: false,
               indictmentReviewDecision: null,
               publicProsecutorIsRegisteredInPoliceSystem: null,
+              isDrivingLicenseSuspended: null,
             },
             transaction,
           ),

--- a/apps/judicial-system/backend/src/app/modules/case/test/caseController/update.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/case/test/caseController/update.spec.ts
@@ -1057,6 +1057,7 @@ describe('CaseController - Update', () => {
         isSentToPrisonAdmin: false,
         indictmentReviewDecision: null,
         publicProsecutorIsRegisteredInPoliceSystem: null,
+        isDrivingLicenseSuspended: null,
       }
       expect(mockDefendantService.updateDatabaseDefendant).toHaveBeenCalledWith(
         caseId,

--- a/apps/judicial-system/backend/src/app/modules/repository/services/verdictRepository.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/repository/services/verdictRepository.service.ts
@@ -47,7 +47,7 @@ interface UpdateVerdict {
   appealDecision?: string
   appealDate?: Date
   serviceInformationForDefendant?: InformationForDefendant[]
-  isDefaultJudgement?: boolean
+  isDefaultJudgement?: boolean | null
   isAcquittedByPublicProsecutionOffice?: boolean | null
   defendantHasRequestedAppeal?: boolean | null
   hash?: string

--- a/apps/judicial-system/backend/src/app/modules/repository/types/caseRepository.types.ts
+++ b/apps/judicial-system/backend/src/app/modules/repository/types/caseRepository.types.ts
@@ -638,4 +638,5 @@ export interface UpdateDefendant {
   alternativeServiceDescription?: string
   indictmentReviewDecision?: IndictmentCaseReviewDecision | null
   publicProsecutorIsRegisteredInPoliceSystem?: boolean | null
+  isDrivingLicenseSuspended?: boolean | null
 }

--- a/apps/judicial-system/backend/src/app/modules/verdict/test/verdictService/update.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/verdict/test/verdictService/update.spec.ts
@@ -11,6 +11,7 @@ import { createTestingVerdictModule } from '../createTestingVerdictModule'
 
 import { Case, Verdict, VerdictRepositoryService } from '../../../repository'
 import { UpdateVerdictDto } from '../../dto/updateVerdict.dto'
+import { VerdictService } from '../../verdict.service'
 
 interface Then {
   result: Verdict
@@ -32,9 +33,7 @@ describe('VerdictService - update', () => {
   let mockVerdictRepositoryService: VerdictRepositoryService
   let transaction: Transaction
   let mockAddMessagesToQueue: jest.Mock
-  let verdictService: Awaited<
-    ReturnType<typeof createTestingVerdictModule>
-  >['verdictService']
+  let verdictService: VerdictService
 
   let givenWhenThen: GivenWhenThen
 

--- a/apps/judicial-system/backend/src/app/modules/verdict/test/verdictService/update.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/verdict/test/verdictService/update.spec.ts
@@ -32,15 +32,19 @@ describe('VerdictService - update', () => {
   let mockVerdictRepositoryService: VerdictRepositoryService
   let transaction: Transaction
   let mockAddMessagesToQueue: jest.Mock
+  let verdictService: Awaited<
+    ReturnType<typeof createTestingVerdictModule>
+  >['verdictService']
 
   let givenWhenThen: GivenWhenThen
 
   beforeEach(async () => {
     jest.resetAllMocks()
 
-    const { verdictService, verdictRepositoryService } =
+    const { verdictService: service, verdictRepositoryService } =
       await createTestingVerdictModule()
 
+    verdictService = service
     mockVerdictRepositoryService = verdictRepositoryService
     transaction = {} as Transaction
     mockAddMessagesToQueue = (
@@ -157,6 +161,37 @@ describe('VerdictService - update', () => {
       expect(mockVerdictRepositoryService.update).toHaveBeenCalledTimes(1)
       expect(mockAddMessagesToQueue).not.toHaveBeenCalled()
       expect(then.result).toBeDefined()
+    })
+  })
+
+  describe('resetVerdictDataForReopen', () => {
+    beforeEach(async () => {
+      const verdict = {
+        id: verdictId,
+        caseId,
+        defendantId,
+        isDefaultJudgement: true,
+      } as unknown as Verdict
+
+      const mockUpdate = mockVerdictRepositoryService.update as jest.Mock
+      mockUpdate.mockResolvedValueOnce(verdict)
+
+      await verdictService.resetVerdictDataForReopen(verdict, transaction)
+    })
+
+    it('should reset verdict data including isDefaultJudgement', () => {
+      expect(mockVerdictRepositoryService.update).toHaveBeenCalledWith(
+        caseId,
+        defendantId,
+        verdictId,
+        {
+          isAcquittedByPublicProsecutionOffice: null,
+          defendantHasRequestedAppeal: null,
+          serviceRequirement: null,
+          isDefaultJudgement: null,
+        },
+        { transaction },
+      )
     })
   })
 })

--- a/apps/judicial-system/backend/src/app/modules/verdict/verdict.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/verdict/verdict.service.ts
@@ -47,6 +47,7 @@ type UpdateVerdict = {
   isAcquittedByPublicProsecutionOffice?: boolean | null
   defendantHasRequestedAppeal?: boolean | null
   serviceRequirement?: ServiceRequirement | null
+  isDefaultJudgement?: boolean | null
 } & Pick<
   Verdict,
   | 'externalPoliceDocumentId'
@@ -56,7 +57,6 @@ type UpdateVerdict = {
   | 'appealDecision'
   | 'appealDate'
   | 'serviceInformationForDefendant'
-  | 'isDefaultJudgement'
   | 'hash'
   | 'hashAlgorithm'
 >
@@ -297,6 +297,7 @@ export class VerdictService {
         isAcquittedByPublicProsecutionOffice: null,
         defendantHasRequestedAppeal: null,
         serviceRequirement: null,
+        isDefaultJudgement: null,
       },
       transaction,
     )


### PR DESCRIPTION
## What
When a court user reopens a completed indictment, the two ruling checkboxes on the Conclusion page now reset to blank instead of inheriting their pre-reopen values:

- **"Svipting ökuréttar"** → `defendant.isDrivingLicenseSuspended`
- **"Útivistardómur"** → `verdict.isDefaultJudgement`

Both fields are now cleared (`null`) as part of the existing reopen reset logic:
- `case.service.ts` adds `isDrivingLicenseSuspended: null` to the defendant reset payload (and the field is declared on the `UpdateDefendant` type).
- `verdict.service.ts` `resetVerdictDataForReopen` adds `isDefaultJudgement: null` (the field is made nullable in both the service-level and repository-level `UpdateVerdict` types).

Tests were extended to assert both resets.

## Why
Previously these two checkboxes kept their selected state after a case was reopened, so when the case was completed again they were pre-ticked with stale values. They should start blank — matching the other ruling fields that are already reset on reopen.

This is backend-only; the Conclusion page simply reflects the persisted values, so no schema/codegen change is required.

## Screenshots / Gifs
Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code
- [ ] No AI tools were used in preparing this pull request

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved case reopen handling to fully clear related defendant and verdict fields. This includes resetting driving license suspension status, appeal-related data, service requirements, and default judgment status to ensure consistent case state after reopening.
* **Tests**
  * Updated and expanded unit tests to reflect the new reset payload behavior for reopened cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->