### PR TITLE
fix(my-pages): Medicine prescription history empty table message

### DIFF
--- a/libs/portals/my-pages/health/src/screens/MedicineHistory/MedicinePrescriptionHistory.tsx
+++ b/libs/portals/my-pages/health/src/screens/MedicineHistory/MedicinePrescriptionHistory.tsx
@@ -2,7 +2,6 @@ import { HealthDirectorateMedicineHistoryDispensation } from '@island.is/api/sch
 import { Box, Button, Icon } from '@island.is/island-ui/core'
 import { useLocale } from '@island.is/localization'
 import {
-  EmptyTable,
   formatDate,
   HEALTH_DIRECTORATE_SLUG,
   IntroWrapper,

--- a/libs/portals/my-pages/health/src/screens/MedicineHistory/MedicinePrescriptionHistory.tsx
+++ b/libs/portals/my-pages/health/src/screens/MedicineHistory/MedicinePrescriptionHistory.tsx
@@ -89,6 +89,9 @@ const MedicinePrescriptionHistory = () => {
           mobileTitleKey="medicine"
           ellipsisLength={22}
           tableLoading={loading}
+          emptyTableMessage={formatMessage(messages.noDataFound, {
+            arg: formatMessage(messages.medicineTitle).toLowerCase(),
+          })}
           items={
             history?.map((item, i) => ({
               id: item?.id ?? `${i}`,
@@ -204,14 +207,6 @@ const MedicinePrescriptionHistory = () => {
         />
       )}
       {error && !loading && <Problem error={error} noBorder={false} />}
-
-      {!error && !loading && history && history.length === 0 && (
-        <EmptyTable
-          message={formatMessage(messages.noDataFound, {
-            arg: formatMessage(messages.medicineTitle).toLowerCase(),
-          })}
-        />
-      )}
     </IntroWrapper>
   )
 }


### PR DESCRIPTION
## What

Fix handling of empty prescription history list

## Why

UI bug. The table component was showing up empty with no message, alongside an empty table component below it. The medicine prescription history table now renders its empty state through SortableTable using a localized message, and use of the standalone EmptyTable component was removed.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [x] No AI tools were used in preparing this pull request
- [ ] AI tools were used in preparing this pull request
      Tools used:
