### PR TITLE
feat(j-s): Make "Mættir eru" editable in indictment court record

### DIFF
--- a/apps/judicial-system/backend/src/app/formatters/generatedPdfs/indictmentCourtRecordPdf.ts
+++ b/apps/judicial-system/backend/src/app/formatters/generatedPdfs/indictmentCourtRecordPdf.ts
@@ -224,10 +224,8 @@ export const createIndictmentCourtRecordPdf = (
     }
 
     addEmptyLines(doc)
-    addNormalText(doc, 'Mættir eru:', 'Times-Bold')
     addNormalText(
       doc,
-      // Must use || here as we want to display a default message if the file has no content
       courtSession.attendees?.trim() || 'Enginn er mættur í þinghaldið.',
       'Times-Roman',
     )

--- a/apps/judicial-system/web/src/routes/Court/Indictments/CourtRecord/CourtSessionAccordionItem.tsx
+++ b/apps/judicial-system/web/src/routes/Court/Indictments/CourtRecord/CourtSessionAccordionItem.tsx
@@ -339,7 +339,7 @@ const CourtSessionAccordionItem: FC<Props> = (props) => {
       })
     }
 
-    return attendees.length > 0 ? attendees.join('') : undefined
+    return `Mættir eru\n${attendees.join('')}`
   }, [workingCase.prosecutor, workingCase.defendants])
 
   const initialize = useCallback(() => {
@@ -1005,7 +1005,6 @@ const CourtSessionAccordionItem: FC<Props> = (props) => {
               <Input
                 data-testid="courtAttendees"
                 name="courtAttendees"
-                label="Mættir eru"
                 value={courtSession.attendees ?? getInitialAttendees()}
                 placeholder="Skrifa hér..."
                 onChange={(event) => {


### PR DESCRIPTION
## What

- Remove the fixed "Mættir eru" label from the attendees textarea in indictment court records
- Pre-fill "Mættir eru" as editable text at the top of the field so judges can keep or remove it
- Remove the corresponding bold heading from the indictment court record PDF (the heading is now part of the text content)

## Why

Judges reported that the fixed "Mættir eru" heading is awkward in cases where the defendant does not appear. Making it editable gives judges flexibility to adjust the text as needed.

## Screenshots / Gifs

N/A

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Cursor


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated court session attendee text to display more consistently in both the form and the generated court record.
  * Improved the initial attendee value so it is always shown with a clear heading, and removed a duplicate label from the input area.
  * When no attendees are entered, the existing fallback message continues to appear.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->