### PR TITLE
fix(island-ui): associate Select label with its input element

### DIFF
--- a/libs/island-ui/core/src/lib/Select/Components/index.tsx
+++ b/libs/island-ui/core/src/lib/Select/Components/index.tsx
@@ -297,7 +297,7 @@ export const Control = <
   const { size = 'md' } = props.selectProps
   const label = (
     <label
-      htmlFor={props.selectProps.name}
+      htmlFor={props.selectProps.inputId ?? props.selectProps.name}
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore make web strict
       className={cn(styles.label, styles.labelSizes[size], {

--- a/libs/island-ui/core/src/lib/Select/Select.tsx
+++ b/libs/island-ui/core/src/lib/Select/Select.tsx
@@ -80,6 +80,7 @@ export const Select = <
     >
       <CreatableReactSelect<OptionType<Value>, IsMulti, Group>
         instanceId={id}
+        inputId={`${id}-input`}
         aria-labelledby={id}
         ariaError={ariaError}
         noOptionsMessage={() => noOptionsMessage || null}
@@ -148,6 +149,7 @@ export const Select = <
     >
       <ReactSelect<OptionType<Value>, IsMulti, Group>
         instanceId={id}
+        inputId={`${id}-input`}
         aria-labelledby={id}
         ariaError={ariaError}
         noOptionsMessage={() => noOptionsMessage || null}


### PR DESCRIPTION
## What

Fix the label/input association in the `Select` component (and its creatable variant):

- Pass `inputId={`${id}-input`}` to react-select so the inner `<input>` element gets a real, unique id.
- Point the label's `htmlFor` at that input id instead of `name`.

## Why

The label rendered `htmlFor={name}`, but no element ever carried that id — react-select places the `id` prop on its outer container `<div>` and only gives the actual `<input>` an id via the `inputId` prop, which was never passed. As a result:

- Browsers logged the warning **"Incorrect use of \<label for=FORM_ELEMENT\>"** on every page using `Select` (the `for` attribute pointed at nothing, or at a non-labelable `<div>` when `id` defaulted to `name`).
- Clicking the label did not focus the select, since the association was broken.

The container `<div>` keeps its existing `id`, so consumers relying on `document.getElementById` with the select's id are unaffected. `CountryCodeSelect` has its own copy of these components without a label and is not affected.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved label-to-input association in the Select component for more reliable keyboard and accessibility behavior.
  * Kept the Select field’s internal input ID consistent across both standard and creatable variants, helping validation and error messaging connect correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->