### PR TITLE
feat(j-s): add appeal info to case completed email for dismissals

### DIFF
--- a/apps/judicial-system/backend/src/app/messages/notifications.ts
+++ b/apps/judicial-system/backend/src/app/messages/notifications.ts
@@ -365,16 +365,16 @@ export const notifications = {
         'Notaður sem titill í pósti til hagaðila vegna staðfests dóms',
     },
     prosecutorBody: {
-      id: 'judicial.system.backend:notifications.case_completed.prosecutor_body_v3',
+      id: 'judicial.system.backend:notifications.case_completed.prosecutor_body_v4',
       defaultMessage:
-        '{isCorrection, select, true {Mál {courtCaseNumber} hjá {courtName} hefur verið leiðrétt.} other {Máli {courtCaseNumber} hjá {courtName} hefur verið lokið.<br /><br />Niðurstaða: {caseIndictmentRulingDecision}}}<br /><br />Skjöl málsins eru aðgengileg á {linkStart}yfirlitssíðu málsins í Réttarvörslugátt{linkEnd}.',
+        '{isCorrection, select, true {Mál {courtCaseNumber} hjá {courtName} hefur verið leiðrétt.} other {Máli {courtCaseNumber} hjá {courtName} hefur verið lokið.<br /><br />Niðurstaða: {caseIndictmentRulingDecision}}}<br /><br />Skjöl málsins eru aðgengileg á {linkStart}yfirlitssíðu málsins í Réttarvörslugátt{linkEnd}.{isDismissal, select, true {<br /><br />Hægt er að kæra úrskurðinn og senda greinargerðir og gögn í gegnum Réttarvörslugátt ef við á.} other {}}',
       description:
         'Notaður sem texti í pósti til sækjanda vegna staðfests dóms',
     },
     defenderBody: {
-      id: 'judicial.system.backend:notifications.case_completed.defender_body_v5',
+      id: 'judicial.system.backend:notifications.case_completed.defender_body_v6',
       defaultMessage:
-        '{isCorrection, select, true {Mál {courtCaseNumber} hjá {courtName} hefur verið leiðrétt.} other {Máli {courtCaseNumber} hjá {courtName} hefur verið lokið.<br /><br />Niðurstaða: {caseIndictmentRulingDecision}}}<br /><br />{defenderHasAccessToRvg, select, false {Þú getur nálgast gögn málsins hjá {courtName} ef þau hafa ekki þegar verið afhent} other {Skjöl málsins eru aðgengileg á {linkStart}yfirlitssíðu málsins í Réttarvörslugátt{linkEnd}.}}.',
+        '{isCorrection, select, true {Mál {courtCaseNumber} hjá {courtName} hefur verið leiðrétt.} other {Máli {courtCaseNumber} hjá {courtName} hefur verið lokið.<br /><br />Niðurstaða: {caseIndictmentRulingDecision}}}<br /><br />{defenderHasAccessToRvg, select, false {Þú getur nálgast gögn málsins hjá {courtName} ef þau hafa ekki þegar verið afhent} other {Skjöl málsins eru aðgengileg á {linkStart}yfirlitssíðu málsins í Réttarvörslugátt{linkEnd}.}}.{isDismissal, select, true {<br /><br />Hægt er að kæra úrskurðinn og senda greinargerðir og gögn í gegnum Réttarvörslugátt ef við á.} other {}}',
       description:
         'Notaður sem texti í pósti til verjanda vegna staðfests dóms',
     },

