### PR TITLE
feat(j-s): Slack events for subpoena and verdict RLS delivery

### DIFF
--- a/apps/judicial-system/backend/src/app/modules/event/event.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/event/event.service.ts
@@ -51,7 +51,10 @@ type CaseEvent =
   | 'SCHEDULE_ARRAIGNMENT_DATE'
   | 'SCHEDULE_COURT_DATE'
   | 'SPLIT'
+  | 'SUBPOENA_ISSUED'
+  | 'SUBPOENA_DELIVERED_TO_POLICE'
   | 'SUBPOENA_SERVICE_STATUS'
+  | 'VERDICT_DELIVERED_TO_POLICE'
   | 'VERDICT_SERVICE_STATUS'
 
 type AppealCaseEvent = AppealCaseTransition | 'CREATE_APPEAL'
@@ -87,7 +90,10 @@ const eventHeading: Record<Event, string> = {
   SCHEDULE_COURT_DATE: ':timer_clock: Fyrirtökutíma úthlutað',
   SPLIT: ':scissors: Mál klofið',
   [CaseTransition.SUBMIT]: ':mailbox_with_mail: Sent',
+  SUBPOENA_ISSUED: ':envelope_with_arrow: Fyrirkall gefið út',
+  SUBPOENA_DELIVERED_TO_POLICE: ':oncoming_police_car: Fyrirkall sent til RLS',
   SUBPOENA_SERVICE_STATUS: ':page_with_curl: Staða fyrirkalls uppfærð',
+  VERDICT_DELIVERED_TO_POLICE: ':oncoming_police_car: Dómur sendur til RLS',
   VERDICT_SERVICE_STATUS:
     ':mailbox_with_no_mail: Birtingarstaða á dómi uppfærð',
   [AppealCaseTransition.WITHDRAW_APPEAL]:
@@ -103,7 +109,10 @@ const caseEventsToLog = [
   'REJECT',
   'SCHEDULE_ARRAIGNMENT_DATE',
   'SCHEDULE_COURT_DATE',
+  'SUBPOENA_ISSUED',
+  'SUBPOENA_DELIVERED_TO_POLICE',
   'SUBPOENA_SERVICE_STATUS',
+  'VERDICT_DELIVERED_TO_POLICE',
   'VERDICT_SERVICE_STATUS',
 ]
 

--- a/apps/judicial-system/backend/src/app/modules/subpoena/subpoena.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/subpoena/subpoena.service.ts
@@ -201,6 +201,12 @@ export class SubpoenaService {
       user,
     )
 
+    this.eventService.postEvent('SUBPOENA_ISSUED', theCase, false, {
+      Varnaraðili: defendantsToProcess
+        .map((defendant) => defendant.id)
+        .join(', '),
+    })
+
     return subpoenas
   }
 
@@ -517,6 +523,16 @@ export class SubpoenaService {
 
       this.logger.info(
         `Subpoena with police subpoena id ${createdSubpoena.policeSubpoenaId} delivered to the police centralized file service`,
+      )
+
+      this.eventService.postEvent(
+        'SUBPOENA_DELIVERED_TO_POLICE',
+        theCase,
+        false,
+        {
+          Varnaraðili: defendant.id,
+          'RLS auðkenni': createdSubpoena.policeSubpoenaId,
+        },
       )
 
       return { delivered: true }

--- a/apps/judicial-system/backend/src/app/modules/verdict/verdict.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/verdict/verdict.service.ts
@@ -28,6 +28,7 @@ import { ServiceRequirement } from '@island.is/judicial-system/types'
 
 import { InternalCaseService, PdfService } from '../case'
 import { DefendantService } from '../defendant'
+import { EventService } from '../event'
 import { FileService } from '../file'
 import { PoliceDocumentType, PoliceService } from '../police'
 import {
@@ -79,6 +80,7 @@ export class VerdictService {
     private readonly defendantService: DefendantService,
     @Inject(forwardRef(() => InternalCaseService))
     private readonly internalCaseService: InternalCaseService,
+    private readonly eventService: EventService,
     @Inject(LOGGER_PROVIDER) private readonly logger: Logger,
   ) {}
 
@@ -496,6 +498,11 @@ export class VerdictService {
       },
       transaction,
     )
+
+    this.eventService.postEvent('VERDICT_DELIVERED_TO_POLICE', theCase, false, {
+      Varnaraðili: defendant.id,
+      'RLS auðkenni': createdDocument.externalPoliceDocumentId,
+    })
 
     return { delivered: true }
   }


### PR DESCRIPTION
# Slack events for subpoena and verdict RLS delivery

[Úrbætur vegna incident - slack happy path fyrir birtingar](https://app.asana.com/1/203394141643832/project/1199153462262248/task/1212908057962108)

Adds PROD Slack channel logging across the subpoena and verdict lifecycles so both are traceable end to end (the "happy path" visibility for birtingar requested after the incident).

New events posted via `EventService.postEvent`:

- **`SUBPOENA_ISSUED`** – when subpoenas are created for defendants (_Fyrirkall gefið út_)
- **`SUBPOENA_DELIVERED_TO_POLICE`** – after a subpoena is delivered to RLS, including the returned police id (_Fyrirkall sent til RLS_)
- **`VERDICT_DELIVERED_TO_POLICE`** – after a verdict is delivered to RLS, including the returned police document id (_Dómur sendur til RLS_)

These complement the existing `SCHEDULE_ARRAIGNMENT_DATE`, `SUBPOENA_SERVICE_STATUS` and `VERDICT_SERVICE_STATUS` events, so the full subpoena and verdict flows are now visible in the shared events Slack channel.

The defendant is logged by **id, not name**, for privacy.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code.
