### PR TITLE
fix(native-app): 2 way communications fixes

### DIFF
--- a/apps/native/app/src/app/(auth)/(tabs)/inbox/[id]/communications.tsx
+++ b/apps/native/app/src/app/(auth)/(tabs)/inbox/[id]/communications.tsx
@@ -7,7 +7,7 @@ import {
   SafeAreaView,
   View,
 } from 'react-native'
-import { router, useLocalSearchParams } from 'expo-router'
+import { router, useFocusEffect, useLocalSearchParams } from 'expo-router'
 import styled, { useTheme } from 'styled-components/native'
 
 import { useApolloClient } from '@apollo/client'
@@ -26,6 +26,7 @@ import {
   TOGGLE_ANIMATION_DURATION,
 } from '../../../../../components/document-list-item'
 import { ButtonDrawer } from '../../../../../components/button-drawer'
+import { uiStore } from '@/stores/ui-store'
 
 type FlatListItem = DocumentComment | { __typename: 'Skeleton'; id: string }
 
@@ -108,6 +109,15 @@ export default function DocumentCommunicationsScreen() {
       },
     })
   }
+
+  useFocusEffect(
+    useCallback(() => {
+      uiStore.setState({ tabsHidden: true })
+      return () => {
+        uiStore.setState({ tabsHidden: false })
+      }
+    }, []),
+  )
 
   useEffect(() => {
     if (!isSkeleton && comments.length > 0) {

--- a/apps/native/app/src/app/(auth)/(tabs)/inbox/[id]/communications.tsx
+++ b/apps/native/app/src/app/(auth)/(tabs)/inbox/[id]/communications.tsx
@@ -1,14 +1,10 @@
-import { setStringAsync } from 'expo-clipboard'
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useIntl } from 'react-intl'
 import {
   Animated,
-  Image,
-  LayoutChangeEvent,
   ListRenderItemInfo,
   RefreshControl,
   SafeAreaView,
-  TouchableOpacity,
   View,
 } from 'react-native'
 import { router, useLocalSearchParams } from 'expo-router'
@@ -17,11 +13,13 @@ import styled, { useTheme } from 'styled-components/native'
 import { useApolloClient } from '@apollo/client'
 
 import { StackScreen } from '@/components/stack-screen'
-import { DocumentComment, useGetDocumentQuery } from '@/graphql/types/schema'
-import { useDateTimeFormatter } from '@/hooks/use-date-time-formatter'
+import {
+  DocumentComment,
+  useGetDocumentQuery,
+  useGetProfileQuery,
+} from '@/graphql/types/schema'
 import { useLocale } from '@/hooks/use-locale'
-import { Alert, Button, ListItemSkeleton, TopLine, Typography } from '@/ui'
-import copyIcon from '@/ui/assets/icons/copy.png'
+import { Alert, Button, ListItemSkeleton } from '@/ui'
 import { createSkeletonArr } from '@/utils/create-skeleton-arr'
 import {
   DocumentListItem,
@@ -31,43 +29,19 @@ import { ButtonDrawer } from '../../../../../components/button-drawer'
 
 type FlatListItem = DocumentComment | { __typename: 'Skeleton'; id: string }
 
-const CaseNumberWrapper = styled.View`
-  flex-direction: row;
-  align-items: center;
-  justify-content: center;
-  column-gap: ${({ theme }) => theme.spacing.smallGutter}px;
-`
-
-const ListWrapper = styled.View`
-  flex: 1;
-  margin-top: ${({ theme }) => theme.spacing[2]}px;
-`
-
 const AlertsContainer = styled.View`
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  z-index: 1;
-  padding-bottom: ${({ theme }) => theme.spacing.p4}px;
   padding-horizontal: ${({ theme }) => theme.spacing[2]}px;
+  padding-bottom: ${({ theme }) => theme.spacing[2]}px;
 `
 
 export default function DocumentCommunicationsScreen() {
-  const {
-    id: documentId,
-    ticketId,
-    replyEmail,
-  } = useLocalSearchParams<{
+  const { id: documentId, ticketId } = useLocalSearchParams<{
     id: string
     ticketId?: string
-    replyEmail?: string
   }>()
   const locale = useLocale()
   const theme = useTheme()
   const intl = useIntl()
-  const formatDate = useDateTimeFormatter()
-  const [actionsHeight, setActionsHeight] = useState(0)
   const [refetching, setRefetching] = useState(false)
   const flatListRef = useRef<Animated.FlatList>(null)
   const scrollY = useRef(new Animated.Value(0)).current
@@ -98,6 +72,9 @@ export default function DocumentCommunicationsScreen() {
     },
   })
 
+  const profileRes = useGetProfileQuery()
+  const userEmail = profileRes.data?.getUserProfile?.email ?? undefined
+
   const document = docRes.data?.documentV2
   const comments = document?.ticket?.comments ?? []
   const replyable =
@@ -106,6 +83,11 @@ export default function DocumentCommunicationsScreen() {
       : false
   const closedForMoreReplies = document?.closedForMoreReplies ?? false
   const isSkeleton = docRes.loading && !docRes.data
+
+  const hasUserComment = comments.some((c) => c.isZendeskAgent === false)
+  const hasAgencyReply = comments.some((c) => c.isZendeskAgent === true)
+  const showAwaitingReplyAlert =
+    replyable && hasUserComment && !hasAgencyReply && !!userEmail
 
   const handleRefresh = () => {
     setRefetching(true)
@@ -142,6 +124,12 @@ export default function DocumentCommunicationsScreen() {
     [],
   )
 
+  const ticketIdNumber = document?.ticket?.id ?? ticketId ?? ''
+  const ticketIdValue = `#${ticketIdNumber}`
+  const caseNumberLabel = intl.formatMessage({
+    id: 'documentCommunications.caseNumber',
+  })
+
   const renderItem = useCallback(
     ({ item, index }: ListRenderItemInfo<FlatListItem>) => {
       if (item.__typename === 'Skeleton') {
@@ -156,13 +144,23 @@ export default function DocumentCommunicationsScreen() {
           sender={item.author ?? ''}
           title={item.author ?? ''}
           body={item.body ?? undefined}
-          date={item.createdDate ? formatDate(item.createdDate) : undefined}
+          date={
+            item.createdDate
+              ? intl.formatDate(new Date(item.createdDate), {
+                  day: 'numeric',
+                  month: 'long',
+                  year: 'numeric',
+                })
+              : undefined
+          }
+          caseNumber={ticketIdNumber || undefined}
+          caseNumberLabel={caseNumberLabel}
           hasTopBorder={index !== 0}
         />
       )
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [comments.length],
+    [comments.length, ticketIdNumber, caseNumberLabel],
   )
 
   const data = useMemo(
@@ -171,36 +169,46 @@ export default function DocumentCommunicationsScreen() {
     [isSkeleton, docRes.data],
   ) as FlatListItem[]
 
-  const ticketIdValue = `#${document?.ticket?.id ?? ticketId ?? ''}`
-
   return (
     <>
       <StackScreen
         networkStatus={docRes.networkStatus}
         options={{
-          headerTitle: () => (
-            <CaseNumberWrapper style={{ backgroundColor: 'white' }}>
-              <Typography variant="eyebrow" color={theme.color.purple400}>
-                {intl.formatMessage({
-                  id: 'documentCommunications.caseNumber',
-                })}
-              </Typography>
-              <Typography variant="body3">{ticketIdValue}</Typography>
-              <TouchableOpacity
-                onPress={() => setStringAsync(ticketIdValue)}
-                style={{ marginLeft: 4 }}
-              >
-                <Image
-                  source={copyIcon}
-                  style={{ width: 24, height: 24 }}
-                  resizeMode="contain"
-                />
-              </TouchableOpacity>
-            </CaseNumberWrapper>
-          ),
+          title: document?.subject ?? '',
+          headerTitleAlign: 'center',
         }}
       />
       <View style={{ flexDirection: 'column', flex: 1 }}>
+        {(closedForMoreReplies || showAwaitingReplyAlert) && (
+          <AlertsContainer>
+            <View style={{ rowGap: theme.spacing[2] }}>
+              {closedForMoreReplies && (
+                <Alert
+                  type="info"
+                  message={intl.formatMessage({
+                    id: 'documentCommunications.cannotReply',
+                  })}
+                  hasBorder
+                />
+              )}
+              {showAwaitingReplyAlert && (
+                <Alert
+                  type="info"
+                  message={intl.formatMessage(
+                    {
+                      id: 'documentCommunications.initialReply',
+                    },
+                    {
+                      email: userEmail,
+                      caseNumber: ticketIdValue,
+                    },
+                  )}
+                  hasBorder
+                />
+              )}
+            </View>
+          </AlertsContainer>
+        )}
         <Animated.FlatList
           ref={flatListRef}
           keyExtractor={keyExtractor}
@@ -216,39 +224,6 @@ export default function DocumentCommunicationsScreen() {
           automaticallyAdjustContentInsets
           ListFooterComponent={<SafeAreaView style={{ height: 160 }} />}
         />
-        {(closedForMoreReplies || (replyEmail && replyable)) && (
-          <AlertsContainer
-            onLayout={(event: LayoutChangeEvent) => {
-              setActionsHeight(event.nativeEvent.layout.height)
-            }}
-          >
-            <SafeAreaView style={{ rowGap: theme.spacing[2] }}>
-              {closedForMoreReplies && (
-                <Alert
-                  type="info"
-                  message={intl.formatMessage({
-                    id: 'documentCommunications.cannotReply',
-                  })}
-                  hasBorder
-                />
-              )}
-              {replyEmail && replyable && (
-                <Alert
-                  type="info"
-                  message={intl.formatMessage(
-                    {
-                      id: 'documentCommunications.initialReply',
-                    },
-                    {
-                      email: replyEmail,
-                    },
-                  )}
-                  hasBorder
-                />
-              )}
-            </SafeAreaView>
-          </AlertsContainer>
-        )}
         {replyable && !closedForMoreReplies && (
           <ButtonDrawer>
             <SafeAreaView>

--- a/apps/native/app/src/app/(auth)/(tabs)/inbox/[id]/communications.tsx
+++ b/apps/native/app/src/app/(auth)/(tabs)/inbox/[id]/communications.tsx
@@ -85,10 +85,22 @@ export default function DocumentCommunicationsScreen() {
   const closedForMoreReplies = document?.closedForMoreReplies ?? false
   const isSkeleton = docRes.loading && !docRes.data
 
-  const hasUserComment = comments.some((c) => c.isZendeskAgent === false)
-  const hasAgencyReply = comments.some((c) => c.isZendeskAgent === true)
+  const ticketIdNumber = document?.ticket?.id ?? ticketId ?? ''
+  const firstUserCommentIndex = comments.findIndex(
+    (c) => c.isZendeskAgent === false,
+  )
+  const hasUserComment = firstUserCommentIndex !== -1
+  const hasAgencyReplyAfterUser =
+    hasUserComment &&
+    comments
+      .slice(firstUserCommentIndex + 1)
+      .some((c) => c.isZendeskAgent === true)
   const showAwaitingReplyAlert =
-    replyable && hasUserComment && !hasAgencyReply && !!userEmail
+    replyable &&
+    hasUserComment &&
+    !hasAgencyReplyAfterUser &&
+    !!userEmail &&
+    !!ticketIdNumber
 
   const handleRefresh = () => {
     setRefetching(true)
@@ -134,10 +146,12 @@ export default function DocumentCommunicationsScreen() {
     [],
   )
 
-  const ticketIdNumber = document?.ticket?.id ?? ticketId ?? ''
   const ticketIdValue = `#${ticketIdNumber}`
   const caseNumberLabel = intl.formatMessage({
     id: 'documentCommunications.caseNumber',
+  })
+  const copyCaseNumberLabel = intl.formatMessage({
+    id: 'documentCommunications.copyCaseNumber',
   })
 
   const renderItem = useCallback(
@@ -165,12 +179,13 @@ export default function DocumentCommunicationsScreen() {
           }
           caseNumber={ticketIdNumber || undefined}
           caseNumberLabel={caseNumberLabel}
+          caseNumberCopyLabel={copyCaseNumberLabel}
           hasTopBorder={index !== 0}
         />
       )
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [comments.length, ticketIdNumber, caseNumberLabel],
+    [comments.length, ticketIdNumber, caseNumberLabel, copyCaseNumberLabel],
   )
 
   const data = useMemo(

--- a/apps/native/app/src/app/(auth)/(tabs)/inbox/[id]/reply.tsx
+++ b/apps/native/app/src/app/(auth)/(tabs)/inbox/[id]/reply.tsx
@@ -146,9 +146,7 @@ export default function DocumentReplyScreen() {
       <StackScreen
         networkStatus={networkStatus}
         closeable
-        options={{
-          title: subject,
-        }}
+        options={{ title: '' }}
       />
       <Host>
         <ToastHost />
@@ -162,6 +160,11 @@ export default function DocumentReplyScreen() {
             keyboardShouldPersistTaps="handled"
           >
             <KeyboardAvoidingView behavior="padding">
+              <HeaderTitle>
+                <Typography variant="heading5" numberOfLines={2}>
+                  {subject}
+                </Typography>
+              </HeaderTitle>
               <Row>
                 <Typography
                   variant="body3"

--- a/apps/native/app/src/app/(auth)/(tabs)/inbox/_layout.tsx
+++ b/apps/native/app/src/app/(auth)/(tabs)/inbox/_layout.tsx
@@ -61,7 +61,6 @@ export default function InboxLayout() {
       <Stack.Screen
         name="[id]/reply"
         options={{
-          headerShown: false,
           ...modalScreenOptions,
         }}
       />

--- a/apps/native/app/src/app/(auth)/(tabs)/inbox/_layout.tsx
+++ b/apps/native/app/src/app/(auth)/(tabs)/inbox/_layout.tsx
@@ -4,6 +4,7 @@ import {
   tabScreenOptions,
 } from '../../../../constants/screen-options'
 import { useIntl } from 'react-intl'
+import { theme } from '@/ui'
 
 export const unstable_settings = {
   initialRouteName: 'index',
@@ -49,7 +50,9 @@ export default function InboxLayout() {
         name="[id]/communications"
         options={{
           headerShown: false,
-          ...modalScreenOptions,
+          ...tabScreenOptions,
+          headerTransparent: false,
+          headerStyle: { backgroundColor: theme.color.white },
           title: intl.formatMessage({
             id: 'documentDetail.buttonCommunications',
           }),

--- a/apps/native/app/src/components/document-list-item.tsx
+++ b/apps/native/app/src/components/document-list-item.tsx
@@ -9,10 +9,9 @@ import Animated, {
 import styled, { useTheme } from 'styled-components/native'
 import { PressableHighlight } from '@/components/pressable-highlight/pressable-highlight'
 import { useOrganizationsStore } from '@/stores/organizations-store'
-import { Container, Icon, Typography } from '@/ui'
+import { Avatar, Container, Icon, Typography } from '@/ui'
 import { Markdown } from '@/ui/lib/markdown/markdown'
 import { isAndroid } from '@/utils/devices'
-import { getInitials } from '@/utils/get-initials'
 
 export const TOGGLE_ANIMATION_DURATION = 300
 
@@ -44,8 +43,8 @@ const Body = styled(Container)`
 const IconBackground = styled.View`
   align-items: center;
   justify-content: center;
-  width: 42px;
-  height: 42px;
+  width: 40px;
+  height: 40px;
   background-color: ${({ theme }) => theme.color.blue100};
   border-radius: ${({ theme }) => theme.border.radius.full};
 `
@@ -131,20 +130,13 @@ export const DocumentListItem = ({
       >
         <View>
           <Host>
-            <IconBackground>
-              {!source ? (
-                <Typography
-                  variant="body"
-                  weight="600"
-                  lineHeight={0}
-                  color={theme.color.blue400}
-                >
-                  {getInitials(sender)}
-                </Typography>
-              ) : (
+            {source ? (
+              <IconBackground>
                 <Icon source={source} width={24} height={24} />
-              )}
-            </IconBackground>
+              </IconBackground>
+            ) : (
+              <Avatar name={sender} isSmall />
+            )}
             <Content>
               <Typography variant="eyebrow">{title}</Typography>
               <Typography variant="body3">{date}</Typography>

--- a/apps/native/app/src/components/document-list-item.tsx
+++ b/apps/native/app/src/components/document-list-item.tsx
@@ -158,9 +158,7 @@ export const DocumentListItem = ({
             <Content>
               <Typography variant="heading5">{title}</Typography>
               <MetaRow>
-                {date ? (
-                  <Typography variant="body3">{date}</Typography>
-                ) : null}
+                {date ? <Typography variant="body3">{date}</Typography> : null}
                 {caseNumber ? (
                   <>
                     {date ? <MetaSeparator /> : null}

--- a/apps/native/app/src/components/document-list-item.tsx
+++ b/apps/native/app/src/components/document-list-item.tsx
@@ -76,6 +76,7 @@ type DocumentListItemProps = {
   date?: string
   caseNumber?: string
   caseNumberLabel?: string
+  caseNumberCopyLabel?: string
   isOpen?: boolean
   closeable?: boolean
   hasTopBorder?: boolean
@@ -89,6 +90,7 @@ export const DocumentListItem = ({
   date,
   caseNumber,
   caseNumberLabel,
+  caseNumberCopyLabel,
   closeable = false,
   isOpen = false,
   hasTopBorder = true,
@@ -169,6 +171,8 @@ export const DocumentListItem = ({
                     <TouchableOpacity
                       onPress={() => setStringAsync(`#${caseNumber}`)}
                       hitSlop={8}
+                      accessibilityRole="button"
+                      accessibilityLabel={caseNumberCopyLabel}
                     >
                       <Image
                         source={copyIcon}

--- a/apps/native/app/src/components/document-list-item.tsx
+++ b/apps/native/app/src/components/document-list-item.tsx
@@ -1,5 +1,6 @@
+import { setStringAsync } from 'expo-clipboard'
 import { useEffect } from 'react'
-import { View } from 'react-native'
+import { Image, TouchableOpacity, View } from 'react-native'
 import Animated, {
   useAnimatedStyle,
   useDerivedValue,
@@ -10,6 +11,7 @@ import styled, { useTheme } from 'styled-components/native'
 import { PressableHighlight } from '@/components/pressable-highlight/pressable-highlight'
 import { useOrganizationsStore } from '@/stores/organizations-store'
 import { Avatar, Container, Icon, Typography } from '@/ui'
+import copyIcon from '@/ui/assets/icons/copy.png'
 import { Markdown } from '@/ui/lib/markdown/markdown'
 import { isAndroid } from '@/utils/devices'
 
@@ -55,11 +57,25 @@ const Content = styled.View`
   row-gap: 2px;
 `
 
+const MetaRow = styled.View`
+  flex-direction: row;
+  align-items: center;
+  column-gap: ${({ theme }) => theme.spacing.smallGutter}px;
+`
+
+const MetaSeparator = styled.View`
+  width: 1px;
+  height: 12px;
+  background-color: ${({ theme }) => theme.color.blue200};
+`
+
 type DocumentListItemProps = {
   sender: string
   title: string
   body?: string
   date?: string
+  caseNumber?: string
+  caseNumberLabel?: string
   isOpen?: boolean
   closeable?: boolean
   hasTopBorder?: boolean
@@ -71,6 +87,8 @@ export const DocumentListItem = ({
   title,
   body,
   date,
+  caseNumber,
+  caseNumberLabel,
   closeable = false,
   isOpen = false,
   hasTopBorder = true,
@@ -138,8 +156,31 @@ export const DocumentListItem = ({
               <Avatar name={sender} isSmall />
             )}
             <Content>
-              <Typography variant="eyebrow">{title}</Typography>
-              <Typography variant="body3">{date}</Typography>
+              <Typography variant="heading5">{title}</Typography>
+              <MetaRow>
+                {date ? (
+                  <Typography variant="body3">{date}</Typography>
+                ) : null}
+                {caseNumber ? (
+                  <>
+                    {date ? <MetaSeparator /> : null}
+                    <Typography variant="body3">
+                      {caseNumberLabel ? `${caseNumberLabel} ` : ''}
+                      {caseNumber}
+                    </Typography>
+                    <TouchableOpacity
+                      onPress={() => setStringAsync(`#${caseNumber}`)}
+                      hitSlop={8}
+                    >
+                      <Image
+                        source={copyIcon}
+                        style={{ width: 16, height: 16 }}
+                        resizeMode="contain"
+                      />
+                    </TouchableOpacity>
+                  </>
+                ) : null}
+              </MetaRow>
             </Content>
           </Host>
           <Animated.View style={bodyStyle}>

--- a/apps/native/app/src/graphql/fragments/document.fragment.graphql
+++ b/apps/native/app/src/graphql/fragments/document.fragment.graphql
@@ -14,6 +14,7 @@ fragment DocumentTicket on DocumentV2 {
       author
       body
       createdDate
+      isZendeskAgent
     }
   }
 }

--- a/apps/native/app/src/messages/en.ts
+++ b/apps/native/app/src/messages/en.ts
@@ -291,6 +291,7 @@ export const en: TranslatedMessages = {
 
   // document communications
   'documentCommunications.caseNumber': 'Case number',
+  'documentCommunications.copyCaseNumber': 'Copy case number',
   'documentCommunications.initialReply':
     'The message has been received and a case has been created. You can continue the conversation here or via your personal email {email}.',
   'documentCommunications.cannotReply':

--- a/apps/native/app/src/messages/is.ts
+++ b/apps/native/app/src/messages/is.ts
@@ -289,9 +289,9 @@ export const is = {
   'documentReply.pleaseTryAgain': 'Vinsamlegast prófaðu aftur síðar',
 
   // document communications
-  'documentCommunications.caseNumber': 'Málsnúmer',
+  'documentCommunications.caseNumber': 'Málsnr.',
   'documentCommunications.initialReply':
-    'Skilaboðin eru móttekin og mál hefur verið stofnað. Þú getur haldið áfram samskiptunum hér eða í gegnum þitt persónulega netfang {email}.',
+    'Skilaboðin eru móttekin og mál hefur verið stofnað. Þú getur haldið áfram samskiptunum hér eða í gegnum þitt persónulega netfang {email}. Málsnúmerið er: {caseNumber}',
   'documentCommunications.cannotReply':
     'Ekki er hægt að svara þessum skilaboðum því sendandi hefur lokað fyrir frekari svör í þessu samtali.',
 

--- a/apps/native/app/src/messages/is.ts
+++ b/apps/native/app/src/messages/is.ts
@@ -290,6 +290,7 @@ export const is = {
 
   // document communications
   'documentCommunications.caseNumber': 'Málsnr.',
+  'documentCommunications.copyCaseNumber': 'Afrita málsnúmer',
   'documentCommunications.initialReply':
     'Skilaboðin eru móttekin og mál hefur verið stofnað. Þú getur haldið áfram samskiptunum hér eða í gegnum þitt persónulega netfang {email}. Málsnúmerið er: {caseNumber}',
   'documentCommunications.cannotReply':

--- a/apps/native/app/src/ui/lib/avatar/avatar.tsx
+++ b/apps/native/app/src/ui/lib/avatar/avatar.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import styled from 'styled-components/native'
+import { getInitials } from '../../../utils/get-initials'
 import { dynamicColor } from '../../utils'
 import { font } from '../../utils/font'
 
@@ -8,11 +9,10 @@ const Host = styled.View<{ isSmall?: boolean }>`
   justify-content: center;
   align-items: center;
   flex-direction: row;
-  height: ${(props) => (props.isSmall ? '48px' : '80px')};
-  width: ${(props) => (props.isSmall ? '48px' : '80px')};
-  padding-top: ${(props) => (props.isSmall ? '0' : '3px')};
+  height: ${(props) => (props.isSmall ? '40px' : '48px')};
+  width: ${(props) => (props.isSmall ? '40px' : '48px')};
   overflow: hidden;
-  border-radius: ${(props) => (props.isSmall ? '48px' : '80px')};
+  border-radius: ${(props) => (props.isSmall ? '40px' : '48px')};
   background-color: ${dynamicColor(({ theme }) => ({
     light: theme.color.blue100,
     dark: theme.shades.dark.shade300,
@@ -21,9 +21,9 @@ const Host = styled.View<{ isSmall?: boolean }>`
 
 const Text = styled.Text<{ isSmall?: boolean }>`
   ${font({
-    fontSize: (props) => (props.isSmall ? 20 : 32),
+    fontSize: (props) => (props.isSmall ? 16 : 20),
     fontWeight: '600',
-    lineHeight: (props) => (props.isSmall ? 26 : 38),
+    lineHeight: (props) => (props.isSmall ? 20 : 26),
     color: ({ theme }) => ({
       light: theme.color.blue400,
       dark: theme.color.roseTinted200,
@@ -37,21 +37,9 @@ interface AvatarProps {
 }
 
 export function Avatar({ name, isSmall }: AvatarProps) {
-  function getFirstLetters(str: string) {
-    const names = str.split(' ')
-
-    let initials = names[0].substring(0, 1).toUpperCase()
-
-    if (names.length > 1) {
-      initials += names[names.length - 1].substring(0, 1).toUpperCase()
-    }
-
-    return initials
-  }
-
   return (
     <Host isSmall={isSmall}>
-      <Text isSmall={isSmall}>{getFirstLetters(name)}</Text>
+      <Text isSmall={isSmall}>{getInitials(name)}</Text>
     </Host>
   )
 }

--- a/apps/native/app/src/ui/lib/card/family-member-card.tsx
+++ b/apps/native/app/src/ui/lib/card/family-member-card.tsx
@@ -54,7 +54,7 @@ export function FamilyMemberCard({ name, nationalId }: FamilyMemberCardProps) {
     <Host>
       {name.length ? (
         <ImageWrap>
-          <Avatar name={name} isSmall />
+          <Avatar name={name} />
         </ImageWrap>
       ) : null}
       <Content>


### PR DESCRIPTION
## What

Updates to 2 way communications flow:
* Communications are now a page not a modal
* Updated design of communications, now mirrors Mínar síður.
* No tab bar visible on communications page
* Fixed so info bubble is showing until first reply from organization occurs
* Updated reply modal a bit as well

## Screenshots / Gifs

Communications:
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-06-29 at 08 53 30" src="https://github.com/user-attachments/assets/551bc8b7-6732-4ed7-a21a-8e9d38f1e630" />



Reply:

<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-06-26 at 15 35 56" src="https://github.com/user-attachments/assets/9be63c2f-0c4a-4498-86b1-318be8e05a23" />

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Improved inbox communications with clearer subject presentation and enhanced case number details (including copy-to-clipboard).
  * Updated initial-reply alerts to show the case number alongside the recipient email.

* **Bug Fixes**
  * Refined reply/alert visibility based on the conversation’s comment/reply type, including correct initial-reply triggering.
  * Improved date and header presentation for message threads.
  * Hide bottom tabs while the communications screen is in focus.

* **Style**
  * Refreshed avatar and list item layout for a cleaner, more consistent look.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->