### PR TITLE
fix(ids-api): Accept compound personal representative types in delegation verification (2026.06.30)

### DIFF
--- a/apps/services/auth/ids-api/src/app/delegations/delegation-verification.dto.ts
+++ b/apps/services/auth/ids-api/src/app/delegations/delegation-verification.dto.ts
@@ -1,7 +1,20 @@
 import { ApiProperty } from '@nestjs/swagger'
-import { IsArray, IsEnum, IsString } from 'class-validator'
+import { IsArray, IsIn, IsString } from 'class-validator'
 
+import {
+  DelegationRecordType,
+  PersonalRepresentativeDelegationType,
+} from '@island.is/auth-api-lib'
 import { AuthDelegationType } from '@island.is/shared/types'
+
+// Delegations sourced from the district commissioners registry carry compound
+// personal representative types, e.g. PersonalRepresentative:postholf, so the
+// accepted values are the DelegationRecordType union rather than the base
+// AuthDelegationType enum.
+const delegationRecordTypes: DelegationRecordType[] = [
+  ...Object.values(AuthDelegationType),
+  ...Object.values(PersonalRepresentativeDelegationType),
+]
 
 export class DelegationVerification {
   @IsString()
@@ -9,11 +22,11 @@ export class DelegationVerification {
   fromNationalId!: string
 
   @IsArray()
-  @IsEnum(AuthDelegationType, { each: true })
+  @IsIn(delegationRecordTypes, { each: true })
   @ApiProperty({
-    enum: AuthDelegationType,
-    enumName: 'AuthDelegationType',
+    enum: delegationRecordTypes,
+    enumName: 'DelegationRecordType',
     isArray: true,
   })
-  delegationTypes!: AuthDelegationType[]
+  delegationTypes!: DelegationRecordType[]
 }

--- a/apps/services/auth/ids-api/src/app/delegations/test/delegations-filters.spec.ts
+++ b/apps/services/auth/ids-api/src/app/delegations/test/delegations-filters.spec.ts
@@ -7,6 +7,7 @@ import request from 'supertest'
 import {
   MergedDelegationDTO,
   NationalRegistryV3FeatureService,
+  PersonalRepresentativeDelegationType,
 } from '@island.is/auth-api-lib'
 import { RskRelationshipsClient } from '@island.is/clients-rsk-relationships'
 import { NationalRegistryClientService } from '@island.is/clients/national-registry-v2'
@@ -17,7 +18,10 @@ import {
   AuthDelegationProvider,
   AuthDelegationType,
 } from '@island.is/shared/types'
-import { createNationalRegistryUser } from '@island.is/testing/fixtures'
+import {
+  createNationalId,
+  createNationalRegistryUser,
+} from '@island.is/testing/fixtures'
 import { TestApp, truncate } from '@island.is/testing/nest'
 
 import {
@@ -196,6 +200,7 @@ describe('DelegationsController', () => {
         const testCase = testCases['legalRepresentative1']
         testCase.user = user
         const path = '/v1/delegations/verify'
+        const fromPersonalRepresentative = createNationalId('person')
 
         beforeAll(async () => {
           await truncate(sequelize)
@@ -222,6 +227,18 @@ describe('DelegationsController', () => {
             type: AuthDelegationType.LegalRepresentative,
             provider: AuthDelegationProvider.DistrictCommissionersRegistry,
           })
+
+          await factory.createDelegationType({
+            id: PersonalRepresentativeDelegationType.PersonalRepresentativePostholf,
+            providerId: AuthDelegationProvider.DistrictCommissionersRegistry,
+          })
+
+          await factory.createDelegationIndexRecord({
+            fromNationalId: fromPersonalRepresentative,
+            toNationalId: testCase.user.nationalId,
+            type: PersonalRepresentativeDelegationType.PersonalRepresentativePostholf,
+            provider: AuthDelegationProvider.DistrictCommissionersRegistry,
+          })
         })
 
         let res: request.Response
@@ -239,6 +256,30 @@ describe('DelegationsController', () => {
           res = await server.post(path).send({
             fromNationalId: nonExistingLegalRepresentativeNationalId,
             delegationTypes: [AuthDelegationType.LegalRepresentative],
+          })
+
+          expect(res.status).toEqual(200)
+          expect(res.body.verified).toEqual(false)
+        })
+
+        it(`POST ${path} returns verified response for compound personal representative delegation type`, async () => {
+          res = await server.post(path).send({
+            fromNationalId: fromPersonalRepresentative,
+            delegationTypes: [
+              PersonalRepresentativeDelegationType.PersonalRepresentativePostholf,
+            ],
+          })
+
+          expect(res.status).toEqual(200)
+          expect(res.body.verified).toEqual(true)
+        })
+
+        it(`POST ${path} returns non-verified response for compound personal representative delegation type`, async () => {
+          res = await server.post(path).send({
+            fromNationalId: nonExistingLegalRepresentativeNationalId,
+            delegationTypes: [
+              PersonalRepresentativeDelegationType.PersonalRepresentativePostholf,
+            ],
           })
 
           expect(res.status).toEqual(200)

--- a/apps/services/auth/ids-api/src/app/delegations/test/delegations.controller.spec.ts
+++ b/apps/services/auth/ids-api/src/app/delegations/test/delegations.controller.spec.ts
@@ -90,7 +90,9 @@ describe('DelegationsController', () => {
           client: client.clientId,
         })
 
-        const domain = createDomain()
+        // Unique name so it can never collide with the random-word default
+        // domains created by setupWithAuth.
+        const domain = createDomain({ name: `test-domain-${uuid()}` })
         let nationalRegistryApiSpy: jest.SpyInstance
         let nationalRegistryV3ApiSpy: jest.SpyInstance
 

--- a/libs/auth-api-lib/src/lib/delegations/delegations-incoming.service.ts
+++ b/libs/auth-api-lib/src/lib/delegations/delegations-incoming.service.ts
@@ -37,6 +37,7 @@ import { MergedDelegationDTO } from './dto/merged-delegation.dto'
 import { DelegationScope } from './models/delegation-scope.model'
 import { Delegation } from './models/delegation.model'
 import { NationalRegistryV3FeatureService } from './national-registry-v3-feature.service'
+import { DelegationRecordType } from './types/delegationRecord'
 
 type ClientDelegationInfo = Pick<
   Client,
@@ -448,7 +449,7 @@ export class DelegationsIncomingService {
   async verifyDelegationAtProvider(
     user: User,
     fromNationalId: string,
-    delegationTypes: AuthDelegationType[],
+    delegationTypes: DelegationRecordType[],
   ): Promise<boolean> {
     const providers = await this.delegationProviderService.findProviders(
       delegationTypes,

--- a/libs/auth-api-lib/src/lib/delegations/utils/delegations.ts
+++ b/libs/auth-api-lib/src/lib/delegations/utils/delegations.ts
@@ -81,7 +81,7 @@ export const validateToAndFromNationalId = ({
 export interface ValidateDistrictCommissionersDelegationsParams {
   user: User
   fromNationalId: string
-  delegationTypes: AuthDelegationType[]
+  delegationTypes: DelegationRecordType[]
   featureFlagService: FeatureFlagService
   syslumennService: SyslumennService
   delegationsIndexService: DelegationsIndexService


### PR DESCRIPTION
Cherry-pick of #23165 (`63f6d23340`) onto `release/2026.06.30.00` as a hotfix.

## What

Accept compound personal representative delegation types (e.g. `PersonalRepresentative:postholf`) in delegation verification, instead of only the base `PersonalRepresentative` type.

## Why

Delegation verification in the IDS API rejects valid personal representative delegations that use compound type identifiers, so this needs to go out on the current release.

## Screenshots / Gifs

N/A

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)