### PR TITLE
fix(j-s): url-encode S3 CopySource when duplicating case files

### DIFF
--- a/apps/judicial-system/backend/src/app/modules/aws-s3/awsS3.service.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/aws-s3/awsS3.service.spec.ts
@@ -1,0 +1,65 @@
+import type { Logger } from '@island.is/logging'
+import type { ConfigType } from '@island.is/nest/config'
+
+import { CaseType } from '@island.is/judicial-system/types'
+
+import { awsS3ModuleConfig } from './awsS3.config'
+import { AwsS3Service } from './awsS3.service'
+
+const mockCopyObject = jest
+  .fn()
+  .mockReturnValue({ promise: () => Promise.resolve({}) })
+
+jest.mock('aws-sdk', () => ({
+  S3: jest.fn().mockImplementation(() => ({
+    copyObject: mockCopyObject,
+  })),
+}))
+
+describe('AwsS3Service - copyObject', () => {
+  const bucket = 'test-bucket'
+  let service: AwsS3Service
+
+  beforeEach(() => {
+    mockCopyObject.mockClear()
+
+    service = new AwsS3Service(
+      { region: 'eu-west-1', bucket } as ConfigType<typeof awsS3ModuleConfig>,
+      { error: jest.fn() } as unknown as Logger,
+    )
+  })
+
+  it('URL-encodes the CopySource for keys with spaces and non-ASCII characters', async () => {
+    const sourceKey = 'caseId/uuid/Dómur snidmat.pdf'
+    const destKey = 'newCaseId/uuid2/Dómur snidmat.pdf'
+
+    await service.copyObject(CaseType.INDICTMENT, sourceKey, destKey)
+
+    expect(mockCopyObject).toHaveBeenCalledTimes(1)
+    const arg = mockCopyObject.mock.calls[0][0]
+
+    // The bucket and structural slashes are preserved, but each segment is
+    // URL-encoded so the source object resolves (space -> %20, ó -> %C3%B3).
+    // Without this, S3 rejects the copy with SignatureDoesNotMatch.
+    expect(arg.CopySource).toBe(
+      'test-bucket/indictments/caseId/uuid/D%C3%B3mur%20snidmat.pdf',
+    )
+    expect(arg.CopySource).not.toContain('ó')
+    expect(arg.CopySource).not.toContain(' ')
+
+    // The destination is passed via `Key`, which the SDK encodes itself.
+    expect(arg.Key).toBe('indictments/newCaseId/uuid2/Dómur snidmat.pdf')
+  })
+
+  it('leaves plain ASCII keys structurally intact', async () => {
+    await service.copyObject(
+      CaseType.INDICTMENT,
+      'caseId/uuid/file.pdf',
+      'newCaseId/uuid2/file.pdf',
+    )
+
+    const arg = mockCopyObject.mock.calls[0][0]
+
+    expect(arg.CopySource).toBe('test-bucket/indictments/caseId/uuid/file.pdf')
+  })
+})

--- a/apps/judicial-system/backend/src/app/modules/aws-s3/awsS3.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/aws-s3/awsS3.service.ts
@@ -267,10 +267,20 @@ export class AwsS3Service {
     const src = formatS3Key(caseType, sourceKey)
     const dst = formatS3Key(caseType, destKey)
 
+    // Unlike the `Key` parameter (which the SDK URL-encodes automatically),
+    // `CopySource` must be URL-encoded by the caller. Encode each path segment
+    // but keep the slashes so keys containing spaces or non-ASCII characters
+    // (e.g. Icelandic ó, ð, þ) resolve to the correct source object instead of
+    // failing with SignatureDoesNotMatch.
+    const copySource = `${this.config.bucket}/${src}`
+      .split('/')
+      .map((segment) => encodeURIComponent(segment))
+      .join('/')
+
     await this.s3
       .copyObject({
         Bucket: this.config.bucket,
-        CopySource: `${this.config.bucket}/${src}`,
+        CopySource: copySource,
         Key: dst,
       })
       .promise()


### PR DESCRIPTION
# Fix case files with special characters dropped when copying case to draft

## What

When duplicating a revoked indictment into a new draft case (the "copy case to draft" feature, #22934), uploaded case files whose S3 key contained spaces or non-ASCII characters (e.g. Icelandic `ó`, `ð`, `þ`) were silently dropped from the new draft.

This fixes `AwsS3Service.copyObject` to URL-encode the `CopySource` path per segment, and adds unit tests for the S3 service.

## Why

The AWS SDK automatically URL-encodes the `Key` parameter when signing a request (so upload/download always worked), but it treats `CopySource` as a pre-formed path and does **not** encode it. AWS requires the caller to URL-encode `CopySource`.

With an unencoded `CopySource`, the SigV4 signer canonicalizes the source one way while the bytes actually sent on the `x-amz-copy-source` header differ (unencoded space / UTF-8), so S3 rejects the copy with `SignatureDoesNotMatch`. The duplicate loop catches that error and `continue`s, silently skipping the file.

This was confirmed via runtime logs — all affected files failed with `code: "SignatureDoesNotMatch"`. It was never category-specific; any key needing URL-encoding failed.

## Screenshots / Gifs


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed S3 object copy operations to correctly handle source keys containing spaces and non-ASCII characters, ensuring reliable document transfer and storage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->