### PR TITLE
fix(j-s): guard indictment completion against stale decisions

### DIFF
--- a/apps/judicial-system/api/src/app/modules/case/dto/transitionCase.input.ts
+++ b/apps/judicial-system/api/src/app/modules/case/dto/transitionCase.input.ts
@@ -2,9 +2,15 @@ import { Allow } from 'class-validator'
 
 import { Field, ID, InputType, registerEnumType } from '@nestjs/graphql'
 
-import { CaseTransition } from '@island.is/judicial-system/types'
+import {
+  CaseIndictmentRulingDecision,
+  CaseTransition,
+  IndictmentDecision,
+} from '@island.is/judicial-system/types'
 
 registerEnumType(CaseTransition, { name: 'CaseTransition' })
+
+// IndictmentDecision and CaseIndictmentRulingDecision are registered in case.model.ts
 
 @InputType()
 export class TransitionCaseInput {
@@ -15,4 +21,12 @@ export class TransitionCaseInput {
   @Allow()
   @Field(() => CaseTransition)
   readonly transition!: CaseTransition
+
+  @Allow()
+  @Field(() => IndictmentDecision, { nullable: true })
+  readonly indictmentDecision?: IndictmentDecision
+
+  @Allow()
+  @Field(() => CaseIndictmentRulingDecision, { nullable: true })
+  readonly indictmentRulingDecision?: CaseIndictmentRulingDecision
 }

--- a/apps/judicial-system/backend/src/app/modules/case/dto/transitionCase.dto.ts
+++ b/apps/judicial-system/backend/src/app/modules/case/dto/transitionCase.dto.ts
@@ -1,12 +1,26 @@
-import { IsEnum, IsNotEmpty } from 'class-validator'
+import { IsEnum, IsNotEmpty, IsOptional } from 'class-validator'
 
 import { ApiProperty } from '@nestjs/swagger'
 
-import { CaseTransition } from '@island.is/judicial-system/types'
+import {
+  CaseIndictmentRulingDecision,
+  CaseTransition,
+  IndictmentDecision,
+} from '@island.is/judicial-system/types'
 
 export class TransitionCaseDto {
   @IsNotEmpty()
   @IsEnum(CaseTransition)
   @ApiProperty({ enum: CaseTransition })
   readonly transition!: CaseTransition
+
+  @IsOptional()
+  @IsEnum(IndictmentDecision)
+  @ApiProperty({ enum: IndictmentDecision, required: false })
+  readonly indictmentDecision?: IndictmentDecision
+
+  @IsOptional()
+  @IsEnum(CaseIndictmentRulingDecision)
+  @ApiProperty({ enum: CaseIndictmentRulingDecision, required: false })
+  readonly indictmentRulingDecision?: CaseIndictmentRulingDecision
 }

--- a/apps/judicial-system/backend/src/app/modules/case/guards/caseTransition.guard.ts
+++ b/apps/judicial-system/backend/src/app/modules/case/guards/caseTransition.guard.ts
@@ -1,12 +1,13 @@
 import {
   CanActivate,
+  ConflictException,
   ExecutionContext,
   ForbiddenException,
   Injectable,
   InternalServerErrorException,
 } from '@nestjs/common'
 
-import { User } from '@island.is/judicial-system/types'
+import { CaseTransition, User } from '@island.is/judicial-system/types'
 
 import { getTransitionRule } from './caseTransitionRules'
 
@@ -20,7 +21,8 @@ export class CaseTransitionGuard implements CanActivate {
   canActivate(context: ExecutionContext): boolean {
     const request = context.switchToHttp().getRequest()
 
-    const { transition } = request.body
+    const { transition, indictmentDecision, indictmentRulingDecision } =
+      request.body
     const theCase = request.case
     const user: User = request.user?.currentUser
 
@@ -33,6 +35,25 @@ export class CaseTransitionGuard implements CanActivate {
 
     if (!transitionRule(theCase, user)) {
       throw new ForbiddenException('Forbidden transition')
+    }
+
+    // Guard against completing a case against stale decisions: the completing
+    // user must confirm completion against the decisions that are actually
+    // persisted on the case. If another user changed them in the meantime, the
+    // values sent by the client will no longer match and we reject the
+    // completion to avoid leaving the case in an inconsistent state.
+    if (transition === CaseTransition.COMPLETE) {
+      const decisionMismatch =
+        (indictmentDecision !== undefined &&
+          indictmentDecision !== theCase.indictmentDecision) ||
+        (indictmentRulingDecision !== undefined &&
+          indictmentRulingDecision !== theCase.indictmentRulingDecision)
+
+      if (decisionMismatch) {
+        throw new ConflictException(
+          'The case decision has changed since it was selected. Reload the case and try again.',
+        )
+      }
     }
 
     return true

--- a/apps/judicial-system/backend/src/app/modules/case/guards/test/caseTransitionGuard.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/case/guards/test/caseTransitionGuard.spec.ts
@@ -1,4 +1,5 @@
 import {
+  ConflictException,
   ExecutionContext,
   ForbiddenException,
   InternalServerErrorException,
@@ -8,6 +9,7 @@ import {
   CaseIndictmentRulingDecision,
   CaseTransition,
   CaseType,
+  IndictmentDecision,
 } from '@island.is/judicial-system/types'
 
 import { CaseTransitionGuard } from '../caseTransition.guard'
@@ -33,9 +35,11 @@ describe('CaseTransitionGuard', () => {
     type: CaseType,
     rulingDecision: unknown,
     judgeId: string,
+    indictmentDecision?: unknown,
   ) => ({
     type,
     indictmentRulingDecision: rulingDecision,
+    indictmentDecision,
     judgeId,
   })
 
@@ -69,6 +73,86 @@ describe('CaseTransitionGuard', () => {
     })
 
     expect(() => guard.canActivate(context)).toThrow(ForbiddenException)
+  })
+
+  it('should activate when the completing decisions match the persisted case', () => {
+    const mockCase = createMockCase(
+      CaseType.INDICTMENT,
+      CaseIndictmentRulingDecision.FINE,
+      'judgeId',
+      IndictmentDecision.COMPLETING,
+    )
+    const context = mockExecutionContext({
+      body: {
+        transition: CaseTransition.COMPLETE,
+        indictmentDecision: IndictmentDecision.COMPLETING,
+        indictmentRulingDecision: CaseIndictmentRulingDecision.FINE,
+      },
+      case: mockCase,
+      user: { currentUser: { id: 'judgeId' } },
+    })
+
+    const result = guard.canActivate(context)
+
+    expect(result).toBe(true)
+  })
+
+  it('should throw ConflictException when the indictment decision has changed', () => {
+    const mockCase = createMockCase(
+      CaseType.INDICTMENT,
+      CaseIndictmentRulingDecision.FINE,
+      'judgeId',
+      IndictmentDecision.COMPLETING,
+    )
+    const context = mockExecutionContext({
+      body: {
+        transition: CaseTransition.COMPLETE,
+        indictmentDecision: IndictmentDecision.POSTPONING,
+        indictmentRulingDecision: CaseIndictmentRulingDecision.FINE,
+      },
+      case: mockCase,
+      user: { currentUser: { id: 'judgeId' } },
+    })
+
+    expect(() => guard.canActivate(context)).toThrow(ConflictException)
+  })
+
+  it('should throw ConflictException when the indictment ruling decision has changed', () => {
+    const mockCase = createMockCase(
+      CaseType.INDICTMENT,
+      CaseIndictmentRulingDecision.FINE,
+      'judgeId',
+      IndictmentDecision.COMPLETING,
+    )
+    const context = mockExecutionContext({
+      body: {
+        transition: CaseTransition.COMPLETE,
+        indictmentDecision: IndictmentDecision.COMPLETING,
+        indictmentRulingDecision: CaseIndictmentRulingDecision.DISMISSAL,
+      },
+      case: mockCase,
+      user: { currentUser: { id: 'judgeId' } },
+    })
+
+    expect(() => guard.canActivate(context)).toThrow(ConflictException)
+  })
+
+  it('should activate when completing decisions are omitted from the body', () => {
+    const mockCase = createMockCase(
+      CaseType.INDICTMENT,
+      CaseIndictmentRulingDecision.FINE,
+      'judgeId',
+      IndictmentDecision.COMPLETING,
+    )
+    const context = mockExecutionContext({
+      body: { transition: CaseTransition.COMPLETE },
+      case: mockCase,
+      user: { currentUser: { id: 'judgeId' } },
+    })
+
+    const result = guard.canActivate(context)
+
+    expect(result).toBe(true)
   })
 
   it('should activate using the default rule for transitions not in the rule map', () => {

--- a/apps/judicial-system/web/src/routes/Court/Indictments/Summary/Summary.tsx
+++ b/apps/judicial-system/web/src/routes/Court/Indictments/Summary/Summary.tsx
@@ -116,6 +116,10 @@ const Summary: FC = () => {
       workingCase.id,
       CaseTransition.COMPLETE,
       setWorkingCase,
+      {
+        indictmentDecision: workingCase.indictmentDecision,
+        indictmentRulingDecision: workingCase.indictmentRulingDecision,
+      },
     )
 
     if (!transitionSuccess) {

--- a/apps/judicial-system/web/src/utils/hooks/useCase/index.ts
+++ b/apps/judicial-system/web/src/utils/hooks/useCase/index.ts
@@ -6,7 +6,9 @@ import { errors } from '@island.is/judicial-system-web/messages'
 import { UserContext } from '@island.is/judicial-system-web/src/components'
 import {
   Case,
+  CaseIndictmentRulingDecision,
   CaseTransition,
+  IndictmentDecision,
   TrackedNotificationType,
 } from '@island.is/judicial-system-web/src/graphql/schema'
 
@@ -210,6 +212,10 @@ const useCase = () => {
         caseId: string,
         transition: CaseTransition,
         setWorkingCase?: Dispatch<SetStateAction<Case>>,
+        transitionUpdate?: {
+          indictmentDecision?: IndictmentDecision | null
+          indictmentRulingDecision?: CaseIndictmentRulingDecision | null
+        },
       ): Promise<boolean> => {
         const mutation = limitedAccess
           ? limitedAccessTransitionCaseMutation
@@ -225,6 +231,7 @@ const useCase = () => {
               input: {
                 id: caseId,
                 transition,
+                ...transitionUpdate,
               },
             },
           })


### PR DESCRIPTION
# Guard indictment completion against stale decisions

## What

When a court user completes an indictment case, the decision values (`indictmentDecision` and `indictmentRulingDecision`) are set on the case via a separate `PATCH /case/:caseId` request on the Conclusion page. The completion on the Summary page previously sent only a bare `COMPLETE` transition and relied on whatever decisions happened to be persisted at that moment.

This PR threads the user-confirmed `indictmentDecision` and `indictmentRulingDecision` through the `transitionCase` payload (web → api → backend) and validates them in the backend's `CaseTransitionGuard` for the `COMPLETE` transition. On mismatch it rejects with a `409 Conflict` instead of silently completing.

- `transitionCase.input.ts` (api) / `transitionCase.dto.ts` (backend): add optional decision fields. Resolvers forward them automatically via the existing spread.
- `caseTransition.guard.ts` (backend): reject `COMPLETE` when a supplied decision no longer matches the persisted case.
- `useCase/index.ts` + `Summary.tsx` (web): send the decisions currently displayed to the user.

The fields are optional, so the limited-access transition endpoint (which shares the DTO) and older clients keep working — the check only fires for `COMPLETE` when values are sent.

## Why

There is a concurrency hole that can leave a case in limbo:

1. Court user A selects decisions, navigates to the summary page, but does not complete.
2. Court user B changes the decision on the same case.
3. User A clicks Complete. The backend completes using B's decision values while A confirmed against the values A saw — producing wrong verdicts/file cleanup keyed on the stale decision.

This makes completion impossible against changed data, so the user must reload and confirm against the current state.

## Screenshots / Gifs


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Case completion now includes optional indictment decision details when available.
  * The case transition flow can now carry additional indictment-related fields through to the backend.

* **Bug Fixes**
  * Prevents completing a case with outdated indictment decision data by prompting a reload when the submitted values no longer match the saved case.

* **Tests**
  * Expanded coverage for case completion validation, including matching, missing, and conflicting indictment decision values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->