### PR TITLE
chore(j-s): Document shared-code-in-lib rule in AGENTS.md

### DIFF
--- a/apps/judicial-system/AGENTS.md
+++ b/apps/judicial-system/AGENTS.md
@@ -1,5 +1,15 @@
 # Judicial System — Agent Guide
 
+## Shared code
+
+**Code used across services must live in the shared libs**
+(`libs/judicial-system/*`), never be duplicated per app. If a function is
+needed by more than one project — e.g. both `web` and `backend` — put it in
+the appropriate lib (`@island.is/judicial-system/formatters`,
+`@island.is/judicial-system/types`, ...) and import it from there. When you
+find yourself copying an existing function into another project, move it to a
+lib instead.
+
 ## Localization strings
 
 We are moving away from Contentful. **Do not add new strings to `.strings.ts`


### PR DESCRIPTION
## What

Add a "Shared code" section to the judicial system agent guide (`AGENTS.md`) stating that code used across services must live in the shared libs (`libs/judicial-system/*`) rather than being duplicated per app.

## Why

A utility function was recently duplicated in both `web` and `backend`. Documenting the rule in `AGENTS.md` steers AI tools (and readers) toward the shared libs from the start.

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code
- [ ] No AI tools were used in preparing this pull request