### PR TITLE
feat(j-s): Corrected ruling-order appeal info box

### DIFF
--- a/apps/judicial-system/backend/src/app/modules/notification/test/internalNotificationController/sendIndictmentAppealNotifications.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/test/internalNotificationController/sendIndictmentAppealNotifications.spec.ts
@@ -1165,3 +1165,90 @@ describe('InternalNotificationController - Ruling-order appeal uses the ruling o
     )
   })
 })
+
+// ─── 8. APPEAL_COMPLETED for a corrected ruling-order appeal ────────────────
+
+describe('InternalNotificationController - Corrected ruling-order appeal sends the corrected-ruling email identified by file name', () => {
+  const { prosecutor, judge } = createTestUsers(['prosecutor', 'judge'])
+
+  const caseId = uuid()
+  const appealCaseId = uuid()
+  const appealCaseNumber = uuid()
+  const courtCaseNumber = uuid()
+  const rulingFileId = uuid()
+  const rulingOrderFileName = 'Úrskurður 15-2026'
+
+  let mockEmailService: EmailService
+
+  type GivenWhenThen = () => Promise<Then>
+  let givenWhenThen: GivenWhenThen
+
+  beforeEach(async () => {
+    const { emailService, internalNotificationController } =
+      await createTestingNotificationModule()
+
+    mockEmailService = emailService
+
+    givenWhenThen = async () => {
+      const then = {} as Then
+
+      const appealCase = {
+        appealState: AppealCaseState.COMPLETED,
+        appealCaseNumber,
+        appealRulingDecision: AppealCaseRulingDecision.ACCEPTING,
+        appealRulingModifiedHistory: 'Leiðrétting á úrskurði',
+        rulingFileId,
+      } as AppealCase
+
+      await internalNotificationController
+        .sendAppealCaseNotification(
+          caseId,
+          appealCaseId,
+          {
+            id: caseId,
+            type: CaseType.INDICTMENT,
+            indictmentRulingDecision: CaseIndictmentRulingDecision.DISMISSAL,
+            prosecutor: { name: prosecutor.name, email: prosecutor.email },
+            judge: { name: judge.name, email: judge.email },
+            court: { name: 'Héraðsdómur Reykjavíkur' },
+            courtCaseNumber,
+            defendants,
+            civilClaimants,
+            caseFiles: [
+              { id: rulingFileId, userGeneratedFilename: rulingOrderFileName },
+            ],
+            appealCase,
+            rulingOrderAppealCases: [appealCase],
+          } as Case,
+          appealCase,
+          {
+            user: { id: uuid() } as User,
+            type: AppealCaseNotificationType.APPEAL_COMPLETED,
+          },
+        )
+        .then((result) => (then.result = result))
+        .catch((error) => (then.error = error))
+
+      return then
+    }
+  })
+
+  it('sends the corrected-ruling email with the ruling order file name in the subject', async () => {
+    const then = await givenWhenThen()
+
+    expect(mockEmailService.sendEmail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: [{ name: judge.name, address: judge.email }],
+        subject: `Leiðréttur úrskurður í landsréttarmáli ${appealCaseNumber} (${rulingOrderFileName})`,
+      }),
+    )
+
+    expect(mockEmailService.sendEmail).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        subject: `Leiðréttur úrskurður í landsréttarmáli ${appealCaseNumber} (${courtCaseNumber})`,
+      }),
+    )
+
+    expect(then.result).toEqual({ delivered: true })
+  })
+})

--- a/apps/judicial-system/backend/src/app/modules/notification/test/internalNotificationController/sendIndictmentAppealNotifications.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/test/internalNotificationController/sendIndictmentAppealNotifications.spec.ts
@@ -1166,7 +1166,6 @@ describe('InternalNotificationController - Ruling-order appeal uses the ruling o
   })
 })
 
-
 describe('InternalNotificationController - Corrected ruling-order appeal sends the corrected-ruling email identified by file name', () => {
   const { prosecutor, judge } = createTestUsers(['prosecutor', 'judge'])
 

--- a/apps/judicial-system/backend/src/app/modules/notification/test/internalNotificationController/sendIndictmentAppealNotifications.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/test/internalNotificationController/sendIndictmentAppealNotifications.spec.ts
@@ -1166,7 +1166,6 @@ describe('InternalNotificationController - Ruling-order appeal uses the ruling o
   })
 })
 
