### PR TITLE
fix(j-s): Ruling Order

### DIFF
--- a/apps/judicial-system/backend/src/app/modules/court-session/courtSession.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/court-session/courtSession.service.ts
@@ -241,6 +241,19 @@ export class CourtSessionService {
       transaction,
     })
 
+    // TEMPORARY — REMOVE WHEN THE RULING-ORDER APPEAL UI IS DEPLOYED.
+    // The court UI that records per-party "Ákvörðun um kæru" decisions is not in
+    // production yet, so no ORDER session can have any decisions and this check
+    // would block every ruling-order confirmation. While no decisions exist we
+    // skip the completeness check, restoring pre-appeal confirmation behaviour.
+    // Once the data-entry UI (in-court and out-of-court ruling-order appeals)
+    // ships, DELETE this early return so confirming an ORDER session again
+    // requires every party's decision — otherwise a session with no decisions
+    // entered could be confirmed and silently bypass the requirement.
+    if (decisions.length === 0) {
+      return
+    }
+
     const hasDecision = (
       predicate: (decision: AppealDecision) => boolean,
     ): boolean => decisions.some((d) => d.decision !== null && predicate(d))

--- a/apps/judicial-system/backend/src/app/modules/court-session/test/courtSessionController/confirmRulingOrderAppeal.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/court-session/test/courtSessionController/confirmRulingOrderAppeal.spec.ts
@@ -268,4 +268,24 @@ describe('CourtSessionController - Confirm ruling order appeal', () => {
       expect(mockCourtSessionRepositoryService.update).not.toHaveBeenCalled()
     })
   })
+
+  // TEMPORARY — REMOVE WITH THE `decisions.length === 0` SKIP IN
+  // CourtSessionService.validateAppealDecisionsComplete (when the ruling-order
+  // appeal UI ships). Until the data-entry UI is deployed no ORDER session has
+  // any decisions, so confirmation must still succeed. When the skip is removed
+  // this case must flip to a rejection.
+  describe('no decisions recorded at all (temporary pre-UI behaviour)', () => {
+    let then: Then
+
+    beforeEach(async () => {
+      decisions = []
+      then = await givenWhenThen(baseCase)
+    })
+
+    it('should confirm without creating an appeal case', () => {
+      expect(then.error).toBeUndefined()
+      expect(mockCourtSessionRepositoryService.update).toHaveBeenCalled()
+      expect(mockAppealCaseRepositoryService.create).not.toHaveBeenCalled()
+    })
+  })
 })


### PR DESCRIPTION
# Ruling Order

[Kæra úrskurð í þinghaldi 2 - búa til kæru við lok þinghalds](https://app.asana.com/1/203394141643832/project/1199153462262248/task/1215774678832925)

## What

- Temporarily disables in-court appeal decision verification.

## Why

- Causes problems with ruling orders and is not needed now.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Confirmation now succeeds when no appeal decisions have been recorded yet, avoiding an unnecessary validation error.
  * Existing confirmation flow continues to update the court session normally in this case.
  * Added test coverage for the no-decisions scenario to ensure the expected behavior remains stable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->