### PR TITLE
fix(native-app): Change icon color in tab and nav bar

### DIFF
--- a/apps/native/app/src/app/(auth)/(tabs)/_layout.tsx
+++ b/apps/native/app/src/app/(auth)/(tabs)/_layout.tsx
@@ -70,6 +70,7 @@ export default function TabLayout() {
               default: require('@/assets/icons/tabbar-mail.png'),
               selected: require('@/assets/icons/tabbar-mail-selected.png'),
             }}
+            renderingMode="original"
           />
         </NativeTabs.Trigger>
 
@@ -82,6 +83,7 @@ export default function TabLayout() {
               default: require('@/assets/icons/tabbar-wallet.png'),
               selected: require('@/assets/icons/tabbar-wallet-selected.png'),
             }}
+            renderingMode="original"
           />
         </NativeTabs.Trigger>
         <NativeTabs.Trigger name="index">
@@ -105,6 +107,7 @@ export default function TabLayout() {
               default: require('@/assets/icons/tabbar-health.png'),
               selected: require('@/assets/icons/tabbar-health-selected.png'),
             }}
+            renderingMode="original"
           />
         </NativeTabs.Trigger>
         <NativeTabs.Trigger name="more">
@@ -113,6 +116,7 @@ export default function TabLayout() {
           </NativeTabs.Trigger.Label>
           <NativeTabs.Trigger.Icon
             src={require('@/assets/icons/tabbar-more.png')}
+            renderingMode="original"
           />
         </NativeTabs.Trigger>
       </NativeTabs>

--- a/apps/native/app/src/app/(auth)/(tabs)/inbox/index.tsx
+++ b/apps/native/app/src/app/(auth)/(tabs)/inbox/index.tsx
@@ -560,6 +560,7 @@ export default function InboxScreen() {
                       )
                     }
                   },
+                  tintColor: theme.color.blue400,
                 },
               ]
             : [
@@ -576,6 +577,7 @@ export default function InboxScreen() {
                   onPress() {
                     setSelectedState((v) => !v)
                   },
+                  tintColor: theme.color.blue400,
                 },
               ],
           headerRightItems: selectState
@@ -593,7 +595,7 @@ export default function InboxScreen() {
                   onPress() {
                     resetSelectState()
                   },
-                  tintColor: theme.color.purple400,
+                  tintColor: theme.color.blue400,
                 },
               ]
             : [],

--- a/apps/native/app/src/components/navbar/navbar-items.tsx
+++ b/apps/native/app/src/components/navbar/navbar-items.tsx
@@ -3,6 +3,7 @@ import { OfflineIcon } from '../offline/offline-icon'
 import { router } from 'expo-router'
 import { NativeStackHeaderItem } from '@react-navigation/native-stack'
 import { NetworkStatus } from '@apollo/client'
+import { theme } from '../../ui'
 
 export function navbarOfflineItem(
   networkStatus?: NetworkStatus | NetworkStatus[],
@@ -19,6 +20,7 @@ export function navbarCloseItem(): NativeStackHeaderItem {
     type: 'button',
     label: 'Close',
     icon: { type: 'sfSymbol', name: 'xmark' },
+    tintColor: theme.color.blue400,
     onPress: () => router.back(),
   }
 }

--- a/apps/native/app/src/components/stack-screen.tsx
+++ b/apps/native/app/src/components/stack-screen.tsx
@@ -137,7 +137,9 @@ export function StackScreen({
   return (
     <Stack.Screen
       options={{
-        unstable_headerLeftItems: headerLeftItems,
+        ...(options?.headerLeftItems !== undefined && {
+          unstable_headerLeftItems: headerLeftItems,
+        }),
         headerLeft,
         unstable_headerRightItems: headerRightItems,
         headerRight,

--- a/apps/native/app/src/constants/screen-options.ts
+++ b/apps/native/app/src/constants/screen-options.ts
@@ -1,7 +1,25 @@
-import { StackScreenProps } from 'expo-router'
+import { router, StackScreenProps } from 'expo-router'
+import { NativeStackHeaderItem } from '@react-navigation/native-stack'
 import { Platform } from 'react-native'
 import { navbarCloseItem, spacingItem } from '../components/navbar/navbar-items'
 import { theme } from '../ui'
+
+export const blueBackItem = ({
+  canGoBack,
+}: {
+  canGoBack?: boolean
+}): NativeStackHeaderItem[] =>
+  canGoBack
+    ? [
+        {
+          type: 'button',
+          label: '',
+          icon: { type: 'sfSymbol', name: 'chevron.backward' },
+          tintColor: theme.color.blue400,
+          onPress: () => router.back(),
+        },
+      ]
+    : []
 
 export const tabScreenOptions: StackScreenProps['options'] = {
   headerShown: true,
@@ -12,6 +30,8 @@ export const tabScreenOptions: StackScreenProps['options'] = {
       : undefined,
   headerShadowVisible: false,
   headerBackButtonDisplayMode: 'minimal',
+  headerBackVisible: false,
+  unstable_headerLeftItems: blueBackItem,
 }
 
 export const modalScreenOptions: StackScreenProps['options'] = {


### PR DESCRIPTION
When updating to expo the tab and nav bar icons (arrow back, close button) changed to be grey instead of blue.

## Screenshots / Gifs
Before and after:

<img height="622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-02 at 12 11 22" src="https://github.com/user-attachments/assets/6637b941-14bf-482e-9560-a39a960591b0" />
<img  height="622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-02 at 12 12 26" src="https://github.com/user-attachments/assets/02854773-f73e-4e7a-a6fa-c1c75f3777b2" />


## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude
