### PR TITLE
chore(j-s): add withdrawal and merge tags to info cards

### DIFF
--- a/apps/judicial-system/web/src/components/InfoCard/DefendantInfo/DefendantInfo.logic.spec.ts
+++ b/apps/judicial-system/web/src/components/InfoCard/DefendantInfo/DefendantInfo.logic.spec.ts
@@ -1,4 +1,7 @@
-import { ServiceRequirement } from '@island.is/judicial-system-web/src/graphql/schema'
+import {
+  CaseIndictmentRulingDecision,
+  ServiceRequirement,
+} from '@island.is/judicial-system-web/src/graphql/schema'
 
 import {
   getAppealExpirationInfo,
@@ -203,13 +206,11 @@ describe('DefendantInfo', () => {
       })
     })
 
-    test('should return dismissal tag when there is no verdict and dismissal case is true', () => {
+    test('should return dismissal tag when there is no verdict and ruling decision is DISMISSAL', () => {
       const tag = getDefendantTagConfig({
         verdict: null,
         isPublicProsecutionOffice: false,
-        isDismissalCase: true,
-        isCancellationCase: true,
-        isFineCase: true,
+        indictmentRulingDecision: CaseIndictmentRulingDecision.DISMISSAL,
       })
 
       expect(tag).toStrictEqual({
@@ -218,11 +219,37 @@ describe('DefendantInfo', () => {
       })
     })
 
-    test('should return withdrawal tag when there is no verdict and withdrawal case is true', () => {
+    test('should return cancellation tag when there is no verdict and ruling decision is CANCELLATION', () => {
       const tag = getDefendantTagConfig({
         verdict: null,
         isPublicProsecutionOffice: false,
-        isWithdrawalCase: true,
+        indictmentRulingDecision: CaseIndictmentRulingDecision.CANCELLATION,
+      })
+
+      expect(tag).toStrictEqual({
+        label: 'Niðurfelling',
+        variant: 'rose',
+      })
+    })
+
+    test('should return fine tag when there is no verdict and ruling decision is FINE', () => {
+      const tag = getDefendantTagConfig({
+        verdict: null,
+        isPublicProsecutionOffice: false,
+        indictmentRulingDecision: CaseIndictmentRulingDecision.FINE,
+      })
+
+      expect(tag).toStrictEqual({
+        label: 'Viðurlagaákvörðun',
+        variant: 'mint',
+      })
+    })
+
+    test('should return withdrawal tag when there is no verdict and ruling decision is WITHDRAWAL', () => {
+      const tag = getDefendantTagConfig({
+        verdict: null,
+        isPublicProsecutionOffice: false,
+        indictmentRulingDecision: CaseIndictmentRulingDecision.WITHDRAWAL,
       })
 
       expect(tag).toStrictEqual({
@@ -231,11 +258,11 @@ describe('DefendantInfo', () => {
       })
     })
 
-    test('should return merge tag when there is no verdict and merge case is true', () => {
+    test('should return merge tag when there is no verdict and ruling decision is MERGE', () => {
       const tag = getDefendantTagConfig({
         verdict: null,
         isPublicProsecutionOffice: false,
-        isMergeCase: true,
+        indictmentRulingDecision: CaseIndictmentRulingDecision.MERGE,
       })
 
       expect(tag).toStrictEqual({

--- a/apps/judicial-system/web/src/components/InfoCard/DefendantInfo/DefendantInfo.logic.spec.ts
+++ b/apps/judicial-system/web/src/components/InfoCard/DefendantInfo/DefendantInfo.logic.spec.ts
@@ -218,6 +218,32 @@ describe('DefendantInfo', () => {
       })
     })
 
+    test('should return withdrawal tag when there is no verdict and withdrawal case is true', () => {
+      const tag = getDefendantTagConfig({
+        verdict: null,
+        isPublicProsecutionOffice: false,
+        isWithdrawalCase: true,
+      })
+
+      expect(tag).toStrictEqual({
+        label: 'Afturkallað',
+        variant: 'rose',
+      })
+    })
+
+    test('should return merge tag when there is no verdict and merge case is true', () => {
+      const tag = getDefendantTagConfig({
+        verdict: null,
+        isPublicProsecutionOffice: false,
+        isMergeCase: true,
+      })
+
+      expect(tag).toStrictEqual({
+        label: 'Sameinað',
+        variant: 'rose',
+      })
+    })
+
     test('should return null when no statuses match', () => {
       const tag = getDefendantTagConfig({
         verdict: null,

--- a/apps/judicial-system/web/src/components/InfoCard/DefendantInfo/DefendantInfo.logic.ts
+++ b/apps/judicial-system/web/src/components/InfoCard/DefendantInfo/DefendantInfo.logic.ts
@@ -1,7 +1,10 @@
 import { IntlShape } from 'react-intl'
 
 import { formatDate } from '@island.is/judicial-system/formatters'
-import { ServiceRequirement } from '@island.is/judicial-system-web/src/graphql/schema'
+import {
+  CaseIndictmentRulingDecision,
+  ServiceRequirement,
+} from '@island.is/judicial-system-web/src/graphql/schema'
 
 import { strings } from './DefendantInfo.strings'
 
@@ -67,19 +70,11 @@ export const getVerdictViewDateText = (
 export const getDefendantTagConfig = ({
   verdict,
   isPublicProsecutionOffice,
-  isDismissalCase,
-  isCancellationCase,
-  isFineCase,
-  isWithdrawalCase,
-  isMergeCase,
+  indictmentRulingDecision,
 }: {
   verdict?: DefendantVerdictTagInput | null
   isPublicProsecutionOffice: boolean
-  isDismissalCase?: boolean
-  isCancellationCase?: boolean
-  isFineCase?: boolean
-  isWithdrawalCase?: boolean
-  isMergeCase?: boolean
+  indictmentRulingDecision?: CaseIndictmentRulingDecision | null
 }): DefendantTagConfig | null => {
   if (verdict) {
     if (
@@ -116,40 +111,33 @@ export const getDefendantTagConfig = ({
     }
   }
 
-  if (isDismissalCase) {
-    return {
-      label: 'Frávísun',
-      variant: 'blue',
-    }
+  switch (indictmentRulingDecision) {
+    case CaseIndictmentRulingDecision.DISMISSAL:
+      return {
+        label: 'Frávísun',
+        variant: 'blue',
+      }
+    case CaseIndictmentRulingDecision.CANCELLATION:
+      return {
+        label: 'Niðurfelling',
+        variant: 'rose',
+      }
+    case CaseIndictmentRulingDecision.FINE:
+      return {
+        label: 'Viðurlagaákvörðun',
+        variant: 'mint',
+      }
+    case CaseIndictmentRulingDecision.WITHDRAWAL:
+      return {
+        label: 'Afturkallað',
+        variant: 'rose',
+      }
+    case CaseIndictmentRulingDecision.MERGE:
+      return {
+        label: 'Sameinað',
+        variant: 'rose',
+      }
+    default:
+      return null
   }
-
-  if (isCancellationCase) {
-    return {
-      label: 'Niðurfelling',
-      variant: 'rose',
-    }
-  }
-
-  if (isFineCase) {
-    return {
-      label: 'Viðurlagaákvörðun',
-      variant: 'mint',
-    }
-  }
-
-  if (isWithdrawalCase) {
-    return {
-      label: 'Afturkallað',
-      variant: 'rose',
-    }
-  }
-
-  if (isMergeCase) {
-    return {
-      label: 'Sameinað',
-      variant: 'rose',
-    }
-  }
-
-  return null
 }

--- a/apps/judicial-system/web/src/components/InfoCard/DefendantInfo/DefendantInfo.logic.ts
+++ b/apps/judicial-system/web/src/components/InfoCard/DefendantInfo/DefendantInfo.logic.ts
@@ -70,12 +70,16 @@ export const getDefendantTagConfig = ({
   isDismissalCase,
   isCancellationCase,
   isFineCase,
+  isWithdrawalCase,
+  isMergeCase,
 }: {
   verdict?: DefendantVerdictTagInput | null
   isPublicProsecutionOffice: boolean
   isDismissalCase?: boolean
   isCancellationCase?: boolean
   isFineCase?: boolean
+  isWithdrawalCase?: boolean
+  isMergeCase?: boolean
 }): DefendantTagConfig | null => {
   if (verdict) {
     if (
@@ -130,6 +134,20 @@ export const getDefendantTagConfig = ({
     return {
       label: 'Viðurlagaákvörðun',
       variant: 'mint',
+    }
+  }
+
+  if (isWithdrawalCase) {
+    return {
+      label: 'Afturkallað',
+      variant: 'rose',
+    }
+  }
+
+  if (isMergeCase) {
+    return {
+      label: 'Sameinað',
+      variant: 'rose',
     }
   }
 

--- a/apps/judicial-system/web/src/components/InfoCard/DefendantInfo/DefendantInfo.tsx
+++ b/apps/judicial-system/web/src/components/InfoCard/DefendantInfo/DefendantInfo.tsx
@@ -53,6 +53,8 @@ interface DefendantInfoProps {
   isDismissalCase?: boolean
   isCancellationCase?: boolean
   isFineCase?: boolean
+  isWithdrawalCase?: boolean
+  isMergeCase?: boolean
 }
 
 const ConnectedCasesInfo = ({
@@ -121,6 +123,8 @@ export const DefendantInfo: FC<DefendantInfoProps> = (props) => {
     isDismissalCase,
     isCancellationCase,
     isFineCase,
+    isWithdrawalCase,
+    isMergeCase,
   } = props
   const { formatMessage } = useIntl()
   const { user } = useContext(UserContext)
@@ -147,6 +151,8 @@ export const DefendantInfo: FC<DefendantInfoProps> = (props) => {
     isDismissalCase,
     isCancellationCase,
     isFineCase,
+    isWithdrawalCase,
+    isMergeCase,
   })
 
   return (

--- a/apps/judicial-system/web/src/components/InfoCard/DefendantInfo/DefendantInfo.tsx
+++ b/apps/judicial-system/web/src/components/InfoCard/DefendantInfo/DefendantInfo.tsx
@@ -9,12 +9,10 @@ import {
   formatDate,
   formatDOB,
 } from '@island.is/judicial-system/formatters'
-import {
-  CaseIndictmentRulingDecision,
-  isPublicProsecutionOfficeUser,
-} from '@island.is/judicial-system/types'
+import { isPublicProsecutionOfficeUser } from '@island.is/judicial-system/types'
 import { core } from '@island.is/judicial-system-web/messages'
 import {
+  CaseIndictmentRulingDecision,
   Defendant,
   ServiceRequirement,
   SessionArrangements,
@@ -50,11 +48,7 @@ interface DefendantInfoProps {
   displaySentToPrisonAdminDate?: boolean
   defender?: Defender
   displayOpenCaseReference?: boolean
-  isDismissalCase?: boolean
-  isCancellationCase?: boolean
-  isFineCase?: boolean
-  isWithdrawalCase?: boolean
-  isMergeCase?: boolean
+  indictmentRulingDecision?: CaseIndictmentRulingDecision | null
 }
 
 const ConnectedCasesInfo = ({
@@ -120,11 +114,7 @@ export const DefendantInfo: FC<DefendantInfoProps> = (props) => {
     displaySentToPrisonAdminDate = true,
     displayOpenCaseReference,
     defender,
-    isDismissalCase,
-    isCancellationCase,
-    isFineCase,
-    isWithdrawalCase,
-    isMergeCase,
+    indictmentRulingDecision,
   } = props
   const { formatMessage } = useIntl()
   const { user } = useContext(UserContext)
@@ -148,11 +138,7 @@ export const DefendantInfo: FC<DefendantInfoProps> = (props) => {
   const defendantTagConfig = getDefendantTagConfig({
     verdict: defendant.verdict,
     isPublicProsecutionOffice: isPublicProsecutionOfficeUser(user),
-    isDismissalCase,
-    isCancellationCase,
-    isFineCase,
-    isWithdrawalCase,
-    isMergeCase,
+    indictmentRulingDecision,
   })
 
   return (

--- a/apps/judicial-system/web/src/components/InfoCard/useInfoCardItems.tsx
+++ b/apps/judicial-system/web/src/components/InfoCard/useInfoCardItems.tsx
@@ -109,25 +109,8 @@ const useInfoCardItems = () => {
                     displayVerdictViewDate={displayVerdictViewDate}
                     displaySentToPrisonAdminDate={displaySentToPrisonAdminDate}
                     displayOpenCaseReference={displayOpenCaseReference}
-                    isDismissalCase={
-                      workingCase.indictmentRulingDecision ===
-                      CaseIndictmentRulingDecision.DISMISSAL
-                    }
-                    isCancellationCase={
-                      workingCase.indictmentRulingDecision ===
-                      CaseIndictmentRulingDecision.CANCELLATION
-                    }
-                    isFineCase={
-                      workingCase.indictmentRulingDecision ===
-                      CaseIndictmentRulingDecision.FINE
-                    }
-                    isWithdrawalCase={
-                      workingCase.indictmentRulingDecision ===
-                      CaseIndictmentRulingDecision.WITHDRAWAL
-                    }
-                    isMergeCase={
-                      workingCase.indictmentRulingDecision ===
-                      CaseIndictmentRulingDecision.MERGE
+                    indictmentRulingDecision={
+                      workingCase.indictmentRulingDecision
                     }
                   />
                 </div>

--- a/apps/judicial-system/web/src/components/InfoCard/useInfoCardItems.tsx
+++ b/apps/judicial-system/web/src/components/InfoCard/useInfoCardItems.tsx
@@ -121,6 +121,14 @@ const useInfoCardItems = () => {
                       workingCase.indictmentRulingDecision ===
                       CaseIndictmentRulingDecision.FINE
                     }
+                    isWithdrawalCase={
+                      workingCase.indictmentRulingDecision ===
+                      CaseIndictmentRulingDecision.WITHDRAWAL
+                    }
+                    isMergeCase={
+                      workingCase.indictmentRulingDecision ===
+                      CaseIndictmentRulingDecision.MERGE
+                    }
                   />
                 </div>
               ))}


### PR DESCRIPTION
[Asana](https://app.asana.com/1/203394141643832/project/1212657017130395/task/1215937536709334?focus=true)

## What

Add missing tags to infocards

## Why

These two tags were missing from inforcards

## Screenshots / Gifs

For example:
<img width="852" height="444" alt="image" src="https://github.com/user-attachments/assets/c930897b-825a-43fd-963a-7451760c708d" />


## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Cursor


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Defendant info tags now reflect withdrawal and merge case status when no verdict is available.
  * These cases display updated label and color styling for clearer case identification.

* **Tests**
  * Added coverage for withdrawal and merge tag behavior to ensure the correct tag appears in each scenario.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->