### PR TITLE
fix(contentful-apps): Allow non admins to edit theme properties

### DIFF
--- a/apps/contentful-apps/pages/fields/theme-properties-field.tsx
+++ b/apps/contentful-apps/pages/fields/theme-properties-field.tsx
@@ -4,7 +4,6 @@ import { FieldExtensionSDK } from '@contentful/app-sdk'
 import {
   Button,
   FormControl,
-  Paragraph,
   Radio,
   Stack,
   Text,
@@ -69,10 +68,6 @@ const ThemePropertiesField = () => {
     value: ThemeProperties[K],
   ) => {
     setState((prevState) => ({ ...prevState, [key]: value }))
-  }
-
-  if (!sdk.user.spaceMembership.admin) {
-    return <Paragraph>(Only admins can edit this JSON field)</Paragraph>
   }
 
   return (


### PR DESCRIPTION
# Allow non admins to edit theme properties

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [x] No AI tools were used in preparing this pull request
- [ ] AI tools were used in preparing this pull request
      Tools used:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The theme properties field is now available to all users, instead of being hidden from non-admins.
  * Users with appropriate access can now view and edit the JSON field without the UI being blocked by an admin-only check.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->