### PR TITLE
fix(j-s): set null on case_file FKs when claimant/defendant deleted

### DIFF
--- a/apps/judicial-system/backend/migrations/20260623120000-case-file-claimant-defendant-on-delete-set-null.js
+++ b/apps/judicial-system/backend/migrations/20260623120000-case-file-claimant-defendant-on-delete-set-null.js
@@ -1,0 +1,76 @@
+'use strict'
+
+// Adds ON DELETE SET NULL to the case_file -> civil_claimant and
+// case_file -> defendant foreign keys.
+//
+// Both civil_claimant_id and defendant_id were originally added (in
+// 20241122091513-update-case-file.js) with no onDelete behavior, so Postgres
+// defaulted to NO ACTION. Deleting a civil_claimant or defendant that is still
+// referenced by a case_file row therefore failed with:
+//   violates foreign key constraint "case_file_civil_claimant_id_fkey"
+//   violates foreign key constraint "case_file_defendant_id_fkey"
+// This happens when a claimant/defendant with an uploaded file (e.g. a
+// CIVIL_CLAIM document, or a CRIMINAL_RECORD) is removed. case_file rows are
+// soft-deleted, so they keep their foreign keys and keep blocking the delete.
+//
+// SET NULL keeps the case_file rows intact and just clears the dangling
+// reference when the claimant/defendant is deleted.
+module.exports = {
+  up: (queryInterface) =>
+    queryInterface.sequelize.transaction(async (transaction) => {
+      await queryInterface.sequelize.query(
+        `ALTER TABLE case_file
+           DROP CONSTRAINT case_file_civil_claimant_id_fkey`,
+        { transaction },
+      )
+      await queryInterface.sequelize.query(
+        `ALTER TABLE case_file
+           ADD CONSTRAINT case_file_civil_claimant_id_fkey
+           FOREIGN KEY (civil_claimant_id)
+           REFERENCES civil_claimant (id)
+           ON DELETE SET NULL`,
+        { transaction },
+      )
+      await queryInterface.sequelize.query(
+        `ALTER TABLE case_file
+           DROP CONSTRAINT case_file_defendant_id_fkey`,
+        { transaction },
+      )
+      await queryInterface.sequelize.query(
+        `ALTER TABLE case_file
+           ADD CONSTRAINT case_file_defendant_id_fkey
+           FOREIGN KEY (defendant_id)
+           REFERENCES defendant (id)
+           ON DELETE SET NULL`,
+        { transaction },
+      )
+    }),
+
+  down: (queryInterface) =>
+    queryInterface.sequelize.transaction(async (transaction) => {
+      await queryInterface.sequelize.query(
+        `ALTER TABLE case_file
+           DROP CONSTRAINT case_file_civil_claimant_id_fkey`,
+        { transaction },
+      )
+      await queryInterface.sequelize.query(
+        `ALTER TABLE case_file
+           ADD CONSTRAINT case_file_civil_claimant_id_fkey
+           FOREIGN KEY (civil_claimant_id)
+           REFERENCES civil_claimant (id)`,
+        { transaction },
+      )
+      await queryInterface.sequelize.query(
+        `ALTER TABLE case_file
+           DROP CONSTRAINT case_file_defendant_id_fkey`,
+        { transaction },
+      )
+      await queryInterface.sequelize.query(
+        `ALTER TABLE case_file
+           ADD CONSTRAINT case_file_defendant_id_fkey
+           FOREIGN KEY (defendant_id)
+           REFERENCES defendant (id)`,
+        { transaction },
+      )
+    }),
+}


### PR DESCRIPTION
# Set ON DELETE SET NULL on case_file foreign keys

## What

Adds `ON DELETE SET NULL` to the `case_file.civil_claimant_id` and `case_file.defendant_id` foreign keys via a single migration.

## Why

Datadog reported:

```
update or delete on table "civil_claimant" violates foreign key constraint
"case_file_civil_claimant_id_fkey" on table "case_file"
```

Both `civil_claimant_id` and `defendant_id` were originally added (in `20241122091513-update-case-file.js`) with `references` but no `onDelete`, so Postgres defaulted to `NO ACTION`. Deleting a civil claimant or defendant that is still referenced by a `case_file` row therefore failed.

This is reachable in normal use:
- A prosecutor uploads a `CIVIL_CLAIM` document for a civil claimant, then removes the claimant or toggles "Er bótakrafa?" off (`deleteAll`).
- A defendant with an attached file (e.g. `CRIMINAL_RECORD`) is removed.

Because case files are **soft-deleted** (the row stays, only `state` flips to `DELETED`), the row keeps its foreign key even after the file is "removed" in the UI — so it keeps blocking the delete.

`SET NULL` keeps the `case_file` rows intact and just clears the dangling reference when the claimant/defendant is deleted. No application code changes are needed — both deletion paths now resolve at the DB level.

## Verification

- `up` applied locally; both `case_file_civil_claimant_id_fkey` and `case_file_defendant_id_fkey` report `confdeltype = 'n'` (SET NULL) in `pg_constraint`.
- `down` reverts both back to `'a'` (NO ACTION); re-applying `up` restores the fix.

## Screenshots / Gifs


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced system reliability when removing claimant and defendant records from case files, preventing conflicts during data management operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->