-// ─── 8. APPEAL_COMPLETED for a corrected ruling-order appeal ────────────────
 
 describe('InternalNotificationController - Corrected ruling-order appeal sends the corrected-ruling email identified by file name', () => {
   const { prosecutor, judge } = createTestUsers(['prosecutor', 'judge'])

--- a/apps/judicial-system/web/src/components/Alerts/AppealRulingModifiedAlert/AppealRulingModifiedAlert.spec.tsx
+++ b/apps/judicial-system/web/src/components/Alerts/AppealRulingModifiedAlert/AppealRulingModifiedAlert.spec.tsx
@@ -1,0 +1,93 @@
+import { render, screen } from '@testing-library/react'
+
+import { Case } from '@island.is/judicial-system-web/src/graphql/schema'
+import {
+  FormContextWrapper,
+  IntlProviderWrapper,
+} from '@island.is/judicial-system-web/src/utils/testHelpers'
+
+import AppealRulingModifiedAlert from './AppealRulingModifiedAlert'
+
+const renderAlert = (theCase: Partial<Case>) =>
+  render(
+    <IntlProviderWrapper>
+      <FormContextWrapper theCase={theCase as Case}>
+        <AppealRulingModifiedAlert />
+      </FormContextWrapper>
+    </IntlProviderWrapper>,
+  )
+
+describe('AppealRulingModifiedAlert', () => {
+  it('renders nothing when there are no corrected appeals', () => {
+    const { container } = renderAlert({ id: 'case-1' })
+
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders the case-level correction box', () => {
+    renderAlert({
+      id: 'case-1',
+      appealCase: {
+        id: 'appeal-1',
+        appealRulingModifiedHistory: 'Leiðrétting á máli',
+      },
+    })
+
+    expect(
+      screen.getByText('Úrskurður Landsréttar leiðréttur'),
+    ).toBeInTheDocument()
+    expect(screen.getByText('Leiðrétting á máli')).toBeInTheDocument()
+  })
+
+  it('renders one box per corrected ruling-order appeal with the file name', () => {
+    renderAlert({
+      id: 'case-1',
+      caseFiles: [
+        { id: 'file-1', userGeneratedFilename: 'Úrskurður 15-2026' },
+        { id: 'file-2', userGeneratedFilename: 'Úrskurður 16-2026' },
+      ],
+      rulingOrderAppealCases: [
+        {
+          id: 'ro-1',
+          rulingFileId: 'file-1',
+          appealRulingModifiedHistory: 'Leiðrétting eitt',
+        },
+        {
+          id: 'ro-2',
+          rulingFileId: 'file-2',
+          appealRulingModifiedHistory: 'Leiðrétting tvö',
+        },
+      ],
+    })
+
+    expect(
+      screen.getByText('Úrskurður Landsréttar leiðréttur — Úrskurður 15-2026'),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText('Úrskurður Landsréttar leiðréttur — Úrskurður 16-2026'),
+    ).toBeInTheDocument()
+    expect(screen.getByText('Leiðrétting eitt')).toBeInTheDocument()
+    expect(screen.getByText('Leiðrétting tvö')).toBeInTheDocument()
+  })
+
+  it('falls back to the plain title when the file name is missing', () => {
+    renderAlert({
+      id: 'case-1',
+      caseFiles: [],
+      rulingOrderAppealCases: [
+        {
+          id: 'ro-1',
+          rulingFileId: 'missing-file',
+          appealRulingModifiedHistory: 'Leiðrétting án skráarnafns',
+        },
+      ],
+    })
+
+    expect(
+      screen.getByText('Úrskurður Landsréttar leiðréttur'),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText('Leiðrétting án skráarnafns'),
+    ).toBeInTheDocument()
+  })
+})

--- a/apps/judicial-system/web/src/components/Alerts/AppealRulingModifiedAlert/AppealRulingModifiedAlert.spec.tsx
+++ b/apps/judicial-system/web/src/components/Alerts/AppealRulingModifiedAlert/AppealRulingModifiedAlert.spec.tsx
@@ -86,8 +86,6 @@ describe('AppealRulingModifiedAlert', () => {
     expect(
       screen.getByText('Úrskurður Landsréttar leiðréttur'),
     ).toBeInTheDocument()
-    expect(
-      screen.getByText('Leiðrétting án skráarnafns'),
-    ).toBeInTheDocument()
+    expect(screen.getByText('Leiðrétting án skráarnafns')).toBeInTheDocument()
   })
 })

