### PR TITLE
fix(my-pages-occupational-licenses): sailors ui fixes

### DIFF
--- a/libs/portals/core/src/components/Table/Table.tsx
+++ b/libs/portals/core/src/components/Table/Table.tsx
@@ -224,7 +224,7 @@ export const Table = <TData extends object>({
                   </Box>
                 )}
               </Box>
-              <Box marginBottom={isExpanded || isCollapsing ? 0 : 2}>
+              <Box>
                 {dataCells.map((cell) => {
                   const headerGroup = table.getHeaderGroups()[0]
                   const header = headerGroup?.headers.find(
@@ -265,7 +265,7 @@ export const Table = <TData extends object>({
                             cell.getContext(),
                           )
                         ) : (
-                          <Text>
+                          <Text textAlign="right">
                             {flexRender(
                               cell.column.columnDef.cell,
                               cell.getContext(),

--- a/libs/portals/my-pages/core/src/components/NestedLines/NestedLines.tsx
+++ b/libs/portals/my-pages/core/src/components/NestedLines/NestedLines.tsx
@@ -118,9 +118,7 @@ export const NestedLines = ({
             >
               <GridContainer className={cn(styles.innerGrid)}>
                 <GridRow>
-                  <GridColumn
-                    span={isMobile ? '6/12' : ['12/12', '12/12', titleWidth]}
-                  >
+                  <GridColumn span={['12/12', '12/12', titleWidth]}>
                     <Box className={styles.titleCol}>
                       <Text
                         fontWeight={boldTitle ? 'medium' : 'regular'}
@@ -131,9 +129,7 @@ export const NestedLines = ({
                       </Text>
                     </Box>
                   </GridColumn>
-                  <GridColumn
-                    span={isMobile ? '6/12' : ['12/12', '12/12', columnWidth]}
-                  >
+                  <GridColumn span={['12/12', '12/12', columnWidth]}>
                     <Box className={styles.valueCol}>
                       {item.type === 'link' && item.href ? (
                         <LinkButton

--- a/libs/portals/my-pages/occupational-licenses/src/lib/messages.ts
+++ b/libs/portals/my-pages/occupational-licenses/src/lib/messages.ts
@@ -239,7 +239,7 @@ export const olMessage = defineMessages({
   },
   sailorCrewRegistrationsTabsLabel: {
     id: 'sp.occupational-licenses:sailor-crew-registrations-tabs-label',
-    defaultMessage: 'Lögskráningar',
+    defaultMessage: 'Veldu tegund',
   },
   sailorColumnRank: {
     id: 'sp.occupational-licenses:sailor-column-rank',

--- a/libs/portals/my-pages/occupational-licenses/src/screens/Sailors/CompetencyCertificates/CompetencyCertificates.tsx
+++ b/libs/portals/my-pages/occupational-licenses/src/screens/Sailors/CompetencyCertificates/CompetencyCertificates.tsx
@@ -90,7 +90,7 @@ const CompetencyCertificates = () => {
                 <Text fontWeight="semiBold">{title}</Text>
               </Box>
               <Box width="half">
-                <Text>{value}</Text>
+                <Text textAlign="right">{value}</Text>
               </Box>
             </Box>
           ))}

--- a/libs/portals/my-pages/occupational-licenses/src/screens/Sailors/LegalRegistrations/Exemptions/Exemptions.tsx
+++ b/libs/portals/my-pages/occupational-licenses/src/screens/Sailors/LegalRegistrations/Exemptions/Exemptions.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from 'react'
 import { useLocale } from '@island.is/localization'
 import {
   Box,
+  Divider,
   FilterInput,
   GridColumn,
   GridRow,
@@ -98,7 +99,14 @@ export const Exemptions = () => {
       },
     ]
     if (isMobile) {
-      return <NestedLines data={nestedData} />
+      return (
+        <>
+          <Box paddingTop={3} paddingBottom={2}>
+            <Divider />
+          </Box>
+          <NestedLines data={nestedData} />
+        </>
+      )
     }
     return <NestedTable data={nestedData} />
   }

--- a/libs/portals/my-pages/occupational-licenses/src/screens/Sailors/LegalRegistrations/LegalRegistrations.tsx
+++ b/libs/portals/my-pages/occupational-licenses/src/screens/Sailors/LegalRegistrations/LegalRegistrations.tsx
@@ -31,6 +31,7 @@ const LegalRegistrations = () => {
       <Box marginTop={5} marginBottom={5}>
         <Tabs
           label={formatMessage(om.sailorCrewRegistrationsTabsLabel)}
+          size="xs"
           contentBackground="white"
           selected="seagoing-service"
           onlyRenderSelectedTab

--- a/libs/portals/my-pages/occupational-licenses/src/screens/Sailors/LegalRegistrations/SeagoingTime/SeagoingTime.tsx
+++ b/libs/portals/my-pages/occupational-licenses/src/screens/Sailors/LegalRegistrations/SeagoingTime/SeagoingTime.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from 'react'
 import { useLocale } from '@island.is/localization'
-import { Box, Pagination, Stack, Text } from '@island.is/island-ui/core'
+import { Box, Divider, Pagination, Stack, Text } from '@island.is/island-ui/core'
 import {
   CardLoader,
   NestedLines,
@@ -178,7 +178,14 @@ export const SeagoingTime = () => {
     ]
 
     if (isMobile) {
-      return <NestedLines data={nestedData} />
+      return (
+        <>
+          <Box paddingTop={3} paddingBottom={2}>
+            <Divider />
+          </Box>
+          <NestedLines data={nestedData} />
+        </>
+      )
     }
     return <NestedTable data={nestedData} />
   }

--- a/libs/portals/my-pages/occupational-licenses/src/screens/Sailors/LegalRegistrations/SeagoingTime/SeagoingTime.tsx
+++ b/libs/portals/my-pages/occupational-licenses/src/screens/Sailors/LegalRegistrations/SeagoingTime/SeagoingTime.tsx
@@ -1,6 +1,12 @@
 import { useEffect, useMemo, useState } from 'react'
 import { useLocale } from '@island.is/localization'
-import { Box, Divider, Pagination, Stack, Text } from '@island.is/island-ui/core'
+import {
+  Box,
+  Divider,
+  Pagination,
+  Stack,
+  Text,
+} from '@island.is/island-ui/core'
 import {
   CardLoader,
   NestedLines,

--- a/libs/portals/my-pages/occupational-licenses/src/screens/Sailors/RightCertificates/RightCertificates.tsx
+++ b/libs/portals/my-pages/occupational-licenses/src/screens/Sailors/RightCertificates/RightCertificates.tsx
@@ -96,7 +96,7 @@ const RightCertificates = () => {
                 <Text fontWeight="semiBold">{title}</Text>
               </Box>
               <Box width="half">
-                <Text>{value}</Text>
+                <Text textAlign="right">{value}</Text>
               </Box>
             </Box>
           ))}


### PR DESCRIPTION


## What
 
Minor UI fixes for the sailors section on mobile:

  * Right-align values in mobile key-value rows (competency certs, right certs, table cells)
 * Add a Divider above NestedLines in seagoing time and exemptions on mobile to visually separate entries
  * Fix NestedLines column spans — remove the manual isMobile conditional that was overriding the responsive span array
  * Remove stale bottom margin on collapsed table rows
  * Change tabs label to "Veldu tegund" and set tab size to xs

## Why

The mobile layout had misaligned values (left-aligned where right was expected) and missing separators between list items, making the data hard to read on small screens.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: claude code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mobile/tablet rendering for tables and expanded-row layouts.
  * Added clearer visual separation for nested exemption and seagoing time details using dividers.
  * Updated mobile grid layout behavior for nested line titles/values.
  * Right-aligned value text across several mobile expanded-row/cell views for better readability.
* **Style**
  * Updated compact tab sizing in the sailors occupational licenses screen.
  * Adjusted one occupational-licenses label to match the current selection prompt.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->