--- a/apps/judicial-system/backend/src/app/messages/notifications.ts
+++ b/apps/judicial-system/backend/src/app/messages/notifications.ts
@@ -361,7 +361,7 @@ export const notifications = {
     defenderBody: {
       id: 'judicial.system.backend:notifications.case_completed.defender_body_v6',
       defaultMessage:
-        '{isCorrection, select, true {Mál {courtCaseNumber} hjá {courtName} hefur verið leiðrétt.} other {Máli {courtCaseNumber} hjá {courtName} hefur verið lokið.<br /><br />Niðurstaða: {caseIndictmentRulingDecision}}}<br /><br />{defenderHasAccessToRvg, select, false {Þú getur nálgast gögn málsins hjá {courtName} ef þau hafa ekki þegar verið afhent} other {Skjöl málsins eru aðgengileg á {linkStart}yfirlitssíðu málsins í Réttarvörslugátt{linkEnd}.}}.{isDismissal, select, true {<br /><br />Hægt er að kæra úrskurðinn og senda greinargerðir og gögn í gegnum Réttarvörslugátt ef við á.} other {}}',
+        '{isCorrection, select, true {Mál {courtCaseNumber} hjá {courtName} hefur verið leiðrétt.} other {Máli {courtCaseNumber} hjá {courtName} hefur verið lokið.<br /><br />Niðurstaða: {caseIndictmentRulingDecision}}}<br /><br />{defenderHasAccessToRvg, select, false {Þú getur nálgast gögn málsins hjá {courtName} ef þau hafa ekki þegar verið afhent} other {Skjöl málsins eru aðgengileg á {linkStart}yfirlitssíðu málsins í Réttarvörslugátt{linkEnd}}}.{isDismissal, select, true {<br /><br />Hægt er að kæra úrskurðinn og senda greinargerðir og gögn í gegnum Réttarvörslugátt ef við á.} other {}}',
       description:
         'Notaður sem texti í pósti til verjanda vegna staðfests dóms',
     },

--- a/apps/judicial-system/backend/src/app/messages/notifications.ts
+++ b/apps/judicial-system/backend/src/app/messages/notifications.ts
@@ -285,25 +285,12 @@ export const notifications = {
       description:
         'Notaður sem titill í pósti til hagaðila vegna undirritunar úrskurðar',
     },
-    courtRecordAttachment: {
-      id: 'judicial.system.backend:notifications.signed_ruling.court_record_attachment',
-      defaultMessage: 'Þingbók {courtCaseNumber}.pdf',
-      description:
-        'Notaður sem nafn á þingbókarviðhengi í pósti til hagaðila vegna undirritunar úrskurðar',
-    },
     prosecutorBodyS3: {
       id: 'judicial.system.backend:notifications.signed_ruling.prosecutor_body_s3_v3',
       defaultMessage:
         'Dómari hefur {isModifyingRuling, select, true {leiðrétt} other {undirritað og staðfest}} úrskurð í máli {courtCaseNumber} hjá {courtName}.<br /><br />Skjöl málsins eru aðgengileg á {linkStart}yfirlitssíðu málsins í Réttarvörslugátt{linkEnd}.',
       description:
         'Notaður sem texti í pósti til sækjanda vegna undirritunar úrskurðar ef tókst að vista úrskurð í AWS S3',
-    },
-    courtBody: {
-      id: 'judicial.system.backend:notifications.signed_ruling.court_body_v1',
-      defaultMessage:
-        'Ekki tókst að vista þingbók og/eða úrskurð í máli {courtCaseNumber} í Auði.<br /><br />Skjöl málsins eru aðgengileg á {linkStart}yfirlitssíðu málsins í Réttarvörslugátt{linkEnd}.',
-      description:
-        'Notaður sem texti í pósti til dómara og dómritara vegna undirritunar úrskurðar ef ekki tókst að vista þingbók eða úrskurð í Auði',
     },
     defenderBody: {
       id: 'judicial.system.backend:notifications.signed_ruling.defender_body_v4',

--- a/apps/judicial-system/backend/src/app/modules/notification/services/caseNotification/caseNotification.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/services/caseNotification/caseNotification.service.ts
@@ -955,6 +955,9 @@ export class CaseNotificationService extends BaseNotificationService {
           getHumanReadableCaseIndictmentRulingDecision(
             theCase.indictmentRulingDecision,
           ),
+        isDismissal:
+          theCase.indictmentRulingDecision ===
+          CaseIndictmentRulingDecision.DISMISSAL,
         linkStart: `<a href="${this.config.clientUrl}${PROSECUTION_INDICTMENT_CASE_OVERVIEW_ROUTE}/${theCase.id}">`,
         linkEnd: '</a>',
       }),
@@ -1064,6 +1067,9 @@ export class CaseNotificationService extends BaseNotificationService {
               getHumanReadableCaseIndictmentRulingDecision(
                 theCase.indictmentRulingDecision,
               ),
+            isDismissal:
+              theCase.indictmentRulingDecision ===
+              CaseIndictmentRulingDecision.DISMISSAL,
             ...sharedHtmlProps,
           })
         : this.formatMessage(rulingMessage.body, {

--- a/apps/judicial-system/backend/src/app/modules/notification/test/internalNotificationController/sendRulingNotifications.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/test/internalNotificationController/sendRulingNotifications.spec.ts
@@ -118,6 +118,39 @@ describe('InternalNotificationController - Send ruling notifications', () => {
     })
   })
 
