### PR TITLE
fix(application-system): Fixing users stuck in prereq

### DIFF
--- a/libs/application/templates/financial-aid/src/forms/Prerequisites.ts
+++ b/libs/application/templates/financial-aid/src/forms/Prerequisites.ts
@@ -31,6 +31,7 @@ export const Prerequisites: Form = buildForm({
   id: 'FinancialAidApplication',
   title: m.application.name,
   mode: FormModes.DRAFT,
+  renderLastScreenButton: true,
   logo: (application: Application) => {
     const logo = createElement(Logo, { application })
     return () => logo
@@ -107,11 +108,6 @@ export const Prerequisites: Form = buildForm({
               ],
             }),
           ],
-        }),
-        // This is here to be able to show submit button on former screen :( :( :(
-        buildMultiField({
-          id: '',
-          children: [],
         }),
       ],
     }),


### PR DESCRIPTION
The recent lastNavigableScreenIndex + 1 change to numberOfScreens in FormShell.tsx caused the empty multifield workaround used here to stop working, it was no longer counted, making the contract screen the last screen and hiding the footer. Replaced the workaround with renderLastScreenButton: true on the form.

## Before
<img width="1319" height="764" alt="image" src="https://github.com/user-attachments/assets/8f795314-7831-45a3-b5ac-6c4b7edb92f3" />


## After
<img width="1278" height="753" alt="image" src="https://github.com/user-attachments/assets/cfd74fad-2281-49db-ad1d-ebc3e5e77306" />


Attach a link to issue if relevant

## What

Specify what you're trying to achieve

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [X] AI tools were used in preparing this pull request
      Tools used: Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed form navigation behavior in the financial aid prerequisites section. The submit button now properly displays on the final screen, enabling users to successfully complete their application without issues.
  * Removed unnecessary placeholder form elements that were previously required as a workaround for displaying navigation buttons on intermediate form screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->