### PR TITLE
fix(web): Open zendesk web chat also on url changes in case a specific query param is present

### DIFF
--- a/apps/web/components/ChatPanel/ZendeskChatPanel/ZendeskChatPanel.tsx
+++ b/apps/web/components/ChatPanel/ZendeskChatPanel/ZendeskChatPanel.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useRouter } from 'next/router'
 import { useQuery } from '@apollo/client'
 
 import { Query, QueryGetNamespaceArgs } from '@island.is/web/graphql/schema'
@@ -33,6 +34,8 @@ export const ZendeskChatPanel = ({
   const [isLoading, setIsLoading] = useState(false)
   const [isChatOpen, setIsChatOpen] = useState(false)
   const { activeLocale } = useI18n()
+  const router = useRouter()
+  const hasOpenedChatViaQueryParams = useRef(false)
 
   const openChat = useCallback(() => {
     const setup = () => {
@@ -81,7 +84,8 @@ export const ZendeskChatPanel = ({
     const queryParam = new URLSearchParams(window.location.search).get('wa_lid')
 
     let timeout: NodeJS.Timeout | null = null
-    if (queryParam === 't10') {
+    if (queryParam === 't10' && !hasOpenedChatViaQueryParams.current) {
+      hasOpenedChatViaQueryParams.current = true
       timeout = setTimeout(() => {
         openChat()
       }, 100)
@@ -90,8 +94,9 @@ export const ZendeskChatPanel = ({
     return () => {
       if (timeout) window.clearTimeout(timeout)
     }
+
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
+  }, [router.asPath])
 
   useEffect(
     () => () => {

--- a/apps/web/components/ChatPanel/ZendeskChatPanel/ZendeskChatPanel.tsx
+++ b/apps/web/components/ChatPanel/ZendeskChatPanel/ZendeskChatPanel.tsx
@@ -35,7 +35,6 @@ export const ZendeskChatPanel = ({
   const [isChatOpen, setIsChatOpen] = useState(false)
   const { activeLocale } = useI18n()
   const router = useRouter()
-  const hasOpenedChatViaQueryParams = useRef(false)
 
   const openChat = useCallback(() => {
     const setup = () => {
@@ -84,10 +83,14 @@ export const ZendeskChatPanel = ({
     const queryParam = new URLSearchParams(window.location.search).get('wa_lid')
 
     let timeout: NodeJS.Timeout | null = null
-    if (queryParam === 't10' && !hasOpenedChatViaQueryParams.current) {
-      hasOpenedChatViaQueryParams.current = true
+    if (queryParam === 't10') {
       timeout = setTimeout(() => {
         openChat()
+        const query = { ...router.query }
+        delete query['wa_lid']
+        router.replace({ pathname: router.pathname, query }, undefined, {
+          shallow: true,
+        })
       }, 100)
     }
 


### PR DESCRIPTION
# Open zendesk web chat also on url changes in case a specific query param is present

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Zendesk chat auto-open to react to Next.js route changes, so it triggers correctly when the page state changes.
  * When `wa_lid=t10` is present, the chat still opens after the brief delay, and the triggering parameter is removed from the URL to prevent repeated or lingering auto-open behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->