--- a/apps/judicial-system/web/src/components/Alerts/AppealRulingModifiedAlert/AppealRulingModifiedAlert.tsx
+++ b/apps/judicial-system/web/src/components/Alerts/AppealRulingModifiedAlert/AppealRulingModifiedAlert.tsx
@@ -1,22 +1,64 @@
+import { useContext } from 'react'
+
 import { AlertMessage } from '@island.is/island-ui/core'
-import { MarkdownWrapper } from '@island.is/judicial-system-web/src/components'
-import { useTargetAppealCaseByAppealCaseId } from '@island.is/judicial-system-web/src/utils/hooks'
+import {
+  FormContext,
+  MarkdownWrapper,
+} from '@island.is/judicial-system-web/src/components'
+import { grid } from '@island.is/judicial-system-web/src/utils/styles/recipes.css'
+
+const modifiedTitle = 'Úrskurður Landsréttar leiðréttur'
 
 const AppealRulingModifiedAlert = () => {
-  const targetAppealCase = useTargetAppealCaseByAppealCaseId()
+  const { workingCase } = useContext(FormContext)
 
-  return targetAppealCase?.appealRulingModifiedHistory ? (
-    <AlertMessage
-      type="info"
-      title="Úrskurður Landsréttar leiðréttur"
-      message={
-        <MarkdownWrapper
-          markdown={targetAppealCase.appealRulingModifiedHistory}
-          textProps={{ variant: 'small' }}
+  const caseLevelHistory = workingCase.appealCase?.appealRulingModifiedHistory
+
+  const rulingOrderCorrections = (
+    workingCase.rulingOrderAppealCases ?? []
+  ).filter((appealCase) => Boolean(appealCase.appealRulingModifiedHistory))
+
+  if (!caseLevelHistory && rulingOrderCorrections.length === 0) {
+    return null
+  }
+
+  const rulingOrderTitle = (rulingFileId?: string | null) => {
+    const fileName = workingCase.caseFiles?.find(
+      (file) => file.id === rulingFileId,
+    )?.userGeneratedFilename
+
+    return fileName ? `${modifiedTitle} — ${fileName}` : modifiedTitle
+  }
+
+  return (
+    <div className={grid({ gap: 2 })}>
+      {caseLevelHistory && (
+        <AlertMessage
+          type="info"
+          title={modifiedTitle}
+          message={
+            <MarkdownWrapper
+              markdown={caseLevelHistory}
+              textProps={{ variant: 'small' }}
+            />
+          }
         />
-      }
-    />
-  ) : null
+      )}
+      {rulingOrderCorrections.map((appealCase) => (
+        <AlertMessage
+          key={appealCase.id}
+          type="info"
+          title={rulingOrderTitle(appealCase.rulingFileId)}
+          message={
+            <MarkdownWrapper
+              markdown={appealCase.appealRulingModifiedHistory ?? ''}
+              textProps={{ variant: 'small' }}
+            />
+          }
+        />
+      ))}
+    </div>
+  )
 }
 
 export default AppealRulingModifiedAlert

