### PR TITLE
fix(j-s): add accessible names to icon-only controls

### DIFF
--- a/apps/judicial-system/web/src/components/AlertBanner/AlertBanner.spec.tsx
+++ b/apps/judicial-system/web/src/components/AlertBanner/AlertBanner.spec.tsx
@@ -1,0 +1,21 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+
+import { AlertBanner } from './index'
+
+describe('AlertBanner', () => {
+  test('should give the dismiss button a descriptive accessible name', () => {
+    render(<AlertBanner title="Villa" dismissable />)
+
+    expect(screen.getByRole('button', { name: 'Loka' })).toBeInTheDocument()
+  })
+
+  test('should dismiss the banner when the close button is activated', () => {
+    const onDismiss = jest.fn()
+    render(<AlertBanner title="Villa" dismissable onDismiss={onDismiss} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Loka' }))
+
+    expect(onDismiss).toHaveBeenCalledTimes(1)
+    expect(screen.queryByText('Villa')).not.toBeInTheDocument()
+  })
+})

--- a/apps/judicial-system/web/src/components/AlertBanner/index.tsx
+++ b/apps/judicial-system/web/src/components/AlertBanner/index.tsx
@@ -138,6 +138,7 @@ export const AlertBanner: FC<PropsWithChildren<AlertBannerProps>> = ({
         >
           <button
             className={alertBannerStyles.closeBtn}
+            aria-label="Loka"
             onClick={() => {
               setDismissed(true)
               if (onDismiss) {

--- a/apps/judicial-system/web/src/components/BreadCrumbs/BreadCrumbs.spec.tsx
+++ b/apps/judicial-system/web/src/components/BreadCrumbs/BreadCrumbs.spec.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from '@testing-library/react'
+
+import BreadCrumbs from './BreadCrumbs'
+
+jest.mock(
+  '../../utils/hooks/useCaseTableMembership/caseTableMembership.generated',
+  () => ({
+    useCaseTableMembershipQuery: () => ({
+      data: undefined,
+      loading: false,
+      error: undefined,
+    }),
+  }),
+)
+
+describe('BreadCrumbs', () => {
+  test('should give the home link a descriptive accessible name', () => {
+    render(<BreadCrumbs />)
+
+    expect(screen.getByRole('link', { name: 'Heim' })).toHaveAttribute(
+      'href',
+      '/malalistar',
+    )
+  })
+})

--- a/apps/judicial-system/web/src/components/BreadCrumbs/BreadCrumbs.tsx
+++ b/apps/judicial-system/web/src/components/BreadCrumbs/BreadCrumbs.tsx
@@ -35,7 +35,7 @@ const BreadCrumbs: FC = () => {
 
   return (
     <Box display="flex" alignItems="center">
-      <Link href="/malalistar" className={styles.link}>
+      <Link href="/malalistar" className={styles.link} aria-label="Heim">
         <Icon icon="home" size="small" color="purple400" type="outline" />
       </Link>
       <Box marginX={1}>

--- a/apps/judicial-system/web/src/components/HideableText/HideableText.spec.tsx
+++ b/apps/judicial-system/web/src/components/HideableText/HideableText.spec.tsx
@@ -1,0 +1,38 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+
+import HideableText from './HideableText'
+
+describe('HideableText', () => {
+  test('should give the visibility toggle a descriptive accessible name when visible', () => {
+    render(<HideableText text="Leyniupplýsingar" onToggleVisibility={jest.fn()} />)
+
+    expect(
+      screen.getByRole('button', { name: 'Fela texta' }),
+    ).toBeInTheDocument()
+  })
+
+  test('should give the visibility toggle a descriptive accessible name when hidden', () => {
+    render(
+      <HideableText
+        text="Leyniupplýsingar"
+        isHidden
+        onToggleVisibility={jest.fn()}
+      />,
+    )
+
+    expect(
+      screen.getByRole('button', { name: 'Sýna texta' }),
+    ).toBeInTheDocument()
+  })
+
+  test('should toggle visibility when the button is activated', () => {
+    const onToggleVisibility = jest.fn()
+    render(
+      <HideableText text="Leyniupplýsingar" onToggleVisibility={onToggleVisibility} />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Fela texta' }))
+
+    expect(onToggleVisibility).toHaveBeenCalledWith(true)
+  })
+})

--- a/apps/judicial-system/web/src/components/HideableText/HideableText.spec.tsx
+++ b/apps/judicial-system/web/src/components/HideableText/HideableText.spec.tsx
@@ -4,7 +4,9 @@ import HideableText from './HideableText'
 
 describe('HideableText', () => {
   test('should give the visibility toggle a descriptive accessible name when visible', () => {
-    render(<HideableText text="Leyniupplýsingar" onToggleVisibility={jest.fn()} />)
+    render(
+      <HideableText text="Leyniupplýsingar" onToggleVisibility={jest.fn()} />,
+    )
 
     expect(
       screen.getByRole('button', { name: 'Fela texta' }),
@@ -28,7 +30,10 @@ describe('HideableText', () => {
   test('should toggle visibility when the button is activated', () => {
     const onToggleVisibility = jest.fn()
     render(
-      <HideableText text="Leyniupplýsingar" onToggleVisibility={onToggleVisibility} />,
+      <HideableText
+        text="Leyniupplýsingar"
+        onToggleVisibility={onToggleVisibility}
+      />,
     )
 
     fireEvent.click(screen.getByRole('button', { name: 'Fela texta' }))

--- a/apps/judicial-system/web/src/components/HideableText/HideableText.tsx
+++ b/apps/judicial-system/web/src/components/HideableText/HideableText.tsx
@@ -21,6 +21,7 @@ const HideableText: FC<Props> = ({
   const renderVisibilityButton = () => (
     <button
       className={styles.eyeButton}
+      aria-label={isHidden ? 'Sýna texta' : 'Fela texta'}
       onClick={() => {
         onToggleVisibility(!isHidden)
       }}


### PR DESCRIPTION
## What
Adds descriptive accessible names to icon-only controls in the judicial-system web app that previously exposed no name to assistive technology:

- **HideableText** — the eye toggle now has a dynamic `aria-label` (`Sýna texta` when hidden, `Fela texta` when visible).
- **AlertBanner** — the dismiss button now has `aria-label="Loka"` (shared component; inherited by all callers).
- **BreadCrumbs** — the home link (icon only) now has `aria-label="Heim"`.

Also adds component tests asserting the accessible name and activation behavior for each control.

## Why
These icon-only buttons/links rendered only an `Icon` with no text, so screen-reader users had no way to know what they do (a serious WCAG accessible-name issue). Follows the app's existing convention of hardcoded Icelandic `aria-label` strings (no `.strings.ts` additions).

## Screenshots / Gifs
Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code
- [ ] No AI tools were used in preparing this pull request

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accessibility labels for the dismiss button, breadcrumbs home link, and visibility toggle so screen readers announce them more clearly.
  * Kept existing click behavior intact while ensuring the dismiss action still removes the banner as expected.

* **Tests**
  * Added coverage for alert dismiss behavior, breadcrumb link accessibility, and hide/show toggle behavior.
  * Verified accessible names and user interactions for the updated components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->