### PR TITLE
fix: module resolution for payment worker

### DIFF
--- a/apps/services/payments/src/app/worker/worker.module.ts
+++ b/apps/services/payments/src/app/worker/worker.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common'
 import { ConfigModule } from '@nestjs/config'
 import { SequelizeModule } from '@nestjs/sequelize'
 
+import { BlikkClientConfig } from '@island.is/clients/blikk'
 import { ChargeFjsV2ClientConfig } from '@island.is/clients/charge-fjs-v2'
 import { LoggingModule } from '@island.is/logging'
 
@@ -43,6 +44,7 @@ import { WorkerService } from './worker.service'
         XRoadConfig,
         FeatureFlagConfig,
         ChargeFjsV2ClientConfig,
+        BlikkClientConfig,
         PaymentFlowModuleConfig,
         JwksConfig,
         WorkerModuleConfig,


### PR DESCRIPTION
## What

The payments worker was crashing in prod. It imports
`PaymentFlowModule`, which transitively pulls in `BankTransferPaymentModule` +
`BlikkClientModule` — so the worker has to satisfy that whole subtree at boot, even
though it only does FJS backfill for card flows and never touches bank transfers.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated payment service configuration loading to include an additional client config, improving the worker’s runtime setup and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->