### PR TITLE
fix(j-s): Case files record table of contents corruption

### DIFF
--- a/apps/judicial-system/backend/src/app/formatters/generatedPdfs/caseFilesRecordPdf.spec.ts
+++ b/apps/judicial-system/backend/src/app/formatters/generatedPdfs/caseFilesRecordPdf.spec.ts
@@ -178,8 +178,18 @@ const collectLinkTargets = (document: PDFDocument): Set<string> => {
     }
 
     for (let index = 0; index < annots.size(); index++) {
-      const annot = document.context.lookup(annots.get(index), PDFDict)
-      const dest = annot.lookup(PDFName.of('Dest'), PDFArray)
+      const annot = document.context.lookup(annots.get(index))
+
+      if (!(annot instanceof PDFDict)) {
+        continue
+      }
+
+      const dest = annot.lookup(PDFName.of('Dest'))
+
+      if (!(dest instanceof PDFArray)) {
+        continue
+      }
+
       const target = dest.get(0)
 
       if (target instanceof PDFRef) {

--- a/apps/judicial-system/backend/src/app/formatters/generatedPdfs/caseFilesRecordPdf.spec.ts
+++ b/apps/judicial-system/backend/src/app/formatters/generatedPdfs/caseFilesRecordPdf.spec.ts
@@ -1,5 +1,18 @@
-import { Defendant } from '../../modules/repository'
-import { formatDefendant } from './caseFilesRecordPdf'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { PDFArray, PDFDict, PDFDocument, PDFName, PDFRef } from 'pdf-lib'
+
+import { createTestIntl } from '@island.is/cms-translations/test'
+
+import { IndictmentSubtype } from '@island.is/judicial-system/types'
+
+import {
+  Case,
+  Defendant,
+  PoliceDigitalCaseFile,
+} from '../../modules/repository'
+import { createCaseFilesRecord, formatDefendant } from './caseFilesRecordPdf'
 
 describe('FormatDefendant', () => {
   test('with national id', () => {
@@ -33,3 +46,147 @@ describe('FormatDefendant', () => {
     expect(result).toBe('John Doe, 123 Main Street')
   })
 })
+
+describe('createCaseFilesRecord - table of contents', () => {
+  const formatMessage = createTestIntl({
+    locale: 'is-IS',
+    onError: jest.fn,
+  }).formatMessage
+
+  const policeCaseNumber = '007-2024-000001'
+
+  const theCase = {
+    id: 'case-id',
+    prosecutorsOffice: { name: 'Héraðssaksóknari' },
+    defendants: [
+      {
+        name: 'Jón Jónsson',
+        nationalId: '0101012519',
+        address: 'Suðurgata 1',
+      },
+    ],
+    indictmentSubtypes: { [policeCaseNumber]: [IndictmentSubtype.THEFT] },
+  } as unknown as Case
+
+  // The number of files per chapter is chosen so that one table of contents
+  // row starts in the narrow band just above the bottom margin of the cover
+  // page (y ≈ 756, where the invisible line-link text still fits on the page
+  // but the date/page number - drawn with marginTop 1 - does not)
+  const chapterCounts = [10, 5, 6, 4, 4]
+  const caseFiles = chapterCounts.flatMap((count, chapter) =>
+    Array.from({ length: count }, (_, index) => async () => ({
+      date: new Date('2024-03-01T10:00:00Z'),
+      name: `Skjal ${chapter + 1}.${index + 1}`,
+      chapter,
+      buffer: undefined, // each file renders as a one-page missing-file page
+    })),
+  )
+
+  // Realistic police digital case file names: long and without any whitespace
+  const policeDigitalCaseFiles = Array.from({ length: 5 }, (_, index) => ({
+    id: `digital-${index + 1}`,
+    name: `Hljodupptaka_007-2024-000001_yfirheyrsla_nr_${
+      index + 1
+    }_2024-03-01.mp4`,
+    policeDigitalFileId: `IDES-${1000 + index}`,
+    policeExternalVendorId: `VENDOR-${2000 + index}`,
+    displayDate: new Date('2024-03-02T10:00:00Z'),
+    orderWithinChapter: index,
+  })) as unknown as PoliceDigitalCaseFile[]
+
+  it('should not insert extra pages when stamping page numbers', async () => {
+    const pdf = await createCaseFilesRecord(
+      theCase,
+      policeCaseNumber,
+      caseFiles,
+      policeDigitalCaseFiles,
+      formatMessage,
+    )
+
+    const outPath = path.join(os.tmpdir(), 'caseFilesRecord.pdf')
+    fs.writeFileSync(outPath, pdf)
+    // eslint-disable-next-line no-console
+    console.log(`Case files record written to ${outPath}`)
+
+    const document = await PDFDocument.load(new Uint8Array(pdf))
+
+    // 1 cover page + 1 table of contents page + 29 case file pages
+    // + 1 digital case files page = 32 pages
+    // Guards against a regression where stamping the page number of a table
+    // of contents row starting in the overflow window triggered
+    // auto-pagination, inserting a phantom page into the finished document
+    // and tearing the table of contents apart (stray page numbers on the
+    // phantom page, none on the real table of contents page, and all page
+    // references off by one)
+    expect(document.getPageCount()).toBe(32)
+  })
+
+  it('should reference each digital case file page in the table of contents', async () => {
+    // Eight digital case files: the first seven fill the first digital case
+    // files page and the eighth overflows to a second page. The eighth also
+    // has no display date.
+    const digitalCaseFiles = Array.from({ length: 8 }, (_, index) => ({
+      id: `digital-${index + 1}`,
+      name: `Hljodupptaka_007-2024-000001_yfirheyrsla_nr_${
+        index + 1
+      }_2024-03-01.mp4`,
+      policeDigitalFileId: `IDES-${1000 + index}`,
+      policeExternalVendorId: `VENDOR-${2000 + index}`,
+      displayDate: index < 7 ? new Date('2024-03-02T10:00:00Z') : undefined,
+      orderWithinChapter: index,
+    })) as unknown as PoliceDigitalCaseFile[]
+
+    const pdf = await createCaseFilesRecord(
+      theCase,
+      policeCaseNumber,
+      caseFiles,
+      digitalCaseFiles,
+      formatMessage,
+    )
+
+    const outPath = path.join(os.tmpdir(), 'caseFilesRecord-digital.pdf')
+    fs.writeFileSync(outPath, pdf)
+    // eslint-disable-next-line no-console
+    console.log(`Case files record written to ${outPath}`)
+
+    const document = await PDFDocument.load(new Uint8Array(pdf))
+
+    // 1 cover page + 1 table of contents page + 29 case file pages
+    // + 2 digital case files pages = 33 pages
+    expect(document.getPageCount()).toBe(33)
+
+    const pages = document.getPages()
+    const linkTargets = collectLinkTargets(document)
+
+    // The table of contents should link to both digital case files pages.
+    // The last page is only linked if the file without a display date is
+    // listed in the table of contents and its row links to the second
+    // digital case files page instead of the first
+    expect(linkTargets.has(pages[31].ref.toString())).toBe(true)
+    expect(linkTargets.has(pages[32].ref.toString())).toBe(true)
+  })
+})
+
+const collectLinkTargets = (document: PDFDocument): Set<string> => {
+  const targets = new Set<string>()
+
+  for (const page of document.getPages()) {
+    const annots = page.node.Annots()
+
+    if (!annots) {
+      continue
+    }
+
+    for (let index = 0; index < annots.size(); index++) {
+      const annot = document.context.lookup(annots.get(index), PDFDict)
+      const dest = annot.lookup(PDFName.of('Dest'), PDFArray)
+      const target = dest.get(0)
+
+      if (target instanceof PDFRef) {
+        targets.add(target.toString())
+      }
+    }
+  }
+
+  return targets
+}

--- a/apps/judicial-system/backend/src/app/formatters/generatedPdfs/caseFilesRecordPdf.ts
+++ b/apps/judicial-system/backend/src/app/formatters/generatedPdfs/caseFilesRecordPdf.ts
@@ -35,9 +35,11 @@ const addPoliceDigitalCaseFilesPage = (
   pageMargin: number,
   textFontSize: number,
   subtitleFontSize: number,
-) => {
+): { file: PoliceDigitalCaseFile; pageIndex: number }[] => {
   const bulletIndent = pageMargin + 16
   const valueIndent = pageMargin + 180
+
+  const filePages: { file: PoliceDigitalCaseFile; pageIndex: number }[] = []
 
   pdfDocument.addPage().addText('6. Rafræn gögn (IDES)', subtitleFontSize, {
     bold: true,
@@ -49,6 +51,13 @@ const addPoliceDigitalCaseFilesPage = (
     pdfDocument.addText(file.name, textFontSize, {
       bold: true,
       marginTop: 8,
+    })
+
+    // Capture the page after drawing the name as drawing it may have
+    // overflowed to a new page
+    filePages.push({
+      file,
+      pageIndex: pdfDocument.getCurrentLineLink().pageNumber,
     })
 
     pdfDocument
@@ -85,6 +94,8 @@ const addPoliceDigitalCaseFilesPage = (
         },
       )
   }
+
+  return filePages
 }
 
 export const createCaseFilesRecord = async (
@@ -114,7 +125,7 @@ export const createCaseFilesRecord = async (
   const chapters = [0, 1, 2, 3, 4, 5]
   const pageReferences: {
     chapter: number
-    date: Date
+    date?: Date
     name: string
     pageNumber: number
     pageLink: PageLink
@@ -158,14 +169,12 @@ export const createCaseFilesRecord = async (
     })
   }
 
-  // Add police digital case files page (IDES)
+  // Add police digital case files pages (IDES)
   if (policeDigitalCaseFiles.length > 0) {
-    const pageNumber = pdfDocument.getPageCount()
-
     const sortedFiles = [...policeDigitalCaseFiles].sort(
       (a, b) => (a.orderWithinChapter ?? 0) - (b.orderWithinChapter ?? 0),
     )
-    addPoliceDigitalCaseFilesPage(
+    const digitalCaseFilePages = addPoliceDigitalCaseFilesPage(
       pdfDocument,
       sortedFiles,
       formatMessage,
@@ -174,19 +183,13 @@ export const createCaseFilesRecord = async (
       subtitleFontSize,
     )
 
-    const digitalCaseFilesPage = pageNumber + 1
-
-    for (const digitalCaseFile of sortedFiles) {
-      const date = digitalCaseFile.displayDate
-      if (!date) {
-        continue
-      }
+    for (const { file, pageIndex } of digitalCaseFilePages) {
       pageReferences.push({
         chapter: 5,
-        date,
-        name: digitalCaseFile.name,
-        pageNumber: digitalCaseFilesPage,
-        pageLink: pdfDocument.getPageLink(pageNumber),
+        date: file.displayDate,
+        name: file.name,
+        pageNumber: pageIndex + 1,
+        pageLink: pdfDocument.getPageLink(pageIndex),
       })
     }
   }
@@ -321,9 +324,14 @@ export const createCaseFilesRecord = async (
     for (const pageReference of pageReferences.filter(
       (pageReference) => pageReference.chapter === chapter,
     )) {
+      // The line link must be captured with the same top margin as the date,
+      // name and page number are drawn with. Otherwise the link can be
+      // captured at the bottom of a page while the rest of the line overflows
+      // to the next page, and stamping the page number at the link position
+      // later inserts an extra page into the finished document.
       tableOfContentsLineReferences.push({
         lineLink: pdfDocument
-          .addText('', textFontSize, { newLine: false })
+          .addText('', textFontSize, { newLine: false, marginTop: 1 })
           .getCurrentLineLink(),
         pageNumber: pageReference.pageNumber,
         pageLink: pageReference.pageLink,
@@ -332,10 +340,12 @@ export const createCaseFilesRecord = async (
         pageLink: pageReference.pageLink,
         newLine: false,
         position: { x: pageDateIndent },
-        marginTop: 1,
       })
 
-      const nameChunks = pageReference.name.match(/.{1,40}(?=\s|$)/g)
+      // Split the name at whitespace into chunks of at most 40 characters,
+      // hard-splitting runs longer than 40 characters, which would otherwise
+      // not match and be silently dropped
+      const nameChunks = pageReference.name.match(/.{1,40}(?=\s|$)|.{1,40}/g)
 
       // Add name in chunks of max 40 characters
       for (const chunk of nameChunks ?? []) {
@@ -350,7 +360,9 @@ export const createCaseFilesRecord = async (
 
   const tableOfContentsPageCount = pdfDocument.getPageCount() - pageCount
 
-  // Add page numbers to table of contents
+  // Add page numbers to table of contents. The line links already include
+  // the line's top margin, so no margin may be added here as that could
+  // overflow the page and insert an extra page into the finished document.
   for (const lineReference of tableOfContentsLineReferences) {
     pdfDocument
       .setCurrentLine(lineReference.lineLink)
@@ -361,7 +373,6 @@ export const createCaseFilesRecord = async (
           alignment: Alignment.Right,
           pageLink: lineReference.pageLink,
           newLine: false,
-          marginTop: 1,
         },
       )
   }


### PR DESCRIPTION
# Case files record table of contents corruption

[Brenglað efnisyfirlit í gagnapakka](https://app.asana.com/1/203394141643832/project/1199153462262248/task/1216308028989266)

The table of contents in the case files record PDF was sometimes corrupt, typically when police digital case files (IDES) were present. This PR fixes four defects in `createCaseFilesRecord`:

- **Phantom page insertion**: A table of contents row could start in a 4pt band just above the bottom margin, where the invisible line-link text (drawn with no top margin) still fit on the page but the date and page number (drawn with `marginTop: 1`) did not. Stamping the page number at the recorded link position then triggered auto-pagination, inserting an extra page into the finished document. Since line links store raw page indices, all subsequent page numbers were stamped onto the wrong pages, and the already-computed table of contents page count went stale, shifting every page reference by one. Fixed by capturing the line link with the same top margin the row content is drawn with, so all overflow checks agree and the page break happens before the link is recorded.
- **Torn rows**: The same margin asymmetry could leave a row's page number at the bottom of one page while its date and name overflowed to the next. Fixed by the same change — the whole row now moves to the next page together.
- **Truncated names**: The name-wrapping regex `/.{1,40}(?=\s|$)/g` silently dropped leading characters of any run longer than 40 characters without whitespace — typical for police digital case file names (e.g. `Hljodupptaka_007-2024-000001_yfirheyrsla_nr_1_2024-03-01.mp4` rendered without its first 12 characters). The regex now falls back to hard-splitting long runs so no characters are lost.
- **Wrong digital case file references**: When the digital case files section overflowed to more than one page, every table of contents entry referenced and linked to the first page. Additionally, digital case files without a display date were omitted from the table of contents entirely. Each entry now references the page the file is actually listed on, and files without a display date appear with an empty date column.

Digital case files triggered the corruption in practice because they lengthen the table of contents (one row per file, with long two-line names), pushing it onto continuation pages that fill down to the bottom margin where the overflow window lies.

Two regression tests were added: one with a fixture calibrated so a row starts exactly in the overflow window (previously produced a 33-page document with a phantom page instead of 32), and one with eight digital case files where the eighth — without a display date — overflows to a second IDES page, verified via the PDF link annotations.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016gCRnq2AwN5miAdfVEusmE


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved the case files PDF table of contents so page links accurately target police digital case file pages, including entries that span multiple pages.
  * Long table-of-contents names now split more reliably, even when they contain no spaces.

* **Bug Fixes**
  * Fixed table-of-contents page-number stamping to avoid unexpected content shifts or page-count changes near overflow limits.
  * Improved handling for table-of-contents entries that lack a display date.

* **Tests**
  * Expanded PDF generation tests to validate table-of-contents link destinations and overflow behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->