### PR TITLE
fix(j-s): improve Modal accessibility

### DIFF
--- a/apps/judicial-system/web/src/components/Modals/Modal/Modal.spec.tsx
+++ b/apps/judicial-system/web/src/components/Modals/Modal/Modal.spec.tsx
@@ -1,0 +1,49 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+
+import { Modal } from './Modal'
+
+describe('Modal', () => {
+  it('labels the dialog with its title via aria-labelledby', () => {
+    render(<Modal title="Ertu viss?" />)
+
+    expect(
+      screen.getByRole('dialog', { name: 'Ertu viss?' }),
+    ).toBeInTheDocument()
+  })
+
+  it('renders a labelled icon-only close button that closes the modal', () => {
+    const onClose = jest.fn()
+    render(<Modal title="Titill" onClose={onClose} />)
+
+    const closeButton = screen.getByRole('button', { name: 'Loka glugga' })
+    fireEvent.click(closeButton)
+
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('closes the modal when Escape is pressed', () => {
+    const onClose = jest.fn()
+    render(<Modal title="Titill" onClose={onClose} />)
+
+    fireEvent.keyDown(window, { key: 'Escape' })
+
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not close on Escape while loading', () => {
+    const onClose = jest.fn()
+    render(<Modal title="Titill" onClose={onClose} loading />)
+
+    fireEvent.keyDown(window, { key: 'Escape' })
+
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('exposes the error message in an assertive live region', () => {
+    render(<Modal title="Titill" errorMessage="Eitthvað fór úrskeiðis" />)
+
+    const alert = screen.getByRole('alert')
+    expect(alert).toHaveTextContent('Eitthvað fór úrskeiðis')
+    expect(alert).toHaveAttribute('aria-live', 'assertive')
+  })
+})

--- a/apps/judicial-system/web/src/components/Modals/Modal/Modal.tsx
+++ b/apps/judicial-system/web/src/components/Modals/Modal/Modal.tsx
@@ -56,7 +56,7 @@ interface ModalProps {
   footerJustifyContent?: BoxProps['justifyContent']
 }
 
-const Modal: FC<PropsWithChildren<ModalProps>> = ({
+export const Modal: FC<PropsWithChildren<ModalProps>> = ({
   title,
   text,
   primaryButton,
@@ -82,6 +82,13 @@ const Modal: FC<PropsWithChildren<ModalProps>> = ({
   }
 
   const footerCheckboxId = useId()
+  const titleId = useId()
+
+  useKeyboardCombo('Escape', () => {
+    if (onClose && !loading) {
+      onClose()
+    }
+  })
 
   useEffect(() => {
     document.body.style.overflow = 'hidden'
@@ -101,6 +108,7 @@ const Modal: FC<PropsWithChildren<ModalProps>> = ({
         exit={{ opacity: 0 }}
         role="dialog"
         aria-modal="true"
+        aria-labelledby={titleId}
         data-testid="modal"
         layout
         transition={{
@@ -131,13 +139,14 @@ const Modal: FC<PropsWithChildren<ModalProps>> = ({
                 className={styles.closeButton}
                 onClick={onClose}
                 disabled={loading}
+                aria-label="Loka glugga"
               >
                 <Icon icon="close" type="outline" color="blue400" />
               </button>
             </Box>
           )}
           <Box marginBottom={3}>
-            <Text variant="h1" as="h2">
+            <Text id={titleId} variant="h1" as="h2">
               {title}
             </Text>
           </Box>
@@ -201,7 +210,12 @@ const Modal: FC<PropsWithChildren<ModalProps>> = ({
             </Box>
           </Box>
           {errorMessage && (
-            <Box marginTop={1} data-testid="modalErrorMessage">
+            <Box
+              marginTop={1}
+              role="alert"
+              aria-live="assertive"
+              data-testid="modalErrorMessage"
+            >
               <Text variant="eyebrow" color="red600">
                 {errorMessage}
               </Text>

--- a/apps/judicial-system/web/src/routes/Court/Indictments/Subpoena/Subpoena.tsx
+++ b/apps/judicial-system/web/src/routes/Court/Indictments/Subpoena/Subpoena.tsx
@@ -7,6 +7,7 @@ import {
   useState,
 } from 'react'
 import { useIntl } from 'react-intl'
+import { AnimatePresence } from 'motion/react'
 import router from 'next/router'
 
 import { Box, Button } from '@island.is/island-ui/core'
@@ -512,21 +513,24 @@ const Subpoena: FC = () => {
           nextIsDisabled={!stepIsValid}
         />
       </FormContentContainer>
-      {modalContent && (
-        <Modal
-          title={modalContent.title}
-          text={modalContent.text}
-          primaryButton={{
-            text: modalContent.primaryButtonText,
-            onClick: () => scheduleArraignmentDate(),
-            isLoading: isCreatingSubpoena,
-          }}
-          secondaryButton={{
-            text: formatMessage(strings.modalSecondaryButtonText),
-            onClick: () => setNavigateTo(undefined),
-          }}
-        />
-      )}
+      <AnimatePresence>
+        {modalContent && (
+          <Modal
+            title={modalContent.title}
+            text={modalContent.text}
+            primaryButton={{
+              text: modalContent.primaryButtonText,
+              onClick: () => scheduleArraignmentDate(),
+              isLoading: isCreatingSubpoena,
+            }}
+            secondaryButton={{
+              text: formatMessage(strings.modalSecondaryButtonText),
+              onClick: () => setNavigateTo(undefined),
+            }}
+            onClose={() => setNavigateTo(undefined)}
+          />
+        )}
+      </AnimatePresence>
     </PageLayout>
   )
 }


### PR DESCRIPTION
# Modal accessibility fixes

## What

Fixes four accessibility issues in the shared `Modal` component
(`apps/judicial-system/web/src/components/Modals/Modal/Modal.tsx`) so all
consuming modals inherit the fixes:

- **Escape-to-close** — `Modal` now closes on Escape (guarded with `!loading`),
  matching the existing close-button behaviour. Previously only the bare
  `ModalContainer` variant had this.
- **Dialog accessible name** — added `aria-labelledby` on the `role="dialog"`
  element pointing at the title.
- **aria-live error region** — the error message now uses `role="alert"` +
  `aria-live="assertive"` so screen readers announce it.
- **Labelled close button** — added an accessible name to the icon-only close
  button.

The previously-internal `Modal` const is now exported so it can be rendered
directly in tests.

## Why

The icon-only close button had no accessible name, the dialog had no accessible
name, errors were not announced to assistive tech, and keyboard users could not
dismiss the modal with Escape. Fixing at the shared level covers 7+ consuming
modals.

## Screenshots / Gifs

N/A — markup/a11y-only change.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Modal dialog now uses accessible title labeling for screen readers.
  * Close button includes an explicit accessible label.
  * Escape key now closes the modal only when not loading.
  * Error messages now announce with proper alert semantics.
  * Modal showing and hiding is now animated.
* **Tests**
  * Added accessibility-focused Modal interaction tests (close button, Escape behavior, and error announcements).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->