### PR TITLE
fix(j-s): deliver court record to LÖKE when cancellation-completed

### DIFF
--- a/apps/judicial-system/backend/src/app/modules/case/case.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/case/case.service.ts
@@ -1078,6 +1078,14 @@ export class CaseService {
         if (isIndictment) {
           if (theCase.state === CaseState.WAITING_FOR_CANCELLATION) {
             this.addMessagesForIndictmentConclusionToQueue(updatedCase, user)
+
+            if (updatedCase.origin === CaseOrigin.LOKE) {
+              addMessagesToQueue({
+                type: MessageType.DELIVERY_TO_POLICE_INDICTMENT_CASE,
+                user,
+                caseId: updatedCase.id,
+              })
+            }
           } else {
             this.addMessagesForCompletedIndictmentCaseToQueue(updatedCase, user)
           }

--- a/apps/judicial-system/backend/src/app/modules/case/test/caseController/transition.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/case/test/caseController/transition.spec.ts
@@ -299,6 +299,7 @@ describe('CaseController - Transition', () => {
       ${CaseTransition.ASK_FOR_CANCELLATION} | ${CaseState.SUBMITTED}                | ${CaseState.WAITING_FOR_CANCELLATION}
       ${CaseTransition.ASK_FOR_CANCELLATION} | ${CaseState.RECEIVED}                 | ${CaseState.WAITING_FOR_CANCELLATION}
       ${CaseTransition.RECEIVE}              | ${CaseState.SUBMITTED}                | ${CaseState.RECEIVED}
+      ${CaseTransition.COMPLETE}             | ${CaseState.WAITING_FOR_CANCELLATION} | ${CaseState.COMPLETED}
       ${CaseTransition.COMPLETE}             | ${CaseState.RECEIVED}                 | ${CaseState.COMPLETED}
       ${CaseTransition.DELETE}               | ${CaseState.DRAFT}                    | ${CaseState.DELETED}
       ${CaseTransition.DELETE}               | ${CaseState.WAITING_FOR_CONFIRMATION} | ${CaseState.DELETED}
@@ -378,25 +379,38 @@ describe('CaseController - Transition', () => {
           )
 
           if (completedIndictmentCaseStates.includes(newState)) {
-            expect(mockQueuedMessages).toEqual([
-              {
-                type: MessageType.NOTIFICATION,
-                user: {
-                  ...defaultUser,
-                  canConfirmIndictment: isIndictmentCase(theCase.type),
+            if (oldState === CaseState.WAITING_FOR_CANCELLATION) {
+              expect(mockQueuedMessages).toEqual([
+                {
+                  type: MessageType.DELIVERY_TO_POLICE_INDICTMENT_CASE,
+                  user: {
+                    ...defaultUser,
+                    canConfirmIndictment: isIndictmentCase(theCase.type),
+                  },
+                  caseId,
                 },
-                caseId,
-                body: { type: RequestCaseNotificationType.RULING },
-              },
-              {
-                type: MessageType.DELIVERY_TO_POLICE_INDICTMENT_CASE,
-                user: {
-                  ...defaultUser,
-                  canConfirmIndictment: isIndictmentCase(theCase.type),
+              ])
+            } else {
+              expect(mockQueuedMessages).toEqual([
+                {
+                  type: MessageType.NOTIFICATION,
+                  user: {
+                    ...defaultUser,
+                    canConfirmIndictment: isIndictmentCase(theCase.type),
+                  },
+                  caseId,
+                  body: { type: RequestCaseNotificationType.RULING },
                 },
-                caseId,
-              },
-            ])
+                {
+                  type: MessageType.DELIVERY_TO_POLICE_INDICTMENT_CASE,
+                  user: {
+                    ...defaultUser,
+                    canConfirmIndictment: isIndictmentCase(theCase.type),
+                  },
+                  caseId,
+                },
+              ])
+            }
           } else if (
             newState === CaseState.DELETED &&
             !isIndictmentCase(theCase.type)


### PR DESCRIPTION
[Asana](https://app.asana.com/0/0/1213290103272292/f)


## Summary

When an indictment case completed from `WAITING_FOR_CANCELLATION` state, the `DELIVERY_TO_POLICE_INDICTMENT_CASE` message was not queued, so the court record and verdict were never delivered to LÖKE. This affected split cases (Case B split from Case A) and any other indictment case completing through the cancellation path.

- Adds `DELIVERY_TO_POLICE_INDICTMENT_CASE` to the cancellation-completion path in `addMessagesForUpdatedCaseToQueue`
- Adds `WAITING_FOR_CANCELLATION → COMPLETED` transition to the test matrix
- Test verifies the police delivery message is queued for cancellation-completed cases

## Test plan

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Cursor



Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated completed indictment case transitions so cases coming from a waiting-for-cancellation state now trigger the correct police delivery message.
  * Refined transition behavior for indictment cases to match the expected final state when cancellation waiting is resolved.
  
* **Tests**
  * Expanded transition coverage for indictment cases to include the waiting-for-cancellation completion path.
  * Adjusted expected queued messages to reflect the updated case flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->