### PR TITLE
fix(services-payments): restore inner join for card details in worker…

### DIFF
--- a/apps/services/payments/src/app/paymentFlow/paymentFlow.service.ts
+++ b/apps/services/payments/src/app/paymentFlow/paymentFlow.service.ts
@@ -1050,9 +1050,8 @@ export class PaymentFlowService {
         paymentMethod === 'card'
           ? {
               model: CardPaymentDetails,
-              required: false,
+              required: true,
               where: { isDeleted: false },
-              separate: true,
             }
           : {
               // Carries the providerPaymentId needed to rebuild the FJS charge.

--- a/apps/services/payments/src/app/worker/worker.service.spec.ts
+++ b/apps/services/payments/src/app/worker/worker.service.spec.ts
@@ -369,8 +369,8 @@ describe('WorkerService', () => {
     })
 
     it('should record a failure for a card flow with no active card payment details (e.g. interrupted refund)', async () => {
-      // The query left-joins card details, so a card flow whose details are all
-      // soft-deleted is returned and must surface as a failure — not be silently skipped.
+      // The card sweep inner-joins card details so such flows are normally excluded;
+      // if one slips through anyway it must surface as a failure — not crash the run.
       const flow = createMockFlow({
         id: 'card-orphan',
         cardPaymentDetails: [],

--- a/apps/services/payments/src/app/worker/worker.service.ts
+++ b/apps/services/payments/src/app/worker/worker.service.ts
@@ -339,11 +339,9 @@ export class WorkerService {
   private getLatestCardPaymentDetails(
     details?: InferAttributes<CardPaymentDetails>[],
   ): InferAttributes<CardPaymentDetails> {
-    // The db query left-joins card details (bank-transfer flows have none), so a card
-    // flow can reach here with zero rows — e.g. all its details soft-deleted.
     if (!details || details.length === 0) {
       throw new BadRequestException(
-        'No card payment details found for payment flow (possible interrupted refund — card confirmation deleted while fulfillment is active)',
+        'No card payment details found for payment flow',
       )
     }
 


### PR DESCRIPTION

fix(services-payments): restore inner join for card details in worker sweep


## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [x] No AI tools were used in preparing this pull request
- [ ] AI tools were used in preparing this pull request
      Tools used: 
