### PR TITLE
fix(driving-license): localize hardcoded UI strings and remove placeholder copy

### DIFF
--- a/libs/application/templates/driving-license/src/fields/EligibilitySummary/EligibilitySummary.tsx
+++ b/libs/application/templates/driving-license/src/fields/EligibilitySummary/EligibilitySummary.tsx
@@ -1,18 +1,24 @@
 import React, { FC, useEffect } from 'react'
 import type { FieldBaseProps } from '@island.is/application/types'
-import { Box, Text } from '@island.is/island-ui/core'
-import { getValueViaPath } from '@island.is/application/core'
+import {
+  Box,
+  LoadingDots,
+  Text,
+  VisuallyHidden,
+} from '@island.is/island-ui/core'
+import { coreErrorMessages, getValueViaPath } from '@island.is/application/core'
 import { useLocale } from '@island.is/localization'
 import ReviewSection from './ReviewSection'
 import { useFormContext } from 'react-hook-form'
 import { extractReasons } from './extractReasons'
 import { useEligibility } from './useEligibility'
+import { m } from '../../lib/messages'
 
 export const EligibilitySummary: FC<
   React.PropsWithChildren<FieldBaseProps>
 > = ({ application }) => {
   const { setValue, watch } = useFormContext()
-  const { lang } = useLocale()
+  const { lang, formatMessage } = useLocale()
 
   // The redesign flags are written by hidden inputs on this same screen
   // (sectionRequirements.ts), so `application.answers` is still stale on
@@ -37,11 +43,26 @@ export const EligibilitySummary: FC<
   }, [eligibility?.isEligible, setValue])
 
   if (loading) {
-    return <Text>Sæki upplýsingar...</Text>
+    return (
+      <Box
+        display="flex"
+        justifyContent="center"
+        paddingY={4}
+        role="status"
+        aria-live="polite"
+      >
+        <VisuallyHidden>{formatMessage(m.loadingEligibility)}</VisuallyHidden>
+        <LoadingDots />
+      </Box>
+    )
   }
 
   if (error || !eligibility) {
-    return <Text>Villa kom upp við að sækja upplýsingar</Text>
+    return (
+      <Box role="alert">
+        <Text>{formatMessage(coreErrorMessages.failedDataProvider)}</Text>
+      </Box>
+    )
   }
 
   const requirements = extractReasons(eligibility, lang)

