### PR TITLE
fix(payment-service): enable feature-flag-gated endpoints in controller tests

### DIFF
--- a/apps/services/payments/src/app/invoicePayment/invoicePayment.controller.spec.ts
+++ b/apps/services/payments/src/app/invoicePayment/invoicePayment.controller.spec.ts
@@ -8,6 +8,7 @@ import {
   InvoiceErrorCode,
   PaymentServiceCode,
 } from '@island.is/shared/constants'
+import { overrideFeatureFlags } from '../../../test/setup'
 import { SequelizeConfigService } from '../../sequelizeConfig.service'
 import { PaymentMethod, PaymentStatus } from '../../types'
 import { AppModule } from '../app.module'
@@ -44,6 +45,7 @@ describe('InvoicePaymentController', () => {
     app = await testServer({
       appModule: AppModule,
       enableVersioning: true,
+      override: overrideFeatureFlags,
       hooks: [
         useDatabase({ type: 'postgres', provider: SequelizeConfigService }),
       ],

--- a/apps/services/payments/test/setup.ts
+++ b/apps/services/payments/test/setup.ts
@@ -1,11 +1,31 @@
+import { TestingModuleBuilder } from '@nestjs/testing'
+
+import { FeatureFlagService, Features } from '@island.is/nest/feature-flags'
 import { TestApp, testServer, useDatabase } from '@island.is/testing/nest'
 import { AppModule } from '../src/app/app.module'
 import { SequelizeConfigService } from '../src/sequelizeConfig.service'
+
+// Feature flags that gate the payment controllers via FeatureFlagGuard. In tests the
+// ConfigCat client cannot fetch, so each flag would otherwise resolve to its `false`
+// default and every gated endpoint would respond 403. Enable them explicitly.
+const enabledFeatureFlags = new Set<Features>([
+  Features.isIslandisPaymentEnabled,
+  Features.isIslandisBankTransferPaymentEnabled,
+  Features.isIslandisInvoicePaymentEnabled,
+])
+
+export const overrideFeatureFlags = (builder: TestingModuleBuilder) =>
+  builder.overrideProvider(FeatureFlagService).useValue({
+    getValue: jest.fn((feature: Features) =>
+      Promise.resolve(enabledFeatureFlags.has(feature)),
+    ),
+  })
 
 export const setupTestApp = async (): Promise<TestApp> => {
   const app = await testServer({
     appModule: AppModule,
     enableVersioning: true,
+    override: overrideFeatureFlags,
     hooks: [
       useDatabase({ type: 'postgres', provider: SequelizeConfigService }),
     ],


### PR DESCRIPTION
## What

- Add a shared `overrideFeatureFlags` helper to the payments test setup that enables the feature-flag-gated payment endpoints (`isIslandisPaymentEnabled`, `isIslandisBankTransferPaymentEnabled`, `isIslandisInvoicePaymentEnabled`)
- Apply it in `setupTestApp` (covers the bank-transfer and payment-flow controller specs) and in the invoice controller spec, which builds its own test server

## Why

- The payment controllers are gated by `FeatureFlagGuard`, which resolves flags with a `false` default
- In tests the ConfigCat client cannot fetch, so every gated flag fell back to `false` and the guard rejected requests with `403`, failing 17 controller tests across three suites
- Overriding `FeatureFlagService` to enable these flags mirrors the existing pattern in `cardPayment.controller.spec`

## Screenshots / Gifs

N/A — backend/test-only change

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated the payment service test environment to enable relevant payment feature flags during server bootstrap.
  * Improved controller integration tests so feature-guarded payment endpoints behave consistently and no longer fall back to default disabled behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->