### PR TITLE
fix(j-s): fix Loka glugga modal locator in regression e2e tests

### DIFF
--- a/apps/system-e2e/src/tests/judicial-system/regression/custody-tests.spec.ts
+++ b/apps/system-e2e/src/tests/judicial-system/regression/custody-tests.spec.ts
@@ -149,7 +149,7 @@ test.describe.serial('Custody tests', () => {
     // Submit to court
     await expect(page).toHaveURL(`/krafa/stadfesta/${caseId}`)
     await page.getByRole('button', { name: 'Senda kröfu á héraðsdóm' }).click()
-    await page.getByRole('button', { name: 'Loka glugga' }).click()
+    await page.getByTestId('modalSecondaryButton').click()
     await expect(page).toHaveURL('/malalistar')
   })
 

--- a/apps/system-e2e/src/tests/judicial-system/regression/search-warrant-tests.spec.ts
+++ b/apps/system-e2e/src/tests/judicial-system/regression/search-warrant-tests.spec.ts
@@ -118,7 +118,7 @@ test.describe.serial('Search warrant tests', () => {
     // Submit to court
     await expect(page).toHaveURL(`/krafa/rannsoknarheimild/stadfesta/${caseId}`)
     await page.getByRole('button', { name: 'Senda kröfu á héraðsdóm' }).click()
-    await page.getByRole('button', { name: 'Loka glugga' }).click()
+    await page.getByTestId('modalSecondaryButton').click()
     await expect(page).toHaveURL('/malalistar')
   })
 

--- a/apps/system-e2e/src/tests/judicial-system/regression/travel-ban-tests.spec.ts
+++ b/apps/system-e2e/src/tests/judicial-system/regression/travel-ban-tests.spec.ts
@@ -101,7 +101,7 @@ test.describe.serial('Travel ban tests', () => {
 
     await expect(page).toHaveURL(`/krafa/stadfesta/${caseId}`)
     await page.getByRole('button', { name: 'Senda kröfu á héraðsdóm' }).click()
-    await page.getByRole('button', { name: 'Loka glugga' }).click()
+    await page.getByTestId('modalSecondaryButton').click()
     await expect(page).toHaveURL('/malalistar')
   })
 


### PR DESCRIPTION
# Fix ambiguous "Loka glugga" locator in judicial-system regression e2e tests

## What

Three judicial-system regression e2e tests (custody, search-warrant, travel-ban)
clicked the confirmation modal's close button via
`page.getByRole('button', { name: 'Loka glugga' })`. This now resolves to two
elements and throws a Playwright strict-mode violation. Switched them to target
the secondary button via its stable `data-testid="modalSecondaryButton"`.

## Why

[PR #23011](https://github.com/island-is/island.is/pull/23011) added
`aria-label="Loka glugga"` to the shared `Modal`'s icon-only close (X) button.
The "Senda kröfu á héraðsdóm" confirmation modal also renders a secondary button
whose text is `core.closeModal` ("Loka glugga"). Both now expose the same
accessible name, so the role-based locator matched two buttons and the click
failed under Playwright strict mode. Targeting the testid is unambiguous and
decoupled from the button label.

## Screenshots / Gifs

N/A — test-only change.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated end-to-end regression flows to use a more reliable modal dismissal action in several court-related scenarios.
  * No user-facing behavior changed; test steps and validations remain the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->