### PR TITLE
feat(native-app): use logoUrl from documents endpoint for logos in inbox

### DIFF
--- a/apps/native/app/src/app/(auth)/(tabs)/inbox/[id]/index.tsx
+++ b/apps/native/app/src/app/(auth)/(tabs)/inbox/[id]/index.tsx
@@ -68,7 +68,7 @@ export default function DocumentScreen() {
   }>()
   const intl = useIntl()
   const { openBrowser } = useBrowser()
-  const { getOrganizationLogoUrl } = useOrganizationsStore()
+  const { getSenderLogo } = useOrganizationsStore()
   const isFeature2WayMailboxEnabled = useFeatureFlag(
     'is2WayMailboxEnabled',
     false,
@@ -271,7 +271,7 @@ export default function DocumentScreen() {
           date={document.publicationDate ?? undefined}
           message={document.subject}
           isLoading={loading && !document.subject}
-          logo={getOrganizationLogoUrl(document.sender?.name ?? '', 75)}
+          logo={getSenderLogo(document.sender, 75)}
           label={isUrgent ? intl.formatMessage({ id: 'inbox.urgent' }) : ''}
         />
       </Host>

--- a/apps/native/app/src/components/home/inbox-module.tsx
+++ b/apps/native/app/src/components/home/inbox-module.tsx
@@ -125,10 +125,7 @@ const InboxModule = React.memo(({ data, loading, error }: InboxModuleProps) => {
               unread={!item.opened}
               replyable={item.replyable}
               senderName={item.sender.name}
-              icon={
-                (item.sender.name || item.sender.logoUrl) &&
-                getSenderLogo(item.sender, 75)
-              }
+              icon={getSenderLogo(item.sender, 75)}
               isUrgent={item.isUrgent}
               onPress={() =>
                 router.navigate({

--- a/apps/native/app/src/components/home/inbox-module.tsx
+++ b/apps/native/app/src/components/home/inbox-module.tsx
@@ -56,7 +56,7 @@ const validateInboxInitialData = ({
 const InboxModule = React.memo(({ data, loading, error }: InboxModuleProps) => {
   const theme = useTheme()
   const intl = useIntl()
-  const { getOrganizationLogoUrl } = useOrganizationsStore()
+  const { getSenderLogo } = useOrganizationsStore()
 
   if (error && !data) {
     return null
@@ -126,7 +126,8 @@ const InboxModule = React.memo(({ data, loading, error }: InboxModuleProps) => {
               replyable={item.replyable}
               senderName={item.sender.name}
               icon={
-                item.sender.name && getOrganizationLogoUrl(item.sender.name, 75)
+                (item.sender.name || item.sender.logoUrl) &&
+                getSenderLogo(item.sender, 75)
               }
               isUrgent={item.isUrgent}
               onPress={() =>

--- a/apps/native/app/src/components/pressable-list-item.tsx
+++ b/apps/native/app/src/components/pressable-list-item.tsx
@@ -34,10 +34,7 @@ export const PressableListItem = memo(
       [selectable, selectedItems, item.id],
     )
     const icon = useMemo(
-      () =>
-        item.sender.name || item.sender.logoUrl
-          ? getSenderLogo(item.sender, 75)
-          : undefined,
+      () => getSenderLogo(item.sender, 75),
       [item.sender, getSenderLogo],
     )
 

--- a/apps/native/app/src/components/pressable-list-item.tsx
+++ b/apps/native/app/src/components/pressable-list-item.tsx
@@ -28,17 +28,17 @@ export const PressableListItem = memo(
     setSelectedItems,
     setSelectedState,
   }: PressableListItemProps) => {
-    const { getOrganizationLogoUrl } = useOrganizationsStore()
+    const { getSenderLogo } = useOrganizationsStore()
     const isSelected = useMemo(
       () => selectable && selectedItems.includes(item.id),
       [selectable, selectedItems, item.id],
     )
     const icon = useMemo(
       () =>
-        item.sender.name
-          ? getOrganizationLogoUrl(item.sender.name, 75)
+        item.sender.name || item.sender.logoUrl
+          ? getSenderLogo(item.sender, 75)
           : undefined,
-      [item.sender.name, getOrganizationLogoUrl],
+      [item.sender, getSenderLogo],
     )
 
     const toggleSelectItem = useCallback(() => {

--- a/apps/native/app/src/graphql/fragments/document.fragment.graphql
+++ b/apps/native/app/src/graphql/fragments/document.fragment.graphql
@@ -48,6 +48,7 @@ fragment ListDocument on DocumentV2 {
   sender {
     id
     name
+    logoUrl
   }
   archived @client
 }

--- a/apps/native/app/src/stores/organizations-store.ts
+++ b/apps/native/app/src/stores/organizations-store.ts
@@ -46,6 +46,14 @@ interface OrganizationsStore {
     size?: number,
     canReturnEmpty?: boolean,
   ): ImageSourcePropType | undefined
+  getSenderLogo(
+    sender:
+      | { name?: string | null; logoUrl?: string | null }
+      | null
+      | undefined,
+    size?: number,
+    canReturnEmpty?: boolean,
+  ): ImageSourcePropType | undefined
   getOrganizationNameBySlug(slug: string): string
   actions: {
     updateOriganizations(): Promise<void>
@@ -113,6 +121,22 @@ export const organizationsStore = create<OrganizationsStore>()(
         const uri = `${url}?w=${size}&h=${size}&fit=pad&fm=png`
 
         return { uri }
+      },
+      getSenderLogo(
+        sender:
+          | { name?: string | null; logoUrl?: string | null }
+          | null
+          | undefined,
+        size = 100,
+        canReturnEmpty = false,
+      ) {
+        if (sender?.logoUrl) {
+          const url = sender.logoUrl.startsWith('https://')
+            ? sender.logoUrl
+            : `https:${sender.logoUrl}`
+          return { uri: `${url}?w=${size}&h=${size}&fit=pad&fm=png` }
+        }
+        return get().getOrganizationLogoUrl(sender?.name ?? '', size, canReturnEmpty)
       },
       getOrganizationNameBySlug(slug: string) {
         const org = get().organizations.find((o) => o.slug === slug)

--- a/apps/native/app/src/stores/organizations-store.ts
+++ b/apps/native/app/src/stores/organizations-store.ts
@@ -47,13 +47,9 @@ interface OrganizationsStore {
     canReturnEmpty?: boolean,
   ): ImageSourcePropType | undefined
   getSenderLogo(
-    sender:
-      | { name?: string | null; logoUrl?: string | null }
-      | null
-      | undefined,
+    sender: { logoUrl?: string | null } | null | undefined,
     size?: number,
-    canReturnEmpty?: boolean,
-  ): ImageSourcePropType | undefined
+  ): ImageSourcePropType
   getOrganizationNameBySlug(slug: string): string
   actions: {
     updateOriganizations(): Promise<void>
@@ -68,6 +64,9 @@ function processItems(items: Omit<Organization, 'query'>[]) {
 }
 
 const logoCache = new Map()
+
+const COAT_OF_ARMS_URL =
+  'https://images.ctfassets.net/8k0h54kbe6bj/6XhCz5Ss17OVLxpXNVDxAO/d3d6716bdb9ecdc5041e6baf68b92ba6/coat_of_arms.svg'
 
 export const organizationsStore = create<OrganizationsStore>()(
   persist(
@@ -115,28 +114,18 @@ export const organizationsStore = create<OrganizationsStore>()(
           return undefined
         }
 
-        const url =
-          c ??
-          'https://images.ctfassets.net/8k0h54kbe6bj/6XhCz5Ss17OVLxpXNVDxAO/d3d6716bdb9ecdc5041e6baf68b92ba6/coat_of_arms.svg'
+        const url = c ?? COAT_OF_ARMS_URL
         const uri = `${url}?w=${size}&h=${size}&fit=pad&fm=png`
 
         return { uri }
       },
       getSenderLogo(
-        sender:
-          | { name?: string | null; logoUrl?: string | null }
-          | null
-          | undefined,
+        sender: { logoUrl?: string | null } | null | undefined,
         size = 100,
-        canReturnEmpty = false,
       ) {
-        if (sender?.logoUrl) {
-          const url = sender.logoUrl.startsWith('https://')
-            ? sender.logoUrl
-            : `https:${sender.logoUrl}`
-          return { uri: `${url}?w=${size}&h=${size}&fit=pad&fm=png` }
-        }
-        return get().getOrganizationLogoUrl(sender?.name ?? '', size, canReturnEmpty)
+        const raw = sender?.logoUrl ?? COAT_OF_ARMS_URL
+        const url = raw.startsWith('https://') ? raw : `https:${raw}`
+        return { uri: `${url}?w=${size}&h=${size}&fit=pad&fm=png` }
       },
       getOrganizationNameBySlug(slug: string) {
         const org = get().organizations.find((o) => o.slug === slug)


### PR DESCRIPTION
## What

- Inbox sender logos now use the backend-resolved Sender.logoUrl (kennitala-based, via Contentful) instead of fuzzy name-matching against a local organizations.json cache.
- Fixes silent fallback to Skjaldarmerki for senders whose name didn't match the cache exactly (e.g. HMS / Húsnæðis- og mannvirkjastofnun).
- Matches the mínar síður web behavior: sender.logoUrl → coat-of-arms fallback. Communications (Zendesk authors) and license/wallet cards keep the legacy name lookup.
- 
## Why

We are repeatedly getting reports of logos showing on mínar síður but not in the app. This fixes that so it should always be the same.

## Screenshots / Gifs
Before and after:
<div><img height="622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-06-29 at 13 29 42" src="https://github.com/user-attachments/assets/76b58319-1752-44c3-8388-3c007c14f96d" />
<img height="622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-06-29 at 13 17 25" src="https://github.com/user-attachments/assets/c3ee50f2-0d04-42a0-8036-f2732860f1f6" /></div>

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Inbox and document items now show sender logos more consistently, using available sender logo data when present.
* **Bug Fixes**
  * Improved logo handling for missing sender info and normalized image URLs so logos load more reliably.
  * Added sender logo data to document lists to support the updated display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->