--- a/libs/application/templates/driving-license/src/fields/EligibilitySummary/ReviewSection/index.tsx
+++ b/libs/application/templates/driving-license/src/fields/EligibilitySummary/ReviewSection/index.tsx
@@ -91,10 +91,11 @@ const ReviewSection: FC<React.PropsWithChildren<ReviewSectionProps>> = ({
             : formatMessage(description)}
         </Text>
         {showLocalRequirementDays && (
-          <Text
-            marginTop={2}
-            fontWeight="medium"
-          >{`Þú hefur aðeins búið á Íslandi í ${daysOfResidency} daga.`}</Text>
+          <Text marginTop={2} fontWeight="medium">
+            {formatMessage(m.localResidencyDaysSpent, {
+              days: daysOfResidency,
+            })}
+          </Text>
         )}
       </Box>
     </Box>

--- a/libs/application/templates/driving-license/src/forms/draft/subSectionDelivery.ts
+++ b/libs/application/templates/driving-license/src/forms/draft/subSectionDelivery.ts
@@ -44,15 +44,15 @@ export const subSectionDelivery = buildSubSection({
           condition: (answers) =>
             getValueViaPath(answers, 'delivery.deliveryMethod') ===
             Pickup.DISTRICT,
-          options: ({
-            externalData: {
-              jurisdictions: { data },
-            },
-          }) => {
-            return (data as Jurisdiction[]).map(({ id, name, zip }) => ({
+          options: (application) => {
+            const data = (getValueViaPath(
+              application.externalData,
+              'jurisdictions.data',
+            ) ?? []) as Jurisdiction[]
+            return data.map(({ id, name, zip }) => ({
               value: `${id}`,
               label: name,
-              tooltip: `Póstnúmer ${zip}`,
+              tooltip: { ...m.postalCodeTooltip, values: { zip } },
             }))
           },
         }),

--- a/libs/application/templates/driving-license/src/lib/messages.spec.ts
+++ b/libs/application/templates/driving-license/src/lib/messages.spec.ts
@@ -1,0 +1,39 @@
+import { createIntl } from 'react-intl'
+import { m } from './messages'
+
+// The residency-days line uses an ICU plural message. Icelandic CLDR puts every
+// number ending in 1 *except* 11 into the `one` category (1, 21, 31, …, 181),
+// so the `one` branch must still render the count (`# dag`) rather than a literal
+// "einn dag" — otherwise 21 would render the literal "einn dag", dropping the
+// real count. This guards that regression.
+describe('m.localResidencyDaysSpent (Icelandic ICU plural)', () => {
+  // `defaultLocale: 'is'` matters: the strings under test are Icelandic
+  // `defaultMessage`s, and react-intl selects the plural category for a
+  // defaultMessage using `defaultLocale` (the app's IntlProvider sets it to
+  // the Icelandic `defaultLanguage`). Without it, English rules would apply
+  // and 21 would wrongly fall to `other`.
+  const intl = createIntl({
+    locale: 'is',
+    defaultLocale: 'is',
+    messages: {},
+    onError: () => undefined,
+  })
+  const format = (days: number) =>
+    intl.formatMessage(m.localResidencyDaysSpent, { days })
+
+  it.each([1, 21, 31, 181])(
+    'keeps the count with the singular noun "dag" for n ending in 1: %i',
+    (days) => {
+      expect(format(days)).toBe(`Þú hefur aðeins búið á Íslandi í ${days} dag.`)
+    },
+  )
+
+  it.each([5, 11, 22, 100])(
+    'keeps the count with the plural noun "daga" otherwise: %i',
+    (days) => {
+      expect(format(days)).toBe(
+        `Þú hefur aðeins búið á Íslandi í ${days} daga.`,
+      )
+    },
+  )
+})

--- a/libs/application/templates/driving-license/src/lib/messages.ts
+++ b/libs/application/templates/driving-license/src/lib/messages.ts
@@ -102,8 +102,14 @@ export const m = defineMessages({
   pickupLocationDescription: {
     id: 'dl.application:pickupLocationDescription',
     defaultMessage:
-      'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam.',
+      'Veldu hvort þú vilt fá ökuskírteinið sent á lögheimili með pósti eða sækja það hjá völdu sýslumannsembætti.',
     description: 'location for pickup',
+  },
+  postalCodeTooltip: {
+    id: 'dl.application:postalCodeTooltip',
+    defaultMessage: 'Póstnúmer {zip}',
+    description:
+      'Postal code tooltip shown on a jurisdiction (sýslumaður) option',
   },
   deliveryMethodHeader: {
     id: 'dl.application:deliveryMethodHeader',
@@ -472,38 +478,18 @@ export const m = defineMessages({
     description:
       'Your application for a full driving license has been received. Before a full driving license can be applied for, you must bring the following to the district commissioner.',
   },
-  digitalLicenseInfoTitle: {
-    id: 'dl.application:digitalLicenseInfoTitle',
-    defaultMessage: 'Stafrænt ökuskírteini',
-    description: 'Digital driving license',
-  },
-  digitalLicenseInfoDescription: {
-    id: 'dl.application:digitalLicenseInfoDescription',
-    defaultMessage: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
-    description: 'Digital driving license',
-  },
-  digitalLicenseInfoAlertTitle: {
-    id: 'dl.application:digitalLicenseInfoAlertTitle',
-    defaultMessage: 'Athugið',
-    description: 'Digital driving license',
-  },
-  digitalLicenseInfoAlertMessageBTemp: {
-    id: 'dl.application:digitalLicenseInfoAlertMessageBTemp#markdown',
+  localResidencyDaysSpent: {
+    id: 'dl.application:localResidencyDaysSpent',
     defaultMessage:
-      'Þú ert að sækja um bráðabirgðaökuskírteini. Ökuskírteini þitt verður einungis gefið út sem stafrænt ökuskírteini og verður aðgengilegt fyrir þig um leið og öll skilyrði fyrir bráðabirgðaökuskírteini eru uppfyllt.',
-    description: 'Digital driving license',
+      '{days, plural, one {Þú hefur aðeins búið á Íslandi í # dag.} other {Þú hefur aðeins búið á Íslandi í # daga.}}',
+    description:
+      'Shown under the residency requirement: number of days the applicant has lived in Iceland (ICU plural)',
   },
-  digitalLicenseInfoAlertMessageBFull: {
-    id: 'dl.application:digitalLicenseInfoAlertMessageBFull#markdown',
-    defaultMessage:
-      'Þú ert að sækja um fullnaðarökuskírteini. Ökuskírteini þitt verður núna einungis gefið út sem stafrænt ökuskírteini og verður aðgengilegt fyrir þig þegar þú hefur lokið þessari pöntun um fullnaðarökuskírteini. Fullnaðarökuskírteini þitt verður framleitt í plasti í byrjun febrúar 2025 og sent til þín með Póstinum, á skráð lögheimili þitt um leið og plastökuskírteinið er tilbúið.',
-    description: 'Digital driving license',
-  },
-  digitalLicenseInfoAlertMessageExtraInfo: {
-    id: 'dl.application:digitalLicenseInfoAlertMessageExtraInfo#markdown',
-    defaultMessage:
-      'Upplýsingar um stafrænt ökuskírteini, hvernig þú sækir það og hleður því í símannn þinn eru aðgengilegar hér [https://island.is/okuskirteini](https://island.is/okuskirteini)',
-    description: 'Digital driving license',
+  loadingEligibility: {
+    id: 'dl.application:loadingEligibility',
+    defaultMessage: 'Sæki upplýsingar',
+    description:
+      'Screen-reader label for the loading spinner while eligibility is being fetched',
   },
   congratulationsTempHelpText: {
     id: 'dl.application:congratulationsTempHelpText',


### PR DESCRIPTION
## What

Localizes Icelandic UI strings that bypassed the translation system in the
driving-license **eligibility** and **delivery** screens, and removes leftover
placeholder copy.

- **EligibilitySummary**: loading → accessible `role="status"` region with a
  visually-hidden localized label + `<LoadingDots />`; error → the already-translated
  `coreErrorMessages.failedDataProvider` wrapped in `role="alert"` so screen readers
  announce the async failure.
- **ReviewSection**: residency-days line → localized **ICU-plural** message
  (`localResidencyDaysSpent`), keeping the count in both branches (`# dag` / `# daga`).
  Icelandic CLDR puts numbers ending in 1 except 11 (1, 21, 31 …) in `one`, so the
  count must render there with the singular-accusative noun ("21 dag"), not "einn dag".
  Added `messages.spec.ts` covering 1 / 11 / 21 / 22.
- **Delivery**: jurisdiction tooltip → localized message (`postalCodeTooltip`,
  "Póstnúmer {zip}") via a `StaticTextObject` with `values`, replacing the inline ternary.
- **messages**: replace the Lorem ipsum `pickupLocationDescription` with real copy;
  delete the 6 unused `digitalLicenseInfo*` placeholders; add `loadingEligibility`,
  `postalCodeTooltip`.

## Why

English-speaking applicants (a meaningful share of driving-licence users) saw
Icelandic on these screens regardless of locale, because the strings were hardcoded
rather than routed through the message system. The delivery screen also rendered
literal "Lorem ipsum", and the loading/error states had no accessible announcement.

## ⚠️ Before merge — human action required

- [x] **Add EN (and confirm IS) Contentful entries for the three NEW ids:**
      - `dl.application:localResidencyDaysSpent` — **keep the ICU plural structure**
        (`{days, plural, one {…} other {…}}`)
      - `dl.application:loadingEligibility`
      - `dl.application:postalCodeTooltip` — EN `"Postal code {zip}"` (until this exists,
        English users see `Póstnúmer 101`)
- [x] **Update the EXISTING `dl.application:pickupLocationDescription` entry** (is + en) —
      it likely still holds the old Lorem-ipsum placeholder, so the code fallback alone
      won't change prod; the entry itself must be updated. Include a **product/copy review**
      of the new wording: "Veldu hvort þú vilt fá ökuskírteinið sent á lögheimili með pósti
      eða sækja það hjá völdu sýslumannsembætti."

_Out of scope (separate follow-up): submitted-application **email localization** — the
shared `sendEmail(generator, application, locale = 'is')` already accepts a locale; the
driving-licence caller just omits it, so it's fixable in the driving-licence
submission/email code (not a shared-service change)._

## Screenshots / Gifs

N/A — text/localization. Delivery no longer shows Lorem ipsum; the eligibility loading
state is a spinner with an accessible status label, and the error state is announced.

## Verification

- TypeScript check passes
- Lint passes (0 errors; 2 pre-existing `any` warnings in an unrelated spec)
- 6 test suites / 49 tests pass (incl. new ICU-plural coverage for 1/11/21/22)
- Prettier (repo 2.6.2) clean
- Rebased on latest `main`; diff limited to 5 files, no unrelated churn

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code (Opus 4.8); OpenAI Codex (independent review)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved localization for eligibility, residency-days, and delivery-related text.
  * Added clearer, accessible loading and error states for eligibility checks.
* **Bug Fixes**
  * Replaced hardcoded text with localized messages across the driving license flow.
  * Updated delivery location options to show consistent tooltip messaging.
* **Documentation**
  * Improved user-facing instructions for choosing delivery or pickup options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->