### PR TITLE
fix(web): Zendesk web chat widget - Delete window injected functions on unmount

### DIFF
--- a/apps/web/components/ChatPanel/ZendeskChatPanel/ZendeskChatPanel.tsx
+++ b/apps/web/components/ChatPanel/ZendeskChatPanel/ZendeskChatPanel.tsx
@@ -17,6 +17,9 @@ const SCRIPT_ID = 'ze-snippet'
 declare global {
   interface Window {
     zE?: ZendeskMessengerAPI
+    zEACLoaded?: boolean
+    zEmbed?: ZendeskMessengerAPI
+    $zopim?: unknown
   }
 }
 
@@ -31,7 +34,7 @@ export const ZendeskChatPanel = ({
   const [isChatOpen, setIsChatOpen] = useState(false)
   const { activeLocale } = useI18n()
 
-  const loadScript = useCallback(() => {
+  const openChat = useCallback(() => {
     const setup = () => {
       setIsChatOpen(true)
       setIsLoading(false)
@@ -76,7 +79,7 @@ export const ZendeskChatPanel = ({
 
   useEffect(() => {
     const queryParam = new URLSearchParams(window.location.search).get('wa_lid')
-    if (queryParam === 't10') loadScript()
+    if (queryParam === 't10') openChat()
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
@@ -84,6 +87,10 @@ export const ZendeskChatPanel = ({
     () => () => {
       window.zE?.('messenger', 'hide')
       document.getElementById(SCRIPT_ID)?.remove()
+      delete window.zEACLoaded
+      delete window.zE
+      delete window.zEmbed
+      delete window.$zopim
     },
     [],
   )
@@ -106,7 +113,7 @@ export const ZendeskChatPanel = ({
 
   return (
     <ChatBubble
-      onClick={loadScript}
+      onClick={openChat}
       text={n('chatBubbleText', 'Hæ, get ég aðstoðað?')}
       variant={chatBubbleVariant}
       pushUp={pushUp}

--- a/apps/web/components/ChatPanel/ZendeskChatPanel/ZendeskChatPanel.tsx
+++ b/apps/web/components/ChatPanel/ZendeskChatPanel/ZendeskChatPanel.tsx
@@ -79,12 +79,17 @@ export const ZendeskChatPanel = ({
 
   useEffect(() => {
     const queryParam = new URLSearchParams(window.location.search).get('wa_lid')
-    if (queryParam === 't10') openChat()
+    if (queryParam === 't10') {
+      setTimeout(() => {
+        openChat()
+      }, 100)
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   useEffect(
     () => () => {
+      console.log('cleanup')
       window.zE?.('messenger', 'hide')
       document.getElementById(SCRIPT_ID)?.remove()
       delete window.zEACLoaded

--- a/apps/web/components/ChatPanel/ZendeskChatPanel/ZendeskChatPanel.tsx
+++ b/apps/web/components/ChatPanel/ZendeskChatPanel/ZendeskChatPanel.tsx
@@ -89,7 +89,6 @@ export const ZendeskChatPanel = ({
 
   useEffect(
     () => () => {
-      console.log('cleanup')
       window.zE?.('messenger', 'hide')
       document.getElementById(SCRIPT_ID)?.remove()
       delete window.zEACLoaded

--- a/apps/web/components/ChatPanel/ZendeskChatPanel/ZendeskChatPanel.tsx
+++ b/apps/web/components/ChatPanel/ZendeskChatPanel/ZendeskChatPanel.tsx
@@ -79,10 +79,16 @@ export const ZendeskChatPanel = ({
 
   useEffect(() => {
     const queryParam = new URLSearchParams(window.location.search).get('wa_lid')
+
+    let timeout: NodeJS.Timeout | null = null
     if (queryParam === 't10') {
-      setTimeout(() => {
+      timeout = setTimeout(() => {
         openChat()
       }, 100)
+    }
+
+    return () => {
+      if (timeout) window.clearTimeout(timeout)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])


### PR DESCRIPTION
# Zendesk web chat widget - Delete window injected functions on unmount

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [x] No AI tools were used in preparing this pull request
- [ ] AI tools were used in preparing this pull request
      Tools used:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the support chat-opening flow so the widget opens more reliably when selected.
  * Updated the automatic open behavior to trigger after a brief delay (including the `wa_lid=t10` path).
  * Strengthened cleanup on close/unmount by fully clearing injected widget globals to reduce stale chat behavior when navigating away.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->