### PR TITLE
fix(services-bff): Clean up session when refresh token is dead

### DIFF
--- a/apps/services/bff/src/app/modules/auth/token-refresh.service.spec.ts
+++ b/apps/services/bff/src/app/modules/auth/token-refresh.service.spec.ts
@@ -183,6 +183,47 @@ describe('TokenRefreshService', () => {
       expect(mockLogger.warn).toHaveBeenCalledWith('Token refresh failed')
     })
 
+    it('should propagate an OAuth2 error (e.g. invalid_grant) so the session can be cleaned up', async () => {
+      // Arrange - identity server rejects with a dead/revoked refresh token
+      const oauthError = { body: { error: 'invalid_grant' } }
+      jest
+        .spyOn(idsService, 'refreshToken')
+        .mockRejectedValueOnce(oauthError)
+
+      // Act & Assert - the error must propagate (not be swallowed and returned as null)
+      // so the caller's ErrorService.handleAuthorizedError can clear the session.
+      await expect(
+        service.refreshToken({
+          cacheKey: testCacheKey,
+          encryptedRefreshToken: testRefreshToken,
+        }),
+      ).rejects.toBe(oauthError)
+
+      expect(idsService.refreshToken).toHaveBeenCalledWith(testRefreshToken)
+    })
+
+    it('should return the cached token on OAuth2 error if a concurrent refresh already succeeded (rotation race)', async () => {
+      // Arrange - our refresh fails with invalid_grant (token already rotated),
+      // but a concurrent request has stored a fresh, valid token in the cache.
+      jest
+        .spyOn(idsService, 'refreshToken')
+        .mockRejectedValueOnce({ body: { error: 'invalid_grant' } })
+      await cacheService.save({
+        key: `current_${testCacheKey}`,
+        value: mockTokenResponse,
+        ttl: 3600,
+      })
+
+      // Act
+      const result = await service.refreshToken({
+        cacheKey: testCacheKey,
+        encryptedRefreshToken: testRefreshToken,
+      })
+
+      // Assert - the valid session is preserved instead of being torn down
+      expect(result).toEqual(mockTokenResponse)
+    })
+
     it('should prevent concurrent refresh token requests', async () => {
       // Arrange
       const refreshPromises = []

--- a/apps/services/bff/src/app/modules/auth/token-refresh.service.spec.ts
+++ b/apps/services/bff/src/app/modules/auth/token-refresh.service.spec.ts
@@ -186,9 +186,7 @@ describe('TokenRefreshService', () => {
     it('should propagate an OAuth2 error (e.g. invalid_grant) so the session can be cleaned up', async () => {
       // Arrange - identity server rejects with a dead/revoked refresh token
       const oauthError = { body: { error: 'invalid_grant' } }
-      jest
-        .spyOn(idsService, 'refreshToken')
-        .mockRejectedValueOnce(oauthError)
+      jest.spyOn(idsService, 'refreshToken').mockRejectedValueOnce(oauthError)
 
       // Act & Assert - the error must propagate (not be swallowed and returned as null)
       // so the caller's ErrorService.handleAuthorizedError can clear the session.

--- a/apps/services/bff/src/app/modules/auth/token-refresh.service.spec.ts
+++ b/apps/services/bff/src/app/modules/auth/token-refresh.service.spec.ts
@@ -168,7 +168,7 @@ describe('TokenRefreshService', () => {
     })
 
     it('should handle refresh token failure', async () => {
-      // Arrange
+      // Arrange - a transient (non-OAuth2) failure
       const error = new Error('Refresh token failed')
       jest.spyOn(idsService, 'refreshToken').mockRejectedValueOnce(error)
 
@@ -177,10 +177,14 @@ describe('TokenRefreshService', () => {
         cacheKey: testCacheKey,
         encryptedRefreshToken: testRefreshToken,
       })
-      //
-      expect(cachedTokenResponse).toBe(null)
 
-      expect(mockLogger.warn).toHaveBeenCalledWith('Token refresh failed')
+      // Assert - swallowed (returns null) and logged, so a blip does not tear
+      // down a potentially valid session.
+      expect(cachedTokenResponse).toBe(null)
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        'Failed to refresh tokens: ',
+        error,
+      )
     })
 
     it('should propagate an OAuth2 error (e.g. invalid_grant) so the session can be cleaned up', async () => {

--- a/apps/services/bff/src/app/modules/auth/token-refresh.service.ts
+++ b/apps/services/bff/src/app/modules/auth/token-refresh.service.ts
@@ -1,6 +1,7 @@
 import type { Logger } from '@island.is/logging'
 import { LOGGER_PROVIDER } from '@island.is/logging'
 import { Inject, Injectable } from '@nestjs/common'
+import { getOAuth2ErrorCode } from '../../services/error.service'
 import { hasTimestampExpiredInMS } from '../../utils/has-timestamp-expired-in-ms'
 import { CacheService } from '../cache/cache.service'
 import { IdsService } from '../ids/ids.service'
@@ -86,6 +87,18 @@ export class TokenRefreshService {
       )
       tokenResponse = await this.authService.updateTokenCache(newTokenCache)
     } catch (error) {
+      // A dead refresh token (OAuth2 error such as `invalid_grant`) means the
+      // session can no longer be recovered. Propagate it so the caller's
+      // ErrorService.handleAuthorizedError clears the session (deletes the cached
+      // token + clears the session cookie) and returns a 401 right away. Otherwise
+      // the stale token lingers in the cache until its TTL expires, leaving the
+      // user endpoint returning 200 while every API request fails with 401.
+      if (getOAuth2ErrorCode(error)) {
+        throw error
+      }
+
+      // Transient failures (network errors, identity server 5xx, ...) should not
+      // tear down a potentially valid session, so we swallow them and return null.
       this.logger.warn('Failed to refresh tokens: ', error)
     } finally {
       await this.cacheService.delete(refreshTokenKey)
@@ -118,7 +131,7 @@ export class TokenRefreshService {
         return true
       }
 
-      // Wait for for POLL_INTERVAL before next attempt
+      // Wait for POLL_INTERVAL before the next attempt
       await this.delay(TokenRefreshService.POLL_INTERVAL)
 
       attempts++
@@ -209,15 +222,23 @@ export class TokenRefreshService {
       this.logger.warn('Retrying token refresh after failed wait')
     }
 
-    const updatedTokenResponse = await this.executeTokenRefresh({
-      refreshTokenKey,
-      encryptedRefreshToken,
-    })
+    try {
+      return await this.executeTokenRefresh({
+        refreshTokenKey,
+        encryptedRefreshToken,
+      })
+    } catch (error) {
+      // The refresh failed with an OAuth2 error. Before treating the session as
+      // dead, re-check the cache: a concurrent request may have refreshed
+      // successfully in the meantime (refresh token rotation), in which case we
+      // return the fresh token instead of tearing down a valid session.
+      const cachedToken = await this.getTokenFromCache(tokenResponseKey)
 
-    if (!updatedTokenResponse) {
-      this.logger.warn('Token refresh failed')
+      if (cachedToken) {
+        return cachedToken
+      }
+
+      throw error
     }
-
-    return updatedTokenResponse
   }
 }

--- a/apps/services/bff/src/app/services/error.service.ts
+++ b/apps/services/bff/src/app/services/error.service.ts
@@ -26,6 +26,22 @@ export const OAUTH2_ERROR_CODES: OAuth2ErrorCode[] = [
   'invalid_scope',
 ]
 
+/**
+ * Extracts a known OAuth2 error code from an error thrown by the identity server
+ * (e.g. a FetchError whose `body.error` is `invalid_grant`), or returns undefined
+ * if the error is not a recognized OAuth2 error.
+ * @see https://datatracker.ietf.org/doc/html/rfc6749#section-5.2
+ */
+export const getOAuth2ErrorCode = (
+  error: unknown,
+): OAuth2ErrorCode | undefined => {
+  const code = (error as { body?: { error?: string } })?.body?.error
+
+  return code && OAUTH2_ERROR_CODES.includes(code as OAuth2ErrorCode)
+    ? (code as OAuth2ErrorCode)
+    : undefined
+}
+
 @Injectable()
 export class ErrorService {
   constructor(
@@ -35,14 +51,6 @@ export class ErrorService {
     private readonly cacheService: CacheService,
     private readonly sessionCookieService: SessionCookieService,
   ) {}
-
-  /**
-   * Validates if the given string is a known OAuth2 error code
-   * @see https://datatracker.ietf.org/doc/html/rfc6749#section-5.2
-   */
-  private isKnownOAuth2ErrorCode(code: string): code is OAuth2ErrorCode {
-    return OAUTH2_ERROR_CODES.includes(code as OAuth2ErrorCode)
-  }
 
   /**
    * Handles authorization errors by cleaning up user session and logging the error
@@ -67,13 +75,13 @@ export class ErrorService {
     error: unknown
     tokenResponseKey: string
   }): Promise<never> {
-    const errorCode = (error as { body?: { error?: string } })?.body?.error
+    const errorCode = getOAuth2ErrorCode(error)
 
     // If the error is an OAuth2 error
     // 1. Delete the cached token response
     // 2. Clear the session cookie
     // 3. Throw an UnauthorizedException
-    if (errorCode && this.isKnownOAuth2ErrorCode(errorCode)) {
+    if (errorCode) {
       this.logger.warn(
         `${operation} failed with OAuth2 error: ${errorCode}`,
         error,


### PR DESCRIPTION
## What

Fixes a regression in the BFF inactivity logic where, after the session has actually died, the web app (mínarsíður / umsóknir / etc.) stays visible and interactive but every API request fails — until the logout state finally appears "some time later".

Concretely:
- `/bff/api/graphql` returns **401** (correct — the access token is expired and the refresh token is dead)
- but `/bff/user?refresh=false` keeps returning **200** with the stale cached profile, so the poller doesn't show the session-expired modal until the cache entry's 1-hour TTL evicts it.

## Why

When the access token is expired, the GraphQL proxy (and `/user?refresh=true`) call `TokenRefreshService.refreshToken()`. If the refresh token is dead (idle past its rolling lifetime → IDS returns `400 invalid_grant`), `executeTokenRefresh` **caught and swallowed** the error and returned `null`. The caller then threw a *plain* `UnauthorizedException`, so the OAuth2 error code never reached `ErrorService.handleAuthorizedError` — which is the only path (outside explicit logout) that **deletes the cached token and clears the session cookie**.

So the dead session was never cleaned up: graphql 401'd, but the cache entry + cookie survived, and `/user?refresh=false` kept serving the stale token (200) for up to ~1 hour (`BFF_CACHE_USER_PROFILE_TTL_MS`), far longer than the refresh token's rolling lifetime. That gap is the zombie state.

### Fix

- `token-refresh.service.ts` — `executeTokenRefresh` now **re-throws** OAuth2 errors (`invalid_grant`, etc.) so the existing `handleAuthorizedError` cleanup runs (cache deleted, cookie cleared) and the next poll returns 401 → session-expired modal. Transient failures (network / IDS 5xx) are still swallowed → `null`, so a blip doesn't tear down a valid session.
- `refreshToken` re-checks the cache on an OAuth2 error before propagating, so a concurrent refresh that already succeeded (refresh-token rotation race) is honored instead of wrongly logging the user out.
- `error.service.ts` — extracted the OAuth2-code detection into an exported `getOAuth2ErrorCode` helper, reused in both `handleAuthorizedError` and the refresh service.

The poller stays on `refresh: 'false'` — background polling must not keep the session alive.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code (Opus 4.8)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OAuth2 token refresh behavior for concurrent rotation, preserving sessions when a newer token is already cached.
  * Correctly handles OAuth2 `invalid_grant`: transient refresh failures are safely swallowed, while OAuth2 “dead” refresh tokens trigger proper unauthorized handling with cleanup.
* **Tests**
  * Added coverage for `invalid_grant` propagation and for returning the cached token response during rotation race conditions.
* **Refactor**
  * Centralized OAuth2 error-code extraction/validation for consistent warning and unauthorized handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->