### PR TITLE
chore(j-s): reuse confirmed-representative model methods in file guards

### DIFF
--- a/apps/judicial-system/backend/src/app/modules/file/guards/civilClaimFileVisibility.ts
+++ b/apps/judicial-system/backend/src/app/modules/file/guards/civilClaimFileVisibility.ts
@@ -34,9 +34,10 @@ export const canDefenceUserViewCivilClaimCaseFile = (
   // The claimant's own confirmed spokesperson (lögmaður/réttargæslumaður) always
   // has standing (aðild) to their own civil claim, so they may view it.
   if (
-    claimant.hasSpokesperson &&
-    claimant.isSpokespersonConfirmed &&
-    claimant.spokespersonNationalId === defenderUserNationalId
+    CivilClaimant.isConfirmedSpokespersonOfCivilClaimant(
+      defenderUserNationalId,
+      [claimant],
+    )
   ) {
     return true
   }

--- a/apps/judicial-system/backend/src/app/modules/file/guards/limitedAccessCreateCivilClaimantCaseFile.guard.ts
+++ b/apps/judicial-system/backend/src/app/modules/file/guards/limitedAccessCreateCivilClaimantCaseFile.guard.ts
@@ -39,10 +39,9 @@ export class LimitedAccessCreateCivilClaimantCaseFileGuard
 
     // Verify the logged-in user is the confirmed spokesperson for this civil claimant
     if (
-      !civilClaimant.hasSpokesperson ||
-      !civilClaimant.isSpokespersonConfirmed ||
-      !civilClaimant.spokespersonNationalId ||
-      civilClaimant.spokespersonNationalId !== user.nationalId
+      !CivilClaimant.isConfirmedSpokespersonOfCivilClaimant(user.nationalId, [
+        civilClaimant,
+      ])
     ) {
       return false
     }

--- a/apps/judicial-system/backend/src/app/modules/file/guards/limitedAccessCreateDefendantCaseFile.guard.ts
+++ b/apps/judicial-system/backend/src/app/modules/file/guards/limitedAccessCreateDefendantCaseFile.guard.ts
@@ -37,9 +37,7 @@ export class LimitedAccessCreateDefendantCaseFileGuard implements CanActivate {
 
     // Verify the logged-in user is the confirmed defender for this defendant
     if (
-      !defendant.isDefenderChoiceConfirmed ||
-      !defendant.defenderNationalId ||
-      defendant.defenderNationalId !== user.nationalId
+      !Defendant.isConfirmedDefenderOfDefendant(user.nationalId, [defendant])
     ) {
       return false
     }

--- a/apps/judicial-system/backend/src/app/modules/file/guards/limitedAccessDeleteCaseFile.guard.ts
+++ b/apps/judicial-system/backend/src/app/modules/file/guards/limitedAccessDeleteCaseFile.guard.ts
@@ -13,7 +13,7 @@ import {
   User,
 } from '@island.is/judicial-system/types'
 
-import { Case, CaseFile } from '../../repository'
+import { Case, CaseFile, CivilClaimant, Defendant } from '../../repository'
 
 @Injectable()
 export class LimitedAccessDeleteCaseFileGuard implements CanActivate {
@@ -68,18 +68,16 @@ export class LimitedAccessDeleteCaseFileGuard implements CanActivate {
 
     if (
       (defendantId &&
-        theCase.defendants?.find(
-          (d) =>
-            d.id === caseFile.defendantId &&
-            d.isDefenderChoiceConfirmed &&
-            d.defenderNationalId === user.nationalId,
+        Defendant.isConfirmedDefenderOfDefendant(
+          user.nationalId,
+          theCase.defendants?.filter((d) => d.id === caseFile.defendantId),
         )) ||
       (civilClaimantId &&
-        theCase.civilClaimants?.find(
-          (c) =>
-            c.id === caseFile.civilClaimantId &&
-            c.isSpokespersonConfirmed &&
-            c.spokespersonNationalId === user.nationalId,
+        CivilClaimant.isConfirmedSpokespersonOfCivilClaimant(
+          user.nationalId,
+          theCase.civilClaimants?.filter(
+            (c) => c.id === caseFile.civilClaimantId,
+          ),
         ))
     ) {
       // The user controls this case file

--- a/apps/judicial-system/backend/src/app/modules/file/guards/test/limitedAccessDeleteCaseFileGuard.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/file/guards/test/limitedAccessDeleteCaseFileGuard.spec.ts
@@ -157,6 +157,7 @@ describe('LimitedAccess Delete Case File Guard', () => {
               civilClaimants: [
                 {
                   id: civilClaimantId,
+                  hasSpokesperson: true,
                   isSpokespersonConfirmed: true,
                   spokespersonNationalId: nationalId,
                 },


### PR DESCRIPTION
# Reuse confirmed-representative model methods in file guards

[Betrumbæta tékk fyrir staðfesta verjendur og talsmenn](https://app.asana.com/1/203394141643832/project/1199153462262248/task/1216234302245278)

The limited-access file guards each duplicated the "is this national id the
confirmed defender / spokesperson of this party" predicate inline. This replaces
those with the shared model methods `Defendant.isConfirmedDefenderOfDefendant` /
`CivilClaimant.isConfirmedSpokespersonOfCivilClaimant`, so the rule lives in one
place.

## What changed

- `limitedAccessCreateDefendantCaseFile.guard.ts` /
  `limitedAccessCreateCivilClaimantCaseFile.guard.ts` — the single-party
  confirmation checks become `!isConfirmedDefenderOfDefendant(...)` /
  `!isConfirmedSpokespersonOfCivilClaimant(...)`.
- `limitedAccessDeleteCaseFile.guard.ts` — the per-party `.find` checks become
  the model methods over the id-filtered party.
- `civilClaimFileVisibility.ts` — the claimant's-own-spokesperson branch uses the
  model method.

## Latent gap closed

The delete guard's civil-claimant check omitted `hasSpokesperson` (which the model
method enforces), so a civil claimant with `isSpokespersonConfirmed` but no
spokesperson would have passed. Reusing the method closes that; the delete-guard
test fixture now sets `hasSpokesperson` on the confirmed spokesperson to match.

## Not changed

The notification services also read these fields, but for a different purpose —
collecting *all* confirmed representatives' emails, with no target national id —
so the methods don't apply there. Left as-is.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file access checks for civil claimants and defendants, so confirmed spokespersons and defenders are recognized more reliably.
  * Fixed limited-access file deletion rules to better match the user’s role and case-file relationship.
* **Tests**
  * Updated test coverage to reflect the revised access-control behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->