### PR TITLE
fix(native-app): make sure header on ios is still transparent

### DIFF
--- a/apps/native/app/src/app/(auth)/(tabs)/index/index.tsx
+++ b/apps/native/app/src/app/(auth)/(tabs)/index/index.tsx
@@ -516,9 +516,16 @@ export default function HomeScreen() {
         keyExtractor={keyExtractor}
         data={data}
         renderItem={renderItem}
-        style={{ flex: 1 }}
+        style={{
+          flex: 1,
+          backgroundColor:
+            Platform.OS === 'ios' ? theme.color.blue100 : undefined,
+        }}
         contentContainerStyle={{
           paddingBottom: insets.bottom + (Platform.OS === 'android' ? 0 : 30),
+          backgroundColor:
+            Platform.OS === 'ios' ? theme.color.white : undefined,
+          flexGrow: Platform.OS === 'ios' ? 1 : undefined,
         }}
         refreshControl={
           <RefreshControl refreshing={refetching} onRefresh={refetch} />


### PR DESCRIPTION
## What

Small additional fix after #23083 to make sure the ios navbar is still transparent and when pulling to refresh that the area that appears is also blue.

## Screenshots / Gifs

https://github.com/user-attachments/assets/e5b9cbd0-91a4-4a90-8d78-bc34609e6850


## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the Home screen list container styling for iOS, including background color and layout behavior.
  * Adjusted the list’s content area sizing so it fills the screen more consistently on iOS while leaving Android behavior unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->