### PR TITLE
fix(web): Handle multiple 'gegn' words in verdict details html view

### DIFF
--- a/apps/web/screens/Verdicts/VerdictDetails.tsx
+++ b/apps/web/screens/Verdicts/VerdictDetails.tsx
@@ -214,7 +214,8 @@ const HtmlView = ({ item }: VerdictDetailsProps) => {
   const { format } = useDateUtils()
   const logoUrl = formatMessage(m.verdictPage.htmlVerdictLogoUrl)
 
-  const [a, b] = item.title.split('gegn')
+  const [a, ...rest] = item.title.split('gegn')
+  const b = rest.join('gegn')
 
   return (
     <>


### PR DESCRIPTION
# Handle multiple 'gegn' words in verdict details html view

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [x] No AI tools were used in preparing this pull request
- [ ] AI tools were used in preparing this pull request
      Tools used:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved title parsing so content containing multiple instances of the delimiter is displayed correctly.
  * Preserved the full text after the first delimiter instead of dropping or merging extra occurrences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->