### PR TITLE
fix(native-app): add back arrow for android back

### DIFF
--- a/apps/native/app/src/constants/screen-options.ts
+++ b/apps/native/app/src/constants/screen-options.ts
@@ -30,8 +30,12 @@ export const tabScreenOptions: StackScreenProps['options'] = {
       : undefined,
   headerShadowVisible: false,
   headerBackButtonDisplayMode: 'minimal',
-  headerBackVisible: false,
-  unstable_headerLeftItems: blueBackItem,
+  // The blue chevron back item uses an SF Symbol, which is iOS-only. On
+  // Android we keep the default native back arrow (black) instead.
+  ...(Platform.OS === 'ios' && {
+    headerBackVisible: false,
+    unstable_headerLeftItems: blueBackItem,
+  }),
 }
 
 export const modalScreenOptions: StackScreenProps['options'] = {


### PR DESCRIPTION
## What

When we updated the nav bar icons (specifically the back arrow) to be blue we added SF- Symbols for that. Turns out they only render on iOS so the back arrows disappeared on android. Adding them back in, conditionally rendering based on platforms.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the back navigation header behavior on non-iOS platforms by restoring the default native back arrow.
  * Kept the custom iOS back header setup active only on iOS, ensuring platform-appropriate navigation UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->