### PR TITLE
feat(my-pages): Health overview quick links

### DIFF
--- a/libs/portals/my-pages/health/src/lib/messages.ts
+++ b/libs/portals/my-pages/health/src/lib/messages.ts
@@ -1273,6 +1273,10 @@ export const messages = defineMessages({
     id: 'sp.health:quick-link-waitlists',
     defaultMessage: 'Biðlistar',
   },
+  quickLinkQuestionnaires: {
+    id: 'sp.health:quick-link-questionnaires',
+    defaultMessage: 'Spurningalistar',
+  },
   paymentDocument: {
     defaultMessage: 'Greiðsluskjal',
     id: 'sp.health:payment-document',

--- a/libs/portals/my-pages/health/src/lib/messages.ts
+++ b/libs/portals/my-pages/health/src/lib/messages.ts
@@ -1261,6 +1261,18 @@ export const messages = defineMessages({
     defaultMessage:
       'Hér getur þú séð yfirlit yfir grunnupplýsingar þínar í Heilsu, tímabókanir, skráningar, stöðu á listum og mælingar.',
   },
+  quickLinkMedicinePrescription: {
+    id: 'sp.health:quick-link-medicine-prescription',
+    defaultMessage: 'Endurnýja lyf',
+  },
+  quickLinkMedicineDelegation: {
+    id: 'sp.health:quick-link-medicine-delegation',
+    defaultMessage: 'Umboðsstillingar',
+  },
+  quickLinkWaitlists: {
+    id: 'sp.health:quick-link-waitlists',
+    defaultMessage: 'Biðlistar',
+  },
   paymentDocument: {
     defaultMessage: 'Greiðsluskjal',
     id: 'sp.health:payment-document',

--- a/libs/portals/my-pages/health/src/screens/HealthOverview/HealthOverview.tsx
+++ b/libs/portals/my-pages/health/src/screens/HealthOverview/HealthOverview.tsx
@@ -156,7 +156,7 @@ export const HealthOverview = () => {
             </Text>
             {showQuickLinks && (
               <Box marginTop={3}>
-                <Inline space={1}>
+                <Inline space={[1, 2]}>
                   {quickLinks.map((link) => (
                     <LinkResolver key={link.href} href={link.href}>
                       <Tag variant="blue">{link.label}</Tag>

--- a/libs/portals/my-pages/health/src/screens/HealthOverview/HealthOverview.tsx
+++ b/libs/portals/my-pages/health/src/screens/HealthOverview/HealthOverview.tsx
@@ -8,11 +8,11 @@ import {
 } from '@island.is/island-ui/core'
 import { theme } from '@island.is/island-ui/theme'
 import { useLocale, useNamespaces } from '@island.is/localization'
+import { LinkResolver } from '@island.is/portals/my-pages/core'
 import subYears from 'date-fns/subYears'
 import { useWindowSize } from 'react-use'
 import { HealthPaths } from '../../lib/paths'
 import { messages } from '../../lib/messages'
-import { LinkResolver } from '@island.is/portals/my-pages/core'
 import {
   CONTENT_GAP_LG,
   DEFAULT_APPOINTMENTS_STATUS,
@@ -136,6 +136,10 @@ export const HealthOverview = () => {
     {
       href: HealthPaths.HealthWaitlists,
       label: formatMessage(messages.quickLinkWaitlists),
+    },
+    {
+      href: HealthPaths.HealthQuestionnaires,
+      label: formatMessage(messages.quickLinkQuestionnaires),
     },
   ]
 

--- a/libs/portals/my-pages/health/src/screens/HealthOverview/HealthOverview.tsx
+++ b/libs/portals/my-pages/health/src/screens/HealthOverview/HealthOverview.tsx
@@ -1,9 +1,18 @@
-import { GridColumn, GridRow, Text } from '@island.is/island-ui/core'
+import {
+  Box,
+  GridColumn,
+  GridRow,
+  Inline,
+  Tag,
+  Text,
+} from '@island.is/island-ui/core'
 import { theme } from '@island.is/island-ui/theme'
 import { useLocale, useNamespaces } from '@island.is/localization'
 import subYears from 'date-fns/subYears'
 import { useWindowSize } from 'react-use'
+import { HealthPaths } from '../../lib/paths'
 import { messages } from '../../lib/messages'
+import { LinkResolver } from '@island.is/portals/my-pages/core'
 import {
   CONTENT_GAP_LG,
   DEFAULT_APPOINTMENTS_STATUS,
@@ -36,6 +45,10 @@ export const HealthOverview = () => {
   const isMobile = width < theme.breakpoints.md
   const { value: showAppointments } = useFeatureFlag(
     Features.isServicePortalHealthAppointmentsPageEnabled,
+    false,
+  )
+  const { value: showQuickLinks } = useFeatureFlag(
+    Features.servicePortalHealthMedicineLandlaeknirPageEnabled,
     false,
   )
 
@@ -111,6 +124,21 @@ export const HealthOverview = () => {
   const firstTwoAppointments =
     appointmentsData?.healthDirectorateAppointments?.data?.slice(0, 2) || []
 
+  const quickLinks = [
+    {
+      href: HealthPaths.HealthMedicinePrescription,
+      label: formatMessage(messages.quickLinkMedicinePrescription),
+    },
+    {
+      href: HealthPaths.HealthMedicineDelegation,
+      label: formatMessage(messages.quickLinkMedicineDelegation),
+    },
+    {
+      href: HealthPaths.HealthWaitlists,
+      label: formatMessage(messages.quickLinkWaitlists),
+    },
+  ]
+
   return (
     <>
       <GridRow marginBottom={CONTENT_GAP_LG}>
@@ -119,10 +147,20 @@ export const HealthOverview = () => {
             <Text variant="h3" as={'h1'}>
               {formatMessage(messages.healthOverview)}
             </Text>
-
             <Text variant="default" paddingTop={1}>
               {formatMessage(messages.healthOverviewIntro)}
             </Text>
+            {showQuickLinks && (
+              <Box marginTop={3}>
+                <Inline space={1}>
+                  {quickLinks.map((link) => (
+                    <LinkResolver key={link.href} href={link.href}>
+                      <Tag variant="blue">{link.label}</Tag>
+                    </LinkResolver>
+                  ))}
+                </Inline>
+              </Box>
+            )}
           </>
         </GridColumn>
       </GridRow>


### PR DESCRIPTION
## What

Add quick link tags to health overview page

## Why

To add a shortcut to 4 pages that product owners want to highlight specifically on the health overview page. 

## Images

<img width="646" height="317" alt="image" src="https://github.com/user-attachments/assets/16c67b55-f773-4254-b3a1-2077d9393b90" />


## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a new “quick links” section to the Health Overview page for faster access to key health items.
  * Included links for medicine prescriptions, medicine delegations, waitlists, and questionnaires.
  * The section is displayed conditionally based on an enabled feature flag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->