### PR TITLE
chore(j-s): document moving away from Contentful strings

### DIFF
--- a/apps/judicial-system/AGENTS.md
+++ b/apps/judicial-system/AGENTS.md
@@ -1,5 +1,12 @@
 # Judicial System — Agent Guide
 
+## Localization strings
+
+We are moving away from Contentful. **Do not add new strings to `.strings.ts`
+files.** Existing strings stay where they are, but any new user-facing text
+should be hardcoded directly in code rather than introducing new entries in
+`.strings.ts` (and therefore Contentful).
+
 ## Codegen
 
 Regenerate after changing GraphQL schema/resolvers, REST controllers/DTOs, or

--- a/apps/judicial-system/AGENTS.md
+++ b/apps/judicial-system/AGENTS.md
@@ -3,9 +3,8 @@
 ## Localization strings
 
 We are moving away from Contentful. **Do not add new strings to `.strings.ts`
-files.** Existing strings stay where they are, but any new user-facing text
-should be hardcoded directly in code rather than introducing new entries in
-`.strings.ts` (and therefore Contentful).
+files.** New user-facing text should be hardcoded directly in code rather than
+introducing new entries in `.strings.ts` (and therefore Contentful).
 
 ## Codegen
 


### PR DESCRIPTION
## What
Adds a "Localization strings" section to the judicial-system AGENTS.md documenting that we are moving away from Contentful: no new strings should be added to `.strings.ts` files, and new user-facing text should be hardcoded directly in code.

## Why
To give AI tools and contributors clear, consistent guidance reflecting the move away from Contentful.

## Screenshots / Gifs
N/A — documentation only.

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code
- [ ] No AI tools were used in preparing this pull request

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contributor guidelines regarding localization string handling procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->