### PR TITLE
test(j-s): clear act and unmocked-query warnings in web specs

### DIFF
--- a/apps/judicial-system/web/src/components/Alerts/AppealRulingModifiedAlert/AppealRulingModifiedAlert.spec.tsx
+++ b/apps/judicial-system/web/src/components/Alerts/AppealRulingModifiedAlert/AppealRulingModifiedAlert.spec.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 
 import { Case } from '@island.is/judicial-system-web/src/graphql/schema'
 import {
@@ -18,13 +18,13 @@ const renderAlert = (theCase: Partial<Case>) =>
   )
 
 describe('AppealRulingModifiedAlert', () => {
-  it('renders nothing when there are no corrected appeals', () => {
+  it('renders nothing when there are no corrected appeals', async () => {
     const { container } = renderAlert({ id: 'case-1' })
 
-    expect(container).toBeEmptyDOMElement()
+    await waitFor(() => expect(container).toBeEmptyDOMElement())
   })
 
-  it('renders the case-level correction box', () => {
+  it('renders the case-level correction box', async () => {
     renderAlert({
       id: 'case-1',
       appealCase: {
@@ -34,12 +34,12 @@ describe('AppealRulingModifiedAlert', () => {
     })
 
     expect(
-      screen.getByText('Úrskurður Landsréttar leiðréttur'),
+      await screen.findByText('Úrskurður Landsréttar leiðréttur'),
     ).toBeInTheDocument()
     expect(screen.getByText('Leiðrétting á máli')).toBeInTheDocument()
   })
 
-  it('renders one box per corrected ruling-order appeal with the file name', () => {
+  it('renders one box per corrected ruling-order appeal with the file name', async () => {
     renderAlert({
       id: 'case-1',
       caseFiles: [
@@ -61,7 +61,9 @@ describe('AppealRulingModifiedAlert', () => {
     })
 
     expect(
-      screen.getByText('Úrskurður Landsréttar leiðréttur — Úrskurður 15-2026'),
+      await screen.findByText(
+        'Úrskurður Landsréttar leiðréttur — Úrskurður 15-2026',
+      ),
     ).toBeInTheDocument()
     expect(
       screen.getByText('Úrskurður Landsréttar leiðréttur — Úrskurður 16-2026'),
@@ -70,7 +72,7 @@ describe('AppealRulingModifiedAlert', () => {
     expect(screen.getByText('Leiðrétting tvö')).toBeInTheDocument()
   })
 
-  it('falls back to the plain title when the file name is missing', () => {
+  it('falls back to the plain title when the file name is missing', async () => {
     renderAlert({
       id: 'case-1',
       caseFiles: [],
@@ -84,7 +86,7 @@ describe('AppealRulingModifiedAlert', () => {
     })
 
     expect(
-      screen.getByText('Úrskurður Landsréttar leiðréttur'),
+      await screen.findByText('Úrskurður Landsréttar leiðréttur'),
     ).toBeInTheDocument()
     expect(screen.getByText('Leiðrétting án skráarnafns')).toBeInTheDocument()
   })

--- a/apps/judicial-system/web/src/components/BaseSelect/BaseSelect.spec.tsx
+++ b/apps/judicial-system/web/src/components/BaseSelect/BaseSelect.spec.tsx
@@ -9,7 +9,7 @@ const options: ReactSelectOption[] = [
 ]
 
 describe('<BaseSelect />', () => {
-  test('should fall back to the placeholder as the accessible name', () => {
+  test('should fall back to the placeholder as the accessible name', async () => {
     render(
       <BaseSelect
         options={options}
@@ -18,12 +18,12 @@ describe('<BaseSelect />', () => {
       />,
     )
 
-    expect(screen.getByRole('combobox')).toHaveAccessibleName(
+    expect(await screen.findByRole('combobox')).toHaveAccessibleName(
       'Hver lagði fram?',
     )
   })
 
-  test('should prefer an explicit aria-label over the placeholder', () => {
+  test('should prefer an explicit aria-label over the placeholder', async () => {
     render(
       <BaseSelect
         options={options}
@@ -33,6 +33,8 @@ describe('<BaseSelect />', () => {
       />,
     )
 
-    expect(screen.getByRole('combobox')).toHaveAccessibleName('Veldu málsaðila')
+    expect(await screen.findByRole('combobox')).toHaveAccessibleName(
+      'Veldu málsaðila',
+    )
   })
 })

--- a/apps/judicial-system/web/src/components/Modals/Modal/Modal.spec.tsx
+++ b/apps/judicial-system/web/src/components/Modals/Modal/Modal.spec.tsx
@@ -3,46 +3,50 @@ import { fireEvent, render, screen } from '@testing-library/react'
 import { Modal } from './Modal'
 
 describe('Modal', () => {
-  it('labels the dialog with its title via aria-labelledby', () => {
+  it('labels the dialog with its title via aria-labelledby', async () => {
     render(<Modal title="Ertu viss?" />)
 
     expect(
-      screen.getByRole('dialog', { name: 'Ertu viss?' }),
+      await screen.findByRole('dialog', { name: 'Ertu viss?' }),
     ).toBeInTheDocument()
   })
 
-  it('renders a labelled icon-only close button that closes the modal', () => {
+  it('renders a labelled icon-only close button that closes the modal', async () => {
     const onClose = jest.fn()
     render(<Modal title="Titill" onClose={onClose} />)
 
-    const closeButton = screen.getByRole('button', { name: 'Loka glugga' })
+    const closeButton = await screen.findByRole('button', {
+      name: 'Loka glugga',
+    })
     fireEvent.click(closeButton)
 
     expect(onClose).toHaveBeenCalledTimes(1)
   })
 
-  it('closes the modal when Escape is pressed', () => {
+  it('closes the modal when Escape is pressed', async () => {
     const onClose = jest.fn()
     render(<Modal title="Titill" onClose={onClose} />)
 
+    await screen.findByRole('button', { name: 'Loka glugga' })
     fireEvent.keyDown(window, { key: 'Escape' })
 
     expect(onClose).toHaveBeenCalledTimes(1)
   })
 
-  it('does not close on Escape while loading', () => {
+  it('does not close on Escape while loading', async () => {
     const onClose = jest.fn()
     render(<Modal title="Titill" onClose={onClose} loading />)
 
+    await screen.findByRole('button', { name: 'Loka glugga' })
     fireEvent.keyDown(window, { key: 'Escape' })
 
     expect(onClose).not.toHaveBeenCalled()
   })
 
-  it('exposes the error message in an assertive live region', () => {
+  it('exposes the error message in an assertive live region', async () => {
     render(<Modal title="Titill" errorMessage="Eitthvað fór úrskeiðis" />)
 
-    const alert = screen.getByRole('alert')
+    const alert = await screen.findByRole('alert')
     expect(alert).toHaveTextContent('Eitthvað fór úrskeiðis')
     expect(alert).toHaveAttribute('aria-live', 'assertive')
   })

--- a/apps/judicial-system/web/src/components/Table/CaseFileTable/CaseFileTable.spec.tsx
+++ b/apps/judicial-system/web/src/components/Table/CaseFileTable/CaseFileTable.spec.tsx
@@ -48,7 +48,9 @@ describe('<CaseFileTable />', () => {
       } as CaseFile,
     ])
 
-    const button = screen.getByRole('button', { name: 'Opna document.pdf' })
+    const button = await screen.findByRole('button', {
+      name: 'Opna document.pdf',
+    })
     expect(button).toHaveAttribute('tabindex', '0')
 
     button.focus()
@@ -59,7 +61,7 @@ describe('<CaseFileTable />', () => {
     expect(onOpenFile).toHaveBeenCalledWith('file-1')
   })
 
-  test('should not render a button for a rejected file', () => {
+  test('should not render a button for a rejected file', async () => {
     renderTable([
       {
         id: 'file-1',
@@ -67,6 +69,9 @@ describe('<CaseFileTable />', () => {
         state: CaseFileState.REJECTED,
       } as CaseFile,
     ])
+
+    // Await the table to settle (lazy Icon load) before asserting absence.
+    await screen.findByRole('columnheader', { name: /Nafn skjals/ })
 
     expect(
       screen.queryByRole('button', { name: 'Opna document.pdf' }),
@@ -95,7 +100,7 @@ describe('<CaseFileTable />', () => {
 
     // The table is sorted by the received/created column by default.
     expect(
-      screen.getByRole('columnheader', { name: /Nafn skjals/ }),
+      await screen.findByRole('columnheader', { name: /Nafn skjals/ }),
     ).toHaveAttribute('aria-sort', 'none')
     expect(
       screen.getByRole('columnheader', { name: /Móttekið/ }),

--- a/apps/judicial-system/web/src/components/Table/GenericTable.spec.tsx
+++ b/apps/judicial-system/web/src/components/Table/GenericTable.spec.tsx
@@ -48,7 +48,9 @@ describe('GenericTable', () => {
   it('marks the sortable column header with aria-sort', async () => {
     renderTable()
 
-    const header = screen.getByRole('columnheader', { name: /Málsnúmer/ })
+    const header = await screen.findByRole('columnheader', {
+      name: /Málsnúmer/,
+    })
     expect(header).toHaveAttribute('aria-sort', 'none')
 
     await user.click(screen.getByRole('button', { name: /Raða eftir dálki/ }))
@@ -62,11 +64,11 @@ describe('GenericTable', () => {
     ).toHaveAttribute('aria-sort', 'descending')
   })
 
-  it('exposes a descriptive accessible name on the row', () => {
+  it('exposes a descriptive accessible name on the row', async () => {
     renderTable()
 
     expect(
-      screen.getByRole('button', { name: 'Opna mál R-123/2021' }),
+      await screen.findByRole('button', { name: 'Opna mál R-123/2021' }),
     ).toBeInTheDocument()
   })
 
@@ -74,7 +76,9 @@ describe('GenericTable', () => {
     const onClick = jest.fn()
     renderTable(onClick)
 
-    const row = screen.getByRole('button', { name: 'Opna mál R-123/2021' })
+    const row = await screen.findByRole('button', {
+      name: 'Opna mál R-123/2021',
+    })
     expect(row).toHaveAttribute('tabindex', '0')
 
     row.focus()
@@ -89,7 +93,9 @@ describe('GenericTable', () => {
     const onClick = jest.fn()
     renderTable(onClick, true)
 
-    const row = screen.getByRole('button', { name: 'Opna mál R-123/2021' })
+    const row = await screen.findByRole('button', {
+      name: 'Opna mál R-123/2021',
+    })
     expect(row).toHaveAttribute('tabindex', '-1')
     expect(row).toHaveAttribute('aria-disabled', 'true')
 
@@ -98,14 +104,14 @@ describe('GenericTable', () => {
     expect(onClick).not.toHaveBeenCalled()
   })
 
-  it('exposes the context menu as a single named trigger', () => {
+  it('exposes the context menu as a single named trigger', async () => {
     renderTable(jest.fn(), false, [{ title: 'Eyða', onClick: jest.fn() }])
 
     // A single, accessibly-named menu trigger — not a duplicate tab stop with
     // an empty-named wrapper plus a redundant inner button. The name is
     // descriptive (derived from the row label) so screen reader users can tell
     // each row's menu apart.
-    const triggers = screen.getAllByRole('button', {
+    const triggers = await screen.findAllByRole('button', {
       name: 'Frekari aðgerðir fyrir mál R-123/2021',
     })
     expect(triggers).toHaveLength(1)

--- a/apps/judicial-system/web/src/routes/Court/Indictments/Overview/Overview.spec.tsx
+++ b/apps/judicial-system/web/src/routes/Court/Indictments/Overview/Overview.spec.tsx
@@ -12,6 +12,7 @@ import {
 } from '@island.is/judicial-system-web/src/graphql/schema'
 import {
   mockCase,
+  mockCaseTableMembershipQuery,
   mockUser,
 } from '@island.is/judicial-system-web/src/utils/mocks'
 import { IntlProviderWrapper } from '@island.is/judicial-system-web/src/utils/testHelpers'
@@ -38,7 +39,10 @@ const renderOverview = (
   isCaseUpToDate = true,
 ) => {
   const wrapInProviders = (children: ReactNode) => (
-    <MockedProvider addTypename={false}>
+    <MockedProvider
+      mocks={[...mockCaseTableMembershipQuery(theCase.id)]}
+      addTypename={false}
+    >
       <IntlProviderWrapper>
         <UserContext.Provider value={{ user: mockUser(userRole) }}>
           <FormContext.Provider

--- a/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Indictment/IndictmentCountsList.spec.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Indictment/IndictmentCountsList.spec.tsx
@@ -136,7 +136,7 @@ describe('IndictmentCountsList', () => {
     renderComponent(workingCase)
 
     await user.click(
-      screen.getByRole('button', { name: 'Raða ákæruliðum í tímaröð' }),
+      await screen.findByRole('button', { name: 'Raða ákæruliðum í tímaröð' }),
     )
 
     await waitFor(() => {
@@ -165,7 +165,7 @@ describe('IndictmentCountsList', () => {
       workingCase,
     )
 
-    const dragHandle = screen.getByTestId('indictmentCountDragHandle')
+    const dragHandle = await screen.findByTestId('indictmentCountDragHandle')
     const warningIconPlaceholder = Array.from(
       document.querySelectorAll('[class*="Icon_placeholder"]'),
     ).find((element) => !dragHandle.contains(element))
@@ -196,7 +196,7 @@ describe('IndictmentCountsList', () => {
 
     renderComponent(workingCase)
 
-    const countOneAccordion = screen.getByRole('button', {
+    const countOneAccordion = await screen.findByRole('button', {
       name: /1\. 007-2021-001/,
     })
     const countTwoAccordion = screen.getByRole('button', {
@@ -249,7 +249,7 @@ describe('IndictmentCountsList', () => {
 
     const { unmount } = renderComponent(workingCase)
 
-    await user.click(screen.getByRole('button', { name: 'Loka öllum' }))
+    await user.click(await screen.findByRole('button', { name: 'Loka öllum' }))
 
     await waitFor(() => {
       expect(
@@ -264,7 +264,7 @@ describe('IndictmentCountsList', () => {
     renderComponent(workingCase)
 
     expect(
-      screen.getByRole('button', { name: /1\. 007-2021-001/ }),
+      await screen.findByRole('button', { name: /1\. 007-2021-001/ }),
     ).toHaveAttribute('aria-expanded', 'false')
     expect(
       screen.getByRole('button', { name: /2\. 007-2021-002/ }),

--- a/apps/judicial-system/web/src/routes/Prosecutor/Indictments/IndictmentOverview/IndictmentOverview.spec.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/Indictments/IndictmentOverview/IndictmentOverview.spec.tsx
@@ -11,6 +11,7 @@ import {
 } from '@island.is/judicial-system-web/src/graphql/schema'
 import {
   mockCase,
+  mockCaseTableMembershipQuery,
   mockUser,
 } from '@island.is/judicial-system-web/src/utils/mocks'
 import {
@@ -45,7 +46,10 @@ window.scrollTo = jest.fn()
 describe('Prosecutor IndictmentOverview', () => {
   it('should not render a review decision for a defendant whose indictment was cancelled or dismissed (completed for some)', async () => {
     const { container } = render(
-      <MockedProvider mocks={[]} addTypename={false}>
+      <MockedProvider
+        mocks={[...mockCaseTableMembershipQuery('test_id')]}
+        addTypename={false}
+      >
         <UserContext.Provider value={{ user: reviewerUser }}>
           <IntlProviderWrapper>
             <FormContextWrapper

--- a/apps/judicial-system/web/src/routes/PublicProsecutor/Indictments/Overview/Overview.spec.tsx
+++ b/apps/judicial-system/web/src/routes/PublicProsecutor/Indictments/Overview/Overview.spec.tsx
@@ -6,7 +6,11 @@ import {
   CaseType,
   UserRole,
 } from '@island.is/judicial-system-web/src/graphql/schema'
-import { mockCase } from '@island.is/judicial-system-web/src/utils/mocks'
+import {
+  mockCase,
+  mockCaseTableMembershipQuery,
+  mockProsecutorSelectionUsersQuery,
+} from '@island.is/judicial-system-web/src/utils/mocks'
 import {
   FormContextWrapper,
   IntlProviderWrapper,
@@ -29,7 +33,13 @@ window.scrollTo = jest.fn()
 describe('PublicProsecutor Overview', () => {
   it('should not render a verdict timeline card for a defendant whose indictment was cancelled or dismissed (completed for some)', async () => {
     render(
-      <MockedProvider mocks={[]} addTypename={false}>
+      <MockedProvider
+        mocks={[
+          ...mockCaseTableMembershipQuery('test_id'),
+          ...mockProsecutorSelectionUsersQuery,
+        ]}
+        addTypename={false}
+      >
         <UserContextWrapper userRole={UserRole.PUBLIC_PROSECUTOR_STAFF}>
           <IntlProviderWrapper>
             <FormContextWrapper

--- a/apps/judicial-system/web/src/utils/mocks.ts
+++ b/apps/judicial-system/web/src/utils/mocks.ts
@@ -1,5 +1,6 @@
 import faker from 'faker'
 
+import { ProsecutorSelectionUsersDocument } from '@island.is/judicial-system-web/src/components/ProsecutorSelection/prosecutorSelectionUsers.generated'
 import { CurrentUserDocument } from '@island.is/judicial-system-web/src/components/UserProvider/currentUser.generated'
 import {
   AppealCaseState,
@@ -169,6 +170,22 @@ export const mockCaseTableMembershipQuery = (caseId: string) => [
         caseTableMembership: {
           caseTableTypes: [],
         },
+      },
+    },
+  },
+]
+
+// IndictmentReviewerSelector (rendered for public prosecutor staff) fires this
+// query to populate the reviewer dropdown. Include it in MockedProvider mocks
+// to avoid unmocked-query warnings.
+export const mockProsecutorSelectionUsersQuery = [
+  {
+    request: {
+      query: ProsecutorSelectionUsersDocument,
+    },
+    result: {
+      data: {
+        users: [],
       },
     },
   },


### PR DESCRIPTION
# Clear noisy test warnings in judicial-system web specs

## What

Removes two families of console warnings that showed up when running the
`judicial-system-web` test suite:

1. **`Warning: A suspended resource finished loading inside a test, but the
   event was not wrapped in act(...)`** — in specs that rendered a component
   and then asserted only with synchronous `getBy*` queries. island-ui's
   `Icon` lazy-loads its SVG via `React.lazy`/`Suspense`, and
   `IntlProviderWrapper` suspends its message load, so those resources resolved
   after the test finished (outside `act`). Fixed by making each test `async`
   and awaiting a `findBy*` query after render so pending work settles within
   the test.

2. **`No more mocked responses for the query: query CaseTableMembership` /
   `query ProsecutorSelectionUsers`** — `BreadCrumbs`/`PageLayout` fires
   `CaseTableMembership` whenever the working case has an id, and
   `IndictmentReviewerSelector` fires `ProsecutorSelectionUsers`. The affected
   `MockedProvider`s had no matching mocks. Reused the existing
   `mockCaseTableMembershipQuery` helper and added a new reusable
   `mockProsecutorSelectionUsersQuery` helper in `utils/mocks.ts`.

Affected specs: `AppealRulingModifiedAlert`, `BaseSelect`, `Modal`,
`CaseFileTable`, `GenericTable`, `IndictmentCountsList`, and the Court /
PublicProsecutor / Prosecutor indictment overview specs.

## Why

The warnings added noise to test output and the act-warnings can mask real
async-state bugs. This continues the cleanup started in #23031.

## Screenshots / Gifs


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated multiple component and route test suites to use async rendering/assertions, improving reliability with lazily loaded UI elements and accessibility checks.
  * Added GraphQL mock coverage for indictment and prosecutor overview flows so related pages can be tested with realistic data.
* **Chores**
  * Expanded shared test mocks to support an additional query used by the staff UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->