### PR TITLE
fix(documents-v2): disable circuit breaker for proxied document requests

### DIFF
--- a/libs/clients/documents-v2/src/lib/documentsClientV2.provider.ts
+++ b/libs/clients/documents-v2/src/lib/documentsClientV2.provider.ts
@@ -13,6 +13,10 @@ export const DocumentsClientV2Provider: Provider<CustomersApi> = {
       new Configuration({
         fetchApi: createEnhancedFetch({
           name: 'clients-documents-v2',
+          // This API proxies requests to document providers. We don't want a
+          // single document provider to open the circuit and break all other
+          // document requests.
+          circuitBreaker: false,
           autoAuth: {
             mode: 'token',
             clientId: config.clientId,


### PR DESCRIPTION
## What

Disables the circuit breaker on the enhanced fetch used by the documents-v2 client.

## Why

The documents-v2 API proxies requests to individual document providers. A single failing provider should not open the circuit and break requests for **all** other providers. Disabling the circuit breaker keeps one provider's outage from cascading into a full document outage.

- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of document requests by preventing one provider issue from affecting unrelated document access.
  * Reduced the chance of document fetches being interrupted due to shared failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->