### PR TITLE
fix(native-app): Make sure air discount link doesn't wrap

### DIFF
--- a/apps/native/app/src/app/(auth)/(tabs)/more/air-discount.tsx
+++ b/apps/native/app/src/app/(auth)/(tabs)/more/air-discount.tsx
@@ -1,6 +1,6 @@
 import React, { useRef } from 'react'
 import { FormattedMessage, useIntl } from 'react-intl'
-import { Animated, Image, SafeAreaView, View } from 'react-native'
+import { Animated, SafeAreaView, View } from 'react-native'
 import styled, { useTheme } from 'styled-components/native'
 
 import { testIDs } from '@/utils/test-ids'
@@ -187,12 +187,11 @@ export default function AirDiscountScreen() {
                 'https://island.is/loftbru/notendaskilmalar-vegagerdarinnar-fyrir-loftbru'
               }
             >
-              <LinkText>
+              <LinkText icon={externalLinkIcon}>
                 <FormattedMessage
                   id="airDiscount.tosLinkText"
                   defaultMessage="Notendaskilmálar"
-                />{' '}
-                <Image source={externalLinkIcon} />
+                />
               </LinkText>
             </Link>
           </TOSLink>


### PR DESCRIPTION
Air discount link wrapped to two lines on smaller devices. Make sure it doesn't happen.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the “Notendaskilmálar” link so its external-link icon now displays consistently.
  * Kept the link text and destination unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->