### PR TITLE
fix(j-s): Don't send reminder for indictment review if it's already reviewed.

### DIFF
--- a/apps/judicial-system/backend/src/app/modules/case/internalCase.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/case/internalCase.service.ts
@@ -1938,8 +1938,6 @@ export class InternalCaseService {
           model: Defendant,
           as: 'defendants',
           required: true,
-          order: [['created', 'DESC']],
-          separate: true,
           where: {
             indictmentReviewDecision: null,
           },


### PR DESCRIPTION
[Asana](https://app.asana.com/1/203394141643832/project/1199153462262248/task/1216026773813721?focus=true)

## What

The defendants include had separate: true which made Sequelize load defendants in a separate query instead of a JOIN, silently nullifying the required: true that was supposed to filter out already-reviewed cases. Removing separate: true (and the now-purposeless order) restores the INNER JOIN, so only cases with at least one unreviewed defendant are returned.

## Why

The notification makes no sense if the indictment was reviewed already.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Cursor


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved case listing logic for indictment cases with verdict appeal deadlines, helping ensure results are returned more consistently on the target date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->