### PR TITLE
fix(j-s): Invite confirmed parties to court date when only a regular session is scheduled

### DIFF
--- a/apps/judicial-system/backend/src/app/modules/notification/services/baseNotification.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/services/baseNotification.service.ts
@@ -16,6 +16,8 @@ import {
   filterWhitelistEmails,
   formatArraignmentDateEmailNotification,
   formatCourtCalendarInvitation,
+  formatDefenderRoute,
+  formatPostponedCourtDateEmailNotification,
   stripHtmlTags,
 } from '../../../formatters'
 import { notifications } from '../../../messages'
@@ -332,5 +334,98 @@ export abstract class BaseNotificationService {
 
       return recipient
     })
+  }
+
+  private async sendPostponedCourtDateEmailNotificationToRecipient({
+    theCase,
+    user,
+    courtDate,
+    recipientName,
+    recipientEmail,
+    recipientHasAccessToRVG,
+  }: {
+    theCase: Case
+    user: UserDescriptor
+    courtDate: DateLog
+    recipientName: string
+    recipientEmail: string
+    recipientHasAccessToRVG: boolean
+  }): Promise<Recipient> {
+    const overviewUrl = recipientHasAccessToRVG
+      ? formatDefenderRoute(this.config.clientUrl, theCase.type, theCase.id)
+      : undefined
+
+    const { subject, body } = formatPostponedCourtDateEmailNotification(
+      this.formatMessage,
+      theCase,
+      courtDate,
+      overviewUrl,
+    )
+
+    const calendarInvite = this.getCourtDateCalendarInvite(theCase, courtDate)
+
+    return this.sendEmail({
+      subject,
+      html: body,
+      recipientName,
+      recipientEmail,
+      attachments: calendarInvite ? [calendarInvite] : undefined,
+      skipTail: !overviewUrl,
+    }).then((recipient) => {
+      if (recipient.success) {
+        // No need to wait
+        this.uploadEmailToCourt(theCase, user, subject, body, recipientEmail)
+      }
+
+      return recipient
+    })
+  }
+
+  /**
+   * Sends an invitation to the next scheduled court session to a party that was
+   * just confirmed. The arraignment (þingfesting / ARRAIGNMENT_DATE) takes
+   * precedence over a regularly scheduled court session (þinghald / COURT_DATE) -
+   * the party is invited to whichever is scheduled in the future. Returns null
+   * when neither date is in the future, meaning nothing should be sent.
+   */
+  protected async sendCourtDateFollowUpEmailNotification({
+    theCase,
+    user,
+    recipientName,
+    recipientEmail,
+    recipientHasAccessToRVG,
+  }: {
+    theCase: Case
+    user: UserDescriptor
+    recipientName: string
+    recipientEmail: string
+    recipientHasAccessToRVG: boolean
+  }): Promise<Recipient | null> {
+    const arraignmentDate = DateLog.arraignmentDate(theCase.dateLogs)
+
+    if (arraignmentDate && arraignmentDate.date.getTime() > Date.now()) {
+      return this.sendArraignmentDateEmailNotification({
+        theCase,
+        user,
+        arraignmentDateLog: arraignmentDate,
+        recipientName,
+        recipientEmail,
+      })
+    }
+
+    const courtDate = DateLog.courtDate(theCase.dateLogs)
+
+    if (courtDate && courtDate.date.getTime() > Date.now()) {
+      return this.sendPostponedCourtDateEmailNotificationToRecipient({
+        theCase,
+        user,
+        courtDate,
+        recipientName,
+        recipientEmail,
+        recipientHasAccessToRVG,
+      })
+    }
+
+    return null
   }
 }

--- a/apps/judicial-system/backend/src/app/modules/notification/services/civilClaimantNotification/civilClaimantNotification.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/services/civilClaimantNotification/civilClaimantNotification.service.ts
@@ -25,7 +25,6 @@ import { EventService } from '../../../event'
 import {
   Case,
   CivilClaimant,
-  DateLog,
   Notification,
   Recipient,
 } from '../../../repository'
@@ -137,22 +136,25 @@ export class CivilClaimantNotificationService extends BaseNotificationService {
       civilClaimant,
       TrackedNotificationType.SPOKESPERSON_COURT_DATE_FOLLOW_UP,
     )
