### PR TITLE
fix(j-s): Avoid nested interactive elements in ZipButton

### DIFF
--- a/apps/judicial-system/web/src/components/ZipButton/ZipButton.spec.tsx
+++ b/apps/judicial-system/web/src/components/ZipButton/ZipButton.spec.tsx
@@ -1,0 +1,34 @@
+import { IntlProvider } from 'react-intl'
+import { render, screen } from '@testing-library/react'
+
+import ZipButton from './ZipButton'
+
+const renderZipButton = (courtCaseNumber?: string) =>
+  render(
+    <IntlProvider locale="is" onError={jest.fn}>
+      <ZipButton caseId="test-case-id" courtCaseNumber={courtCaseNumber} />
+    </IntlProvider>,
+  )
+
+describe('<ZipButton />', () => {
+  test('should render a single download link with an accessible name', () => {
+    renderZipButton('R-123/2024')
+
+    const link = screen.getByRole('link', { name: 'Sækja öll skjöl' })
+
+    expect(link).toBeInTheDocument()
+    expect(link).toHaveAttribute(
+      'href',
+      '/api/case/test-case-id/limitedAccess/allFiles',
+    )
+    expect(link).toHaveAttribute('download', 'mal_R-123/2024')
+  })
+
+  test('should not nest an interactive button inside the link', () => {
+    renderZipButton('R-123/2024')
+
+    // The visual button is rendered as a span so the anchor is the only
+    // interactive element (no interactive-in-interactive nesting).
+    expect(screen.queryByRole('button')).not.toBeInTheDocument()
+  })
+})

--- a/apps/judicial-system/web/src/components/ZipButton/ZipButton.tsx
+++ b/apps/judicial-system/web/src/components/ZipButton/ZipButton.tsx
@@ -22,7 +22,13 @@ const ZipButton: FC<Props> = (props) => {
       download={`mal_${courtCaseNumber}`}
       className={styles.downloadAllButton}
     >
-      <Button variant="ghost" size="small" icon="download" iconType="outline">
+      <Button
+        as="span"
+        variant="ghost"
+        size="small"
+        icon="download"
+        iconType="outline"
+      >
         {formatMessage(strings.getAllDocuments)}
       </Button>
     </a>


### PR DESCRIPTION
## What

Fixes a serious accessibility violation in `ZipButton`: a `<Button>` (which emits `role="button"`) was nested inside the download `<a>`, producing an interactive-element-inside-interactive-element error.

The anchor (`<a href download>`) is the real interactive control — the inner `<Button>` was only there for styling. This passes `as="span"` to the island-ui `Button`, which (per its API) drops `role="button"` and the `type` attribute, rendering it as a styled, non-interactive span. The anchor is now the sole interactive element. Visual styling, `href`, `download`, and link text are unchanged.

## Why

The nested interactive elements break keyboard/AT semantics and were flagged as a serious a11y issue. Consumers ([Defender CaseOverview](https://github.com/island-is/island.is/blob/main/apps/judicial-system/web/src/routes/Defender/RequestCase/CaseOverview.tsx) and [Defender IndictmentOverview](https://github.com/island-is/island.is/blob/main/apps/judicial-system/web/src/routes/Defender/IndictmentCase/IndictmentOverview.tsx)) are unaffected — the `Props` interface is unchanged.

## Screenshots / Gifs

No visual change.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for the download button to ensure it renders as a single accessible link with the correct download behavior.
  * Verified the link does not contain an extra interactive control inside it.

* **Refactor**
  * Cleaned up the button markup used in the download link without changing its appearance or download behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->