+  describe('email to prosecutor for dismissed indictment case', () => {
+    const caseId = uuid()
+
+    const prosecutor = {
+      name: testProsecutor.name,
+      email: testProsecutor.email,
+    }
+    const theCase = {
+      id: caseId,
+      type: CaseType.INDICTMENT,
+      courtCaseNumber: '007-2022-07',
+      court: { name: 'Héraðsdómur Reykjavíkur' },
+      indictmentRulingDecision: CaseIndictmentRulingDecision.DISMISSAL,
+      prosecutor,
+    } as Case
+
+    beforeEach(async () => {
+      await givenWhenThen(caseId, theCase, notificationDto)
+    })
+
+    it('should send email with appeal information to prosecutor', () => {
+      const expectedLink = `<a href="${mockConfig.clientUrl}${PROSECUTION_INDICTMENT_CASE_OVERVIEW_ROUTE}/${caseId}">`
+      expect(mockEmailService.sendEmail).toHaveBeenCalledTimes(1)
+      expect(mockEmailService.sendEmail).toHaveBeenCalledWith(
+        expect.objectContaining({
+          to: [{ name: prosecutor.name, address: prosecutor.email }],
+          subject: 'Máli lokið 007-2022-07',
+          html: `Máli 007-2022-07 hjá Héraðsdómi Reykjavíkur hefur verið lokið.<br /><br />Niðurstaða: Frávísun<br /><br />Skjöl málsins eru aðgengileg á ${expectedLink}yfirlitssíðu málsins í Réttarvörslugátt</a>.<br /><br />Hægt er að kæra úrskurðinn og senda greinargerðir og gögn í gegnum Réttarvörslugátt ef við á.`,
+        }),
+      )
+    })
+  })
+
   describe('email to prosecutor for restriction case', () => {
     const caseId = uuid()
     const prosecutor = {


### PR DESCRIPTION
# Add appeal information to the "case completed" email for dismissals

## What

When an indictment case (S-case) is completed with a **dismissal** ruling (`Frávísun`), the "case completed" notification email now includes an extra line informing recipients that the ruling can be appealed and that briefs and documents can be submitted through Réttarvörslugátt:

> Hægt er að kæra úrskurðinn og senda greinargerðir og gögn í gegnum Réttarvörslugátt ef við á.

The line is added conditionally via a new `isDismissal` ICU argument, so it only appears when the ruling decision is `DISMISSAL`. All other outcomes (RULING, FINE, MERGE, etc.) produce the exact same email as before.

Because prosecutors, defenders and civil-claimant spokespersons (réttargæslumenn/lögmenn) all use the `caseCompleted.prosecutorBody`/`caseCompleted.defenderBody` templates, updating those two templates covers every recipient group with no changes to recipient logic.

## Why

Unlike R-cases, appeals of dismissals in indictment cases also go through Réttarvörslugátt, but this path is much less common and people generally do not discover it unless they open the gateway and see the yellow banner. Surfacing it directly in the completion email makes the appeal option discoverable.

## Screenshots / Gifs


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated case completion and indictment ruling emails to include dismissal/court-appeal wording when applicable.
  * Refreshed email template versions for both prosecutor and defender notifications.
  * Signed ruling notifications were adjusted to remove specific content sections from the published set.
* **Bug Fixes**
  * Dismissal decisions now correctly drive the dismissal-related text shown in indictment ruling emails.
* **Tests**
  * Added coverage for dismissed indictment cases to verify the prosecutor receives the expected email subject, link, and updated HTML text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->