### PR TITLE
fix(my-pages): Tax card submit buttons

### DIFF
--- a/libs/portals/my-pages/social-benefits/src/lib/messages/socialInsurance.ts
+++ b/libs/portals/my-pages/social-benefits/src/lib/messages/socialInsurance.ts
@@ -296,14 +296,6 @@ export const m = defineMessages({
     id: 'sp.social-insurance-maintenance:my-tax-credit-usage',
     defaultMessage: 'Nýting persónuafsláttar',
   },
-  spouseNoUsage: {
-    id: 'sp.social-insurance-maintenance:spouse-no-usage',
-    defaultMessage: 'Engin nýting',
-  },
-  youAreUsingSpouseTaxCreditTitle: {
-    id: 'sp.social-insurance-maintenance:you-are-using-spouse-tax-credit-title',
-    defaultMessage: 'Þú nýtir persónuafslátt maka',
-  },
   spousePersonalTaxCreditDescription: {
     id: 'sp.social-insurance-maintenance:spouse-personal-tax-credit-description',
     defaultMessage:

--- a/libs/portals/my-pages/social-benefits/src/screens/social-insurance/PersonalTaxCredit/PersonalTaxCredit.tsx
+++ b/libs/portals/my-pages/social-benefits/src/screens/social-insurance/PersonalTaxCredit/PersonalTaxCredit.tsx
@@ -35,7 +35,14 @@ const PersonalTaxCredit = () => {
   const hasRegistrations = !!page?.taxCards?.length
 
   const form = usePersonalTaxCreditForm()
-  const { spouseAction } = form
+  const { personalAction, spouseAction } = form
+
+  // If personal form is standalone (not yet registered), bottom buttons handle both personal + spouse
+  // If personal is edited via inline table row, bottom buttons handle spouse only
+  const personalIsStandalone = !isAlreadyRegistered
+  const showBottomButtons = personalIsStandalone
+    ? personalAction !== null || spouseAction !== null
+    : spouseAction !== null
 
   const isSpouseBlocked =
     (spouseAction === 'grant' &&
@@ -44,6 +51,25 @@ const PersonalTaxCredit = () => {
     (spouseAction === 'deceased' &&
       (!!spouseInfo?.deceasedReasonNotAllowedCode ||
         !spouseInfo?.deceasedMonthsAndYears?.length))
+
+  const handleBottomCancel = personalIsStandalone
+    ? form.handleCancelAll
+    : form.handleCancelSpouse
+  const handleBottomSave = () => {
+    if (personalIsStandalone && spouseAction !== null) {
+      void form.handleSaveAll()
+    } else if (personalIsStandalone) {
+      void form.handleSavePersonal()
+    } else {
+      void form.handleSaveSpouse()
+    }
+  }
+  const bottomDisabled = personalIsStandalone
+    ? !form.canSubmitAll || form.savingAll || isSpouseBlocked
+    : !form.canSubmitSpouse || form.savingSpouse || isSpouseBlocked
+  const bottomLoading = personalIsStandalone
+    ? form.savingAll
+    : form.savingSpouse
 
   return (
     <IntroWrapper
@@ -166,44 +192,16 @@ const PersonalTaxCredit = () => {
             />
           </Box>
 
-          {!hasRegistrations && (
+          {showBottomButtons && (
             <Inline space={2} justifyContent="flexEnd">
-              <Button
-                variant="ghost"
-                size="small"
-                onClick={form.handleCancelAll}
-              >
+              <Button variant="ghost" size="small" onClick={handleBottomCancel}>
                 {formatMessage(coreMessages.buttonCancel)}
               </Button>
               <Button
                 size="small"
-                onClick={() => void form.handleSaveAll()}
-                disabled={
-                  !form.canSubmitAll || form.savingAll || isSpouseBlocked
-                }
-                loading={form.savingAll}
-              >
-                {formatMessage(coreMessages.submit)}
-              </Button>
-            </Inline>
-          )}
-
-          {hasRegistrations && spouseAction !== null && (
-            <Inline space={2} justifyContent="flexEnd">
-              <Button
-                variant="ghost"
-                size="small"
-                onClick={form.handleCancelSpouse}
-              >
-                {formatMessage(coreMessages.buttonCancel)}
-              </Button>
-              <Button
-                size="small"
-                onClick={() => void form.handleSaveSpouse()}
-                disabled={
-                  !form.canSubmitSpouse || form.savingSpouse || isSpouseBlocked
-                }
-                loading={form.savingSpouse}
+                onClick={handleBottomSave}
+                disabled={bottomDisabled}
+                loading={bottomLoading}
               >
                 {formatMessage(coreMessages.submit)}
               </Button>

--- a/libs/portals/my-pages/social-benefits/src/screens/social-insurance/PersonalTaxCredit/usePersonalTaxCreditForm.ts
+++ b/libs/portals/my-pages/social-benefits/src/screens/social-insurance/PersonalTaxCredit/usePersonalTaxCreditForm.ts
@@ -123,7 +123,10 @@ export const usePersonalTaxCreditForm = () => {
     return true
   }
 
-  const personalAction = useWatch({ control: personalForm.control, name: 'action' })
+  const personalAction = useWatch({
+    control: personalForm.control,
+    name: 'action',
+  })
   const spouseAction = useWatch({ control: spouseForm.control, name: 'action' })
 
   return {

--- a/libs/portals/my-pages/social-benefits/src/screens/social-insurance/PersonalTaxCredit/usePersonalTaxCreditForm.ts
+++ b/libs/portals/my-pages/social-benefits/src/screens/social-insurance/PersonalTaxCredit/usePersonalTaxCreditForm.ts
@@ -1,4 +1,4 @@
-import { useForm } from 'react-hook-form'
+import { useForm, useWatch } from 'react-hook-form'
 import { useLocale } from '@island.is/localization'
 import { toast } from '@island.is/island-ui/core'
 import { m } from '../../../lib/messages'
@@ -123,12 +123,13 @@ export const usePersonalTaxCreditForm = () => {
     return true
   }
 
-  const personalAction = personalForm.watch('action')
-  const spouseAction = spouseForm.watch('action')
+  const personalAction = useWatch({ control: personalForm.control, name: 'action' })
+  const spouseAction = useWatch({ control: spouseForm.control, name: 'action' })
 
   return {
     personalForm,
     spouseForm,
+    personalAction,
     spouseAction,
 
     handleCancelPersonal,


### PR DESCRIPTION
## What

Fix tax credit submit button logic

## Why

The shared submit button was not being enabled when a user had already chosen to use spousal tax card allowance but had yet to use their own personal allowance and was trying to do so. 

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the personal tax credit bottom action buttons to show only when appropriate and to support personal-only, spouse-only, and combined submissions correctly.
  * Centralized save/cancel handling so loading and disabled states reflect the selected save path more reliably.
  * Removed two spouse-related i18n messages from the social insurance text catalog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->