### PR TITLE
chore(j-s): Add tooltip on warning triangle

### DIFF
--- a/apps/judicial-system/web/src/components/IndictmentCaseFilesList/RulingOrderFileRow.tsx
+++ b/apps/judicial-system/web/src/components/IndictmentCaseFilesList/RulingOrderFileRow.tsx
@@ -237,6 +237,11 @@ const RulingOrderFileRow: FC<Props> = ({ file, onOpenFile }) => {
     statusIconColor = 'yellow600'
   }
 
+  const statusIconTooltip =
+    statusIcon === 'warning' && hasBeenAppealed
+      ? 'Kæruferli í gangi'
+      : undefined
+
   const showCompletedPill =
     appealCase?.appealState === AppealCaseState.COMPLETED
 
@@ -250,6 +255,7 @@ const RulingOrderFileRow: FC<Props> = ({ file, onOpenFile }) => {
           subtitle={statusText}
           subtitleIcon={statusIcon}
           subtitleIconColor={statusIconColor}
+          subtitleIconTooltip={statusIconTooltip}
           renderAs="row"
           disabled={!file.isKeyAccessible}
           handleClick={() => onOpenFile(file.id)}

--- a/apps/judicial-system/web/src/components/PdfButton/PdfButton.tsx
+++ b/apps/judicial-system/web/src/components/PdfButton/PdfButton.tsx
@@ -1,7 +1,14 @@
 import { ComponentProps, FC, PropsWithChildren, useContext } from 'react'
 import cn from 'classnames'
 
-import { Box, Button, Icon, IconMapIcon, Text } from '@island.is/island-ui/core'
+import {
+  Box,
+  Button,
+  Icon,
+  IconMapIcon,
+  Text,
+  Tooltip,
+} from '@island.is/island-ui/core'
 import { api } from '@island.is/judicial-system-web/src/services'
 
 import { UserContext } from '../UserProvider/UserProvider'
@@ -14,6 +21,7 @@ interface Props {
   subtitle?: string | null
   subtitleIcon?: IconMapIcon
   subtitleIconColor?: ComponentProps<typeof Icon>['color']
+  subtitleIconTooltip?: string
   pdfType?:
     | 'ruling'
     | 'caseFilesRecord'
@@ -42,6 +50,7 @@ const PdfButton: FC<PropsWithChildren<Props>> = ({
   subtitle,
   subtitleIcon,
   subtitleIconColor,
+  subtitleIconTooltip,
   pdfType,
   disabled,
   renderAs = 'button',
@@ -113,9 +122,14 @@ const PdfButton: FC<PropsWithChildren<Props>> = ({
       </Box>
       {subtitle && (
         <Box marginTop={1} display="flex" alignItems="center" columnGap={1}>
-          {subtitleIcon && (
-            <Icon icon={subtitleIcon} color={subtitleIconColor} />
-          )}
+          {subtitleIcon &&
+            (subtitleIconTooltip ? (
+              <Tooltip text={subtitleIconTooltip} placement="top">
+                <Icon icon={subtitleIcon} color={subtitleIconColor} />
+              </Tooltip>
+            ) : (
+              <Icon icon={subtitleIcon} color={subtitleIconColor} />
+            ))}
           <Text variant="small" color="dark400">
             {subtitle}
           </Text>

--- a/apps/judicial-system/web/src/components/PdfButton/PdfButton.tsx
+++ b/apps/judicial-system/web/src/components/PdfButton/PdfButton.tsx
@@ -125,7 +125,9 @@ const PdfButton: FC<PropsWithChildren<Props>> = ({
           {subtitleIcon &&
             (subtitleIconTooltip ? (
               <Tooltip text={subtitleIconTooltip} placement="top">
-                <Icon icon={subtitleIcon} color={subtitleIconColor} />
+                <span>
+                  <Icon icon={subtitleIcon} color={subtitleIconColor} />
+                </span>
               </Tooltip>
             ) : (
               <Icon icon={subtitleIcon} color={subtitleIconColor} />


### PR DESCRIPTION
[Asana](https://app.asana.com/1/203394141643832/project/1212657017130395/task/1215433969546540?focus=true)

## What

Add tooltip that says "Kæruferli í gangi" on hover, when an appeal is in progress.

## Why

To help users understand why this icon is there.

## Screenshots / Gifs

<img width="605" height="198" alt="image" src="https://github.com/user-attachments/assets/bb4034fa-2164-452a-9827-8714c31447a9" />

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Cursor


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a hover tooltip for warning status icons in indictment case file rows when an appeal is already in progress.
  * PDF buttons can now show optional helper text for subtitle icons, giving users more context at a glance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->