### PR TITLE
fix(j-s): unique form field ids per indictment count

### DIFF
--- a/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Indictment/IndictmentCount.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Indictment/IndictmentCount.tsx
@@ -520,6 +520,7 @@ export const IndictmentCount: FC<Props> = ({
           />
           <Box marginBottom={2}>
             <Input
+              id={`vehicleRegistrationNumber-${indictmentCount.id}`}
               name="vehicleRegistrationNumber"
               autoComplete="off"
               label={formatMessage(strings.vehicleRegistrationNumberLabel)}
@@ -573,6 +574,7 @@ export const IndictmentCount: FC<Props> = ({
                   marginBottom={2}
                 />
                 <Select
+                  id={`lawsBroken-${indictmentCount.id}`}
                   name="lawsBroken"
                   options={lawsBrokenOptions}
                   label={formatMessage(strings.lawsBrokenLabel)}
@@ -652,6 +654,7 @@ export const IndictmentCount: FC<Props> = ({
         />
         <Box marginBottom={2}>
           <Input
+            id={`incidentDescription-${indictmentCount.id}`}
             name="incidentDescription"
             autoComplete="off"
             label={formatMessage(strings.incidentDescriptionLabel)}
@@ -698,6 +701,7 @@ export const IndictmentCount: FC<Props> = ({
         />
 
         <Input
+          id={`legalArguments-${indictmentCount.id}`}
           name="legalArguments"
           autoComplete="off"
           label={formatMessage(strings.legalArgumentsLabel)}

--- a/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Indictment/Offenses/Offenses.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Indictment/Offenses/Offenses.tsx
@@ -220,6 +220,7 @@ export const Offenses = ({
           marginBottom={2}
         />
         <Select
+          id={`offenses-${indictmentCount.id}`}
           name="offenses"
           options={offensesOptions}
           label={formatMessage(strings.incidentLabel)}
@@ -319,6 +320,7 @@ export const Offenses = ({
                 alcoholValue,
               )
             }}
+            id={`alcohol-${indictmentCount.id}`}
             name="alcohol"
             autoComplete="off"
             label={formatMessage(strings.bloodAlcoholContentLabel)}

--- a/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Indictment/Offenses/SpeedingOffenseFields.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Indictment/Offenses/SpeedingOffenseFields.tsx
@@ -81,6 +81,7 @@ export const SpeedingOffenseFields = ({
 
             handleIndictmentCountChanges({ recordedSpeed })
           }}
+          id={`recordedSpeed-${indictmentCount.id}`}
           name="recordedSpeed"
           autoComplete="off"
           label={formatMessage(strings.recordedSpeedLabel)}
@@ -121,6 +122,7 @@ export const SpeedingOffenseFields = ({
 
           handleIndictmentCountChanges({ speedLimit })
         }}
+        id={`speedLimit-${indictmentCount.id}`}
         name="speedLimit"
         autoComplete="off"
         label={formatMessage(strings.speedLimitLabel)}


### PR DESCRIPTION
## What

Give every form field rendered per indictment count an explicit DOM id scoped to the count's id (e.g. `incidentDescription-${indictmentCount.id}`):

- `IndictmentCount`: `incidentDescription`, `legalArguments`, `vehicleRegistrationNumber`, `lawsBroken`
- `Offenses`: `offenses`, `alcohol`
- `SpeedingOffenseFields`: `recordedSpeed`, `speedLimit`

The `name` props are unchanged, and the `policeCaseNumber` select keeps its existing unique `id={indictmentCount.id}` (it is referenced by `getElementById` for scroll-into-view).

## Why

The island-ui `Input` and `Select` components default their DOM `id` to the `name` prop. Since `IndictmentCount` is rendered once per count in the indictment counts list, every count produced elements with identical ids, triggering the browser console warning "Duplicate form field id in the same form" for `incidentDescription` and `legalArguments` — and latently for the traffic-violation fields whenever two counts show them.

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code
- [ ] No AI tools were used in preparing this pull request

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved form field labeling and accessibility by adding stable, unique IDs to several indictment and offense inputs.
  * Made key fields easier to target for browser autofill, testing, and assistive technologies.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->