### PR TITLE
fix(j-s): Don't show error toaster for Aðilar máls when extending restriction case

### DIFF
--- a/apps/judicial-system/web/src/utils/hooks/usePoliceDefendants/useSyncDefendantsFromPolice.ts
+++ b/apps/judicial-system/web/src/utils/hooks/usePoliceDefendants/useSyncDefendantsFromPolice.ts
@@ -21,13 +21,17 @@ import {
  */
 export const useSyncDefendantsFromPolice = () => {
   const client = useApolloClient()
-  const { workingCase, setWorkingCase, refreshCase } = useContext(FormContext)
+  const { workingCase, setWorkingCase, refreshCase, isLoadingWorkingCase } =
+    useContext(FormContext)
   const { createDefendant } = useDefendants()
   const syncingRef = useRef(false)
 
   const { loading, error, refetch } = usePoliceDefendantsQuery({
     variables: { input: { caseId: workingCase.id } },
-    skip: workingCase.origin !== CaseOrigin.LOKE || !workingCase.id,
+    skip:
+      workingCase.origin !== CaseOrigin.LOKE ||
+      !workingCase.id ||
+      isLoadingWorkingCase,
     fetchPolicy: 'cache-first',
     onCompleted: (data: PoliceDefendantsQuery) => {
       const policeDefendants = data?.policeDefendants


### PR DESCRIPTION
[Asana](https://app.asana.com/1/203394141643832/project/1212657017130395/task/1215433969546564?focus=true)

## What

When extending a restriction case, we would get an error toaster saying "Ekki tókst að sækja aðila máls". The issue was that the query was being triggered for the original case while creating the extended case, which at this time had been marked complete. We have a guard that prevents this request from running for completed cases.

The fix was simple, just don't run the query when we are loading a case. 

## Why

So users don't see an incorrect error toaster, when in fact nothing went wrong.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Cursor


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved defendant syncing so it waits until the current case has finished loading before fetching police defendant data.
  * This helps avoid unnecessary or premature updates when opening a case, especially during slower load times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->