### PR TITLE
feat(driving-license): prune BE drafts after 24h

### DIFF
--- a/libs/application/templates/driving-license/src/lib/drivingLicenseTemplate.ts
+++ b/libs/application/templates/driving-license/src/lib/drivingLicenseTemplate.ts
@@ -4,6 +4,7 @@ import {
   coreHistoryMessages,
 } from '@island.is/application/core'
 import {
+  Application,
   ApplicationTemplate,
   ApplicationTypes,
   ApplicationContext,
@@ -175,7 +176,20 @@ const DrivingLicenseTemplate: ApplicationTemplate<
           name: m.applicationForDrivingLicense.defaultMessage,
           status: 'draft',
           progress: 0.4,
-          lifecycle: DefaultStateLifeCycle,
+          // BE drafts are short-lived (24h); all other license types keep the
+          // default 30 day lifecycle.
+          lifecycle: {
+            shouldBeListed: true,
+            shouldBePruned: true,
+            whenToPrune: (application: Application) =>
+              new Date(
+                Date.now() +
+                  (application.answers.applicationFor === BE ? 1 : 30) *
+                    24 *
+                    3600 *
+                    1000,
+              ),
+          },
           roles: [
             {
               id: Roles.APPLICANT,


### PR DESCRIPTION
## What

Prune **BE** (eftirvagn) driving-license applications in the `DRAFT` state after **24 hours** instead of the default 30 days. All other license types (B_TEMP, B_FULL, 65+ renewal, advanced) keep the 30-day default.

`DRAFT` was the only state where a BE application lived longer than 24h — `PREREQUISITES` is already ephemeral (24h, unlisted) and `PAYMENT` already prunes after 1 day. The change scopes the lifecycle via the function-form `whenToPrune`, keyed on `answers.applicationFor`.

```ts
whenToPrune: (application: Application) =>
  new Date(
    Date.now() +
      (application.answers.applicationFor === BE ? 1 : 30) * 24 * 3600 * 1000,
  )
```

## Why

BE drafts should be short-lived. A stale BE draft sits in `DRAFT` for 30 days and, via the `ExistingApplicationApi` check in `PREREQUISITES` (which looks at `DRAFT` + `PAYMENT`), can block the user from starting a fresh application. A 24h prune lets users restart sooner.

> Open question for the PO: the exact business rationale for 24h wasn't captured on the task. This PR implements DRAFT-only, BE-scoped pruning as the most sensible first step; happy to add a user-facing `pruneMessage` warning before deletion if that's wanted.

## Screenshots / Gifs

N/A — backend lifecycle config only, no UI change.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code (Opus 4.8)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Draft applications now have automatic cleanup based on application type.
  * Business-related applications are removed after 1 day, while other draft applications are kept for 30 days before cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->