### PR TITLE
fix(j-s): File service certificate even if no open court session

### DIFF
--- a/apps/judicial-system/backend/src/app/modules/subpoena/subpoena.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/subpoena/subpoena.service.ts
@@ -362,12 +362,7 @@ export class SubpoenaService {
       ].includes(serviceStatus)
 
     // File the service certificate as a court document
-    if (
-      wasSubpoenaSuccessfullyServed &&
-      theCase.withCourtSessions &&
-      theCase.courtSessions &&
-      theCase.courtSessions.length > 0
-    ) {
+    if (wasSubpoenaSuccessfullyServed && theCase.withCourtSessions) {
       const name = `Birtingarvottorð ${defendant.name}`
 
       await this.courtDocumentRepositoryService.create(


### PR DESCRIPTION
[Asana](https://app.asana.com/1/203394141643832/project/1212657017130395/task/1215526985946757?focus=true)

## What

File service certificate even if no open court session. The certificate will then instead be added to the court record of the next held court session.

## Why

So we handle the case when the service certificate is created when there is no open court session.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Cursor


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Service certificates are now filed as court documents whenever a subpoena is successfully served in cases with court sessions, even if no sessions are currently listed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->