### PR TITLE
feat(j-s): Send revocation email to court officials for request cases

### DIFF
--- a/apps/judicial-system/backend/src/app/messages/notifications.ts
+++ b/apps/judicial-system/backend/src/app/messages/notifications.ts
@@ -698,21 +698,6 @@ export const notifications = {
       description: 'Texti í pósti til dómstóls þegar ákæra er afturkölluð',
     },
   }),
-  courtRevokedRequestCaseEmail: defineMessages({
-    subject: {
-      id: 'judicial.system.backend:notifications.court_revoked_request_case_email.subject',
-      defaultMessage: 'Krafa afturkölluð í máli {courtCaseNumber}',
-      description:
-        'Fyrirsögn í pósti til dómstóls þegar krafa í R-máli er afturkölluð',
-    },
-    body: {
-      id: 'judicial.system.backend:notifications.court_revoked_request_case_email.body',
-      defaultMessage:
-        '{prosecutorsOffice} hefur afturkallað kröfu í máli {courtCaseNumber}.',
-      description:
-        'Texti í pósti til dómstóls þegar krafa í R-máli er afturkölluð',
-    },
-  }),
   caseFilesUpdated: defineMessages({
     subject: {
       id: 'judicial.system.backend:notifications.case_files_updated.subject',

--- a/apps/judicial-system/backend/src/app/messages/notifications.ts
+++ b/apps/judicial-system/backend/src/app/messages/notifications.ts
@@ -698,6 +698,21 @@ export const notifications = {
       description: 'Texti í pósti til dómstóls þegar ákæra er afturkölluð',
     },
   }),
+  courtRevokedRequestCaseEmail: defineMessages({
+    subject: {
+      id: 'judicial.system.backend:notifications.court_revoked_request_case_email.subject',
+      defaultMessage: 'Krafa afturkölluð í máli {courtCaseNumber}',
+      description:
+        'Fyrirsögn í pósti til dómstóls þegar krafa í R-máli er afturkölluð',
+    },
+    body: {
+      id: 'judicial.system.backend:notifications.court_revoked_request_case_email.body',
+      defaultMessage:
+        '{prosecutorsOffice} hefur afturkallað kröfu í máli {courtCaseNumber}.',
+      description:
+        'Texti í pósti til dómstóls þegar krafa í R-máli er afturkölluð',
+    },
+  }),
   caseFilesUpdated: defineMessages({
     subject: {
       id: 'judicial.system.backend:notifications.case_files_updated.subject',

--- a/apps/judicial-system/backend/src/app/modules/notification/services/caseNotification/caseNotification.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/services/caseNotification/caseNotification.service.ts
@@ -1595,17 +1595,8 @@ export class CaseNotificationService extends BaseNotificationService {
     recipientName?: string,
     recipientEmail?: string,
   ): Promise<Recipient> {
-    const subject = this.formatMessage(
-      notifications.courtRevokedRequestCaseEmail.subject,
-      { courtCaseNumber: theCase.courtCaseNumber },
-    )
-    const body = this.formatMessage(
-      notifications.courtRevokedRequestCaseEmail.body,
-      {
-        prosecutorsOffice: theCase.creatingProsecutor?.institution?.name,
-        courtCaseNumber: theCase.courtCaseNumber,
-      },
-    )
+    const subject = `Krafa afturkölluð í máli ${theCase.courtCaseNumber}`
+    const body = `${theCase.creatingProsecutor?.institution?.name} hefur afturkallað kröfu í máli ${theCase.courtCaseNumber}.`
 
     return this.sendEmail({
       subject,

--- a/apps/judicial-system/backend/src/app/modules/notification/services/caseNotification/caseNotification.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/services/caseNotification/caseNotification.service.ts
@@ -1590,6 +1590,32 @@ export class CaseNotificationService extends BaseNotificationService {
     })
   }
 
+  private sendRevokedEmailNotificationToCourtForRequestCase(
+    theCase: Case,
+    recipientName?: string,
+    recipientEmail?: string,
+  ): Promise<Recipient> {
+    const subject = this.formatMessage(
+      notifications.courtRevokedRequestCaseEmail.subject,
+      { courtCaseNumber: theCase.courtCaseNumber },
+    )
+    const body = this.formatMessage(
+      notifications.courtRevokedRequestCaseEmail.body,
+      {
+        prosecutorsOffice: theCase.creatingProsecutor?.institution?.name,
+        courtCaseNumber: theCase.courtCaseNumber,
+      },
+    )
+
+    return this.sendEmail({
+      subject,
+      html: body,
+      recipientName,
+      recipientEmail,
+      skipTail: true,
+    })
+  }
+
   private async sendRevokedNotificationsForRequestCase(
     theCase: Case,
   ): Promise<DeliverResponse> {
@@ -1603,6 +1629,38 @@ export class CaseNotificationService extends BaseNotificationService {
 
     if (courtWasNotified) {
       promises.push(this.sendRevokedSmsNotificationToCourt(theCase))
+    }
+
+    if (theCase.courtCaseNumber) {
+      if (!theCase.judge && !theCase.registrar) {
+        promises.push(
+          this.sendRevokedEmailNotificationToCourtForRequestCase(
+            theCase,
+            theCase.court?.name,
+            this.getCourtEmail(theCase.courtId),
+          ),
+        )
+      } else {
+        if (theCase.judge) {
+          promises.push(
+            this.sendRevokedEmailNotificationToCourtForRequestCase(
+              theCase,
+              theCase.judge.name,
+              theCase.judge.email,
+            ),
+          )
+        }
+
+        if (theCase.registrar) {
+          promises.push(
+            this.sendRevokedEmailNotificationToCourtForRequestCase(
+              theCase,
+              theCase.registrar.name,
+              theCase.registrar.email,
+            ),
+          )
+        }
+      }
     }
 
     const prisonWasNotified = this.hasReceivedNotification(
@@ -1639,7 +1697,6 @@ export class CaseNotificationService extends BaseNotificationService {
     const recipients = await Promise.all(promises)
 
     if (recipients.length === 0) {
-      // Nothing to send
       return { delivered: true }
     }
 

--- a/apps/judicial-system/backend/src/app/modules/notification/test/internalNotificationController/sendRevokedNotificationsForRequestCase.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/test/internalNotificationController/sendRevokedNotificationsForRequestCase.spec.ts
@@ -1,0 +1,181 @@
+import { v4 as uuid } from 'uuid'
+
+import { ConfigType } from '@nestjs/config'
+
+import { EmailService } from '@island.is/email-service'
+
+import {
+  CaseType,
+  RequestCaseNotificationType,
+  TrackedNotificationType,
+} from '@island.is/judicial-system/types'
+
+import {
+  createTestingNotificationModule,
+  createTestUsers,
+} from '../createTestingNotificationModule'
+
+import { Case, Notification } from '../../../repository'
+import { CaseNotificationDto } from '../../dto/caseNotification.dto'
+import { DeliverResponse } from '../../models/deliver.response'
+import { notificationModuleConfig } from '../../notification.config'
+
+interface Then {
+  result: DeliverResponse
+  error: Error
+}
+
+type GivenWhenThen = (
+  theCase: object,
+  notifications?: Notification[],
+) => Promise<Then>
+
+describe('InternalNotificationController - Send revoked notifications for request cases', () => {
+  const { judge, registrar } = createTestUsers(['judge', 'registrar'])
+  const caseId = uuid()
+  const courtId = 'd1e6e06f-dcfd-45e0-9a24-2fdabc2cc8bf'
+  const prosecutorsOfficeName = uuid()
+  const courtName = uuid()
+  const courtCaseNumber = 'R-369/2025'
+
+  let mockEmailService: EmailService
+  let mockNotificationModel: typeof Notification
+  let mockConfig: ConfigType<typeof notificationModuleConfig>
+  let givenWhenThen: GivenWhenThen
+
+  beforeEach(async () => {
+    const {
+      emailService,
+      notificationModel,
+      internalNotificationController,
+      notificationConfig,
+    } = await createTestingNotificationModule()
+
+    mockEmailService = emailService
+    mockNotificationModel = notificationModel
+    mockConfig = notificationConfig
+
+    givenWhenThen = async (theCase: object, notifications?: Notification[]) => {
+      const then = {} as Then
+
+      await internalNotificationController
+        .sendCaseNotification(
+          caseId,
+          { ...theCase, notifications } as Case,
+          { type: RequestCaseNotificationType.REVOKED } as CaseNotificationDto,
+        )
+        .then((result) => (then.result = result))
+        .catch((error) => (then.error = error))
+
+      return then
+    }
+  })
+
+  describe('when judge and registrar are assigned', () => {
+    let then: Then
+
+    const theCase = {
+      id: caseId,
+      type: CaseType.CUSTODY,
+      courtId,
+      court: { name: courtName },
+      courtCaseNumber,
+      judge: { name: judge.name, email: judge.email },
+      registrar: { name: registrar.name, email: registrar.email },
+      creatingProsecutor: { institution: { name: prosecutorsOfficeName } },
+    }
+
+    beforeEach(async () => {
+      then = await givenWhenThen(theCase)
+    })
+
+    it('should send email to judge and registrar', () => {
+      const subject = `Krafa afturkölluð í máli ${courtCaseNumber}`
+      const body = `${prosecutorsOfficeName} hefur afturkallað kröfu í máli ${courtCaseNumber}.`
+
+      expect(mockEmailService.sendEmail).toHaveBeenCalledWith(
+        expect.objectContaining({
+          to: [{ address: judge.email, name: judge.name }],
+          subject,
+          html: body,
+        }),
+      )
+      expect(mockEmailService.sendEmail).toHaveBeenCalledWith(
+        expect.objectContaining({
+          to: [{ address: registrar.email, name: registrar.name }],
+          subject,
+          html: body,
+        }),
+      )
+      expect(mockNotificationModel.create).toHaveBeenCalledWith({
+        caseId,
+        type: RequestCaseNotificationType.REVOKED,
+        recipients: [
+          { address: judge.email, success: true },
+          { address: registrar.email, success: true },
+        ],
+      })
+      expect(then.result).toEqual({ delivered: true })
+    })
+  })
+
+  describe('when neither judge nor registrar are assigned', () => {
+    let then: Then
+
+    const theCase = {
+      id: caseId,
+      type: CaseType.CUSTODY,
+      courtId,
+      court: { name: courtName },
+      courtCaseNumber,
+      creatingProsecutor: { institution: { name: prosecutorsOfficeName } },
+    }
+
+    beforeEach(async () => {
+      then = await givenWhenThen(theCase)
+    })
+
+    it('should send email to general court email', () => {
+      const courtEmail = mockConfig.email.courtsEmails[courtId]
+      const subject = `Krafa afturkölluð í máli ${courtCaseNumber}`
+      const body = `${prosecutorsOfficeName} hefur afturkallað kröfu í máli ${courtCaseNumber}.`
+
+      expect(mockEmailService.sendEmail).toHaveBeenCalledWith(
+        expect.objectContaining({
+          to: [{ address: courtEmail, name: courtName }],
+          subject,
+          html: body,
+        }),
+      )
+      expect(mockNotificationModel.create).toHaveBeenCalledWith({
+        caseId,
+        type: RequestCaseNotificationType.REVOKED,
+        recipients: [{ address: courtEmail, success: true }],
+      })
+      expect(then.result).toEqual({ delivered: true })
+    })
+  })
+
+  describe('when case has no court case number', () => {
+    let then: Then
+
+    const theCase = {
+      id: caseId,
+      type: CaseType.CUSTODY,
+      courtId,
+      court: { name: courtName },
+      judge: { name: judge.name, email: judge.email },
+      registrar: { name: registrar.name, email: registrar.email },
+      creatingProsecutor: { institution: { name: prosecutorsOfficeName } },
+    }
+
+    beforeEach(async () => {
+      then = await givenWhenThen(theCase)
+    })
+
+    it('should not send court email notification', () => {
+      expect(mockEmailService.sendEmail).not.toHaveBeenCalled()
+      expect(then.result).toEqual({ delivered: true })
+    })
+  })
+})


### PR DESCRIPTION
[Asana ticket](https://app.asana.com/0/1199153462262248/1214022663602749)

## What

Send email notifications to court officials (judge and registrar) when a request case (R-mál) is revoked after being received by the court (i.e. has a court case number).

- If judge and/or registrar are assigned, each receives an email
- If neither is assigned, the general court email address receives the notification
- Email format: subject "Krafa afturkölluð í máli {courtCaseNumber}", body "{prosecutorsOffice} hefur afturkallað kröfu í máli {courtCaseNumber}."
- No link to the case overview (the case disappears from the portal after revocation)

## Why

When R-cases are revoked, they disappear from the system without notification, making it easy for court staff to forget to close the case in Auður. This matches the existing behavior for indictment cases (S-mál).

## Screenshots / Gifs

N/A (backend-only change)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Cursor


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Revoked case notifications now also reach the court when a request case has been revoked.
  * Emails are sent to the appropriate recipient(s) based on whether a judge, registrar, or general court contact is available.

* **Bug Fixes**
  * Improved handling for request cases without a court case number by safely skipping email delivery while still reporting success.
  * Kept revoked notifications working as expected when no direct recipient is assigned.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->