### PR TITLE
fix(j-s): persist TinyMCE content with debounced autosave

### DIFF
--- a/apps/judicial-system/web/src/components/TinyMCE/TinyMCE.tsx
+++ b/apps/judicial-system/web/src/components/TinyMCE/TinyMCE.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useId, useRef, useState } from 'react'
+import { useDebounce } from 'react-use'
 import { AnimatePresence } from 'motion/react'
 import type { Editor as TinyMCEEditor, Ui } from 'tinymce'
 import { Editor } from '@tinymce/tinymce-react'
@@ -29,6 +30,7 @@ interface Props {
   placeholder: string
   defaultValue?: string
   onChange?: (html: string) => void
+  onDebouncedChange?: (html: string) => void
   onBlur?: (html: string) => void
   disabled?: boolean
   errorMessage?: string
@@ -41,6 +43,7 @@ const TinyMCE = ({
   placeholder,
   defaultValue,
   onChange,
+  onDebouncedChange,
   onBlur,
   disabled,
   errorMessage,
@@ -55,11 +58,27 @@ const TinyMCE = ({
     left: 0,
   })
   const [selectedColor, setSelectedColor] = useState<string | null>(null)
+  const [content, setContent] = useState(defaultValue ?? '')
+  const hasEditedRef = useRef(false)
   const initialValueRef = useRef(defaultValue ?? '')
   const editorRef = useRef<TinyMCEEditor | null>(null)
   const highlightBtnApiRef = useRef<ToolbarToggleButtonInstanceApi | null>(null)
   const pickerRef = useRef<HTMLDivElement>(null)
   const highlightGroupRef = useRef<HTMLElement | null>(null)
+
+  // Persist while the user types so content isn't lost on a refresh that
+  // happens before the editor blurs (TinyMCE's iframe doesn't reliably fire
+  // blur on page unload).
+  useDebounce(
+    () => {
+      if (hasEditedRef.current && !disabled) {
+        onDebouncedChange?.(content)
+        hasEditedRef.current = false
+      }
+    },
+    500,
+    [content],
+  )
 
   useEffect(() => {
     highlightBtnApiRef.current?.setActive(pickerOpen)
@@ -171,6 +190,8 @@ const TinyMCE = ({
               editor.on('blur', () => {
                 setFocused(false)
                 onBlur?.(editor.getContent())
+                // Blur already persisted; don't fire a redundant debounced save.
+                hasEditedRef.current = false
               })
               editor.on('NodeChange', handleNodeChange(editor))
               editor.on('PastePreProcess', (args) => {
@@ -195,8 +216,10 @@ const TinyMCE = ({
             placeholder,
           }}
           initialValue={initialValueRef.current}
-          onEditorChange={(content) => {
-            onChange?.(content)
+          onEditorChange={(newContent) => {
+            hasEditedRef.current = true
+            setContent(newContent)
+            onChange?.(newContent)
           }}
           disabled={disabled}
         />

--- a/apps/judicial-system/web/src/components/TinyMCE/TinyMCE.tsx
+++ b/apps/judicial-system/web/src/components/TinyMCE/TinyMCE.tsx
@@ -1,5 +1,5 @@
-import React, { useEffect, useId, useRef, useState } from 'react'
-import { useDebounce } from 'react-use'
+import React, { useEffect, useId, useMemo, useRef, useState } from 'react'
+import debounce from 'lodash/debounce'
 import { AnimatePresence } from 'motion/react'
 import type { Editor as TinyMCEEditor, Ui } from 'tinymce'
 import { Editor } from '@tinymce/tinymce-react'
@@ -58,8 +58,6 @@ const TinyMCE = ({
     left: 0,
   })
   const [selectedColor, setSelectedColor] = useState<string | null>(null)
-  const [content, setContent] = useState(defaultValue ?? '')
-  const hasEditedRef = useRef(false)
   const initialValueRef = useRef(defaultValue ?? '')
   const editorRef = useRef<TinyMCEEditor | null>(null)
   const highlightBtnApiRef = useRef<ToolbarToggleButtonInstanceApi | null>(null)
@@ -68,17 +66,25 @@ const TinyMCE = ({
 
   // Persist while the user types so content isn't lost on a refresh that
   // happens before the editor blurs (TinyMCE's iframe doesn't reliably fire
-  // blur on page unload).
-  useDebounce(
-    () => {
-      if (hasEditedRef.current && !disabled) {
-        onDebouncedChange?.(content)
-        hasEditedRef.current = false
-      }
-    },
-    500,
-    [content],
+  // blur on page unload). Passing the callback as an argument keeps the
+  // debounced function stable while still flushing with the latest handler.
+  const debouncedSave = useMemo(
+    () =>
+      debounce(
+        (html: string, callback: ((html: string) => void) | undefined) => {
+          callback?.(html)
+        },
+        500,
+      ),
+    [],
   )
+
+  // Flush any pending save on unmount so edits aren't lost on navigation.
+  useEffect(() => {
+    return () => {
+      debouncedSave.flush()
+    }
+  }, [debouncedSave])
 
   useEffect(() => {
     highlightBtnApiRef.current?.setActive(pickerOpen)
@@ -190,8 +196,8 @@ const TinyMCE = ({
               editor.on('blur', () => {
                 setFocused(false)
                 onBlur?.(editor.getContent())
-                // Blur already persisted; don't fire a redundant debounced save.
-                hasEditedRef.current = false
+                // Blur already persisted; drop any pending debounced save.
+                debouncedSave.cancel()
               })
               editor.on('NodeChange', handleNodeChange(editor))
               editor.on('PastePreProcess', (args) => {
@@ -217,9 +223,10 @@ const TinyMCE = ({
           }}
           initialValue={initialValueRef.current}
           onEditorChange={(newContent) => {
-            hasEditedRef.current = true
-            setContent(newContent)
             onChange?.(newContent)
+            if (!disabled) {
+              debouncedSave(newContent, onDebouncedChange)
+            }
           }}
           disabled={disabled}
         />

--- a/apps/judicial-system/web/src/routes/Court/Indictments/CourtRecord/CourtSessionAccordionItem.tsx
+++ b/apps/judicial-system/web/src/routes/Court/Indictments/CourtRecord/CourtSessionAccordionItem.tsx
@@ -1447,6 +1447,13 @@ const CourtSessionAccordionItem: FC<Props> = (props) => {
                     setEntriesErrorMessage('')
                     patchSession(courtSession.id, { entries: html })
                   }}
+                  onDebouncedChange={(html) =>
+                    patchSession(
+                      courtSession.id,
+                      { entries: html },
+                      { persist: true },
+                    )
+                  }
                   onBlur={(html) => {
                     // Decode entities (e.g. &nbsp;) and strip tags so an
                     // otherwise-empty paragraph doesn't pass the required check.


### PR DESCRIPTION
# Persist TinyMCE editor content with debounced autosave

## What

The court record rich-text editor (`Bókanir`) now autosaves content to the server while the user types, instead of only persisting on the editor's blur event.

## Why

The shared TinyMCE component only persisted to the backend inside `editor.on('blur')`. Because TinyMCE renders inside an iframe, its blur event does **not** fire reliably on a page refresh (unlike the native inputs in the same form). As a result, if a user typed into the editor and refreshed the page **without first clicking out**, their text was lost — `onEditorChange` only updated local React state, which is discarded on reload.

The fix adds debounced autosave centralized inside the shared TinyMCE component via a new optional `onDebouncedChange` prop, following the existing `useDebounce`/`react-use` pattern already used by `useDebouncedInput`. Validation remains strictly on real blur, so no "required" error flashes while typing.

## Screenshots / Gifs


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Editor changes are now saved automatically while typing, reducing the risk of losing recent updates.
  * Court record entries can be persisted more smoothly without waiting for focus to leave the editor.
* **Bug Fixes**
  * Prevented duplicate saves after leaving the editor, improving reliability and reducing unnecessary background updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->