### PR TITLE
feat(web): Customs Calculator - Allow CMS to override currency options

### DIFF
--- a/apps/web/components/connected/CustomsCalculator/CustomsCalculator.tsx
+++ b/apps/web/components/connected/CustomsCalculator/CustomsCalculator.tsx
@@ -60,27 +60,29 @@ const CustomsCalculator = ({ slice }: CustomsCalculatorProps) => {
   const { formatMessage } = useIntl()
 
   const currencyOptions = useMemo<StringOption[]>(() => {
-    return [
-      { label: 'ISK', value: 'ISK', description: 'Íslensk króna' },
-      { label: 'AUD', value: 'AUD', description: 'Ástralíudalur' },
-      { label: 'CAD', value: 'CAD', description: 'Kanadadalur' },
-      { label: 'CHF', value: 'CHF', description: 'Svissneskur franki' },
-      { label: 'DKK', value: 'DKK', description: 'Dönsk króna' },
-      { label: 'EUR', value: 'EUR', description: 'Evra' },
-      { label: 'GBP', value: 'GBP', description: 'Sterlingspund' },
-      { label: 'HKD', value: 'HKD', description: 'Hong Kong dalur' },
-      { label: 'INR', value: 'INR', description: 'Indversk Rúpía' },
-      { label: 'JPY', value: 'JPY', description: 'Japanskt jen' },
-      { label: 'NOK', value: 'NOK', description: 'Norsk króna' },
-      { label: 'NZD', value: 'NZD', description: 'Ný-Sjálenskur dalur' },
-      { label: 'PLN', value: 'PLN', description: 'Pólskt slot' },
-      { label: 'SEK', value: 'SEK', description: 'Sænsk króna' },
-      { label: 'SGD', value: 'SGD', description: 'Singapúrskur dalur' },
-      { label: 'THB', value: 'THB', description: 'Taílenskt bat' },
-      { label: 'TWD', value: 'TWD', description: 'Tævanskur dalur' },
-      { label: 'USD', value: 'USD', description: 'Bandaríkjadalur' },
-    ]
-  }, [])
+    return (
+      slice.configJson?.currencyOptions ?? [
+        { label: 'ISK', value: 'ISK', description: 'Íslensk króna' },
+        { label: 'AUD', value: 'AUD', description: 'Ástralíudalur' },
+        { label: 'CAD', value: 'CAD', description: 'Kanadadalur' },
+        { label: 'CHF', value: 'CHF', description: 'Svissneskur franki' },
+        { label: 'DKK', value: 'DKK', description: 'Dönsk króna' },
+        { label: 'EUR', value: 'EUR', description: 'Evra' },
+        { label: 'GBP', value: 'GBP', description: 'Sterlingspund' },
+        { label: 'HKD', value: 'HKD', description: 'Hong Kong dalur' },
+        { label: 'INR', value: 'INR', description: 'Indversk Rúpía' },
+        { label: 'JPY', value: 'JPY', description: 'Japanskt jen' },
+        { label: 'NOK', value: 'NOK', description: 'Norsk króna' },
+        { label: 'NZD', value: 'NZD', description: 'Ný-Sjálenskur dalur' },
+        { label: 'PLN', value: 'PLN', description: 'Pólskt slot' },
+        { label: 'SEK', value: 'SEK', description: 'Sænsk króna' },
+        { label: 'SGD', value: 'SGD', description: 'Singapúrskur dalur' },
+        { label: 'THB', value: 'THB', description: 'Taílenskt bat' },
+        { label: 'TWD', value: 'TWD', description: 'Tævanskur dalur' },
+        { label: 'USD', value: 'USD', description: 'Bandaríkjadalur' },
+      ]
+    )
+  }, [slice.configJson?.currencyOptions])
 
   const [inputState, setInputState] = useState({
     searchInput: '',


### PR DESCRIPTION
# Customs Calculator - Allow CMS to override currency options

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [x] No AI tools were used in preparing this pull request
- [ ] AI tools were used in preparing this pull request
      Tools used:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Currency options in the customs calculator can now be driven by configured settings when available, with a default list still used as a fallback.
* **Bug Fixes**
  * Currency options now refresh correctly when the available configuration changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->