### PR TITLE
feat(native-app): restore Datadog tracking in app

### DIFF
--- a/apps/native/app/src/app/_layout.tsx
+++ b/apps/native/app/src/app/_layout.tsx
@@ -1,11 +1,10 @@
 import { ThemeProvider as AppThemeProvider } from '@/components/providers/theme-provider'
 import { PromptModal } from '@/components/prompt-modal'
 import { ToastHost } from '@/components/toast'
-import { Stack, usePathname } from 'expo-router'
+import { Stack } from 'expo-router'
 import * as SplashScreen from 'expo-splash-screen'
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useState } from 'react'
 import 'react-native-reanimated'
-import { DdRum } from '@datadog/mobile-react-native'
 
 import { LocaleProvider } from '../components/providers/locale-provider'
 import { OfflineProvider } from '../components/providers/offline-provider'
@@ -185,23 +184,6 @@ function RootLayoutNav({
 }: {
   apolloClient: ApolloClient<NormalizedCacheObject>
 }) {
-  // Restore Datadog RUM view tracking lost in the expo-router migration
-  // (was previously wired through Navigation.events() in setup-globals.ts).
-  const pathname = usePathname()
-  const previousPathnameRef = useRef<string | null>(null)
-
-  useEffect(() => {
-    if (__DEV__ || !pathname) {
-      return
-    }
-    const previous = previousPathnameRef.current
-    if (previous && previous !== pathname) {
-      DdRum.stopView(previous).catch(() => {})
-    }
-    DdRum.startView(pathname, pathname).catch(() => {})
-    previousPathnameRef.current = pathname
-  }, [pathname])
-
   return (
     <LocaleProvider>
       <AppThemeProvider>

--- a/apps/native/app/src/app/_layout.tsx
+++ b/apps/native/app/src/app/_layout.tsx
@@ -1,10 +1,11 @@
 import { ThemeProvider as AppThemeProvider } from '@/components/providers/theme-provider'
 import { PromptModal } from '@/components/prompt-modal'
 import { ToastHost } from '@/components/toast'
-import { Stack } from 'expo-router'
+import { Stack, useSegments } from 'expo-router'
 import * as SplashScreen from 'expo-splash-screen'
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import 'react-native-reanimated'
+import { DdRum } from '@datadog/mobile-react-native'
 
 import { LocaleProvider } from '../components/providers/locale-provider'
 import { OfflineProvider } from '../components/providers/offline-provider'
@@ -184,6 +185,26 @@ function RootLayoutNav({
 }: {
   apolloClient: ApolloClient<NormalizedCacheObject>
 }) {
+  // Datadog RUM view tracking. Uses route segment templates (e.g. inbox/[id])
+  // rather than the resolved pathname so dynamic params like document IDs
+  // don't leak into Datadog.
+  const segments = useSegments()
+  const viewName =
+    segments.filter((s) => !s.startsWith('(')).join('/') || 'index'
+  const previousViewRef = useRef<string | null>(null)
+
+  useEffect(() => {
+    if (__DEV__) {
+      return
+    }
+    const previous = previousViewRef.current
+    if (previous && previous !== viewName) {
+      DdRum.stopView(previous).catch(() => {})
+    }
+    DdRum.startView(viewName, viewName).catch(() => {})
+    previousViewRef.current = viewName
+  }, [viewName])
+
   return (
     <LocaleProvider>
       <AppThemeProvider>

--- a/apps/native/app/src/app/_layout.tsx
+++ b/apps/native/app/src/app/_layout.tsx
@@ -1,11 +1,10 @@
 import { ThemeProvider as AppThemeProvider } from '@/components/providers/theme-provider'
 import { PromptModal } from '@/components/prompt-modal'
 import { ToastHost } from '@/components/toast'
-import { Stack, useSegments } from 'expo-router'
+import { Stack } from 'expo-router'
 import * as SplashScreen from 'expo-splash-screen'
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useState } from 'react'
 import 'react-native-reanimated'
-import { DdRum } from '@datadog/mobile-react-native'
 
 import { LocaleProvider } from '../components/providers/locale-provider'
 import { OfflineProvider } from '../components/providers/offline-provider'
@@ -36,6 +35,7 @@ import { IBMPlexSans_500Medium_Italic } from '@expo-google-fonts/ibm-plex-sans/5
 import { IBMPlexSans_600SemiBold_Italic } from '@expo-google-fonts/ibm-plex-sans/600SemiBold_Italic'
 import { IBMPlexSans_700Bold_Italic } from '@expo-google-fonts/ibm-plex-sans/700Bold_Italic'
 import { setupEventHandlers } from '../utils/lifecycle/setup-event-handlers'
+import { useDatadogViewTracking } from '../hooks/use-datadog-view-tracking'
 
 export { ErrorBoundary } from 'expo-router'
 
@@ -185,25 +185,7 @@ function RootLayoutNav({
 }: {
   apolloClient: ApolloClient<NormalizedCacheObject>
 }) {
-  // Datadog RUM view tracking. Uses route segment templates (e.g. inbox/[id])
-  // rather than the resolved pathname so dynamic params like document IDs
-  // don't leak into Datadog.
-  const segments = useSegments()
-  const viewName =
-    segments.filter((s) => !s.startsWith('(')).join('/') || 'index'
-  const previousViewRef = useRef<string | null>(null)
-
-  useEffect(() => {
-    if (__DEV__) {
-      return
-    }
-    const previous = previousViewRef.current
-    if (previous && previous !== viewName) {
-      DdRum.stopView(previous).catch(() => {})
-    }
-    DdRum.startView(viewName, viewName).catch(() => {})
-    previousViewRef.current = viewName
-  }, [viewName])
+  useDatadogViewTracking()
 
   return (
     <LocaleProvider>

--- a/apps/native/app/src/app/_layout.tsx
+++ b/apps/native/app/src/app/_layout.tsx
@@ -1,10 +1,11 @@
 import { ThemeProvider as AppThemeProvider } from '@/components/providers/theme-provider'
 import { PromptModal } from '@/components/prompt-modal'
 import { ToastHost } from '@/components/toast'
-import { Stack } from 'expo-router'
+import { Stack, usePathname } from 'expo-router'
 import * as SplashScreen from 'expo-splash-screen'
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import 'react-native-reanimated'
+import { DdRum } from '@datadog/mobile-react-native'
 
 import { LocaleProvider } from '../components/providers/locale-provider'
 import { OfflineProvider } from '../components/providers/offline-provider'
@@ -184,6 +185,23 @@ function RootLayoutNav({
 }: {
   apolloClient: ApolloClient<NormalizedCacheObject>
 }) {
+  // Restore Datadog RUM view tracking lost in the expo-router migration
+  // (was previously wired through Navigation.events() in setup-globals.ts).
+  const pathname = usePathname()
+  const previousPathnameRef = useRef<string | null>(null)
+
+  useEffect(() => {
+    if (__DEV__ || !pathname) {
+      return
+    }
+    const previous = previousPathnameRef.current
+    if (previous && previous !== pathname) {
+      DdRum.stopView(previous).catch(() => {})
+    }
+    DdRum.startView(pathname, pathname).catch(() => {})
+    previousPathnameRef.current = pathname
+  }, [pathname])
+
   return (
     <LocaleProvider>
       <AppThemeProvider>

--- a/apps/native/app/src/hooks/use-datadog-view-tracking.ts
+++ b/apps/native/app/src/hooks/use-datadog-view-tracking.ts
@@ -1,0 +1,58 @@
+import { DdRum } from '@datadog/mobile-react-native'
+import { useSegments } from 'expo-router'
+import { useEffect, useRef } from 'react'
+
+/**
+ * Maps expo-router segments to a Datadog RUM view name. Uses the route
+ * segment template (e.g. inbox/[id]) rather than the resolved pathname so
+ * dynamic params like document IDs don't leak into Datadog.
+ *
+ * Returns null while the router hasn't resolved a real route yet (the
+ * transient '/' state on launch) — that's not a screen the user sees, so
+ * no view is reported for it.
+ */
+const getViewName = (segments: string[]): string | null => {
+  const path = segments.filter((segment) => !segment.startsWith('(')).join('/')
+
+  if (!path) {
+    return null
+  }
+
+  // The home tab lives in an index folder, so its template is just 'index'.
+  if (path === 'index' || path === 'index/index') {
+    return 'home'
+  }
+
+  // inbox/[id] -> inbox/:id, matching Datadog's web view-name convention.
+  return path.replace(/\[(\w+)\]/g, ':$1')
+}
+
+/**
+ * Reports the currently focused route to Datadog RUM as a view.
+ *
+ * The 'ApplicationLaunch' view preceding the first real view is created by
+ * the Datadog SDK itself and can't be suppressed here — exclude it in
+ * dashboards with -@view.name:ApplicationLaunch if it's noise.
+ */
+export const useDatadogViewTracking = () => {
+  const segments = useSegments()
+  const viewName = getViewName(segments)
+  const previousViewRef = useRef<string | null>(null)
+
+  useEffect(() => {
+    if (__DEV__ || !viewName) {
+      return
+    }
+
+    const previous = previousViewRef.current
+    if (previous && previous !== viewName) {
+      DdRum.stopView(previous).catch(() => {
+        // noop
+      })
+    }
+    DdRum.startView(viewName, viewName).catch(() => {
+      // noop
+    })
+    previousViewRef.current = viewName
+  }, [viewName])
+}

--- a/apps/native/app/src/utils/lifecycle/setup-globals.ts
+++ b/apps/native/app/src/utils/lifecycle/setup-globals.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import {
-  DdRum,
   DdSdkReactNative,
   DatadogProviderConfiguration,
   TrackingConsent,
@@ -72,14 +71,14 @@ if (__DEV__) {
   initializePerformance(app)
 } else {
   // datadog rum config
-  // @todo migration
   const ddconfig = new DatadogProviderConfiguration(
     getConfig().datadog ?? '',
     'production',
-    TrackingConsent.NOT_GRANTED,
+    TrackingConsent.GRANTED,
     {
       site: 'EU',
       service: 'mobile-app',
+      version: Application.nativeApplicationVersion ?? undefined,
       rumConfiguration: {
         applicationId: '2736367a-a841-492d-adef-6f5a509d6ec2',
         trackInteractions: false, // do not track User interactions (e.g.: Tap on buttons.)

--- a/apps/native/app/src/utils/lifecycle/setup-globals.ts
+++ b/apps/native/app/src/utils/lifecycle/setup-globals.ts
@@ -70,7 +70,6 @@ applyDynamicColorSupport()
 if (__DEV__) {
   initializePerformance(app)
 } else {
-  // datadog rum config
   const ddconfig = new DatadogProviderConfiguration(
     getConfig().datadog ?? '',
     'production',


### PR DESCRIPTION
The Expo SDK 55 / expo-router migration (#21631) silently broke Datadog tracking from app version 1.41.x onward — `TrackingConsent` defaulted to `NOT_GRANTED`, so the SDK buffered events on-device but never uploaded them, and the app version stopped being reported. No data from any post-migration build has reached RUM since. This PR restores that baseline and re-adds RUM view tracking so we can see per-screen statistics again.

### Restore Datadog SDK reporting

- Set `TrackingConsent.GRANTED` so events actually upload.
- Pass `version` explicitly via `expo-application.nativeApplicationVersion` (the new SDK no longer auto-detects it from the Expo bundle reliably).
- Drop unused `DdRum` import left over from the migration.

### RUM view tracking (`useDatadogViewTracking`)

New hook that reports the focused expo-router route as a RUM view on every navigation:

- **Views are named by route template, not resolved URL** — `inbox/[id]` is reported as `inbox/:id` (matching Datadog's web view-name convention), so dynamic params like document IDs never leak into Datadog. Route group segments like `(auth)`/`(tabs)` are stripped.
- **Zero-maintenance naming** — names derive from the file-based route, so new screens name themselves. The only special case is the home tab, reported as `home` (its route template is literally `index`).
- **No junk views** — nothing is reported while the router is still resolving the initial route (previously showed up as `/` views). Tracking is disabled entirely in dev builds.
- Note: the `ApplicationLaunch` view is synthesized by the Datadog SDK itself for the window before the first real view and can't be suppressed in code — exclude it in dashboards with `-@view.name:ApplicationLaunch` if it's noise.

### Note on sampling

`sessionSampleRate` remains at **10%**, unchanged. View counts in dashboards are therefore ~10× lower than real traffic (sampling is per-session, all-or-nothing). Fine for comparing screens against each other; raising the rate for fuller absolute numbers is left as a separate decision, pending a check that the RUM session quota can absorb it.

No new data collection beyond the pre-migration baseline — this restores upload consent and view statistics that existed before the migration.

**Example of view tracking from datadog:**
Would we want to add a leading '/' in front?
<img width="1069" height="676" alt="Screenshot 2026-07-02 at 14 28 18" src="https://github.com/user-attachments/assets/f06a7295-8109-4f11-a3e5-b7d9c6b75fad" />


## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude
