### PR TITLE
fix(application): Application - Equality report - ID mixup

### DIFF
--- a/libs/application/template-api-modules/src/lib/modules/templates/directorate-of-equality/directorate-of-equality.service.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/directorate-of-equality/directorate-of-equality.service.ts
@@ -3,10 +3,7 @@ import { BaseTemplateApiService } from '../../base-template-api.service'
 import { ApplicationTypes } from '@island.is/application/types'
 import { TemplateApiModuleActionProps } from '../../../types'
 import { CompanyRegistryClientService } from '@island.is/clients/rsk/company-registry'
-import {
-  CompanyDto,
-  DirectorateOfEqualityClientService,
-} from '@island.is/clients/directorate-of-equality'
+import { DirectorateOfEqualityClientService } from '@island.is/clients/directorate-of-equality'
 import {
   Gender,
   type ApplicationAnswers,
@@ -113,15 +110,18 @@ export class DirectorateOfEqualityService extends BaseTemplateApiService {
     )
     if (!hasActiveReport) return null
 
-    const doeCompany = getValueViaPath<CompanyDto>(
+    // `identifier` is set to the submitting application's id at submit time
+    // (see submitEqualityReport below), the same value stored as `providerId`
+    // — which is what getReport() looks up by.
+    const providerId = getValueViaPath<string>(
       application.externalData,
-      'doeCompany.data',
+      'activeEqualityReport.data.identifier',
     )
-    if (!doeCompany?.id) return null
+    if (!providerId) return null
     try {
       const report = await this.directorateOfEqualityService.getReport(
         auth,
-        doeCompany.id,
+        providerId,
       )
       return { equalityReportContent: report.equalityReportContent ?? '' }
     } catch (error) {
@@ -148,11 +148,6 @@ export class DirectorateOfEqualityService extends BaseTemplateApiService {
       [Gender.FEMALE]: 'FEMALE',
       [Gender.NON_BINARY]: 'NEUTRAL',
     }
-    const doeCompany = getValueViaPath<CompanyDto>(
-      application.externalData,
-      'doeCompany.data',
-    )
-
     const equalityReportContent = getValueViaPath(
       answers,
       'goalsAndActions.customField',
@@ -166,7 +161,7 @@ export class DirectorateOfEqualityService extends BaseTemplateApiService {
         auth,
         {
           identifier: application.id,
-          providerId: doeCompany?.id ?? application.id,
+          providerId: application.id,
           companyAdminName: answers.chiefExecutive?.name ?? '',
           companyAdminEmail: answers.chiefExecutive?.email ?? '',
           companyAdminGender: answers.chiefExecutive?.gender


### PR DESCRIPTION
# Application - Equality report - ID mixup

## What

Fixing the id mixup for submitting and fetching equality reports

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how equality report lookups are matched, helping ensure the correct previous report is retrieved.
  * Updated report submission to use a more consistent application-based identifier, reducing the chance of mismatched submissions.
  * Added safer handling when no report identifier is available, returning no result instead of using an invalid value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->