### PR TITLE
fix(api): require authentication on FileUploadResolver

### DIFF
--- a/libs/api/domains/file-upload/src/lib/file-upload.resolver.ts
+++ b/libs/api/domains/file-upload/src/lib/file-upload.resolver.ts
@@ -1,4 +1,6 @@
 import { Args, Resolver, Mutation, Query } from '@nestjs/graphql'
+import { UseGuards } from '@nestjs/common'
+import { IdsUserGuard, ScopesGuard } from '@island.is/auth-nest-tools'
 import { PresignedPost } from './presignedPost.model'
 import { FileStorageService } from '@island.is/file-storage'
 import { PresignedPost as S3PresignedPost } from '@aws-sdk/s3-presigned-post'
@@ -7,6 +9,7 @@ import { MalwareScanStatus } from './malwareScanStatus.model'
 const MALWARE_FETCH_ATTEMPTS = 5
 const MALWARE_MIN_MS_BETWEEN_FETCHES = 500
 
+@UseGuards(IdsUserGuard, ScopesGuard)
 @Resolver()
 export class FileUploadResolver {
   constructor(private fileStorageService: FileStorageService) {}


### PR DESCRIPTION
Fixes #23039

## What

Adds the platform-standard `@UseGuards(IdsUserGuard, ScopesGuard)` to `FileUploadResolver` so its operations require an authenticated user.

## Why

`FileUploadResolver` (`libs/api/domains/file-upload/src/lib/file-upload.resolver.ts`) exposed two operations with no guard:

- `createUploadUrl` — generates an S3 presigned POST into the upload bucket (signed with the service IAM identity).
- `malwareScanStatus` — returns the GuardDuty scan tag for an arbitrary, caller-supplied object key.

The `api` app registers no `APP_GUARD` backstop (`apps/api/src/app/app.module.ts`), so both operations were reachable **unauthenticated** on the public GraphQL gateway (`/api/graphql`, ingress `public: true`). This is an outlier: the other resolvers in `libs/api/domains` apply `IdsUserGuard`. Full analysis in #23039.

This change requires a valid authenticated user for both operations, matching the existing convention. No `@Scopes(...)` is added so that current legitimate callers are not broken; maintainers may wish to additionally scope these operations and bind generated upload keys to the authenticated user/application as defense-in-depth (noted in the issue).

## Screenshots / Gifs

n/a — non-visual change.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [ ] AI tools were used in preparing this pull request
      Tools used:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened access control on file upload GraphQL operations by requiring the appropriate user and scope checks at the resolver level.
  * This helps ensure only authorized requests can use file upload features such as upload links and scan status checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->