### PR TITLE
chore(j-s): Removes Period from Court Record PDF

### DIFF
--- a/apps/judicial-system/backend/src/app/formatters/pdfHelpers/pdfHelpers.ts
+++ b/apps/judicial-system/backend/src/app/formatters/pdfHelpers/pdfHelpers.ts
@@ -469,7 +469,7 @@ export const addNumberedList = (
   const pageBottomY = doc.page.height - doc.page.margins.bottom
 
   for (const [i, item] of items.entries()) {
-    const label = `${start + i}.`
+    const label = `${start + i}`
     const textHeight = doc.heightOfString(label, {
       width: wrapWidth,
       height: 1.2,


### PR DESCRIPTION
# Removes Period from Court Record PDF

[Þingbók S-mál, sleppa punkti við þingmerkinganúmer](https://app.asana.com/1/203394141643832/project/1199153462262248/task/1215827300133936)

## What

- Removes the period after the filing number of filed court documents.

## Why

- Requested.

## Screenshots / Gifs

<img width="856" height="655" alt="image" src="https://github.com/user-attachments/assets/ad6eb89d-0b85-44c1-b72e-0139a4982e59" />

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [x] No AI tools were used in preparing this pull request
- [ ] AI tools were used in preparing this pull request
      Tools used:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted numbered list formatting in generated PDFs so list labels no longer include a trailing period.
  * Improved the visual consistency of numbered lists in exported documents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->