### PR TITLE
fix(j-s): hide extension steps in side panel for duplicated indictment drafts

### DIFF
--- a/apps/judicial-system/web/src/utils/hooks/useSections/index.ts
+++ b/apps/judicial-system/web/src/utils/hooks/useSections/index.ts
@@ -1522,6 +1522,9 @@ const useSections = (
   }
 
   const getSections = (workingCase: Case, user?: User): RouteSection[] => {
+    const isExtensionCase =
+      Boolean(workingCase.parentCase) && !isIndictmentCase(workingCase.type)
+
     return [
       isRestrictionCase(workingCase.type)
         ? getRestrictionCaseProsecutorSection(workingCase, user)
@@ -1537,20 +1540,20 @@ const useSections = (
         name: formatCaseResult(
           formatMessage,
           workingCase,
-          workingCase.parentCase
+          isExtensionCase && workingCase.parentCase
             ? workingCase.parentCase.state
             : workingCase.state,
         ),
         isActive:
           (workingCase.appealCase?.appealState === AppealCaseState.WITHDRAWN &&
             !workingCase.appealCase?.appealReceivedByCourtDate) ||
-          (!workingCase.parentCase &&
+          (!isExtensionCase &&
             isCompletedCase(workingCase.state) &&
             !workingCase.hasBeenAppealed &&
             workingCase.appealCase?.appealState !== AppealCaseState.COMPLETED),
         children: [],
       },
-      ...(workingCase.parentCase
+      ...(isExtensionCase
         ? [
             isRestrictionCase(workingCase.type)
               ? getRestrictionCaseExtensionSections(workingCase, user)

--- a/apps/judicial-system/web/src/utils/hooks/useSections/useSections.spec.tsx
+++ b/apps/judicial-system/web/src/utils/hooks/useSections/useSections.spec.tsx
@@ -199,4 +199,36 @@ describe('useSections getSections', () => {
       { children: [], isActive: false, name: expect.any(String) },
     ])
   })
+
+  it('should not append extension sections for indictment cases copied to draft (with a parentCase)', () => {
+    const c: Case = {
+      type: CaseType.INDICTMENT,
+      created: faker.date.past().toISOString(),
+      modified: faker.date.past().toISOString(),
+      id: faker.datatype.uuid(),
+      state: CaseState.DRAFT,
+      policeCaseNumbers: [],
+      parentCase: {
+        type: CaseType.INDICTMENT,
+        created: faker.date.past().toISOString(),
+        modified: faker.date.past().toISOString(),
+        id: faker.datatype.uuid(),
+        state: CaseState.COMPLETED,
+        policeCaseNumbers: [],
+      },
+    }
+    const { result } = renderHook(() => useSections(), {
+      wrapper: makeWrapper(c),
+    })
+
+    const sections = result.current.getSections(c, u)
+
+    // A duplicated indictment draft links to its original via `parentCase`,
+    // but must still render only the three normal indictment sections — no
+    // restriction/investigation extension steps ("Krafa um framlengingu" etc.).
+    expect(sections).toHaveLength(3)
+    expect(sections.map((section) => section.name)).not.toContain(
+      'Krafa um framlengingu',
+    )
+  })
 })


### PR DESCRIPTION
# Fix SidePanel showing extension steps for duplicated indictment drafts

## What

When an indictment is copied to a new draft (the "Afrita mál í drög" flow added in #22934), the side panel incorrectly showed the restriction/investigation **extension** steps — **"Krafa um framlengingu"**, **"Úrskurður Héraðsdóms"** and **"Niðurstaða"**. This PR makes a duplicated indictment draft render only the normal indictment steps.

## Why

Duplicated indictment drafts now keep a `parentCase` link (purely so police-system / LÖKE communication resolves to the original ancestor). But `getSections` in `useSections` appended an extension block whenever `workingCase.parentCase` was truthy, and that block only branched on restriction vs. investigation case types — it had no indictment branch. Historically only restriction/investigation cases ever had a `parentCase` (via "extend"), so this was safe until #22934 set `parentCase` on indictment drafts, which then fell into the investigation branch and rendered the wrong steps.

The fix gates all `parentCase`-driven extension logic in `getSections` behind a `!isIndictmentCase(...)` check (`isExtensionCase`), so the restriction/investigation extend flow is unchanged while indictment drafts render only their three normal sections with the correct "Niðurstaða" label.

## Screenshots / Gifs


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed case state display for extension cases to correctly show parent case information when applicable.
  * Corrected section visibility for duplicated indictment cases to display only the relevant case sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->