### PR TITLE
fix(j-s): Casefiles use the same order in all places

### DIFF
--- a/apps/judicial-system/backend/src/app/modules/repository/types/caseRepository.types.ts
+++ b/apps/judicial-system/backend/src/app/modules/repository/types/caseRepository.types.ts
@@ -153,6 +153,10 @@ export const caseInclude: Includeable[] = [
         model: CaseFile,
         as: 'caseFiles',
         required: false,
+        order: [
+          ['orderWithinChapter', 'ASC NULLS LAST'],
+          ['created', 'ASC'],
+        ],
         where: { state: { [Op.not]: CaseFileState.DELETED }, category: null },
         separate: true,
       },

--- a/apps/judicial-system/backend/src/app/modules/repository/types/caseRepository.types.ts
+++ b/apps/judicial-system/backend/src/app/modules/repository/types/caseRepository.types.ts
@@ -284,7 +284,10 @@ export const caseInclude: Includeable[] = [
     model: CaseFile,
     as: 'caseFiles',
     required: false,
-    order: [['created', 'DESC']],
+    order: [
+      ['orderWithinChapter', 'ASC NULLS LAST'],
+      ['created', 'ASC'],
+    ],
     where: { state: { [Op.not]: CaseFileState.DELETED } },
     separate: true,
   },

--- a/apps/judicial-system/web/src/routes/Court/InvestigationCase/Ruling/Ruling.tsx
+++ b/apps/judicial-system/web/src/routes/Court/InvestigationCase/Ruling/Ruling.tsx
@@ -15,7 +15,6 @@ import {
 } from '@island.is/judicial-system/consts'
 import { formatDate } from '@island.is/judicial-system/formatters'
 import { isAcceptingCaseDecision } from '@island.is/judicial-system/types'
-import { sortCaseFiles } from '@island.is/judicial-system/types'
 import { core, ruling, titles } from '@island.is/judicial-system-web/messages'
 import {
   CaseFileList,
@@ -108,9 +107,8 @@ const Ruling = () => {
     [workingCase.id],
   )
   const stepIsValid = isRulingValidIC(workingCase)
-  const caseFiles = sortCaseFiles(
-    workingCase.caseFiles?.filter((file) => !file.category) ?? [],
-  )
+  const caseFiles =
+    workingCase.caseFiles?.filter((file) => !file.category) ?? []
 
   const isRulingRequired = !workingCase.isCompletedWithoutRuling
 

--- a/apps/judicial-system/web/src/routes/Court/RestrictionCase/Ruling/Ruling.tsx
+++ b/apps/judicial-system/web/src/routes/Court/RestrictionCase/Ruling/Ruling.tsx
@@ -17,7 +17,6 @@ import {
 } from '@island.is/judicial-system/consts'
 import { formatDate } from '@island.is/judicial-system/formatters'
 import { isAcceptingCaseDecision } from '@island.is/judicial-system/types'
-import { sortCaseFiles } from '@island.is/judicial-system/types'
 import { core, ruling, titles } from '@island.is/judicial-system-web/messages'
 import {
   CaseFileList,
@@ -125,9 +124,8 @@ export const Ruling = () => {
   )
 
   const stepIsValid = isRulingValidRC(workingCase)
-  const caseFiles = sortCaseFiles(
-    workingCase.caseFiles?.filter((file) => !file.category) ?? [],
-  )
+  const caseFiles =
+    workingCase.caseFiles?.filter((file) => !file.category) ?? []
 
   const handleIsolationChange = useCallback(() => {
     let conclusion = undefined

--- a/apps/judicial-system/web/src/routes/Prosecutor/InvestigationCase/Overview/Overview.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/InvestigationCase/Overview/Overview.tsx
@@ -15,7 +15,6 @@ import {
   PROSECUTION_INVESTIGATION_CASE_CASE_FILES_ROUTE,
 } from '@island.is/judicial-system/consts'
 import { formatDate } from '@island.is/judicial-system/formatters'
-import { sortCaseFiles } from '@island.is/judicial-system/types'
 import {
   core,
   errors,
@@ -134,9 +133,8 @@ export const Overview = () => {
   const { digitalCaseFiles, digitalCaseFilesLoading, openDigitalCaseFileUrl } =
     usePoliceDigitalCaseFile()
 
-  const caseFiles = sortCaseFiles(
-    workingCase.caseFiles?.filter((file) => !file.category) ?? [],
-  )
+  const caseFiles =
+    workingCase.caseFiles?.filter((file) => !file.category) ?? []
 
   return (
     <PageLayout

--- a/apps/judicial-system/web/src/routes/Prosecutor/RestrictionCase/Overview/Overview.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/RestrictionCase/Overview/Overview.tsx
@@ -15,7 +15,6 @@ import {
   PROSECUTION_RESTRICTION_CASE_CASE_FILES_ROUTE,
 } from '@island.is/judicial-system/consts'
 import { formatDate, lowercase } from '@island.is/judicial-system/formatters'
-import { sortCaseFiles } from '@island.is/judicial-system/types'
 import {
   core,
   errors,
@@ -137,9 +136,8 @@ export const Overview = () => {
     setModal('caseSubmittedModal')
   }
 
-  const caseFiles = sortCaseFiles(
-    workingCase.caseFiles?.filter((file) => !file.category) ?? [],
-  )
+  const caseFiles =
+    workingCase.caseFiles?.filter((file) => !file.category) ?? []
 
   return (
     <PageLayout


### PR DESCRIPTION
[Asana](https://app.asana.com/1/203394141643832/project/1212657017130395/task/1213714030115781?focus=true)

## What

The sorting was done client side, and not called for district court users. Changed it so the sorting is done in the backend, so all consumers of casefiles get the correct order, without having to sort before rendering.

## Why

Consistency



## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Cursor


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Case files are now ordered more predictably in backend results, using chapter order first (with missing values last) and then creation time.
  * “Investigation documents” lists in ruling and overview pages now exclude categorized items and no longer apply extra client-side sorting, avoiding unexpected reordering across sections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->