### PR TITLE
fix(j-s): Prevent false all-files-uploaded message in police case files

### DIFF
--- a/apps/judicial-system/web/src/routes/Prosecutor/Indictments/PoliceCaseFiles/UploadFilesToPoliceCase.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/Indictments/PoliceCaseFiles/UploadFilesToPoliceCase.tsx
@@ -57,9 +57,14 @@ const UploadFilesToPoliceCase: FC<UploadFilesToPoliceCaseProps> = ({
 
   const [isUploadingPoliceCaseFiles, setIsUploadingPoliceCaseFiles] =
     useState<boolean>(false)
-  const [policeCaseFileList, setPoliceCaseFileList] = useState<
-    PoliceCaseFileCheck[]
-  >([])
+
+  const policeCaseFileList = useMemo(
+    () =>
+      policeCaseFilesData.files
+        .filter((file) => !uploadFiles.some((f) => f.policeFileId === file.id))
+        .map(mapPoliceCaseFileToPoliceCaseFileCheck),
+    [policeCaseFilesData.files, uploadFiles],
+  )
 
   const errorMessage = useMemo(() => {
     if (uploadFiles.some((file) => file.status === FileUploadStatus.error)) {
@@ -76,48 +81,10 @@ const UploadFilesToPoliceCase: FC<UploadFilesToPoliceCaseProps> = ({
     setAllUploaded(allFilesDoneOrError && !isUploadingPoliceCaseFiles)
   }, [allFilesDoneOrError, isUploadingPoliceCaseFiles, setAllUploaded])
 
-  useEffect(() => {
-    if (policeCaseFilesData.files?.length === 0) {
-      return
-    }
-
-    setPoliceCaseFileList(
-      policeCaseFilesData.files
-        ?.filter(
-          (file) =>
-            !caseFiles.some((caseFile) => caseFile.policeFileId === file.id),
-        )
-        .map(mapPoliceCaseFileToPoliceCaseFileCheck) ?? [],
-    )
-  }, [caseFiles, policeCaseFilesData.files, policeCaseNumber])
-
   const uploadPoliceCaseFileCallback = (file: TUploadFile, id?: string) => {
     if (id) {
-      addUploadFile({ ...file, id: id ?? file.id })
+      addUploadFile({ ...file, id })
     }
-
-    setPoliceCaseFileList((previous) =>
-      id
-        ? previous.filter((p) => p.id !== file.id)
-        : previous.map((p) =>
-            p.id === file.id ? { ...p, checked: false } : p,
-          ),
-    )
-  }
-
-  const removeFileCB = (file: TUploadFile) => {
-    const policeCaseFile = policeCaseFilesData.files.find(
-      (f) => f.id === file.policeFileId,
-    )
-
-    if (policeCaseFile) {
-      setPoliceCaseFileList((previous) => [
-        mapPoliceCaseFileToPoliceCaseFileCheck(policeCaseFile),
-        ...previous,
-      ])
-    }
-
-    removeUploadFile(file)
   }
 
   const onPoliceCaseFileUpload = async (selectedFiles: Item[]) => {
@@ -204,7 +171,7 @@ const UploadFilesToPoliceCase: FC<UploadFilesToPoliceCaseProps> = ({
           )
         }
         onOpenFile={(file) => onOpenFile(file)}
-        onRemove={(file) => handleRemove(file, removeFileCB)}
+        onRemove={(file) => handleRemove(file, removeUploadFile)}
         onRetry={(file) => handleRetry(file, updateUploadFile)}
         errorMessage={errorMessage}
       />

--- a/apps/judicial-system/web/src/routes/Prosecutor/components/CaseFiles/CaseFiles.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/components/CaseFiles/CaseFiles.tsx
@@ -42,7 +42,6 @@ import { grid } from '@island.is/judicial-system-web/src/utils/styles/recipes.cs
 
 import {
   mapPoliceCaseFileToPoliceCaseFileCheck,
-  PoliceCaseFileCheck,
   PoliceCaseFiles,
   PoliceCaseFilesData,
 } from '../../components'
@@ -69,9 +68,6 @@ export const CaseFiles = () => {
     useState<boolean>(false)
   const [editCount, setEditCount] = useState(0)
   const [updateFilesMutation] = useUpdateFilesReorderableMutation()
-  const [policeCaseFileList, setPoliceCaseFileList] = useState<
-    PoliceCaseFileCheck[]
-  >([])
   const [policeCaseFiles, setPoliceCaseFiles] = useState<PoliceCaseFilesData>()
   const {
     uploadFiles,
@@ -130,18 +126,18 @@ export const CaseFiles = () => {
     }
   }, [policeData, policeDataError, policeDataLoading, workingCase.origin])
 
-  useEffect(() => {
-    setPoliceCaseFileList(
+  const policeCaseFileList = useMemo(
+    () =>
       policeCaseFiles?.files
         .filter(
           (policeFile) =>
-            !workingCase.caseFiles?.some(
+            !uploadFiles.some(
               (file) => !file.category && file.policeFileId === policeFile.id,
             ),
         )
-        .map(mapPoliceCaseFileToPoliceCaseFileCheck) || [],
-    )
-  }, [policeCaseFiles, workingCase.caseFiles])
+        .map(mapPoliceCaseFileToPoliceCaseFileCheck) ?? [],
+    [policeCaseFiles, uploadFiles],
+  )
 
   const uploadErrorMessage = useMemo(() => {
     if (uploadFiles.some((file) => file.status === FileUploadStatus.error)) {
@@ -226,14 +222,6 @@ export const CaseFiles = () => {
     if (newId) {
       addUploadFile({ ...file, id: newId })
     }
-
-    setPoliceCaseFileList((previous) =>
-      newId
-        ? previous.filter((p) => p.id !== file.id)
-        : previous.map((p) =>
-            p.id === file.id ? { ...p, checked: false } : p,
-          ),
-    )
   }
 
   const handlePoliceCaseFileUpload = async (selectedFiles: Item[]) => {
@@ -255,21 +243,6 @@ export const CaseFiles = () => {
     await handleUploadFromPolice(filesToUpload, uploadPoliceCaseFileCallback)
 
     setIsUploadingPoliceCaseFiles(false)
-  }
-
-  const removeFileCB = (file: TUploadFile) => {
-    const policeCaseFile = policeCaseFiles?.files.find(
-      (f) => f.id === file.policeFileId,
-    )
-
-    if (policeCaseFile) {
-      setPoliceCaseFileList((previous) => [
-        mapPoliceCaseFileToPoliceCaseFileCheck(policeCaseFile),
-        ...previous,
-      ])
-    }
-
-    removeUploadFile(file)
   }
 
   return (
@@ -328,7 +301,7 @@ export const CaseFiles = () => {
               onFilesChange={(files) =>
                 handleUpload(addUploadFiles(files), updateUploadFile)
               }
-              onRemove={(file) => handleRemove(file, removeFileCB)}
+              onRemove={(file) => handleRemove(file, removeUploadFile)}
               onRetry={(file) => handleRetry(file, updateUploadFile)}
               onOpenFile={(file) => onOpenFile(file)}
               onReorder={handleReorder}

--- a/apps/judicial-system/web/src/routes/Prosecutor/components/PoliceCaseFiles/PoliceCaseFiles.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/components/PoliceCaseFiles/PoliceCaseFiles.tsx
@@ -86,6 +86,9 @@ const PoliceCaseFiles: FC<Props> = ({
           : policeCaseFiles?.isLoading
       }
       successMessage={
+        !policeCaseFiles?.isLoading &&
+        policeCaseFiles &&
+        policeCaseFiles.files.length > 0 &&
         policeCaseFileList?.length === 0
           ? formatMessage(strings.allFilesUploadedMessage)
           : undefined


### PR DESCRIPTION
## What

- The "all files uploaded" success message in the police case files list (`PoliceCaseFiles`) now only shows when the LOKE query has finished loading, actually returned files, and none remain to upload — mirroring the `!isLoading` guard added to the warning message in #23001.
- `policeCaseFileList` is now derived with `useMemo` from the LOKE files and `uploadFiles` in both `CaseFiles` and `UploadFilesToPoliceCase`, replacing the `useState` + `useEffect` pattern. Since `uploadFiles` is already updated on upload (`addUploadFile`) and removal (`removeUploadFile`), the manual list bookkeeping in the upload callbacks and `removeFileCB` became redundant and was removed. A dead `checked: false` update was also dropped — `SelectableList` maintains its own selection state and never receives the parent's `checked` flag.

## Why

An empty `policeCaseFileList` does not mean all files have been uploaded — the list is also empty while the LOKE query is loading, when LOKE returns no files, and for one render after the data lands but before the populating effect ran. In those windows a false "all files uploaded" success message could flash. Deriving the list in the same render as its sources removes the stale-frame window entirely, and the added guards make the success condition mean what it says.

## Screenshots / Gifs
Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code
- [ ] No AI tools were used in preparing this pull request