### PR TITLE
chore(web): Change column order for customs storage locations table

### DIFF
--- a/apps/web/components/connected/CustomsGeneral/CustomsGeneralStorageLocations.tsx
+++ b/apps/web/components/connected/CustomsGeneral/CustomsGeneralStorageLocations.tsx
@@ -21,14 +21,14 @@ const CustomsGeneralStorageLocations = () => {
   const [selectedDate] = useState<Date>(new Date())
 
   const columns = [
-    {
-      key: 'nationalId' as const,
-      label: formatMessage(m.storageLocationNationalId),
-    },
     { key: 'code' as const, label: formatMessage(m.storageLocationCode) },
     {
       key: 'companyName' as const,
       label: formatMessage(m.storageLocationCompanyName),
+    },
+    {
+      key: 'nationalId' as const,
+      label: formatMessage(m.storageLocationNationalId),
     },
     {
       key: 'location' as const,


### PR DESCRIPTION
# Change column order for customs storage locations table

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [x] No AI tools were used in preparing this pull request
- [ ] AI tools were used in preparing this pull request
      Tools used:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Updates**
  * Reordered columns in the customs storage locations table, moving the national ID field to appear after the company name.
  * Table data and behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->