### PR TITLE
chore(j-s): Add civil claims clause to subpoenaServiceCertificate

### DIFF
--- a/apps/judicial-system/backend/src/app/formatters/generatedPdfs/subpoenaServiceCertificatePdf.spec.ts
+++ b/apps/judicial-system/backend/src/app/formatters/generatedPdfs/subpoenaServiceCertificatePdf.spec.ts
@@ -1,0 +1,41 @@
+import { getCivilClaimsServiceText } from './subpoenaServiceCertificatePdf'
+
+describe('getCivilClaimsServiceText', () => {
+  it('should return undefined when hasCivilClaims is false', () => {
+    expect(getCivilClaimsServiceText(false, 0)).toBeUndefined()
+  })
+
+  it('should return undefined when hasCivilClaims is undefined', () => {
+    expect(getCivilClaimsServiceText(undefined, 2)).toBeUndefined()
+  })
+
+  it('should return singular text when there is one civil claimant', () => {
+    expect(getCivilClaimsServiceText(true, 1)).toBe(
+      'Greinargerð vegna bótakröfu í málinu hefur jafnframt verið birt.',
+    )
+  })
+
+  it('should return singular text when civilClaimantsCount is undefined', () => {
+    expect(getCivilClaimsServiceText(true, undefined)).toBe(
+      'Greinargerð vegna bótakröfu í málinu hefur jafnframt verið birt.',
+    )
+  })
+
+  it('should return singular text when civilClaimantsCount is zero', () => {
+    expect(getCivilClaimsServiceText(true, 0)).toBe(
+      'Greinargerð vegna bótakröfu í málinu hefur jafnframt verið birt.',
+    )
+  })
+
+  it('should return plural text when there are multiple civil claimants', () => {
+    expect(getCivilClaimsServiceText(true, 2)).toBe(
+      'Greinargerðir vegna bótakrafna í málinu hafa jafnframt verið birtar.',
+    )
+  })
+
+  it('should return plural text when there are many civil claimants', () => {
+    expect(getCivilClaimsServiceText(true, 5)).toBe(
+      'Greinargerðir vegna bótakrafna í málinu hafa jafnframt verið birtar.',
+    )
+  })
+})

--- a/apps/judicial-system/backend/src/app/formatters/generatedPdfs/subpoenaServiceCertificatePdf.spec.ts
+++ b/apps/judicial-system/backend/src/app/formatters/generatedPdfs/subpoenaServiceCertificatePdf.spec.ts
@@ -15,16 +15,12 @@ describe('getCivilClaimsServiceText', () => {
     )
   })
 
-  it('should return singular text when civilClaimantsCount is undefined', () => {
-    expect(getCivilClaimsServiceText(true, undefined)).toBe(
-      'Greinargerð vegna bótakröfu í málinu hefur jafnframt verið birt.',
-    )
+  it('should return undefined when civilClaimantsCount is undefined', () => {
+    expect(getCivilClaimsServiceText(true, undefined)).toBeUndefined()
   })
 
-  it('should return singular text when civilClaimantsCount is zero', () => {
-    expect(getCivilClaimsServiceText(true, 0)).toBe(
-      'Greinargerð vegna bótakröfu í málinu hefur jafnframt verið birt.',
-    )
+  it('should return undefined when civilClaimantsCount is zero', () => {
+    expect(getCivilClaimsServiceText(true, 0)).toBeUndefined()
   })
 
   it('should return plural text when there are multiple civil claimants', () => {

--- a/apps/judicial-system/backend/src/app/formatters/generatedPdfs/subpoenaServiceCertificatePdf.ts
+++ b/apps/judicial-system/backend/src/app/formatters/generatedPdfs/subpoenaServiceCertificatePdf.ts
@@ -51,6 +51,19 @@ const getRole = (userRole?: UserRole) => {
   }
 }
 
+export const getCivilClaimsServiceText = (
+  hasCivilClaims?: boolean,
+  civilClaimantsCount?: number,
+): string | undefined => {
+  if (!hasCivilClaims) {
+    return undefined
+  }
+
+  return (civilClaimantsCount ?? 0) > 1
+    ? 'Greinargerðir vegna bótakrafna í málinu hafa jafnframt verið birtar.'
+    : 'Greinargerð vegna bótakröfu í málinu hefur jafnframt verið birt.'
+}
+
 export const createSubpoenaServiceCertificate = (
   theCase: Case,
   defendant: Defendant,
@@ -191,6 +204,17 @@ export const createSubpoenaServiceCertificate = (
 
   addNormalText(doc, 'Tegund fyrirkalls: ', 'Times-Bold', true)
   addNormalText(doc, getSubpoenaType(subpoena.type), 'Times-Roman')
+
+  addEmptyLines(doc, 2)
+
+  const civilClaimsText = getCivilClaimsServiceText(
+    theCase.hasCivilClaims,
+    theCase.civilClaimants?.length,
+  )
+
+  if (civilClaimsText) {
+    addNormalText(doc, civilClaimsText, 'Times-Bold')
+  }
 
   addEmptyLines(doc, 3)
 

--- a/apps/judicial-system/backend/src/app/formatters/generatedPdfs/subpoenaServiceCertificatePdf.ts
+++ b/apps/judicial-system/backend/src/app/formatters/generatedPdfs/subpoenaServiceCertificatePdf.ts
@@ -55,11 +55,11 @@ export const getCivilClaimsServiceText = (
   hasCivilClaims?: boolean,
   civilClaimantsCount?: number,
 ): string | undefined => {
-  if (!hasCivilClaims) {
+  if (!hasCivilClaims || !civilClaimantsCount) {
     return undefined
   }
 
-  return (civilClaimantsCount ?? 0) > 1
+  return civilClaimantsCount > 1
     ? 'Greinargerðir vegna bótakrafna í málinu hafa jafnframt verið birtar.'
     : 'Greinargerð vegna bótakröfu í málinu hefur jafnframt verið birt.'
 }
@@ -205,14 +205,13 @@ export const createSubpoenaServiceCertificate = (
   addNormalText(doc, 'Tegund fyrirkalls: ', 'Times-Bold', true)
   addNormalText(doc, getSubpoenaType(subpoena.type), 'Times-Roman')
 
-  addEmptyLines(doc, 2)
-
   const civilClaimsText = getCivilClaimsServiceText(
     theCase.hasCivilClaims,
     theCase.civilClaimants?.length,
   )
 
   if (civilClaimsText) {
+    addEmptyLines(doc, 2)
     addNormalText(doc, civilClaimsText, 'Times-Bold')
   }
 


### PR DESCRIPTION
[Asana](https://app.asana.com/1/203394141643832/project/1199153462262248/task/1213886097750316?focus=true)

## What

Add text for civil claims into subpoena service certificate

If 1 claim: 'Greinargerð vegna bótakröfu í málinu hefur jafnframt verið birt.'
If more than 1: 'Greinargerðir vegna bótakrafna í málinu hafa jafnframt verið birtar.'

And no text if no civil claims

## Why

Request from users

## Screenshots / Gifs

Example with 2 claims: 
<img width="653" height="599" alt="image" src="https://github.com/user-attachments/assets/3a95c553-7e69-48c8-937b-c0a079ed875f" />


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Cursor


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added civil-claims service text to subpoena service certificates when applicable, with wording that adapts to the number of claimants.
* **Tests**
  * Added coverage for the new service-text behavior, including cases where no civil claims exist and singular/plural output variations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->