### PR TITLE
fix(j-s): Fix spacing below defendant list on indictment defendant page

### DIFF
--- a/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Defendant/Defendant.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Defendant/Defendant.tsx
@@ -110,7 +110,9 @@ const Defendant = () => {
           <ProsecutorSection />
         </Box>
         <PoliceCaseList />
-        <DefendantList />
+        <Box component="section" marginBottom={10}>
+          <DefendantList />
+        </Box>
       </FormContentContainer>
       <FormContentContainer isFooter>
         <FormFooter

--- a/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Defendant/DefendantList/DefendantList.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Defendant/DefendantList/DefendantList.tsx
@@ -129,7 +129,7 @@ export const DefendantList = () => {
   }
 
   return (
-    <Box component="section" marginBottom={5}>
+    <>
       <Box
         display="flex"
         alignItems="center"
@@ -180,6 +180,6 @@ export const DefendantList = () => {
           {formatMessage(strings.addDefendantButtonText)}
         </Button>
       </Box>
-    </Box>
+    </>
   )
 }


### PR DESCRIPTION
## What
Move the section wrapper for the defendant list from `DefendantList` up to the parent `Defendant` page component, and increase the bottom margin from 5 to 10.

## Why
The spacing below the defendant list on the indictment defendant page was too small, and the page-level section spacing belongs to the page layout rather than the reusable `DefendantList` component.

## Screenshots / Gifs
Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code
- [ ] No AI tools were used in preparing this pull request

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted spacing and layout on the defendant selection screen for a cleaner, more consistent display.
  * Improved section structure around the defendant list, which may reduce visual spacing issues in the indictment flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->