### PR TITLE
feat(j-s): show case handling comments on court indictment overview

### DIFF
--- a/apps/judicial-system/web/src/routes/Court/Indictments/Overview/Overview.spec.tsx
+++ b/apps/judicial-system/web/src/routes/Court/Indictments/Overview/Overview.spec.tsx
@@ -93,6 +93,37 @@ describe('Court Indictment Overview', () => {
     )
   })
 
+  it('shows case handling comments when present', () => {
+    const caseWithComments: Case = {
+      ...mockCase(CaseType.INDICTMENT),
+      state: CaseState.RECEIVED,
+      comments: 'Flýtimeðferð',
+    }
+    const getCase = jest.fn()
+
+    renderOverview(caseWithComments, UserRole.DISTRICT_COURT_JUDGE, getCase)
+
+    expect(
+      screen.getByText('Athugasemdir vegna málsmeðferðar'),
+    ).toBeInTheDocument()
+    expect(screen.getByText('Flýtimeðferð')).toBeInTheDocument()
+  })
+
+  it('does not show case handling comments when absent', () => {
+    const receivedCase: Case = {
+      ...mockCase(CaseType.INDICTMENT),
+      state: CaseState.RECEIVED,
+      comments: null,
+    }
+    const getCase = jest.fn()
+
+    renderOverview(receivedCase, UserRole.DISTRICT_COURT_JUDGE, getCase)
+
+    expect(
+      screen.queryByText('Athugasemdir vegna málsmeðferðar'),
+    ).not.toBeInTheDocument()
+  })
+
   it('does not show the cancellation modal for a received indictment', async () => {
     const receivedCase: Case = {
       ...mockCase(CaseType.INDICTMENT),

--- a/apps/judicial-system/web/src/routes/Court/Indictments/Overview/Overview.tsx
+++ b/apps/judicial-system/web/src/routes/Court/Indictments/Overview/Overview.tsx
@@ -19,8 +19,8 @@ import {
   isCompletedCase,
   isDistrictCourtUser,
 } from '@island.is/judicial-system/types'
-import { commentsInput } from '@island.is/judicial-system-web/messages/Core/commentsInput'
 import { core, titles } from '@island.is/judicial-system-web/messages'
+import { commentsInput } from '@island.is/judicial-system-web/messages/Core/commentsInput'
 import {
   AppealRulingModifiedAlert,
   ConnectedCaseFilesAccordionItem,

--- a/apps/judicial-system/web/src/routes/Court/Indictments/Overview/Overview.tsx
+++ b/apps/judicial-system/web/src/routes/Court/Indictments/Overview/Overview.tsx
@@ -19,6 +19,7 @@ import {
   isCompletedCase,
   isDistrictCourtUser,
 } from '@island.is/judicial-system/types'
+import { commentsInput } from '@island.is/judicial-system-web/messages/Core/commentsInput'
 import { core, titles } from '@island.is/judicial-system-web/messages'
 import {
   AppealRulingModifiedAlert,
@@ -74,6 +75,13 @@ const OverviewBody = ({
         <CourtCaseInfo workingCase={workingCase} />
         <ServiceAnnouncements defendants={workingCase.defendants} />
         <div className={grid({ gap: 5, marginBottom: 10 })}>
+          {workingCase.comments && (
+            <AlertMessage
+              title={formatMessage(commentsInput.heading)}
+              message={workingCase.comments}
+              type="warning"
+            />
+          )}
           <AppealRulingModifiedAlert />
           {workingCase.reopenReason && !isCompletedCase(workingCase.state) && (
             <AlertMessage


### PR DESCRIPTION
Attach a link to issue if relevant

## What

Show the yellow warning alert for prosecution case-handling comments (`workingCase.comments`) on the district court indictment case overview page, matching the existing pattern on the reception and assignment step.

## Why

Judges and other court users who open a case from the overview need to see comments about case handling (e.g. expedited processing), not only the person assigning the case on reception and assignment.

## Screenshots / Gifs

N/A

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Cursor

Made with [Cursor](https://cursor.com)