### PR TITLE
fix(j-s): remove reference to outdated case transition

### DIFF
--- a/apps/judicial-system/web/src/routes/CourtOfAppeal/Overview/Overview.spec.tsx
+++ b/apps/judicial-system/web/src/routes/CourtOfAppeal/Overview/Overview.spec.tsx
@@ -1,4 +1,3 @@
-import faker from 'faker'
 import { MockedProvider } from '@apollo/client/testing'
 import { render, screen } from '@testing-library/react'
 
@@ -7,10 +6,7 @@ import {
   CaseType,
   UserRole,
 } from '@island.is/judicial-system-web/src/graphql/schema'
-import {
-  mockCase,
-  mockTransitonCaseMutation,
-} from '@island.is/judicial-system-web/src/utils/mocks'
+import { mockCase } from '@island.is/judicial-system-web/src/utils/mocks'
 import {
   FormContextWrapper,
   IntlProviderWrapper,
@@ -30,26 +26,21 @@ window.scrollTo = jest.fn()
 
 describe('Overview', () => {
   it('should show a warning alert that indicates that the prosecutor requests the court of appeal ruling be not published, if the prosecutor requested it', async () => {
-    const caseId = faker.datatype.uuid()
-
     render(
-      <MockedProvider
-        mocks={mockTransitonCaseMutation(caseId)}
-        addTypename={false}
-      >
+      <MockedProvider addTypename={false}>
         <IntlProviderWrapper>
-          <FormContextWrapper
-            theCase={{
-              ...mockCase(CaseType.CUSTODY),
-              appealCase: {
-                id: 'test_appeal_case_id',
-                appealState: AppealCaseState.RECEIVED,
-                requestAppealRulingNotToBePublished: [UserRole.PROSECUTOR],
-              },
-            }}
-          >
-            <Overview />
-          </FormContextWrapper>
+        <FormContextWrapper
+          theCase={{
+            ...mockCase(CaseType.CUSTODY),
+            appealCase: {
+              id: 'test_appeal_case_id',
+              appealState: AppealCaseState.RECEIVED,
+              requestAppealRulingNotToBePublished: [UserRole.PROSECUTOR],
+            },
+          }}
+        >
+          <Overview />
+        </FormContextWrapper>
         </IntlProviderWrapper>
       </MockedProvider>,
     )

--- a/apps/judicial-system/web/src/routes/CourtOfAppeal/Overview/Overview.spec.tsx
+++ b/apps/judicial-system/web/src/routes/CourtOfAppeal/Overview/Overview.spec.tsx
@@ -29,18 +29,18 @@ describe('Overview', () => {
     render(
       <MockedProvider addTypename={false}>
         <IntlProviderWrapper>
-        <FormContextWrapper
-          theCase={{
-            ...mockCase(CaseType.CUSTODY),
-            appealCase: {
-              id: 'test_appeal_case_id',
-              appealState: AppealCaseState.RECEIVED,
-              requestAppealRulingNotToBePublished: [UserRole.PROSECUTOR],
-            },
-          }}
-        >
-          <Overview />
-        </FormContextWrapper>
+          <FormContextWrapper
+            theCase={{
+              ...mockCase(CaseType.CUSTODY),
+              appealCase: {
+                id: 'test_appeal_case_id',
+                appealState: AppealCaseState.RECEIVED,
+                requestAppealRulingNotToBePublished: [UserRole.PROSECUTOR],
+              },
+            }}
+          >
+            <Overview />
+          </FormContextWrapper>
         </IntlProviderWrapper>
       </MockedProvider>,
     )

--- a/apps/judicial-system/web/src/utils/mocks.ts
+++ b/apps/judicial-system/web/src/utils/mocks.ts
@@ -10,7 +10,6 @@ import {
   CaseFileState,
   CaseOrigin,
   CaseState,
-  CaseTransition,
   CaseType,
   Gender,
   InstitutionType,
@@ -19,7 +18,6 @@ import {
 } from '@island.is/judicial-system-web/src/graphql/schema'
 
 import { TransitionAppealCaseDocument } from './hooks/useAppealCase/transitionAppealCase.generated'
-import { TransitionCaseDocument } from './hooks/useCase/transitionCase.generated'
 
 export const mockCourt = {
   id: 'court_id',
@@ -121,30 +119,6 @@ export const mockProsecutorQuery = [
     result: {
       data: {
         currentUser: { user: mockProsecutor },
-      },
-    },
-  },
-]
-
-export const mockTransitonCaseMutation = (caseId: string) => [
-  {
-    request: {
-      query: TransitionCaseDocument,
-      variables: {
-        input: {
-          id: caseId,
-          transition: CaseTransition.COMPLETE_APPEAL,
-        },
-      },
-    },
-    result: {
-      data: {
-        transitionCase: {
-          state: CaseState.ACCEPTED,
-          appealState: AppealCaseState.COMPLETED,
-          statementDeadline: '2021-09-09T12:00:00.000Z',
-          appealReceivedByCourtDate: '2021-09-09T12:00:00.000Z',
-        },
       },
     },
   },


### PR DESCRIPTION
[Asana](https://app.asana.com/1/203394141643832/project/1199153462262248/task/1215991883404442?focus=true)

## What

We were referencing a CaseTransition that has been removed, COMPLETE_APPEAL, in some tests.
Cleaned that up

## Why

So CI can build


## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Cursor


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated automated coverage for the appeal overview to verify that the “do not publish ruling” notice still appears when applicable.
  * Simplified test setup by removing faker-based UUID generation and reducing reliance on GraphQL transition mocks for more stable runs.
* **Chores**
  * Removed an unused GraphQL mock helper related to case transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->