### PR TITLE
fix(driving-license-book): use GetStudentActiveLicenseBookBySsn for B+BE instructor change

### DIFF
--- a/libs/clients/driving-license-book/src/lib/__mock-data__/requestHandlers.ts
+++ b/libs/clients/driving-license-book/src/lib/__mock-data__/requestHandlers.ts
@@ -70,6 +70,37 @@ export const requestHandlers = [
     },
   ),
   rest.get(
+    url(
+      `r1/${XROAD_DRIVING_LICENSE_BOOK_PATH}/api/Student/GetStudentActiveLicenseBookBySsn/:ssn`,
+    ),
+    (req, res, ctx) => {
+      const isFound = req.params.ssn === MOCK_NATIONAL_ID_STUDENT
+      const licenseCategory = req.url.searchParams.get('licenseCategory')
+
+      // The mock student only has an active B book (no active BE book).
+      if (!isFound || licenseCategory !== 'B') {
+        return res(ctx.status(200), ctx.json({ data: null }))
+      }
+
+      return res(
+        ctx.status(200),
+        ctx.json({
+          data: {
+            id: MOCK_LICENSE_BOOK_ID,
+            licenseCategory: 'B',
+            createdOn: new Date(),
+            schoolSsn: MOCK_NATIONAL_ID_SCHOOL,
+            teacherSsn: MOCK_NATIONAL_ID_TEACHER_OLD,
+            studentEmail: null,
+            studentPrimaryPhoneNumber: null,
+            studentSecondaryPhoneNumber: null,
+            practiceDriving: true,
+          },
+        }),
+      )
+    },
+  ),
+  rest.get(
     url(`r1/${XROAD_DRIVING_LICENSE_BOOK_PATH}/api/Student/GetLicenseBook/:id`),
     (req, res, ctx) => {
       const isFound = req.params.id === MOCK_LICENSE_BOOK_ID

--- a/libs/clients/driving-license-book/src/lib/__mock-data__/requestHandlers.ts
+++ b/libs/clients/driving-license-book/src/lib/__mock-data__/requestHandlers.ts
@@ -22,7 +22,7 @@ export const MOCK_USER = {
   userAgent: '',
 } as User
 
-const url = (path: string) => {
+export const url = (path: string) => {
   return new URL(path, XROAD_BASE_PATH).toString()
 }
 

--- a/libs/clients/driving-license-book/src/lib/drivingLicenseBookClient.service.ts
+++ b/libs/clients/driving-license-book/src/lib/drivingLicenseBookClient.service.ts
@@ -1,6 +1,6 @@
 import {
-  BookOverview,
   Configuration,
+  DigitalBook,
   DrivingLicenseBookApi,
 } from '../../gen/fetch'
 import { createEnhancedFetch } from '@island.is/clients/middlewares'
@@ -25,6 +25,7 @@ import {
   DrivingLicenseBookStudentOverview,
   DrivingLicenseBookStudentsInput,
   LICENSE_CATEGORY_B,
+  LICENSE_CATEGORY_BE,
   Organization,
   PracticalDrivingLesson,
   PracticalDrivingLessonsInput,
@@ -45,6 +46,16 @@ import { LOGGER_PROVIDER } from '@island.is/logging'
 import type { Logger } from '@island.is/logging'
 
 const LOGTAG = '[driving-license-book-client]'
+
+// License categories that can have an active ökunám book in the
+// change-instructor flow. A student may hold several at once (e.g. B and BE),
+// so we look up the active book per category instead of guessing from the
+// student overview. Extend this list as more categories start issuing digital
+// books (e.g. advanced rights).
+const UPDATE_INSTRUCTOR_LICENSE_CATEGORIES = [
+  LICENSE_CATEGORY_B,
+  LICENSE_CATEGORY_BE,
+]
 
 @Injectable()
 export class DrivingLicenseBookClientApiFactory {
@@ -343,21 +354,6 @@ export class DrivingLicenseBookClientApiFactory {
     )
   }
 
-  private async getActiveBookId(nationalId: string): Promise<string | null> {
-    const api = await this.create()
-    const { data } = await api.apiStudentGetStudentActiveBookIdSsnGet({
-      ssn: nationalId,
-      licenseCategory: LICENSE_CATEGORY_B,
-    })
-    return data?.bookId || null
-  }
-
-  private async hasPracticeDriving(id: string): Promise<boolean> {
-    const api = await this.create()
-    const { data } = await api.apiStudentGetLicenseBookIdGet({ id })
-    return data?.practiceDriving || false
-  }
-
   async allowPracticeDriving({
     teacherNationalId,
     studentNationalId,
@@ -376,27 +372,68 @@ export class DrivingLicenseBookClientApiFactory {
     }
   }
 
-  async getActiveStudentBook(user: User): Promise<BookOverview | undefined> {
-    const api = await this.create()
-
-    const { data } = await api.apiStudentGetStudentOverviewSsnGet({
-      ssn: user.nationalId,
-      showInactiveBooks: false,
-    })
-
-    const activeBook = data?.books
-      ?.filter((item) => item.status !== 9)
-      ?.reduce(
-        (a, b) =>
-          new Date(a.createdOn ?? '') > new Date(b.createdOn ?? '') ? a : b,
-        {},
+  private async getActiveLicenseBookByCategory(
+    api: DrivingLicenseBookApi,
+    nationalId: string,
+    licenseCategory: string,
+  ): Promise<DigitalBook | undefined> {
+    try {
+      const { data } =
+        await api.apiStudentGetStudentActiveLicenseBookBySsnSsnGet({
+          ssn: nationalId,
+          licenseCategory,
+        })
+      // Only treat it as an active book if it actually carries an id.
+      return data?.id ? data : undefined
+    } catch (e) {
+      // No active book for this category (e.g. the student isn't taking it).
+      // Not an error for the overall flow – other categories may still match.
+      this.logger.debug(
+        `${LOGTAG} No active ${licenseCategory} book for student`,
       )
+      return undefined
+    }
+  }
 
-    if (!activeBook?.id || !activeBook?.createdOn) {
+  private async fetchActiveStudentBooks(
+    api: DrivingLicenseBookApi,
+    nationalId: string,
+  ): Promise<DigitalBook[]> {
+    const books = await Promise.all(
+      UPDATE_INSTRUCTOR_LICENSE_CATEGORIES.map((licenseCategory) =>
+        this.getActiveLicenseBookByCategory(api, nationalId, licenseCategory),
+      ),
+    )
+
+    // Drop empty categories and de-duplicate in case the backend returns the
+    // same book for more than one category.
+    const seen = new Set<string>()
+    return books.filter((book): book is DigitalBook => {
+      if (!book?.id || seen.has(book.id)) {
+        return false
+      }
+      seen.add(book.id)
+      return true
+    })
+  }
+
+  async getActiveStudentBook(user: User): Promise<DigitalBook | undefined> {
+    const api = await this.create()
+    const activeBooks = await this.fetchActiveStudentBooks(api, user.nationalId)
+
+    if (activeBooks.length === 0) {
       return undefined
     }
 
-    return activeBook
+    // When several categories are active, surface the most recently created
+    // book (the instructor is shared across them in practice).
+    return activeBooks.reduce(
+      (mostRecent, book) =>
+        new Date(book.createdOn ?? '') > new Date(mostRecent.createdOn ?? '')
+          ? book
+          : mostRecent,
+      activeBooks[0],
+    )
   }
 
   async updateActiveStudentBookInstructor(
@@ -405,37 +442,38 @@ export class DrivingLicenseBookClientApiFactory {
   ): Promise<{ success: boolean }> {
     const api = await this.create()
 
-    const activeBook = await this.getActiveStudentBook(user)
-    if (!activeBook) {
+    const activeBooks = await this.fetchActiveStudentBooks(api, user.nationalId)
+    if (activeBooks.length === 0) {
       throw new NotFoundException(
         `Active book for national id ${user.nationalId} not found`,
       )
     }
 
-    const { data } = await api.apiStudentGetStudentOverviewSsnGet({
-      ssn: user.nationalId,
-      showInactiveBooks: false,
-    })
-
-    const hasPracticeDriving = await this.hasPracticeDriving(
-      activeBook.id || '',
-    )
-
     try {
-      await api.apiStudentUpdateLicenseBookIdPut({
-        id: activeBook.id || '',
-        digitalBookUpdateRequestBody: {
-          createdOn: activeBook.createdOn || '',
-          teacherSsn: newTeacherSsn,
-          schoolSsn: activeBook.schoolSsn,
-          studentEmail: data?.email,
-          studentPrimaryPhoneNumber: data?.primaryPhoneNumber,
-          studentSecondaryPhoneNumber: data?.secondaryPhoneNumber,
-          practiceDriving: hasPracticeDriving,
-        },
-      })
+      // A student can be taking several categories (e.g. B and BE) at once –
+      // update the instructor on every active book.
+      await Promise.all(
+        activeBooks.map((book) =>
+          api.apiStudentUpdateLicenseBookIdPut({
+            id: book.id ?? '',
+            digitalBookUpdateRequestBody: {
+              createdOn: book.createdOn ?? '',
+              teacherSsn: newTeacherSsn,
+              schoolSsn: book.schoolSsn,
+              studentEmail: book.studentEmail,
+              studentPrimaryPhoneNumber: book.studentPrimaryPhoneNumber,
+              studentSecondaryPhoneNumber: book.studentSecondaryPhoneNumber,
+              practiceDriving: book.practiceDriving,
+            },
+          }),
+        ),
+      )
       return { success: true }
     } catch (e) {
+      this.logger.error(
+        `${LOGTAG} Error updating driving license book instructor`,
+        e,
+      )
       return { success: false }
     }
   }

--- a/libs/clients/driving-license-book/src/lib/drivingLicenseBookClient.service.ts
+++ b/libs/clients/driving-license-book/src/lib/drivingLicenseBookClient.service.ts
@@ -3,7 +3,7 @@ import {
   DigitalBook,
   DrivingLicenseBookApi,
 } from '../../gen/fetch'
-import { createEnhancedFetch } from '@island.is/clients/middlewares'
+import { createEnhancedFetch, FetchError } from '@island.is/clients/middlewares'
 import { XRoadConfig } from '@island.is/nest/config'
 import type { ConfigType } from '@island.is/nest/config'
 import { DrivingLicenseBookClientConfig } from './drivingLicenseBookClient.config'
@@ -56,6 +56,14 @@ const UPDATE_INSTRUCTOR_LICENSE_CATEGORIES = [
   LICENSE_CATEGORY_B,
   LICENSE_CATEGORY_BE,
 ]
+
+// An active book we can actually act on: it must have an id (to address the
+// update) and a createdOn (the update endpoint requires a non-empty yyyy-MM-dd).
+type ActiveLicenseBook = DigitalBook & { id: string; createdOn: string }
+
+const isActiveLicenseBook = (
+  book: DigitalBook | undefined,
+): book is ActiveLicenseBook => !!book?.id && !!book?.createdOn
 
 @Injectable()
 export class DrivingLicenseBookClientApiFactory {
@@ -383,33 +391,37 @@ export class DrivingLicenseBookClientApiFactory {
           ssn: nationalId,
           licenseCategory,
         })
-      // Only treat it as an active book if it actually carries an id.
-      return data?.id ? data : undefined
-    } catch (e) {
-      // No active book for this category (e.g. the student isn't taking it).
-      // Not an error for the overall flow – other categories may still match.
-      this.logger.debug(
-        `${LOGTAG} No active ${licenseCategory} book for student`,
-      )
-      return undefined
+      return data ?? undefined
+    } catch (error) {
+      // Only swallow the "no active book for this category" case – a student
+      // may legitimately have a book in one category but not another. Any other
+      // failure (401/403/5xx/timeout) must propagate, otherwise we could update
+      // some of a student's books, miss others, and still report success.
+      if (error instanceof FetchError && error.status === 404) {
+        this.logger.debug(
+          `${LOGTAG} No active ${licenseCategory} book for student`,
+        )
+        return undefined
+      }
+      throw error
     }
   }
 
   private async fetchActiveStudentBooks(
     api: DrivingLicenseBookApi,
     nationalId: string,
-  ): Promise<DigitalBook[]> {
+  ): Promise<ActiveLicenseBook[]> {
     const books = await Promise.all(
       UPDATE_INSTRUCTOR_LICENSE_CATEGORIES.map((licenseCategory) =>
         this.getActiveLicenseBookByCategory(api, nationalId, licenseCategory),
       ),
     )
 
-    // Drop empty categories and de-duplicate in case the backend returns the
-    // same book for more than one category.
+    // Keep only usable books (id + createdOn) and de-duplicate in case the
+    // backend returns the same book for more than one category.
     const seen = new Set<string>()
-    return books.filter((book): book is DigitalBook => {
-      if (!book?.id || seen.has(book.id)) {
+    return books.filter(isActiveLicenseBook).filter((book) => {
+      if (seen.has(book.id)) {
         return false
       }
       seen.add(book.id)
@@ -429,7 +441,7 @@ export class DrivingLicenseBookClientApiFactory {
     // book (the instructor is shared across them in practice).
     return activeBooks.reduce(
       (mostRecent, book) =>
-        new Date(book.createdOn ?? '') > new Date(mostRecent.createdOn ?? '')
+        new Date(book.createdOn) > new Date(mostRecent.createdOn)
           ? book
           : mostRecent,
       activeBooks[0],
@@ -455,9 +467,9 @@ export class DrivingLicenseBookClientApiFactory {
       await Promise.all(
         activeBooks.map((book) =>
           api.apiStudentUpdateLicenseBookIdPut({
-            id: book.id ?? '',
+            id: book.id,
             digitalBookUpdateRequestBody: {
-              createdOn: book.createdOn ?? '',
+              createdOn: book.createdOn,
               teacherSsn: newTeacherSsn,
               schoolSsn: book.schoolSsn,
               studentEmail: book.studentEmail,

--- a/libs/clients/driving-license-book/src/lib/drivingLicenseBookClient.service.ts
+++ b/libs/clients/driving-license-book/src/lib/drivingLicenseBookClient.service.ts
@@ -461,33 +461,42 @@ export class DrivingLicenseBookClientApiFactory {
       )
     }
 
-    try {
-      // A student can be taking several categories (e.g. B and BE) at once –
-      // update the instructor on every active book.
-      await Promise.all(
-        activeBooks.map((book) =>
-          api.apiStudentUpdateLicenseBookIdPut({
-            id: book.id,
-            digitalBookUpdateRequestBody: {
-              createdOn: book.createdOn,
-              teacherSsn: newTeacherSsn,
-              schoolSsn: book.schoolSsn,
-              studentEmail: book.studentEmail,
-              studentPrimaryPhoneNumber: book.studentPrimaryPhoneNumber,
-              studentSecondaryPhoneNumber: book.studentSecondaryPhoneNumber,
-              practiceDriving: book.practiceDriving,
-            },
-          }),
-        ),
-      )
-      return { success: true }
-    } catch (e) {
+    // A student can be taking several categories (e.g. B and BE) at once –
+    // update the instructor on every active book. Use allSettled so every PUT
+    // is awaited even when one fails, and we can report exactly which book(s)
+    // failed instead of aborting on the first rejection.
+    const results = await Promise.allSettled(
+      activeBooks.map((book) =>
+        api.apiStudentUpdateLicenseBookIdPut({
+          id: book.id,
+          digitalBookUpdateRequestBody: {
+            createdOn: book.createdOn,
+            teacherSsn: newTeacherSsn,
+            schoolSsn: book.schoolSsn,
+            studentEmail: book.studentEmail,
+            studentPrimaryPhoneNumber: book.studentPrimaryPhoneNumber,
+            studentSecondaryPhoneNumber: book.studentSecondaryPhoneNumber,
+            practiceDriving: book.practiceDriving,
+          },
+        }),
+      ),
+    )
+
+    const failures = results.flatMap((result, index) =>
+      result.status === 'rejected'
+        ? [{ bookId: activeBooks[index].id, reason: result.reason }]
+        : [],
+    )
+
+    if (failures.length > 0) {
       this.logger.error(
         `${LOGTAG} Error updating driving license book instructor`,
-        e,
+        failures,
       )
       return { success: false }
     }
+
+    return { success: true }
   }
 
   async getTeacher(nationalId: string): Promise<TeacherRights> {

--- a/libs/clients/driving-license-book/src/lib/drivingLicenseBookClient.spec.ts
+++ b/libs/clients/driving-license-book/src/lib/drivingLicenseBookClient.spec.ts
@@ -1,3 +1,4 @@
+import { rest, RequestHandler } from 'msw'
 import { Test } from '@nestjs/testing'
 import { startMocking } from '@island.is/shared/mocking'
 import { ConfigModule, XRoadConfig } from '@island.is/nest/config'
@@ -6,15 +7,32 @@ import { DrivingLicenseBookClientApiFactory } from './drivingLicenseBookClient.s
 import { DrivingLicenseBookClientModule } from './drivingLicenseBookClient.module'
 import { DrivingLicenseBookClientConfig } from './drivingLicenseBookClient.config'
 import {
+  MOCK_NATIONAL_ID_SCHOOL,
   MOCK_NATIONAL_ID_STUDENT,
   MOCK_NATIONAL_ID_TEACHER_INVALID,
   MOCK_NATIONAL_ID_TEACHER_NEW,
   MOCK_NATIONAL_ID_TEACHER_OLD,
   MOCK_USER,
   requestHandlers,
+  url,
+  XROAD_DRIVING_LICENSE_BOOK_PATH,
 } from './__mock-data__/requestHandlers'
 
-startMocking(requestHandlers)
+// startMocking returns the msw node server; narrow it so we can install
+// per-test handler overrides.
+const server = startMocking(requestHandlers) as unknown as {
+  use: (...handlers: RequestHandler[]) => void
+  resetHandlers: () => void
+}
+
+const activeLicenseBookUrl = url(
+  `r1/${XROAD_DRIVING_LICENSE_BOOK_PATH}/api/Student/GetStudentActiveLicenseBookBySsn/:ssn`,
+)
+const updateLicenseBookUrl = url(
+  `r1/${XROAD_DRIVING_LICENSE_BOOK_PATH}/api/Student/UpdateLicenseBook/:id`,
+)
+
+afterEach(() => server.resetHandlers())
 describe('DrivingLicenseBookClientApiFactory', () => {
   let service: DrivingLicenseBookClientApiFactory
 
@@ -90,6 +108,143 @@ describe('DrivingLicenseBookClientApiFactory', () => {
       expect(response).toStrictEqual({
         success: false,
       })
+    })
+
+    it('updates the instructor on every active book when several categories are active (B and BE)', async () => {
+      const puts: { id: string; body: Record<string, unknown> }[] = []
+
+      server.use(
+        rest.get(activeLicenseBookUrl, (req, res, ctx) => {
+          const licenseCategory = req.url.searchParams.get('licenseCategory')
+          const book =
+            licenseCategory === 'B'
+              ? {
+                  id: 'book-B',
+                  licenseCategory: 'B',
+                  createdOn: '2024-01-01',
+                  schoolSsn: MOCK_NATIONAL_ID_SCHOOL,
+                  teacherSsn: MOCK_NATIONAL_ID_TEACHER_OLD,
+                  studentEmail: 'b@example.is',
+                  practiceDriving: true,
+                }
+              : licenseCategory === 'BE'
+              ? {
+                  id: 'book-BE',
+                  licenseCategory: 'BE',
+                  createdOn: '2024-02-02',
+                  schoolSsn: MOCK_NATIONAL_ID_SCHOOL,
+                  teacherSsn: MOCK_NATIONAL_ID_TEACHER_OLD,
+                  studentEmail: 'be@example.is',
+                  practiceDriving: false,
+                }
+              : null
+          return res(ctx.status(200), ctx.json({ data: book }))
+        }),
+        rest.put(updateLicenseBookUrl, async (req, res, ctx) => {
+          puts.push({
+            id: req.params.id as string,
+            body: (await req.json()) as Record<string, unknown>,
+          })
+          return res(ctx.status(200))
+        }),
+      )
+
+      const response = await service.updateActiveStudentBookInstructor(
+        MOCK_USER,
+        MOCK_NATIONAL_ID_TEACHER_NEW,
+      )
+
+      expect(response).toStrictEqual({ success: true })
+      // Both the B and BE books are updated, each via its own PUT.
+      expect(puts).toHaveLength(2)
+      expect(puts.map((put) => put.id).sort()).toStrictEqual([
+        'book-B',
+        'book-BE',
+      ])
+      // Every book gets the new instructor...
+      expect(
+        puts.every(
+          (put) => put.body.teacherSsn === MOCK_NATIONAL_ID_TEACHER_NEW,
+        ),
+      ).toBe(true)
+      // ...while each book keeps its own details.
+      const bookBE = puts.find((put) => put.id === 'book-BE')
+      expect(bookBE?.body.createdOn).toBe('2024-02-02')
+      expect(bookBE?.body.studentEmail).toBe('be@example.is')
+      expect(bookBE?.body.practiceDriving).toBe(false)
+    })
+
+    it('still updates the B book when the BE lookup reports no active book (404)', async () => {
+      const puts: string[] = []
+
+      server.use(
+        rest.get(activeLicenseBookUrl, (req, res, ctx) => {
+          const licenseCategory = req.url.searchParams.get('licenseCategory')
+          if (licenseCategory === 'B') {
+            return res(
+              ctx.status(200),
+              ctx.json({
+                data: {
+                  id: 'book-B',
+                  createdOn: '2024-01-01',
+                  schoolSsn: MOCK_NATIONAL_ID_SCHOOL,
+                  teacherSsn: MOCK_NATIONAL_ID_TEACHER_OLD,
+                },
+              }),
+            )
+          }
+          return res(ctx.status(404), ctx.text('No active book'))
+        }),
+        rest.put(updateLicenseBookUrl, (req, res, ctx) => {
+          puts.push(req.params.id as string)
+          return res(ctx.status(200))
+        }),
+      )
+
+      const response = await service.updateActiveStudentBookInstructor(
+        MOCK_USER,
+        MOCK_NATIONAL_ID_TEACHER_NEW,
+      )
+
+      expect(response).toStrictEqual({ success: true })
+      expect(puts).toStrictEqual(['book-B'])
+    })
+
+    it('does not silently succeed when a category lookup fails unexpectedly', async () => {
+      const puts: string[] = []
+
+      server.use(
+        rest.get(activeLicenseBookUrl, (req, res, ctx) => {
+          const licenseCategory = req.url.searchParams.get('licenseCategory')
+          if (licenseCategory === 'B') {
+            return res(
+              ctx.status(200),
+              ctx.json({
+                data: {
+                  id: 'book-B',
+                  createdOn: '2024-01-01',
+                  schoolSsn: MOCK_NATIONAL_ID_SCHOOL,
+                  teacherSsn: MOCK_NATIONAL_ID_TEACHER_OLD,
+                },
+              }),
+            )
+          }
+          // Unexpected failure on the BE lookup (token/permission/server error).
+          return res(ctx.status(500), ctx.text('Internal error'))
+        }),
+        rest.put(updateLicenseBookUrl, (req, res, ctx) => {
+          puts.push(req.params.id as string)
+          return res(ctx.status(200))
+        }),
+      )
+
+      // Must reject rather than report success after updating only some books.
+      await expect(
+        service.updateActiveStudentBookInstructor(
+          MOCK_USER,
+          MOCK_NATIONAL_ID_TEACHER_NEW,
+        ),
+      ).rejects.toThrow()
     })
   })
 })

--- a/libs/clients/driving-license-book/src/lib/drivingLicenseBookClient.spec.ts
+++ b/libs/clients/driving-license-book/src/lib/drivingLicenseBookClient.spec.ts
@@ -60,6 +60,15 @@ describe('DrivingLicenseBookClientApiFactory', () => {
     })
   })
 
+  describe('getActiveStudentBook', () => {
+    it('should return the active book with the current instructor', async () => {
+      const response = await service.getActiveStudentBook(MOCK_USER)
+
+      expect(response?.id).toBeTruthy()
+      expect(response?.teacherSsn).toBe(MOCK_NATIONAL_ID_TEACHER_OLD)
+    })
+  })
+
   describe('updateActiveStudentBookInstructor', () => {
     it('student should be able to update the instructor with a valid instructor national id', async () => {
       const response = await service.updateActiveStudentBookInstructor(

--- a/libs/clients/driving-license-book/src/lib/drivingLicenseBookType.types.ts
+++ b/libs/clients/driving-license-book/src/lib/drivingLicenseBookType.types.ts
@@ -1,4 +1,5 @@
 export const LICENSE_CATEGORY_B = 'B'
+export const LICENSE_CATEGORY_BE = 'BE'
 
 export interface CreatePracticalDrivingLessonInput {
   bookId: string


### PR DESCRIPTION
Asana: https://app.asana.com/1/23849317865981/project/1204431115744096/task/1215958659896918

## What

In the **Ökunám – Ökukennari** change-instructor flow (`okunam-okukennari`), switch the driving-license-book client from `GetStudentOverview/:ssn` (returns a list of books, of which only the first/most-recent was used) to `GetStudentActiveLicenseBookBySsn/:ssn?licenseCategory=`, called for **both B and BE**.

- `getActiveStudentBook` (current-instructor display) and `updateActiveStudentBookInstructor` (submit) now look up the active book **per category** and the update applies the new instructor to **every** active book.
- The new endpoint returns `studentEmail`, phone numbers and `practiceDriving` per book, so the extra `GetStudentOverview` and `GetLicenseBook` calls were removed (along with now-dead helpers).
- Categories are driven by a single list, so adding future categories (e.g. advanced rights) is a one-line change.

## Why

Today a student can only have one active book, so picking the first one happens to work. Once more categories are issued as digital books, a student can hold several active books at once (e.g. B **and** BE) and the old approach would silently update only one. This makes the flow correct for the multi-category future.

## Known limitation

With multiple active categories the instructor is updated per book and the operation is **non-atomic** — if one book's PUT fails, the method reports failure (and logs the failing `bookId`) even though an earlier book may already have been updated. Retry is safe (idempotent re-PUT). This is still strictly better than the previous behaviour, which silently updated only one of the books.

## Screenshots / Gifs

No UI change. Backend/client behaviour only.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for new driving license category **BE**.
  * Enhanced the mock API to return active license book data based on **SSN** and **license category**.

* **Improvements**
  * Refined active license book selection using category-based “active” lookups and newest actionable selection.
  * Updated instructor assignment to update **all** active books concurrently, returning clear success/failure outcomes.

* **Tests**
  * Expanded test coverage for active book retrieval and instructor update scenarios, including multi-category and error handling cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
