### PR TITLE
fix(j-s): Allow copy to draft before court completetion

### DIFF
--- a/apps/judicial-system/backend/src/app/modules/case/case.controller.ts
+++ b/apps/judicial-system/backend/src/app/modules/case/case.controller.ts
@@ -49,6 +49,7 @@ import {
   hasGeneratedCourtRecordPdf,
   indictmentCases,
   investigationCases,
+  isCompletedCase,
   isDistrictCourtUser,
   isIndictmentCase,
   isPublicProsecutionOfficeUser,
@@ -1004,7 +1005,6 @@ export class CaseController {
     CaseExistsGuard,
     new CaseTypeGuard(indictmentCases),
     CaseReadGuard,
-    CaseCompletedGuard,
   )
   @RolesRules(prosecutorRule, prosecutorRepresentativeRule)
   @UseInterceptors(CaseInterceptor)
@@ -1021,14 +1021,17 @@ export class CaseController {
   ): Promise<Case> {
     this.logger.debug(`Duplicating indictment case ${caseId} into a new draft`)
 
-    // Only indictments that were revoked after being sent to court can be
-    // duplicated into a new draft case
-    if (
-      theCase.indictmentRulingDecision !==
-        CaseIndictmentRulingDecision.WITHDRAWAL &&
-      theCase.indictmentRulingDecision !==
-        CaseIndictmentRulingDecision.CANCELLATION
-    ) {
+    const isWaitingForCancellation =
+      theCase.state === CaseState.WAITING_FOR_CANCELLATION
+
+    const isCompletedRevocation =
+      isCompletedCase(theCase.state) &&
+      (theCase.indictmentRulingDecision ===
+        CaseIndictmentRulingDecision.WITHDRAWAL ||
+        theCase.indictmentRulingDecision ===
+          CaseIndictmentRulingDecision.CANCELLATION)
+
+    if (!isWaitingForCancellation && !isCompletedRevocation) {
       throw new ForbiddenException(
         `Cannot duplicate indictment case ${caseId} - it has not been revoked`,
       )

--- a/apps/judicial-system/backend/src/app/modules/case/test/caseController/caseControllerGuards.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/case/test/caseController/caseControllerGuards.spec.ts
@@ -282,6 +282,15 @@ describe('CaseController - Split defendant from case guards', () => {
   )
 })
 
+describe('CaseController - Duplicate guards', () => {
+  verifyGuards(
+    CaseController,
+    'duplicate',
+    [RolesGuard, CaseExistsGuard, CaseTypeGuard, CaseReadGuard],
+    [{ guard: CaseTypeGuard, prop: { allowedCaseTypes: indictmentCases } }],
+  )
+})
+
 describe('CaseController - Create court case guards', () => {
   verifyGuards(CaseController, 'createCourtCase', [
     RolesGuard,

--- a/apps/judicial-system/backend/src/app/modules/case/test/caseController/duplicate.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/case/test/caseController/duplicate.spec.ts
@@ -95,7 +95,44 @@ describe('CaseController - Duplicate', () => {
     })
   })
 
-  describe('non-revoked indictment', () => {
+  describe('waiting for cancellation indictment duplicated', () => {
+    const userId = uuid()
+    const prosecutorsOfficeId = uuid()
+    const user = {
+      id: userId,
+      institution: { id: prosecutorsOfficeId },
+    } as TUser
+    const caseId = uuid()
+    const theCase = {
+      id: caseId,
+      type: CaseType.INDICTMENT,
+      state: CaseState.WAITING_FOR_CANCELLATION,
+    } as Case
+    const duplicatedCaseId = uuid()
+    const duplicatedCase = { id: duplicatedCaseId } as Case
+    let then: Then
+
+    beforeEach(async () => {
+      const mockDuplicate =
+        mockCaseRepositoryService.duplicateIndictmentToDraft as jest.Mock
+      mockDuplicate.mockResolvedValueOnce(duplicatedCase)
+
+      then = await givenWhenThen(caseId, user, theCase)
+    })
+
+    it('should duplicate the case into a new draft', () => {
+      expect(
+        mockCaseRepositoryService.duplicateIndictmentToDraft,
+      ).toHaveBeenCalledWith(caseId, {
+        transaction,
+        prosecutorId: userId,
+        prosecutorsOfficeId,
+      })
+      expect(then.result).toBe(duplicatedCase)
+    })
+  })
+
+  describe('non-revoked completed indictment', () => {
     const user = { id: uuid(), institution: { id: uuid() } } as TUser
     const caseId = uuid()
     const theCase = {
@@ -103,6 +140,28 @@ describe('CaseController - Duplicate', () => {
       type: CaseType.INDICTMENT,
       state: CaseState.COMPLETED,
       indictmentRulingDecision: CaseIndictmentRulingDecision.RULING,
+    } as Case
+    let then: Then
+
+    beforeEach(async () => {
+      then = await givenWhenThen(caseId, user, theCase)
+    })
+
+    it('should throw ForbiddenException and not duplicate', () => {
+      expect(then.error).toBeInstanceOf(ForbiddenException)
+      expect(
+        mockCaseRepositoryService.duplicateIndictmentToDraft,
+      ).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('non-revoked active indictment', () => {
+    const user = { id: uuid(), institution: { id: uuid() } } as TUser
+    const caseId = uuid()
+    const theCase = {
+      id: caseId,
+      type: CaseType.INDICTMENT,
+      state: CaseState.RECEIVED,
     } as Case
     let then: Then
 

--- a/apps/judicial-system/web/src/components/Modals/DuplicateIndictmentModal/DuplicateIndictmentModal.tsx
+++ b/apps/judicial-system/web/src/components/Modals/DuplicateIndictmentModal/DuplicateIndictmentModal.tsx
@@ -1,4 +1,4 @@
-import { FC, useContext } from 'react'
+import { FC, useContext, useState } from 'react'
 import { useRouter } from 'next/router'
 
 import { PROSECUTION_INDICTMENT_CASE_DEFENDANT_ROUTE } from '@island.is/judicial-system/consts'
@@ -15,16 +15,22 @@ interface Props {
 const DuplicateIndictmentModal: FC<Props> = ({ onClose }) => {
   const { workingCase } = useContext(FormContext)
   const router = useRouter()
-  const { duplicateIndictmentCase, isDuplicatingIndictmentCase } = useCase()
+  const { duplicateIndictmentCase } = useCase()
+  const [isLoading, setIsLoading] = useState(false)
 
   const handleDuplicateIndictment = async () => {
+    setIsLoading(true)
+
     const duplicatedCase = await duplicateIndictmentCase(workingCase.id)
 
-    if (duplicatedCase) {
-      router.push(
-        `${PROSECUTION_INDICTMENT_CASE_DEFENDANT_ROUTE}/${duplicatedCase.id}`,
-      )
+    if (!duplicatedCase) {
+      setIsLoading(false)
+      return
     }
+
+    await router.push(
+      `${PROSECUTION_INDICTMENT_CASE_DEFENDANT_ROUTE}/${duplicatedCase.id}`,
+    )
   }
 
   return (
@@ -32,15 +38,16 @@ const DuplicateIndictmentModal: FC<Props> = ({ onClose }) => {
       title="Viltu afrita mál í drög?"
       text="Nýtt mál verður til í drögum. Innihald ákæru ásamt gögnum afritast yfir á nýja málið."
       onClose={onClose}
+      loading={isLoading}
       primaryButton={{
         text: 'Afrita mál í drög',
         onClick: handleDuplicateIndictment,
-        isLoading: isDuplicatingIndictmentCase,
+        isLoading,
       }}
       secondaryButton={{
         text: 'Hætta við',
         onClick: onClose,
-        isDisabled: isDuplicatingIndictmentCase,
+        isDisabled: isLoading,
       }}
     />
   )

--- a/apps/judicial-system/web/src/components/Modals/DuplicateIndictmentModal/DuplicateIndictmentModal.tsx
+++ b/apps/judicial-system/web/src/components/Modals/DuplicateIndictmentModal/DuplicateIndictmentModal.tsx
@@ -28,9 +28,13 @@ const DuplicateIndictmentModal: FC<Props> = ({ onClose }) => {
       return
     }
 
-    await router.push(
-      `${PROSECUTION_INDICTMENT_CASE_DEFENDANT_ROUTE}/${duplicatedCase.id}`,
-    )
+    try {
+      await router.push(
+        `${PROSECUTION_INDICTMENT_CASE_DEFENDANT_ROUTE}/${duplicatedCase.id}`,
+      )
+    } catch {
+      setIsLoading(false)
+    }
   }
 
   return (

--- a/apps/judicial-system/web/src/components/Modals/DuplicateIndictmentModal/DuplicateIndictmentModal.tsx
+++ b/apps/judicial-system/web/src/components/Modals/DuplicateIndictmentModal/DuplicateIndictmentModal.tsx
@@ -1,0 +1,49 @@
+import { FC, useContext } from 'react'
+import { useRouter } from 'next/router'
+
+import { PROSECUTION_INDICTMENT_CASE_DEFENDANT_ROUTE } from '@island.is/judicial-system/consts'
+import {
+  FormContext,
+  Modal,
+} from '@island.is/judicial-system-web/src/components'
+import { useCase } from '@island.is/judicial-system-web/src/utils/hooks'
+
+interface Props {
+  onClose: () => void
+}
+
+const DuplicateIndictmentModal: FC<Props> = ({ onClose }) => {
+  const { workingCase } = useContext(FormContext)
+  const router = useRouter()
+  const { duplicateIndictmentCase, isDuplicatingIndictmentCase } = useCase()
+
+  const handleDuplicateIndictment = async () => {
+    const duplicatedCase = await duplicateIndictmentCase(workingCase.id)
+
+    if (duplicatedCase) {
+      router.push(
+        `${PROSECUTION_INDICTMENT_CASE_DEFENDANT_ROUTE}/${duplicatedCase.id}`,
+      )
+    }
+  }
+
+  return (
+    <Modal
+      title="Viltu afrita mál í drög?"
+      text="Nýtt mál verður til í drögum. Innihald ákæru ásamt gögnum afritast yfir á nýja málið."
+      onClose={onClose}
+      primaryButton={{
+        text: 'Afrita mál í drög',
+        onClick: handleDuplicateIndictment,
+        isLoading: isDuplicatingIndictmentCase,
+      }}
+      secondaryButton={{
+        text: 'Hætta við',
+        onClick: onClose,
+        isDisabled: isDuplicatingIndictmentCase,
+      }}
+    />
+  )
+}
+
+export default DuplicateIndictmentModal

--- a/apps/judicial-system/web/src/components/index.ts
+++ b/apps/judicial-system/web/src/components/index.ts
@@ -142,4 +142,5 @@ export { default as ArraignmentAlert } from './Alerts/ArraignmentAlert/Arraignme
 export { default as RulingModifiedAlert } from './Alerts/RulingModifiedAlert/RulingModifiedAlert'
 export { default as AppealRulingModifiedAlert } from './Alerts/AppealRulingModifiedAlert/AppealRulingModifiedAlert'
 export { default as ChangeProsecutorModal } from './Modals/ChangeProsecutorModal/ChangeProsecutorModal'
+export { default as DuplicateIndictmentModal } from './Modals/DuplicateIndictmentModal/DuplicateIndictmentModal'
 export { default as TinyMCE } from './TinyMCE/TinyMCE'

--- a/apps/judicial-system/web/src/routes/Prosecutor/Indictments/IndictmentOverview/IndictmentOverview.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/Indictments/IndictmentOverview/IndictmentOverview.tsx
@@ -10,9 +10,7 @@ import { useIntl } from 'react-intl'
 import { useRouter } from 'next/router'
 
 import { Box, Text } from '@island.is/island-ui/core'
-import {
-  getStandardUserDashboardRoute,
-} from '@island.is/judicial-system/consts'
+import { getStandardUserDashboardRoute } from '@island.is/judicial-system/consts'
 import { formatDate } from '@island.is/judicial-system/formatters'
 import {
   isCompletedCase,
@@ -50,9 +48,7 @@ import {
   IndictmentDecision,
   UserRole,
 } from '@island.is/judicial-system-web/src/graphql/schema'
-import {
-  useAppealCaseBanner,
-} from '@island.is/judicial-system-web/src/utils/hooks'
+import { useAppealCaseBanner } from '@island.is/judicial-system-web/src/utils/hooks'
 import { grid } from '@island.is/judicial-system-web/src/utils/styles/recipes.css'
 
 import { ReviewDecision } from '../../../PublicProsecutor/components/ReviewDecision/ReviewDecision'

--- a/apps/judicial-system/web/src/routes/Prosecutor/Indictments/IndictmentOverview/IndictmentOverview.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/Indictments/IndictmentOverview/IndictmentOverview.tsx
@@ -12,7 +12,6 @@ import { useRouter } from 'next/router'
 import { Box, Text } from '@island.is/island-ui/core'
 import {
   getStandardUserDashboardRoute,
-  PROSECUTION_INDICTMENT_CASE_DEFENDANT_ROUTE,
 } from '@island.is/judicial-system/consts'
 import { formatDate } from '@island.is/judicial-system/formatters'
 import {
@@ -27,13 +26,13 @@ import {
   BlueBox,
   Conclusion,
   CourtCaseInfo,
+  DuplicateIndictmentModal,
   FormContentContainer,
   FormContext,
   FormFooter,
   IndictmentCaseScheduledCard,
   InfoCardActiveIndictment,
   InfoCardClosedIndictment,
-  Modal,
   PageHeader,
   PageLayout,
   PageTitle,
@@ -53,7 +52,6 @@ import {
 } from '@island.is/judicial-system-web/src/graphql/schema'
 import {
   useAppealCaseBanner,
-  useCase,
 } from '@island.is/judicial-system-web/src/utils/hooks'
 import { grid } from '@island.is/judicial-system-web/src/utils/styles/recipes.css'
 
@@ -73,7 +71,6 @@ const IndictmentOverview: FC = () => {
 
   const { formatMessage } = useIntl()
   const router = useRouter()
-  const { duplicateIndictmentCase, isDuplicatingIndictmentCase } = useCase()
 
   const caseHasBeenReceivedByCourt = workingCase.state === CaseState.RECEIVED
   const latestDate = workingCase.courtDate ?? workingCase.arraignmentDate
@@ -113,16 +110,6 @@ const IndictmentOverview: FC = () => {
       CaseIndictmentRulingDecision.WITHDRAWAL ||
       workingCase.indictmentRulingDecision ===
         CaseIndictmentRulingDecision.CANCELLATION)
-
-  const handleDuplicateIndictment = async () => {
-    const duplicatedCase = await duplicateIndictmentCase(workingCase.id)
-
-    if (duplicatedCase) {
-      router.push(
-        `${PROSECUTION_INDICTMENT_CASE_DEFENDANT_ROUTE}/${duplicatedCase.id}`,
-      )
-    }
-  }
 
   const { appealBanner, appealModals } = useAppealCaseBanner()
 
@@ -320,9 +307,6 @@ const IndictmentOverview: FC = () => {
               shouldDisplayReviewDecision &&
               (isReviewMissing || !hasReviewDecisionChanged)
             }
-            nextIsLoading={
-              canDuplicateIndictment && isDuplicatingIndictmentCase
-            }
             nextButtonText={
               canDuplicateIndictment
                 ? 'Afrita mál í drög'
@@ -341,19 +325,8 @@ const IndictmentOverview: FC = () => {
         </FormContentContainer>
         {appealModals}
         {isDuplicateIndictmentModal(modalVisible) && (
-          <Modal
-            title="Viltu afrita mál í drög?"
-            text="Nýtt mál verður til í drögum. Innihald ákæru ásamt gögnum afritast yfir á nýja málið."
-            primaryButton={{
-              text: 'Afrita mál í drög',
-              onClick: handleDuplicateIndictment,
-              isLoading: isDuplicatingIndictmentCase,
-            }}
-            secondaryButton={{
-              text: 'Hætta við',
-              onClick: () => setModalVisible(undefined),
-              isDisabled: isDuplicatingIndictmentCase,
-            }}
+          <DuplicateIndictmentModal
+            onClose={() => setModalVisible(undefined)}
           />
         )}
       </PageLayout>

--- a/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Overview/Overview.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Overview/Overview.tsx
@@ -73,10 +73,7 @@ const Overview: FC = () => {
 
   const router = useRouter()
   const { formatMessage } = useIntl()
-  const {
-    transitionCase,
-    isTransitioningCase,
-  } = useCase()
+  const { transitionCase, isTransitioningCase } = useCase()
 
   const latestDate = workingCase.courtDate ?? workingCase.arraignmentDate
 

--- a/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Overview/Overview.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Overview/Overview.tsx
@@ -14,7 +14,6 @@ import {
 import {
   getStandardUserDashboardRoute,
   PROSECUTION_INDICTMENT_CASE_ADD_FILES_ROUTE,
-  PROSECUTION_INDICTMENT_CASE_DEFENDANT_ROUTE,
   PROSECUTION_INDICTMENT_CASE_INDICTMENT_ROUTE,
 } from '@island.is/judicial-system/consts'
 import { isCompletedCase, isProsecutionUser } from '@island.is/judicial-system/types'
@@ -24,6 +23,7 @@ import {
   AppealRulingModifiedAlert,
   BlueBox,
   ChangeProsecutorModal,
+  DuplicateIndictmentModal,
   FormContentContainer,
   FormContext,
   FormFooter,
@@ -73,8 +73,6 @@ const Overview: FC = () => {
   const {
     transitionCase,
     isTransitioningCase,
-    duplicateIndictmentCase,
-    isDuplicatingIndictmentCase,
   } = useCase()
 
   const latestDate = workingCase.courtDate ?? workingCase.arraignmentDate
@@ -171,16 +169,6 @@ const Overview: FC = () => {
     }
 
     router.push(getStandardUserDashboardRoute(user))
-  }
-
-  const handleDuplicateIndictment = async () => {
-    const duplicatedCase = await duplicateIndictmentCase(workingCase.id)
-
-    if (duplicatedCase) {
-      router.push(
-        `${PROSECUTION_INDICTMENT_CASE_DEFENDANT_ROUTE}/${duplicatedCase.id}`,
-      )
-    }
   }
 
   return (
@@ -334,9 +322,7 @@ const Overview: FC = () => {
             isIndictmentReceived ||
             (isIndictmentWaitingForCancellation && !canDuplicateIndictment)
           }
-          nextIsLoading={
-            canDuplicateIndictment && isDuplicatingIndictmentCase
-          }
+          nextIsLoading={isTransitioningCase}
           infoBoxText={
             isIndictmentReceived
               ? formatMessage(strings.indictmentSentToCourt)
@@ -410,20 +396,7 @@ const Overview: FC = () => {
             }}
           />
         ) : modal === 'duplicateIndictmentModal' ? (
-          <Modal
-            title="Viltu afrita mál í drög?"
-            text="Nýtt mál verður til í drögum. Innihald ákæru ásamt gögnum afritast yfir á nýja málið."
-            primaryButton={{
-              text: 'Afrita mál í drög',
-              onClick: handleDuplicateIndictment,
-              isLoading: isDuplicatingIndictmentCase,
-            }}
-            secondaryButton={{
-              text: 'Hætta við',
-              onClick: () => setModal('noModal'),
-              isDisabled: isDuplicatingIndictmentCase,
-            }}
-          />
+          <DuplicateIndictmentModal onClose={() => setModal('noModal')} />
         ) : modal === 'editProsecutor' ? (
           <ChangeProsecutorModal onClose={() => setModal('noModal')} />
         ) : null}

--- a/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Overview/Overview.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Overview/Overview.tsx
@@ -14,9 +14,10 @@ import {
 import {
   getStandardUserDashboardRoute,
   PROSECUTION_INDICTMENT_CASE_ADD_FILES_ROUTE,
+  PROSECUTION_INDICTMENT_CASE_DEFENDANT_ROUTE,
   PROSECUTION_INDICTMENT_CASE_INDICTMENT_ROUTE,
 } from '@island.is/judicial-system/consts'
-import { isCompletedCase } from '@island.is/judicial-system/types'
+import { isCompletedCase, isProsecutionUser } from '@island.is/judicial-system/types'
 import { core, errors, titles } from '@island.is/judicial-system-web/messages'
 import {
   AllIndictmentCaseFiles,
@@ -61,6 +62,7 @@ const Overview: FC = () => {
     | 'caseSentForConfirmationModal'
     | 'caseDeniedModal'
     | 'askForCancellationModal'
+    | 'duplicateIndictmentModal'
     | 'editProsecutor'
   >('noModal')
   const [indictmentConfirmationDecision, setIndictmentConfirmationDecision] =
@@ -68,7 +70,12 @@ const Overview: FC = () => {
 
   const router = useRouter()
   const { formatMessage } = useIntl()
-  const { transitionCase, isTransitioningCase } = useCase()
+  const {
+    transitionCase,
+    isTransitioningCase,
+    duplicateIndictmentCase,
+    isDuplicatingIndictmentCase,
+  } = useCase()
 
   const latestDate = workingCase.courtDate ?? workingCase.arraignmentDate
 
@@ -88,6 +95,8 @@ const Overview: FC = () => {
   const userCanCancelIndictment =
     (isIndictmentSubmitted || isIndictmentReceived) &&
     !workingCase.indictmentDecision
+  const canDuplicateIndictment =
+    isProsecutionUser(user) && isIndictmentWaitingForCancellation
   const userCanAddDocuments =
     isIndictmentSubmitted ||
     (isIndictmentReceived &&
@@ -162,6 +171,16 @@ const Overview: FC = () => {
     }
 
     router.push(getStandardUserDashboardRoute(user))
+  }
+
+  const handleDuplicateIndictment = async () => {
+    const duplicatedCase = await duplicateIndictmentCase(workingCase.id)
+
+    if (duplicatedCase) {
+      router.push(
+        `${PROSECUTION_INDICTMENT_CASE_DEFENDANT_ROUTE}/${duplicatedCase.id}`,
+      )
+    }
   }
 
   return (
@@ -296,28 +315,38 @@ const Overview: FC = () => {
       </FormContentContainer>
       <FormContentContainer isFooter>
         <FormFooter
-          nextButtonIcon="arrowForward"
+          nextButtonIcon={canDuplicateIndictment ? undefined : 'arrowForward'}
           previousUrl={
             isIndictmentReceived || isIndictmentWaitingForCancellation
               ? getStandardUserDashboardRoute(user)
               : `${PROSECUTION_INDICTMENT_CASE_INDICTMENT_ROUTE}/${workingCase.id}`
           }
           nextButtonText={
-            userCanSendIndictmentToCourt
+            canDuplicateIndictment
+              ? 'Afrita mál í drög'
+              : userCanSendIndictmentToCourt
               ? undefined
               : formatMessage(strings.nextButtonText, {
                   isNewIndictment: isIndictmentNew,
                 })
           }
           hideNextButton={
-            isIndictmentReceived || isIndictmentWaitingForCancellation
+            isIndictmentReceived ||
+            (isIndictmentWaitingForCancellation && !canDuplicateIndictment)
+          }
+          nextIsLoading={
+            canDuplicateIndictment && isDuplicatingIndictmentCase
           }
           infoBoxText={
             isIndictmentReceived
               ? formatMessage(strings.indictmentSentToCourt)
               : undefined
           }
-          onNextButtonClick={handleNextButtonClick}
+          onNextButtonClick={
+            canDuplicateIndictment
+              ? () => setModal('duplicateIndictmentModal')
+              : handleNextButtonClick
+          }
           nextIsDisabled={
             userCanSendIndictmentToCourt && !indictmentConfirmationDecision
           }
@@ -378,6 +407,21 @@ const Overview: FC = () => {
                 strings.askForCancellationSecondaryButtonText,
               ),
               onClick: () => setModal('noModal'),
+            }}
+          />
+        ) : modal === 'duplicateIndictmentModal' ? (
+          <Modal
+            title="Viltu afrita mál í drög?"
+            text="Nýtt mál verður til í drögum. Innihald ákæru ásamt gögnum afritast yfir á nýja málið."
+            primaryButton={{
+              text: 'Afrita mál í drög',
+              onClick: handleDuplicateIndictment,
+              isLoading: isDuplicatingIndictmentCase,
+            }}
+            secondaryButton={{
+              text: 'Hætta við',
+              onClick: () => setModal('noModal'),
+              isDisabled: isDuplicatingIndictmentCase,
             }}
           />
         ) : modal === 'editProsecutor' ? (

--- a/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Overview/Overview.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Overview/Overview.tsx
@@ -17,7 +17,10 @@ import {
   PROSECUTION_INDICTMENT_CASE_DEFENDANT_ROUTE,
   PROSECUTION_INDICTMENT_CASE_INDICTMENT_ROUTE,
 } from '@island.is/judicial-system/consts'
-import { isCompletedCase, isProsecutionUser } from '@island.is/judicial-system/types'
+import {
+  isCompletedCase,
+  isProsecutionUser,
+} from '@island.is/judicial-system/types'
 import { core, errors, titles } from '@island.is/judicial-system-web/messages'
 import {
   AllIndictmentCaseFiles,
@@ -334,9 +337,7 @@ const Overview: FC = () => {
             isIndictmentReceived ||
             (isIndictmentWaitingForCancellation && !canDuplicateIndictment)
           }
-          nextIsLoading={
-            canDuplicateIndictment && isDuplicatingIndictmentCase
-          }
+          nextIsLoading={canDuplicateIndictment && isDuplicatingIndictmentCase}
           infoBoxText={
             isIndictmentReceived
               ? formatMessage(strings.indictmentSentToCourt)


### PR DESCRIPTION
[Asana](https://app.asana.com/1/203394141643832/project/1199153462262248/task/1215934371782761?focus=true)

## What

Allow users to copy cass to draft before the court completes the case

## Why

So users can do it without having to wait for court to do something. 



## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Cursor


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Prosecutor users can now duplicate eligible indictment cases directly from the Indictments overview.
  * Added a dedicated duplication confirmation modal with loading state and a cancel option.
  * After duplication, users are redirected to the newly created case.

* **Bug Fixes**
  * Fixed duplication eligibility rules and tightened controller request protection for the duplicate action.
  * Updated the overview “Next” behavior to open duplication when available.

* **Tests**
  * Added/updated coverage for duplication eligibility and controller guard behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->