### PR TITLE
fix(j-s): Show all police case numbers on info card for defenders

### DIFF
--- a/apps/judicial-system/backend/src/app/modules/case/interceptors/limitedAccessCaseFile.interceptor.ts
+++ b/apps/judicial-system/backend/src/app/modules/case/interceptors/limitedAccessCaseFile.interceptor.ts
@@ -7,19 +7,12 @@ import {
   NestInterceptor,
 } from '@nestjs/common'
 
-import {
-  CaseFileCategory,
-  isDefenceUser,
-  isIndictmentCase,
-  User,
-} from '@island.is/judicial-system/types'
+import { CaseFileCategory, User } from '@island.is/judicial-system/types'
 
 import {
   canLimitedAccessUserViewCaseFile,
-  getDefenceUserVisiblePoliceCaseNumbers,
   isRulingOrderInConfirmedCourtSession,
 } from '../../file'
-import { CivilClaimant, Defendant } from '../../repository'
 
 @Injectable()
 export class LimitedAccessCaseFileInterceptor implements NestInterceptor {
@@ -64,33 +57,9 @@ export class LimitedAccessCaseFileInterceptor implements NestInterceptor {
             }),
         )
 
-        let policeCaseNumbers = theCase.policeCaseNumbers
-
-        if (
-          isDefenceUser(user) &&
-          isIndictmentCase(theCase.type) &&
-          theCase.policeCaseNumbers &&
-          (Defendant.isConfirmedDefenderOfDefendant(
-            user.nationalId,
-            theCase.defendants,
-          ) ||
-            CivilClaimant.isConfirmedSpokespersonOfCivilClaimantWithCaseFileAccess(
-              user.nationalId,
-              theCase.civilClaimants,
-            ))
-        ) {
-          policeCaseNumbers = getDefenceUserVisiblePoliceCaseNumbers(
-            user.nationalId,
-            theCase.defendants,
-            theCase.civilClaimants,
-            theCase.policeCaseNumbers,
-          )
-        }
-
         return {
           ...theCase,
           caseFiles,
-          policeCaseNumbers,
         }
       }),
     )

--- a/apps/judicial-system/backend/src/app/modules/case/interceptors/test/limitedAccessCaseFile.interceptor.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/case/interceptors/test/limitedAccessCaseFile.interceptor.spec.ts
@@ -344,61 +344,6 @@ describe('LimitedAccessCaseFileInterceptor', () => {
     })
   })
 
-  describe('police case number filtering', () => {
-    describe.each(indictmentCases)('for %s cases', (type) => {
-      describe('spokesperson assigned to civil claimant', () => {
-        let then: Then
-
-        beforeEach(async () => {
-          const nationalId = uuid()
-          const spokespersonPoliceCaseNumber = '007-2026-1'
-          const otherPoliceCaseNumber = '007-2026-2'
-          const unassignedPoliceCaseNumber = '007-2026-3'
-          const theCase = {
-            type: type as CaseType,
-            state: CaseState.COMPLETED,
-            policeCaseNumbers: [
-              spokespersonPoliceCaseNumber,
-              otherPoliceCaseNumber,
-              unassignedPoliceCaseNumber,
-            ],
-            defendants: [
-              {
-                id: uuid(),
-                defenderNationalId: uuid(),
-                isDefenderChoiceConfirmed: true,
-                policeCaseNumbers: [otherPoliceCaseNumber],
-              },
-            ],
-            civilClaimants: [
-              {
-                id: uuid(),
-                hasSpokesperson: true,
-                isSpokespersonConfirmed: true,
-                caseFilesSharedWithSpokesperson: true,
-                spokespersonNationalId: nationalId,
-                policeCaseNumbers: [spokespersonPoliceCaseNumber],
-              },
-            ],
-            caseFiles: [],
-          }
-
-          mockRequest.mockImplementationOnce(() => ({
-            user: { currentUser: { role: UserRole.DEFENDER, nationalId } },
-          }))
-          mockHandle.mockReturnValueOnce(of(theCase))
-
-          then = await givenWhenThen()
-        })
-
-        it('should only include spokesperson-visible police case numbers', () => {
-          const result = then.result as { policeCaseNumbers: string[] }
-          expect(result.policeCaseNumbers).toEqual(['007-2026-1', '007-2026-3'])
-        })
-      })
-    })
-  })
-
   describe('DEFENDANT_RULING filtering', () => {
     describe.each(indictmentCases)('for %s cases', (type) => {
       describe('defender is always denied access to DEFENDANT_RULING files', () => {


### PR DESCRIPTION
https://app.asana.com/0/1199153462262248/1214565770353789

## What

Remove police case number filtering from `LimitedAccessCaseFileInterceptor` so defenders see all LÖKE numbers on the info card, not just the ones associated with their client.

## Why

When a case has multiple defendants and LÖKE numbers, defenders currently only see the LÖKE numbers their client is associated with on the info card. The ticket requests that all LÖKE numbers be visible on the info card regardless of which defendant they belong to. File visibility (the data package) remains correctly scoped — `IndictmentCaseFilesList` has its own independent filtering logic.

## Screenshots / Gifs

N/A

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Cursor


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved case file access handling so only permitted files are returned.
  * Simplified visible case information by removing an outdated police case number adjustment for limited-access views.
  * Updated automated coverage to match the current access behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->