--- a/apps/judicial-system/web/src/components/Modals/ReopenModal/ReopenModal.tsx
+++ b/apps/judicial-system/web/src/components/Modals/ReopenModal/ReopenModal.tsx
@@ -25,7 +25,9 @@ import {
 import {
   useAppealCase,
   useCase,
+  useTargetAppealCaseByAppealCaseId,
 } from '@island.is/judicial-system-web/src/utils/hooks'
+import { appendAppealCaseIdQuery } from '@island.is/judicial-system-web/src/utils/utils'
 
 interface Props {
   onClose: () => void
@@ -37,12 +39,13 @@ const ReopenModal: FC<Props> = ({ onClose }) => {
   const { user } = useContext(UserContext)
   const { transitionCase, isTransitioningCase } = useCase()
   const { transitionAppealCase, isTransitioningAppealCase } = useAppealCase()
+  const targetAppealCase = useTargetAppealCaseByAppealCaseId()
 
   const handlePrimaryButtonClick = async () => {
     const caseTransitioned = isCourtOfAppealsUser(user)
       ? await transitionAppealCase(
           workingCase.id,
-          workingCase.appealCase?.id ?? '',
+          targetAppealCase?.id ?? workingCase.appealCase?.id ?? '',
           AppealCaseTransition.REOPEN_APPEAL,
         )
       : isRequestCase(workingCase.type)
@@ -52,7 +55,10 @@ const ReopenModal: FC<Props> = ({ onClose }) => {
     if (caseTransitioned) {
       router.push(
         isCourtOfAppealsUser(user)
-          ? `${COURT_OF_APPEAL_CASE_ROUTE}/${workingCase.id}`
+          ? appendAppealCaseIdQuery(
+              `${COURT_OF_APPEAL_CASE_ROUTE}/${workingCase.id}`,
+              targetAppealCase?.id,
+            )
           : isRestrictionCase(workingCase.type)
           ? `${DISTRICT_COURT_RESTRICTION_CASE_RECEPTION_AND_ASSIGNMENT_ROUTE}/${workingCase.id}`
           : isInvestigationCase(workingCase.type)

--- a/apps/judicial-system/web/src/components/Modals/RulingModifiedModal/RulingModifiedModal.tsx
+++ b/apps/judicial-system/web/src/components/Modals/RulingModifiedModal/RulingModifiedModal.tsx
@@ -21,6 +21,11 @@ interface Props {
   description: string
   defaultExplanation: string
   fieldToModify: 'rulingModifiedHistory' | 'appealRulingModifiedHistory'
+  // The appeal case to update when fieldToModify is
+  // 'appealRulingModifiedHistory'. Defaults to the case-level appeal so
+  // existing request-case behavior is preserved. Ruling-order appeals pass the
+  // resolved target appeal id here.
+  appealCaseId?: string
 }
 
 const RulingModifiedModal: FC<Props> = ({
@@ -30,6 +35,7 @@ const RulingModifiedModal: FC<Props> = ({
   description,
   defaultExplanation,
   fieldToModify,
+  appealCaseId,
 }) => {
   const { formatMessage } = useIntl()
   const { workingCase } = useContext(FormContext)
@@ -41,10 +47,12 @@ const RulingModifiedModal: FC<Props> = ({
 
   const handleContinue = async () => {
     if (fieldToModify === 'appealRulingModifiedHistory') {
-      if (workingCase.appealCase?.id) {
+      const targetAppealCaseId = appealCaseId ?? workingCase.appealCase?.id
+
+      if (targetAppealCaseId) {
         const result = await updateAppealCase(
           workingCase.id,
-          workingCase.appealCase.id,
+          targetAppealCaseId,
           { [fieldToModify]: explanation },
         )
 

--- a/apps/judicial-system/web/src/routes/Court/Indictments/Overview/Overview.tsx
+++ b/apps/judicial-system/web/src/routes/Court/Indictments/Overview/Overview.tsx
@@ -21,6 +21,7 @@ import {
 } from '@island.is/judicial-system/types'
 import { core, titles } from '@island.is/judicial-system-web/messages'
 import {
+  AppealRulingModifiedAlert,
   ConnectedCaseFilesAccordionItem,
   CourtCaseInfo,
   FormContentContainer,
@@ -72,6 +73,7 @@ const OverviewBody = ({
         <CourtCaseInfo workingCase={workingCase} />
         <ServiceAnnouncements defendants={workingCase.defendants} />
         <div className={grid({ gap: 5, marginBottom: 10 })}>
+          <AppealRulingModifiedAlert />
           {workingCase.reopenReason && !isCompletedCase(workingCase.state) && (
             <AlertMessage
               title="Mál enduropnað"

--- a/apps/judicial-system/web/src/routes/Court/Indictments/Summary/Summary.tsx
+++ b/apps/judicial-system/web/src/routes/Court/Indictments/Summary/Summary.tsx
@@ -21,6 +21,7 @@ import {
 import { hasGeneratedCourtRecordPdf } from '@island.is/judicial-system/types'
 import { core } from '@island.is/judicial-system-web/messages'
 import {
+  AppealRulingModifiedAlert,
   ConnectedCaseFilesAccordionItem,
   DateTime,
   FormContentContainer,
@@ -225,6 +226,7 @@ const Summary: FC = () => {
       <FormContentContainer>
         <PageTitle>{formatMessage(strings.title)}</PageTitle>
         <div className={grid({ gap: 5, marginBottom: 10 })}>
+          <AppealRulingModifiedAlert />
           <Box component="section" className={grid({ gap: 1 })}>
             <Text variant="h2" as="h2">
               {formatMessage(core.caseNumber, {

--- a/apps/judicial-system/web/src/routes/CourtOfAppeal/Summary/RulingModifiedModal/RulingModifiedModal.tsx
+++ b/apps/judicial-system/web/src/routes/CourtOfAppeal/Summary/RulingModifiedModal/RulingModifiedModal.tsx
@@ -2,6 +2,7 @@ import { FC } from 'react'
 import { useIntl } from 'react-intl'
 
 import { RulingModifiedModal as BaseModal } from '@island.is/judicial-system-web/src/components'
+import { useTargetAppealCaseByAppealCaseId } from '@island.is/judicial-system-web/src/utils/hooks'
 
 import { strings } from './RulingModifiedModal.strings'
 
@@ -17,6 +18,7 @@ const RulingModifiedModal: FC<Props> = ({
   continueDisabled,
 }) => {
   const { formatMessage } = useIntl()
+  const targetAppealCase = useTargetAppealCaseByAppealCaseId()
 
   return (
     <BaseModal
@@ -26,6 +28,7 @@ const RulingModifiedModal: FC<Props> = ({
       description={formatMessage(strings.description)}
       defaultExplanation={formatMessage(strings.autofill)}
       fieldToModify="appealRulingModifiedHistory"
+      appealCaseId={targetAppealCase?.id}
     />
   )
 }

--- a/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Overview/Overview.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Overview/Overview.tsx
@@ -20,6 +20,7 @@ import { isCompletedCase } from '@island.is/judicial-system/types'
 import { core, errors, titles } from '@island.is/judicial-system-web/messages'
 import {
   AllIndictmentCaseFiles,
+  AppealRulingModifiedAlert,
   BlueBox,
   ChangeProsecutorModal,
   FormContentContainer,
@@ -229,6 +230,7 @@ const Overview: FC = () => {
             </Box>
           )}
         <div className={grid({ gap: 5, marginBottom: 10 })}>
+          <AppealRulingModifiedAlert />
           <Box component="section">
             <InfoCardActiveIndictment
               displayVerdictViewDate

--- a/apps/judicial-system/web/src/utils/hooks/useAppealCase/index.ts
+++ b/apps/judicial-system/web/src/utils/hooks/useAppealCase/index.ts
@@ -11,6 +11,7 @@ import {
   Case,
   UpdateAppealCaseInput,
 } from '@island.is/judicial-system-web/src/graphql/schema'
+import { applyAppealCaseUpdate } from '@island.is/judicial-system-web/src/utils/utils'
 
 import {
   CreateAppealCaseMutation,
@@ -145,13 +146,13 @@ const useAppealCase = () => {
           }
 
           if (setWorkingCase) {
-            setWorkingCase((prevWorkingCase) => ({
-              ...prevWorkingCase,
-              appealCase: {
-                ...prevWorkingCase.appealCase,
-                ...appealCase,
-              } as AppealCase,
-            }))
+            setWorkingCase((prevWorkingCase) =>
+              applyAppealCaseUpdate(
+                prevWorkingCase,
+                appealCaseId,
+                appealCase as Partial<AppealCase>,
+              ),
+            )
           }
 
           return true


### PR DESCRIPTION
[Asana](https://app.asana.com/1/203394141643832/project/1212657017130395/task/1215200877326096?focus=true)

## What

Show an info box on case overview when ruling order appeal is corrected. 



## Screenshots / Gifs

Here is a ruling that was corrected twice:

<img width="858" height="647" alt="image" src="https://github.com/user-attachments/assets/7bbbc8d1-2365-4b0c-90f4-7640f69a393d" />

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Cursor


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added appeal ruling modification alerts to indictment overview and summary pages, highlighting corrected rulings and ruling-order appeal details.
  * Enhanced alert presentation to show case-level corrections and individual correction entries when available.

* **Improvements**
  * Updated reopen and “ruling modified” flows to use the appropriate appeal case context when continuing or navigating.

* **Tests**
  * Added/extended test coverage for corrected-ruling notification behavior and the alert component rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->