### PR TITLE
fix(application-system): only require 1 usage unit in fire appraisal application

### DIFF
--- a/libs/application/templates/hms/fire-compensation-appraisal/src/lib/dataSchema.ts
+++ b/libs/application/templates/hms/fire-compensation-appraisal/src/lib/dataSchema.ts
@@ -23,7 +23,7 @@ const applicantSchema = z.object({
 
 const realEstateSchema = z.string()
 
-const usageUnitsSchema = z.array(z.string()).min(2)
+const usageUnitsSchema = z.array(z.string()).min(1)
 
 const appraisalMethodSchema = z.array(z.string()).min(1)
 


### PR DESCRIPTION
# ...

change Zod validation to only require one usage unit instead of two in application for fire appraisal

## What

Specify what you're trying to achieve

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fire compensation appraisal forms now accept submissions with a single usage unit entry instead of requiring a minimum of two entries, improving form flexibility and reducing unnecessary submission rejections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->