### PR TITLE
fix(ids-api): Deflake provider controller spec delegation type collision

### DIFF
--- a/apps/services/auth/admin-api/src/app/v2/providers/test/provider-controller.spec.ts
+++ b/apps/services/auth/admin-api/src/app/v2/providers/test/provider-controller.spec.ts
@@ -74,8 +74,8 @@ describe('ProverController', () => {
       factory = new FixtureFactory(app)
 
       for (const { id: dpId, delegationTypes } of delegationProviderTypesData) {
-        for (const _ of delegationTypes) {
-          await factory.createDelegationType({ providerId: dpId })
+        for (const { id, name } of delegationTypes) {
+          await factory.createDelegationType({ id, name, providerId: dpId })
         }
       }
     })


### PR DESCRIPTION
## What

Seed delegation types in `provider-controller.spec.ts` with the explicit deterministic ids and names from the test fixture data, instead of relying on the `FixtureFactory.createDelegationType` defaults.

## Why

The factory defaults to `id = faker.random.word()`, which draws from a small word list. When two seeded delegation types randomly get the same id, `findCreateFind` returns the existing row (attached to the first provider) instead of creating a new one, leaving a provider with fewer delegation types than the test expects — so `getDelegationProviders` assertions fail intermittently.

Passing the explicit ids (`custom:1`, `procuration:1`, `procuration:2`) guarantees three distinct rows under the correct providers.

## Screenshots / Gifs

N/A — test-only change.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated provider-related test setup to use explicit delegation type IDs and names, improving the realism of test data while keeping existing provider response assertions unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->