### PR TITLE
feat(web): Query param to auto open web chat

### DIFF
--- a/apps/web/components/ChatPanel/ZendeskChatPanel/ZendeskChatPanel.tsx
+++ b/apps/web/components/ChatPanel/ZendeskChatPanel/ZendeskChatPanel.tsx
@@ -76,10 +76,9 @@ export const ZendeskChatPanel = ({
 
   useEffect(() => {
     const queryParam = new URLSearchParams(window.location.search).get('wa_lid')
-    if (queryParam === 't10') {
-      loadScript()
-    }
-  }, [loadScript])
+    if (queryParam === 't10') loadScript()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   useEffect(
     () => () => {

--- a/apps/web/components/ChatPanel/ZendeskChatPanel/ZendeskChatPanel.tsx
+++ b/apps/web/components/ChatPanel/ZendeskChatPanel/ZendeskChatPanel.tsx
@@ -74,6 +74,13 @@ export const ZendeskChatPanel = ({
     }
   }, [activeLocale, snippetUrl, urlTrackingTicketId])
 
+  useEffect(() => {
+    const queryParam = new URLSearchParams(window.location.search).get('wa_lid')
+    if (queryParam === 't10') {
+      loadScript()
+    }
+  }, [loadScript])
+
   useEffect(
     () => () => {
       window.zE?.('messenger', 'hide')


### PR DESCRIPTION
# Query param to auto open web chat

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The Zendesk chat widget now opens automatically for URLs containing the `wa_lid=t10` query parameter.
  * Chat initialization can happen without requiring a prior user click, improving access to support in eligible flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->