### PR TITLE
feat(native-app): Add new home options button at the bottom and add blue color to home page

### DIFF
--- a/apps/native/app/src/app/(auth)/(tabs)/index/_layout.tsx
+++ b/apps/native/app/src/app/(auth)/(tabs)/index/_layout.tsx
@@ -1,7 +1,9 @@
 import { Stack } from 'expo-router'
+import { Platform } from 'react-native'
 import { useIntl } from 'react-intl'
 import { tabScreenOptions } from '../../../../constants/screen-options'
 import { useNotificationsStore } from '../../../../stores/notifications-store'
+import { theme } from '../../../../ui'
 
 export default function IndexLayout() {
   const intl = useIntl()
@@ -17,6 +19,10 @@ export default function IndexLayout() {
         name="index"
         options={{
           headerTitle: intl.formatMessage({ id: 'home.screenTitle' }),
+          headerStyle:
+            Platform.OS === 'android'
+              ? { backgroundColor: theme.color.blue100 }
+              : undefined,
         }}
       />
     </Stack>

--- a/apps/native/app/src/app/(auth)/(tabs)/index/index.tsx
+++ b/apps/native/app/src/app/(auth)/(tabs)/index/index.tsx
@@ -70,8 +70,10 @@ import * as Application from 'expo-application'
 import { compare, validate } from 'compare-versions'
 import { router, Stack } from 'expo-router'
 import { useIntl } from 'react-intl'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import { useTheme } from 'styled-components/native'
 import { StackScreen } from '../../../../components/stack-screen'
-import { blue400, red400, Typography } from '../../../../ui'
+import { Button, red400, Typography } from '../../../../ui'
 
 interface ListItem {
   id: string
@@ -80,6 +82,8 @@ interface ListItem {
 
 export default function HomeScreen() {
   const intl = useIntl()
+  const theme = useTheme()
+  const insets = useSafeAreaInsets()
   const userProfile = useGetProfileQuery({
     fetchPolicy: 'cache-first',
   })
@@ -449,18 +453,6 @@ export default function HomeScreen() {
           ],
           headerRightItems: [
             {
-              identifier: 'options',
-              type: 'button',
-              label: 'Options',
-              icon: {
-                type: 'image',
-                source: require('@/assets/icons/options.png'),
-              },
-              tintColor: blue400,
-              onPress: () => router.navigate('/homescreen-options'),
-              sharesBackground: false,
-            },
-            {
               type: 'custom',
               element: (
                 <Pressable onPress={() => router.navigate('/notifications')}>
@@ -525,8 +517,26 @@ export default function HomeScreen() {
         data={data}
         renderItem={renderItem}
         style={{ flex: 1 }}
+        contentContainerStyle={{
+          paddingBottom: insets.bottom + (Platform.OS === 'android' ? 0 : 30),
+        }}
         refreshControl={
           <RefreshControl refreshing={refetching} onRefresh={refetch} />
+        }
+        ListFooterComponent={
+          <View
+            style={{
+              marginHorizontal: theme.spacing[2],
+              marginTop: theme.spacing[2],
+            }}
+          >
+            <Button
+              title={intl.formatMessage({ id: 'homeOptions.heading.title' })}
+              isOutlined
+              icon={require('@/assets/icons/options.png')}
+              onPress={() => router.navigate('/homescreen-options')}
+            />
+          </View>
         }
       />
     </>

--- a/apps/native/app/src/components/home/hello-module.tsx
+++ b/apps/native/app/src/components/home/hello-module.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { FormattedMessage } from 'react-intl'
-import { SafeAreaView } from 'react-native'
+import { SafeAreaView, View } from 'react-native'
 import styled, { useTheme } from 'styled-components/native'
 
 import { useAuthStore } from '@/stores/auth-store'
@@ -15,23 +15,25 @@ export const HelloModule = React.memo(() => {
   const { userInfo } = useAuthStore()
 
   return (
-    <SafeAreaView
-      style={{
-        marginHorizontal: theme.spacing[2],
-        marginTop: theme.spacing[2],
-      }}
-    >
-      <Host>
-        <Typography color={theme.color.purple400} weight="600">
-          <FormattedMessage id="home.goodDay" defaultMessage="Góðan dag," />
-        </Typography>
-        <Typography
-          variant={'heading2'}
-          style={{ marginTop: theme.spacing[1] }}
-        >
-          {userInfo?.name}
-        </Typography>
-      </Host>
-    </SafeAreaView>
+    <View style={{ backgroundColor: theme.color.blue100 }}>
+      <SafeAreaView
+        style={{
+          marginHorizontal: theme.spacing[2],
+          marginTop: theme.spacing[2],
+        }}
+      >
+        <Host>
+          <Typography color={theme.color.purple400} weight="600">
+            <FormattedMessage id="home.goodDay" defaultMessage="Góðan dag," />
+          </Typography>
+          <Typography
+            variant={'heading2'}
+            style={{ marginTop: theme.spacing[1] }}
+          >
+            {userInfo?.name}
+          </Typography>
+        </Host>
+      </SafeAreaView>
+    </View>
   )
 })


### PR DESCRIPTION
## What

Add home options button to the bottom of home page and remove it from the top right corner.
Add blue color to header on home page.

## Screenshots / Gifs
<img  height="622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-06-29 at 10 25 45" src="https://github.com/user-attachments/assets/1cc6cda1-6f2a-4d98-976d-43f60470bc9a" />
<img height="622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-06-29 at 10 25 49" src="https://github.com/user-attachments/assets/27f0529d-0769-4d73-9015-b4aa2d8ecbaa" />



## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an in-screen “Options” button on the home screen for quicker access to home screen settings.
  * Improved header and screen styling on Android to better match the app theme.

* **Bug Fixes**
  * Adjusted home screen spacing to respect safe-area insets, helping content avoid being cut off near the bottom of the screen.
  * Updated the home layout so the background and header visuals appear more consistent across devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->