### PR TITLE
fix(j-s): Client side sorting of loke numbers by date

### DIFF
--- a/apps/judicial-system/backend/src/app/modules/repository/services/caseDefendantPoliceCaseNumber.repository.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/repository/services/caseDefendantPoliceCaseNumber.repository.service.ts
@@ -146,24 +146,28 @@ export class CaseDefendantPoliceCaseNumberRepositoryService {
 
     const rows = await this.model.findAll({
       where: { caseId: caseIds },
-      attributes: ['caseId', 'policeCaseNumber'],
+      attributes: ['caseId', 'policeCaseNumber', 'created'],
+      order: [
+        ['created', 'ASC'],
+        ['policeCaseNumber', 'ASC'],
+      ],
       transaction: options?.transaction,
     })
 
-    const byCase = new Map<string, Set<string>>()
+    const seenByCase = new Map<string, Set<string>>()
     for (const id of caseIds) {
-      byCase.set(id, new Set())
+      seenByCase.set(id, new Set())
     }
 
     for (const row of rows) {
-      byCase.get(row.caseId)?.add(row.policeCaseNumber)
-    }
+      const seen = seenByCase.get(row.caseId)
 
-    for (const [caseId, set] of byCase) {
-      result.set(
-        caseId,
-        [...set].sort((a, b) => a.localeCompare(b)),
-      )
+      if (!seen || seen.has(row.policeCaseNumber)) {
+        continue
+      }
+
+      seen.add(row.policeCaseNumber)
+      result.get(row.caseId)?.push(row.policeCaseNumber)
     }
 
     return result

--- a/apps/judicial-system/backend/src/app/modules/repository/test/caseDefendantPoliceCaseNumber.repository.service.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/repository/test/caseDefendantPoliceCaseNumber.repository.service.spec.ts
@@ -101,8 +101,8 @@ describe('CaseDefendantPoliceCaseNumberRepositoryService', () => {
   describe('resolvePoliceCaseNumbersForCases', () => {
     it('sets policeCaseNumbers from junction when rows exist', async () => {
       mockModel.findAll.mockResolvedValue([
-        { caseId: 'case-a', policeCaseNumber: '007-2' },
-        { caseId: 'case-a', policeCaseNumber: '007-1' },
+        { caseId: 'case-a', policeCaseNumber: '007-1', created: new Date(1) },
+        { caseId: 'case-a', policeCaseNumber: '007-2', created: new Date(2) },
       ])
 
       let numbers = ['legacy']
@@ -186,12 +186,12 @@ describe('CaseDefendantPoliceCaseNumberRepositoryService', () => {
   })
 
   describe('findDistinctPoliceCaseNumbersByCaseIds', () => {
-    it('returns sorted distinct numbers per case id', async () => {
+    it('returns distinct numbers per case id in created order', async () => {
       mockModel.findAll.mockResolvedValue([
-        { caseId: 'case-a', policeCaseNumber: '007-2' },
-        { caseId: 'case-a', policeCaseNumber: '007-1' },
-        { caseId: 'case-a', policeCaseNumber: '007-1' },
-        { caseId: 'case-b', policeCaseNumber: '008' },
+        { caseId: 'case-a', policeCaseNumber: '007-1', created: new Date(1) },
+        { caseId: 'case-a', policeCaseNumber: '007-2', created: new Date(2) },
+        { caseId: 'case-a', policeCaseNumber: '007-1', created: new Date(1) },
+        { caseId: 'case-b', policeCaseNumber: '008', created: new Date(3) },
       ])
 
       const map = await service.findDistinctPoliceCaseNumbersByCaseIds(
@@ -201,7 +201,11 @@ describe('CaseDefendantPoliceCaseNumberRepositoryService', () => {
 
       expect(mockModel.findAll).toHaveBeenCalledWith({
         where: { caseId: ['case-a', 'case-b', 'case-c'] },
-        attributes: ['caseId', 'policeCaseNumber'],
+        attributes: ['caseId', 'policeCaseNumber', 'created'],
+        order: [
+          ['created', 'ASC'],
+          ['policeCaseNumber', 'ASC'],
+        ],
         transaction,
       })
       expect(map.get('case-a')).toEqual(['007-1', '007-2'])

--- a/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Defendant/PoliceCaseList/PoliceCase/PoliceCase.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Defendant/PoliceCaseList/PoliceCase/PoliceCase.tsx
@@ -47,6 +47,7 @@ export interface PoliceCaseUpdate {
 interface Props {
   index: number
   policeCaseNumber: string
+  mainLokePoliceCaseNumber?: string
   setPoliceCase: (update: PoliceCaseUpdate) => void
   updatePoliceCase: (update?: PoliceCaseUpdate) => void
   deletePoliceCase?: () => void
@@ -55,6 +56,7 @@ interface Props {
 export const PoliceCase: FC<Props> = ({
   index,
   policeCaseNumber,
+  mainLokePoliceCaseNumber,
   setPoliceCase,
   updatePoliceCase,
   deletePoliceCase,
@@ -176,7 +178,7 @@ export const PoliceCase: FC<Props> = ({
 
   const isPoliceCaseNumberImmutable =
     workingCase.origin === CaseOrigin.LOKE &&
-    policeCaseNumber === workingCase.policeCaseNumbers?.[0]
+    policeCaseNumber === mainLokePoliceCaseNumber
 
   return (
     <BlueBox className={styles.grid}>

--- a/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Defendant/PoliceCaseList/PoliceCase/PoliceCase.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Defendant/PoliceCaseList/PoliceCase/PoliceCase.tsx
@@ -46,6 +46,7 @@ export interface PoliceCaseUpdate {
 
 interface Props {
   index: number
+  policeCaseNumber: string
   setPoliceCase: (update: PoliceCaseUpdate) => void
   updatePoliceCase: (update?: PoliceCaseUpdate) => void
   deletePoliceCase?: () => void
@@ -53,6 +54,7 @@ interface Props {
 
 export const PoliceCase: FC<Props> = ({
   index,
+  policeCaseNumber,
   setPoliceCase,
   updatePoliceCase,
   deletePoliceCase,
@@ -64,11 +66,6 @@ export const PoliceCase: FC<Props> = ({
   const policeCaseNumbers = useMemo(
     () => workingCase.policeCaseNumbers ?? [],
     [workingCase.policeCaseNumbers],
-  )
-
-  const policeCaseNumber = useMemo(
-    () => policeCaseNumbers[index] ?? '',
-    [index, policeCaseNumbers],
   )
 
   const policeCaseNumberSubtypes: IndictmentSubtype[] = useMemo(
@@ -131,8 +128,9 @@ export const PoliceCase: FC<Props> = ({
       // The police case number was modified by the user
       if (
         !policeCaseNumbers.some(
-          (policeCaseNumber, idx) =>
-            idx !== index && policeCaseNumber === policeCaseNumberInput,
+          (otherPoliceCaseNumber) =>
+            otherPoliceCaseNumber !== policeCaseNumber &&
+            otherPoliceCaseNumber === policeCaseNumberInput,
         )
       ) {
         setPoliceCaseNumberErrorMessage('')
@@ -177,7 +175,8 @@ export const PoliceCase: FC<Props> = ({
   ])
 
   const isPoliceCaseNumberImmutable =
-    workingCase.origin === CaseOrigin.LOKE && index === 0
+    workingCase.origin === CaseOrigin.LOKE &&
+    policeCaseNumber === workingCase.policeCaseNumbers?.[0]
 
   return (
     <BlueBox className={styles.grid}>
@@ -201,8 +200,9 @@ export const PoliceCase: FC<Props> = ({
         onChange={(event) => {
           if (
             !policeCaseNumbers.some(
-              (policeCaseNumber, idx) =>
-                idx !== index && policeCaseNumber === event.target.value,
+              (otherPoliceCaseNumber) =>
+                otherPoliceCaseNumber !== policeCaseNumber &&
+                otherPoliceCaseNumber === event.target.value,
             )
           ) {
             removeErrorMessageIfValid(

--- a/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Defendant/PoliceCaseList/PoliceCaseList.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Defendant/PoliceCaseList/PoliceCaseList.tsx
@@ -84,6 +84,35 @@ export const PoliceCaseList = () => {
           }))
         : [{ number: '' }]
 
+    const byDate = (a: TPoliceCase, b: TPoliceCase) => {
+      const at = a.date?.getTime()
+      const bt = b.date?.getTime()
+
+      if (at === undefined) return bt === undefined ? 0 : 1
+      if (bt === undefined) return -1
+
+      return at - bt
+    }
+
+    if (policeCases.length > 1 && policeCases[0].number !== '') {
+      const mainPoliceCaseNumber = workingCase.policeCaseNumbers?.[0]
+
+      if (workingCase.origin === CaseOrigin.LOKE && mainPoliceCaseNumber) {
+        const mainCase = policeCases.find(
+          (policeCase) => policeCase.number === mainPoliceCaseNumber,
+        )
+        const rest = policeCases
+          .filter((policeCase) => policeCase.number !== mainPoliceCaseNumber)
+          .sort(byDate)
+
+        if (mainCase) {
+          policeCases.splice(0, policeCases.length, mainCase, ...rest)
+        }
+      } else {
+        policeCases.sort(byDate)
+      }
+    }
+
     const current = policeCaseIds.current
     policeCaseIds.current = policeCases.reduce((acc, c) => {
       acc[c.number] = current[c.number] ?? uuid()
@@ -143,12 +172,17 @@ export const PoliceCaseList = () => {
       crimeScenes[number] = crimeScene
     })
 
-    const [first, ...rest] = unsortedPoliceCaseNumbers
+    const mainPoliceCaseNumber = workingCase.policeCaseNumbers?.[0]
 
     const policeCaseNumbers =
-      workingCase.origin === CaseOrigin.LOKE
-        ? // If the case is a LÖKE case, we never change the first police case number
-          [first, ...rest.sort(compare)]
+      workingCase.origin === CaseOrigin.LOKE && mainPoliceCaseNumber
+        ? // The main LÖKE number must stay at index 0 in the stored array
+          [
+            mainPoliceCaseNumber,
+            ...unsortedPoliceCaseNumbers
+              .filter((number) => number !== mainPoliceCaseNumber)
+              .sort(compare),
+          ]
         : unsortedPoliceCaseNumbers.sort(compare)
 
     return { policeCaseNumbers, indictmentSubtypes, crimeScenes }
@@ -183,10 +217,15 @@ export const PoliceCaseList = () => {
       // Assumptions:
       // 1. At most one update per indictment count
       // 2. For each update, only one of the updates is set
+      const policeCaseNumber =
+        policeCases[index]?.number ?? oldPoliceCaseNumbers[index]
+
+      if (policeCaseNumber === undefined) {
+        continue
+      }
+
       updatedIndictmentCounts = updatedIndictmentCounts.map(
         (indictmentCount) => {
-          const policeCaseNumber = oldPoliceCaseNumbers[index]
-
           if (indictmentCount.policeCaseNumber !== policeCaseNumber) {
             return indictmentCount
           }
@@ -479,12 +518,16 @@ export const PoliceCaseList = () => {
               {workingCase.policeCaseNumbers && (
                 <PoliceCase
                   index={index}
+                  policeCaseNumber={policeCase.number}
                   setPoliceCase={(update: PoliceCaseUpdate) =>
                     handleSetPoliceCase({ index, update })
                   }
                   deletePoliceCase={
                     workingCase.policeCaseNumbers.length > 1 &&
-                    !(workingCase.origin === CaseOrigin.LOKE && index === 0)
+                    !(
+                      workingCase.origin === CaseOrigin.LOKE &&
+                      policeCase.number === workingCase.policeCaseNumbers[0]
+                    )
                       ? () => handleDeletePoliceCase(index)
                       : undefined
                   }

--- a/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Defendant/PoliceCaseList/PoliceCaseList.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Defendant/PoliceCaseList/PoliceCaseList.tsx
@@ -52,6 +52,18 @@ interface Checkpoint {
   update?: IndexedPoliceCaseUpdate
 }
 
+const getMainLokePoliceCaseNumber = (
+  origin: CaseOrigin | null | undefined,
+  policeCaseNumbers: string[] | null | undefined,
+): string | undefined => {
+  if (origin !== CaseOrigin.LOKE) {
+    return undefined
+  }
+
+  // Index 0 is the LOKE main identifier (first registered on the case).
+  return policeCaseNumbers?.[0]
+}
+
 export const PoliceCaseList = () => {
   const { formatMessage } = useIntl()
   const { workingCase, setWorkingCase, refreshCase } = useContext(FormContext)
@@ -64,6 +76,15 @@ export const PoliceCaseList = () => {
   const gender = useMemo(
     () => getDefaultDefendantGender(workingCase.defendants),
     [workingCase.defendants],
+  )
+
+  const mainLokePoliceCaseNumber = useMemo(
+    () =>
+      getMainLokePoliceCaseNumber(
+        workingCase.origin,
+        workingCase.policeCaseNumbers,
+      ),
+    [workingCase.origin, workingCase.policeCaseNumbers],
   )
 
   const policeCases: TPoliceCase[] = useMemo(() => {
@@ -95,14 +116,14 @@ export const PoliceCaseList = () => {
     }
 
     if (policeCases.length > 1 && policeCases[0].number !== '') {
-      const mainPoliceCaseNumber = workingCase.policeCaseNumbers?.[0]
-
-      if (workingCase.origin === CaseOrigin.LOKE && mainPoliceCaseNumber) {
+      if (workingCase.origin === CaseOrigin.LOKE && mainLokePoliceCaseNumber) {
         const mainCase = policeCases.find(
-          (policeCase) => policeCase.number === mainPoliceCaseNumber,
+          (policeCase) => policeCase.number === mainLokePoliceCaseNumber,
         )
         const rest = policeCases
-          .filter((policeCase) => policeCase.number !== mainPoliceCaseNumber)
+          .filter(
+            (policeCase) => policeCase.number !== mainLokePoliceCaseNumber,
+          )
           .sort(byDate)
 
         if (mainCase) {
@@ -121,7 +142,7 @@ export const PoliceCaseList = () => {
     }, {} as { [key: string]: string })
 
     return policeCases
-  }, [workingCase])
+  }, [workingCase, mainLokePoliceCaseNumber])
 
   const getWorkingCaseUpdates = (
     policeCases: TPoliceCase[],
@@ -172,15 +193,13 @@ export const PoliceCaseList = () => {
       crimeScenes[number] = crimeScene
     })
 
-    const mainPoliceCaseNumber = workingCase.policeCaseNumbers?.[0]
-
     const policeCaseNumbers =
-      workingCase.origin === CaseOrigin.LOKE && mainPoliceCaseNumber
+      workingCase.origin === CaseOrigin.LOKE && mainLokePoliceCaseNumber
         ? // The main LÖKE number must stay at index 0 in the stored array
           [
-            mainPoliceCaseNumber,
+            mainLokePoliceCaseNumber,
             ...unsortedPoliceCaseNumbers
-              .filter((number) => number !== mainPoliceCaseNumber)
+              .filter((number) => number !== mainLokePoliceCaseNumber)
               .sort(compare),
           ]
         : unsortedPoliceCaseNumbers.sort(compare)
@@ -519,6 +538,7 @@ export const PoliceCaseList = () => {
                 <PoliceCase
                   index={index}
                   policeCaseNumber={policeCase.number}
+                  mainLokePoliceCaseNumber={mainLokePoliceCaseNumber}
                   setPoliceCase={(update: PoliceCaseUpdate) =>
                     handleSetPoliceCase({ index, update })
                   }
@@ -526,7 +546,7 @@ export const PoliceCaseList = () => {
                     workingCase.policeCaseNumbers.length > 1 &&
                     !(
                       workingCase.origin === CaseOrigin.LOKE &&
-                      policeCase.number === workingCase.policeCaseNumbers[0]
+                      policeCase.number === mainLokePoliceCaseNumber
                     )
                       ? () => handleDeletePoliceCase(index)
                       : undefined


### PR DESCRIPTION
[Asana](https://app.asana.com/1/203394141643832/project/1212657017130395/task/1215433969546543?focus=true)

## What

Case numbers jumped around when changing dates because the backend order would take over. The backend just sorts alphabetically the numbers themselves.

It's a bit tricky to do this entirely in the backend because the numbers are stored in a separate table that doesn't have all the info, so doing it on the client for now.

## Why

So the numers don't jump around when editing dates.



## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Cursor


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Police cases now display in a more consistent order: the main LÖKE police case remains first, with remaining cases sorted by date (and undefined dates placed last).
  * Duplicate police case number handling is more reliable, reducing incorrect/invalid entries.
  * Indictment counts now stay correctly matched to the intended police case numbers after updates.
  * Police case deletion eligibility is applied more consistently for LÖKE cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->