-    const arraignmentDateLog = DateLog.arraignmentDate(theCase.dateLogs)
-    const hasFutureArraignmentDate =
-      arraignmentDateLog && arraignmentDateLog.date.getTime() > Date.now()
 
-    if (!shouldSendCourtDateFollowUp || !hasFutureArraignmentDate || !user) {
+    if (!shouldSendCourtDateFollowUp || !user) {
       // Nothing should be sent so we return a successful response
       return { delivered: true }
     }
 
-    const recipient = await this.sendArraignmentDateEmailNotification({
+    const recipient = await this.sendCourtDateFollowUpEmailNotification({
       theCase,
       user,
-      arraignmentDateLog,
       recipientName: civilClaimant.spokespersonName ?? '',
       recipientEmail: civilClaimant.spokespersonEmail ?? '',
+      recipientHasAccessToRVG: Boolean(civilClaimant.spokespersonNationalId),
     })
+
+    if (!recipient) {
+      // Neither a court session nor an arraignment is scheduled in the future,
+      // so there is nothing to invite the spokesperson to
+      return { delivered: true }
+    }
 
     const result = await this.recordNotification(
       theCase.id,

--- a/apps/judicial-system/backend/src/app/modules/notification/services/defendantNotification/defendantNotification.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/services/defendantNotification/defendantNotification.service.ts
@@ -28,7 +28,6 @@ import { CourtService } from '../../../court'
 import { EventService } from '../../../event'
 import {
   Case,
-  DateLog,
   Defendant,
   InstitutionContactRepositoryService,
   Notification,
@@ -197,22 +196,25 @@ export class DefendantNotificationService extends BaseNotificationService {
       defendant,
       TrackedNotificationType.DEFENDER_COURT_DATE_FOLLOW_UP,
     )
-    const arraignmentDateLog = DateLog.arraignmentDate(theCase.dateLogs)
-    const hasFutureArraignmentDate =
-      arraignmentDateLog && arraignmentDateLog.date.getTime() > Date.now()
 
-    if (!shouldSendCourtDateFollowUp || !hasFutureArraignmentDate || !user) {
+    if (!shouldSendCourtDateFollowUp || !user) {
       // Nothing should be sent so we return a successful response
       return { delivered: true }
     }
 
-    const recipient = await this.sendArraignmentDateEmailNotification({
+    const recipient = await this.sendCourtDateFollowUpEmailNotification({
       theCase,
       user,
-      arraignmentDateLog,
       recipientName: defendant.defenderName ?? '',
       recipientEmail: defendant.defenderEmail ?? '',
+      recipientHasAccessToRVG: Boolean(defendant.defenderNationalId),
     })
+
+    if (!recipient) {
+      // Neither a court session nor an arraignment is scheduled in the future,
+      // so there is nothing to invite the defender to
+      return { delivered: true }
+    }
 
     const result = await this.recordNotification(
       theCase.id,

--- a/apps/judicial-system/backend/src/app/modules/notification/test/internalNotificationController/civilClaimantNotification/sendSpokespersonCourtDateFollowUpNotifications.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/test/internalNotificationController/civilClaimantNotification/sendSpokespersonCourtDateFollowUpNotifications.spec.ts
@@ -1,0 +1,270 @@
+import { v4 as uuid } from 'uuid'
+
+import { EmailService } from '@island.is/email-service'
+
+import {
+  CaseType,
+  CivilClaimantNotificationType,
+  CourtSessionType,
+  DateType,
+} from '@island.is/judicial-system/types'
+
+import {
+  createTestingNotificationModule,
+  createTestUsers,
+} from '../../createTestingNotificationModule'
+
+import {
+  Case,
+  CivilClaimant,
+  DateLog,
+  Notification,
+} from '../../../../repository'
+import { CivilClaimantNotificationDto } from '../../../dto/civilClaimantNotification.dto'
+import { DeliverResponse } from '../../../models/deliver.response'
+
+jest.mock('../../../../../factories')
+
+interface Then {
+  result: DeliverResponse
+  error: Error
+}
+
+type GivenWhenThen = (
+  caseId: string,
+  civilClaimantId: string,
+  theCase: Case,
+  civilClaimant: CivilClaimant,
+  notificationDto: CivilClaimantNotificationDto,
+) => Promise<Then>
+
+describe('InternalNotificationController - Send spokesperson court date follow up notifications', () => {
+  const caseId = uuid()
+  const civilClaimantId = uuid()
+
+  const { spokesperson, prosecutor } = createTestUsers([
+    'spokesperson',
+    'prosecutor',
+  ])
+  const court = { name: 'Héraðsdómur Reykjavíkur' } as Case['court']
+
+  const futureDate = new Date(Date.now() + 100 * 60 * 1000)
+  const pastDate = new Date(Date.now() - 100 * 60 * 1000)
+
+  let mockEmailService: EmailService
+  let mockNotificationModel: typeof Notification
+  let givenWhenThen: GivenWhenThen
+
+  let civilClaimantNotificationDTO: CivilClaimantNotificationDto
+
+  const buildCase = (dateLogs: DateLog[]): Case =>
+    ({
+      id: caseId,
+      court,
+      courtCaseNumber: 'R-123-456/2024',
+      type: CaseType.INDICTMENT,
+      courtSessionType: CourtSessionType.MAIN_HEARING,
+      prosecutor,
+      dateLogs,
+    } as Case)
+
+  const confirmedCivilClaimant = {
+    id: civilClaimantId,
+    caseId,
+    isSpokespersonConfirmed: true,
+    spokespersonIsLawyer: true,
+    spokespersonNationalId: '1234567890',
+    spokespersonName: spokesperson.name,
+    spokespersonEmail: spokesperson.email,
+  } as CivilClaimant
+
+  beforeEach(async () => {
+    const {
+      emailService,
+      internalNotificationController,
+      notificationModel,
+    } = await createTestingNotificationModule()
+
+    civilClaimantNotificationDTO = {
+      type: CivilClaimantNotificationType.SPOKESPERSON_COURT_DATE_FOLLOW_UP,
+      user: prosecutor as CivilClaimantNotificationDto['user'],
+    }
+
+    mockEmailService = emailService
+    mockNotificationModel = notificationModel
+
+    givenWhenThen = async (
+      caseId: string,
+      civilClaimantId: string,
+      theCase: Case,
+      civilClaimant: CivilClaimant,
+      notificationDto: CivilClaimantNotificationDto,
+    ) => {
+      const then = {} as Then
+
+      try {
+        then.result =
+          await internalNotificationController.sendCivilClaimantNotification(
+            caseId,
+            civilClaimantId,
+            theCase,
+            civilClaimant,
+            notificationDto,
+          )
+      } catch (error) {
+        then.error = error as Error
+      }
+
+      return then
+    }
+  })
+
+  describe('when a regular court session is scheduled in the future', () => {
+    const theCase = buildCase([
+      { dateType: DateType.COURT_DATE, date: futureDate } as DateLog,
+    ])
+
+    beforeEach(async () => {
+      await givenWhenThen(
+        caseId,
+        civilClaimantId,
+        theCase,
+        confirmedCivilClaimant,
+        civilClaimantNotificationDTO,
+      )
+    })
+
+    it('should send a court session invitation with a calendar invite', () => {
+      expect(mockEmailService.sendEmail).toBeCalledTimes(1)
+      expect(mockEmailService.sendEmail).toBeCalledWith(
+        expect.objectContaining({
+          to: [
+            {
+              name: confirmedCivilClaimant.spokespersonName,
+              address: confirmedCivilClaimant.spokespersonEmail,
+            },
+          ],
+          subject: 'Nýtt þinghald í máli R-123-456/2024',
+          attachments: [expect.objectContaining({ filename: 'court-date.ics' })],
+        }),
+      )
+    })
+
+    it('should record the follow up notification', () => {
+      expect(mockNotificationModel.create).toHaveBeenCalledTimes(1)
+      expect(mockNotificationModel.create).toHaveBeenCalledWith({
+        caseId,
+        type: CivilClaimantNotificationType.SPOKESPERSON_COURT_DATE_FOLLOW_UP,
+        recipients: [
+          { address: confirmedCivilClaimant.spokespersonEmail, success: true },
+        ],
+      })
+    })
+  })
+
+  describe('when only an arraignment is scheduled in the future', () => {
+    const theCase = buildCase([
+      { dateType: DateType.ARRAIGNMENT_DATE, date: futureDate } as DateLog,
+    ])
+
+    beforeEach(async () => {
+      await givenWhenThen(
+        caseId,
+        civilClaimantId,
+        theCase,
+        confirmedCivilClaimant,
+        civilClaimantNotificationDTO,
+      )
+    })
+
+    it('should send an arraignment invitation', () => {
+      expect(mockEmailService.sendEmail).toBeCalledTimes(1)
+      expect(mockEmailService.sendEmail).toBeCalledWith(
+        expect.objectContaining({
+          to: [
+            {
+              name: confirmedCivilClaimant.spokespersonName,
+              address: confirmedCivilClaimant.spokespersonEmail,
+            },
+          ],
+          subject: 'Þingfesting í máli: R-123-456/2024',
+        }),
+      )
+    })
+  })
+
+  describe('when both a court session and an arraignment are in the future', () => {
+    const theCase = buildCase([
+      { dateType: DateType.ARRAIGNMENT_DATE, date: futureDate } as DateLog,
+      { dateType: DateType.COURT_DATE, date: futureDate } as DateLog,
+    ])
+
+    beforeEach(async () => {
+      await givenWhenThen(
+        caseId,
+        civilClaimantId,
+        theCase,
+        confirmedCivilClaimant,
+        civilClaimantNotificationDTO,
+      )
+    })
+
+    it('should prefer the arraignment invitation', () => {
+      expect(mockEmailService.sendEmail).toBeCalledTimes(1)
+      expect(mockEmailService.sendEmail).toBeCalledWith(
+        expect.objectContaining({
+          subject: 'Þingfesting í máli: R-123-456/2024',
+        }),
+      )
+    })
+  })
+
+  describe('when no court session or arraignment is scheduled in the future', () => {
+    const theCase = buildCase([
+      { dateType: DateType.COURT_DATE, date: pastDate } as DateLog,
+    ])
+
+    beforeEach(async () => {
+      await givenWhenThen(
+        caseId,
+        civilClaimantId,
+        theCase,
+        confirmedCivilClaimant,
+        civilClaimantNotificationDTO,
+      )
+    })
+
+    it('should not send a notification', () => {
+      expect(mockEmailService.sendEmail).not.toBeCalled()
+    })
+
+    it('should not record a notification', () => {
+      expect(mockNotificationModel.create).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('when the spokesperson is not confirmed', () => {
+    const unconfirmedCivilClaimant = {
+      ...confirmedCivilClaimant,
+      isSpokespersonConfirmed: false,
+    } as CivilClaimant
+
+    const theCase = buildCase([
+      { dateType: DateType.COURT_DATE, date: futureDate } as DateLog,
+    ])
+
+    beforeEach(async () => {
+      await givenWhenThen(
+        caseId,
+        civilClaimantId,
+        theCase,
+        unconfirmedCivilClaimant,
+        civilClaimantNotificationDTO,
+      )
+    })
+
+    it('should not send a notification', () => {
+      expect(mockEmailService.sendEmail).not.toBeCalled()
+    })
+  })
+})

--- a/apps/judicial-system/backend/src/app/modules/notification/test/internalNotificationController/civilClaimantNotification/sendSpokespersonCourtDateFollowUpNotifications.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/test/internalNotificationController/civilClaimantNotification/sendSpokespersonCourtDateFollowUpNotifications.spec.ts
@@ -79,11 +79,8 @@ describe('InternalNotificationController - Send spokesperson court date follow u
   } as CivilClaimant
 
   beforeEach(async () => {
-    const {
-      emailService,
-      internalNotificationController,
-      notificationModel,
-    } = await createTestingNotificationModule()
+    const { emailService, internalNotificationController, notificationModel } =
+      await createTestingNotificationModule()
 
     civilClaimantNotificationDTO = {
       type: CivilClaimantNotificationType.SPOKESPERSON_COURT_DATE_FOLLOW_UP,
@@ -145,7 +142,9 @@ describe('InternalNotificationController - Send spokesperson court date follow u
             },
           ],
           subject: 'Nýtt þinghald í máli R-123-456/2024',
-          attachments: [expect.objectContaining({ filename: 'court-date.ics' })],
+          attachments: [
+            expect.objectContaining({ filename: 'court-date.ics' }),
+          ],
         }),
       )
     })

--- a/apps/judicial-system/backend/src/app/modules/notification/test/internalNotificationController/defendantNotification/sendDefenderCourtDateFollowUpNotifications.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/test/internalNotificationController/defendantNotification/sendDefenderCourtDateFollowUpNotifications.spec.ts
@@ -1,0 +1,274 @@
+import { v4 as uuid } from 'uuid'
+
+import { EmailService } from '@island.is/email-service'
+
+import {
+  CaseType,
+  CourtSessionType,
+  DateType,
+  DefendantNotificationType,
+} from '@island.is/judicial-system/types'
+
+import {
+  createTestingNotificationModule,
+  createTestUsers,
+} from '../../createTestingNotificationModule'
+
+import {
+  Case,
+  DateLog,
+  Defendant,
+  Notification,
+} from '../../../../repository'
+import { DefendantNotificationDto } from '../../../dto/defendantNotification.dto'
+import { DeliverResponse } from '../../../models/deliver.response'
+
+jest.mock('../../../../../factories')
+
+interface Then {
+  result: DeliverResponse
+  error: Error
+}
+
+type GivenWhenThen = (
+  caseId: string,
+  defendantId: string,
+  theCase: Case,
+  defendant: Defendant,
+  notificationDto: DefendantNotificationDto,
+) => Promise<Then>
+
+describe('InternalNotificationController - Send defender court date follow up notifications', () => {
+  const caseId = uuid()
+  const defendantId = uuid()
+
+  const { defender, prosecutor } = createTestUsers(['defender', 'prosecutor'])
+  const court = { name: 'Héraðsdómur Reykjavíkur' } as Case['court']
+
+  const futureDate = new Date(Date.now() + 100 * 60 * 1000)
+  const pastDate = new Date(Date.now() - 100 * 60 * 1000)
+
+  let mockEmailService: EmailService
+  let mockNotificationModel: typeof Notification
+  let givenWhenThen: GivenWhenThen
+
+  let defendantNotificationDTO: DefendantNotificationDto
+
+  const buildCase = (dateLogs: DateLog[]): Case =>
+    ({
+      id: caseId,
+      court,
+      courtCaseNumber: 'R-123-456/2024',
+      type: CaseType.INDICTMENT,
+      courtSessionType: CourtSessionType.MAIN_HEARING,
+      prosecutor,
+      dateLogs,
+    } as Case)
+
+  const confirmedDefendant = {
+    id: defendantId,
+    defenderNationalId: '1234567890',
+    defenderName: defender.name,
+    defenderEmail: defender.email,
+    isDefenderChoiceConfirmed: true,
+  } as Defendant
+
+  beforeEach(async () => {
+    const {
+      emailService,
+      internalNotificationController,
+      notificationModel,
+    } = await createTestingNotificationModule()
+
+    defendantNotificationDTO = {
+      type: DefendantNotificationType.DEFENDER_COURT_DATE_FOLLOW_UP,
+      user: prosecutor as DefendantNotificationDto['user'],
+    }
+
+    mockEmailService = emailService
+    mockNotificationModel = notificationModel
+
+    givenWhenThen = async (
+      caseId: string,
+      defendantId: string,
+      theCase: Case,
+      defendant: Defendant,
+      notificationDto: DefendantNotificationDto,
+    ) => {
+      const then = {} as Then
+
+      try {
+        then.result =
+          await internalNotificationController.sendDefendantNotification(
+            caseId,
+            defendantId,
+            theCase,
+            defendant,
+            notificationDto,
+          )
+      } catch (error) {
+        then.error = error as Error
+      }
+
+      return then
+    }
+  })
+
+  describe('when a regular court session is scheduled in the future', () => {
+    const theCase = buildCase([
+      { dateType: DateType.COURT_DATE, date: futureDate } as DateLog,
+    ])
+
+    beforeEach(async () => {
+      await givenWhenThen(
+        caseId,
+        defendantId,
+        theCase,
+        confirmedDefendant,
+        defendantNotificationDTO,
+      )
+    })
+
+    it('should send a court session invitation with a calendar invite', () => {
+      expect(mockEmailService.sendEmail).toBeCalledTimes(1)
+      expect(mockEmailService.sendEmail).toBeCalledWith(
+        expect.objectContaining({
+          to: [
+            {
+              name: confirmedDefendant.defenderName,
+              address: confirmedDefendant.defenderEmail,
+            },
+          ],
+          subject: 'Nýtt þinghald í máli R-123-456/2024',
+          attachments: [expect.objectContaining({ filename: 'court-date.ics' })],
+        }),
+      )
+    })
+
+    it('should record the follow up notification', () => {
+      expect(mockNotificationModel.create).toHaveBeenCalledTimes(1)
+      expect(mockNotificationModel.create).toHaveBeenCalledWith({
+        caseId,
+        type: DefendantNotificationType.DEFENDER_COURT_DATE_FOLLOW_UP,
+        recipients: [{ address: confirmedDefendant.defenderEmail, success: true }],
+      })
+    })
+  })
+
+  describe('when only an arraignment is scheduled in the future', () => {
+    const theCase = buildCase([
+      { dateType: DateType.ARRAIGNMENT_DATE, date: futureDate } as DateLog,
+    ])
+
+    beforeEach(async () => {
+      await givenWhenThen(
+        caseId,
+        defendantId,
+        theCase,
+        confirmedDefendant,
+        defendantNotificationDTO,
+      )
+    })
+
+    it('should send an arraignment invitation', () => {
+      expect(mockEmailService.sendEmail).toBeCalledTimes(1)
+      expect(mockEmailService.sendEmail).toBeCalledWith(
+        expect.objectContaining({
+          to: [
+            {
+              name: confirmedDefendant.defenderName,
+              address: confirmedDefendant.defenderEmail,
+            },
+          ],
+          subject: 'Þingfesting í máli: R-123-456/2024',
+        }),
+      )
+    })
+
+    it('should record the follow up notification', () => {
+      expect(mockNotificationModel.create).toHaveBeenCalledWith({
+        caseId,
+        type: DefendantNotificationType.DEFENDER_COURT_DATE_FOLLOW_UP,
+        recipients: [{ address: confirmedDefendant.defenderEmail, success: true }],
+      })
+    })
+  })
+
+  describe('when both a court session and an arraignment are in the future', () => {
+    const theCase = buildCase([
+      { dateType: DateType.ARRAIGNMENT_DATE, date: futureDate } as DateLog,
+      { dateType: DateType.COURT_DATE, date: futureDate } as DateLog,
+    ])
+
+    beforeEach(async () => {
+      await givenWhenThen(
+        caseId,
+        defendantId,
+        theCase,
+        confirmedDefendant,
+        defendantNotificationDTO,
+      )
+    })
+
+    it('should prefer the arraignment invitation', () => {
+      expect(mockEmailService.sendEmail).toBeCalledTimes(1)
+      expect(mockEmailService.sendEmail).toBeCalledWith(
+        expect.objectContaining({
+          subject: 'Þingfesting í máli: R-123-456/2024',
+        }),
+      )
+    })
+  })
+
+  describe('when no court session or arraignment is scheduled in the future', () => {
+    const theCase = buildCase([
+      { dateType: DateType.COURT_DATE, date: pastDate } as DateLog,
+    ])
+
+    beforeEach(async () => {
+      await givenWhenThen(
+        caseId,
+        defendantId,
+        theCase,
+        confirmedDefendant,
+        defendantNotificationDTO,
+      )
+    })
+
+    it('should not send a notification', () => {
+      expect(mockEmailService.sendEmail).not.toBeCalled()
+    })
+
+    it('should not record a notification', () => {
+      expect(mockNotificationModel.create).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('when the defender choice is not confirmed', () => {
+    const unconfirmedDefendant = {
+      id: defendantId,
+      defenderNationalId: '1234567890',
+      defenderName: defender.name,
+      defenderEmail: defender.email,
+      isDefenderChoiceConfirmed: false,
+    } as Defendant
+
+    const theCase = buildCase([
+      { dateType: DateType.COURT_DATE, date: futureDate } as DateLog,
+    ])
+
+    beforeEach(async () => {
+      await givenWhenThen(
+        caseId,
+        defendantId,
+        theCase,
+        unconfirmedDefendant,
+        defendantNotificationDTO,
+      )
+    })
+
+    it('should not send a notification', () => {
+      expect(mockEmailService.sendEmail).not.toBeCalled()
+    })
+  })
+})

--- a/apps/judicial-system/backend/src/app/modules/notification/test/internalNotificationController/defendantNotification/sendDefenderCourtDateFollowUpNotifications.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/test/internalNotificationController/defendantNotification/sendDefenderCourtDateFollowUpNotifications.spec.ts
@@ -14,12 +14,7 @@ import {
   createTestUsers,
 } from '../../createTestingNotificationModule'
 
-import {
-  Case,
-  DateLog,
-  Defendant,
-  Notification,
-} from '../../../../repository'
+import { Case, DateLog, Defendant, Notification } from '../../../../repository'
 import { DefendantNotificationDto } from '../../../dto/defendantNotification.dto'
 import { DeliverResponse } from '../../../models/deliver.response'
 
@@ -74,11 +69,8 @@ describe('InternalNotificationController - Send defender court date follow up no
   } as Defendant
 
   beforeEach(async () => {
-    const {
-      emailService,
-      internalNotificationController,
-      notificationModel,
-    } = await createTestingNotificationModule()
+    const { emailService, internalNotificationController, notificationModel } =
+      await createTestingNotificationModule()
 
     defendantNotificationDTO = {
       type: DefendantNotificationType.DEFENDER_COURT_DATE_FOLLOW_UP,
@@ -140,7 +132,9 @@ describe('InternalNotificationController - Send defender court date follow up no
             },
           ],
           subject: 'Nýtt þinghald í máli R-123-456/2024',
-          attachments: [expect.objectContaining({ filename: 'court-date.ics' })],
+          attachments: [
+            expect.objectContaining({ filename: 'court-date.ics' }),
+          ],
         }),
       )
     })
@@ -150,7 +144,9 @@ describe('InternalNotificationController - Send defender court date follow up no
       expect(mockNotificationModel.create).toHaveBeenCalledWith({
         caseId,
         type: DefendantNotificationType.DEFENDER_COURT_DATE_FOLLOW_UP,
-        recipients: [{ address: confirmedDefendant.defenderEmail, success: true }],
+        recipients: [
+          { address: confirmedDefendant.defenderEmail, success: true },
+        ],
       })
     })
   })
@@ -189,7 +185,9 @@ describe('InternalNotificationController - Send defender court date follow up no
       expect(mockNotificationModel.create).toHaveBeenCalledWith({
         caseId,
         type: DefendantNotificationType.DEFENDER_COURT_DATE_FOLLOW_UP,
-        recipients: [{ address: confirmedDefendant.defenderEmail, success: true }],
+        recipients: [
+          { address: confirmedDefendant.defenderEmail, success: true },
+        ],
       })
     })
   })


### PR DESCRIPTION
# Invite confirmed parties to court date when only a regular session is scheduled

[Verjendur og talsmenn fá ekki alltaf boð í þinghald þegar þeir eru staðfestir](https://app.asana.com/1/203394141643832/project/1199153462262248/task/1214960032087822)

When a defender or a civil claimant's spokesperson is **confirmed** on an indictment case, we queue a court-date follow-up notification so the newly-confirmed party gets invited to the upcoming hearing. That follow-up only looked at the **arraignment date** (`ARRAIGNMENT_DATE` / þingfesting), so if the case instead had a regularly scheduled court session (`COURT_DATE` / þinghald) in the future, no invitation was sent.

This PR makes the follow-up invite the party to whichever hearing is scheduled in the future. The arraignment (þingfesting) takes precedence over a regular court session (þinghald) when both are in the future.

### Changes

- `baseNotification.service.ts` — new `sendCourtDateFollowUpEmailNotification(...)` that picks the future date (arraignment first, then court date) and returns `null` when neither is in the future, backed by a private `sendPostponedCourtDateEmailNotificationToRecipient(...)` helper.
- `defendantNotification.service.ts` / `civilClaimantNotification.service.ts` — the follow-up methods delegate to the shared helper (removed the arraignment-only logic and now-unused `DateLog` imports).

### Behaviour

- Future `ARRAIGNMENT_DATE` → arraignment invitation (wins even if a court date is also in the future)
- Future `COURT_DATE` only → court-session invitation (the fix)
- Neither in the future → nothing sent

### Tests

Added two spec files (15 tests) covering both defender and spokesperson: future court date, future arraignment only, both in the future (arraignment wins), nothing in the future, and party not confirmed.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added follow-up email handling for postponed court dates, including calendar invitations when available.
  * Enhanced emails so recipients with access can open a relevant case overview from the message.

* **Bug Fixes**
  * Follow-up notifications now select the most relevant future event more reliably.
  * Notifications are no longer sent when there is no eligible future date or the recipient confirmation is missing.

* **Tests**
  * Added coverage for civil claimant and defender court-date follow-up notification scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->