### PR TITLE
feat(services-payments): render bank-transfer SCA inline with a QR code on the pending screen

### DIFF
--- a/apps/payments/components/BankTransferPendingScreen/BankTransferPendingScreen.tsx
+++ b/apps/payments/components/BankTransferPendingScreen/BankTransferPendingScreen.tsx
@@ -36,7 +36,8 @@ export const BankTransferPendingScreen = ({
   const { formatMessage } = useLocale()
 
   const showSca =
-    pendingStatus === PaymentsBankTransferPendingStatus.sca_required && !!scaRedirectUrl
+    pendingStatus === PaymentsBankTransferPendingStatus.sca_required &&
+    !!scaRedirectUrl
 
   return (
     <Box
@@ -79,24 +80,22 @@ export const BankTransferPendingScreen = ({
             {formatMessage(
               pendingStatus === PaymentsBankTransferPendingStatus.sca_required
                 ? bankTransfer.checkPhone
-                : bankTransfer.waitingForAuthorization,
+                : bankTransfer.waitingForAuthorisation,
             )}
           </Text>
         </Box>
       )}
-      {/* No cancel while processing: the payer has initiated/approved payment, so settlement may be in flight */}
-      {pendingStatus !== PaymentsBankTransferPendingStatus.processing && (
-        <Box display="flex" justifyContent="center">
-          <Button
-            unfocusable
-            variant="text"
-            loading={isCancelling}
-            onClick={onCancel}
-          >
-            {formatMessage(generic.buttonCancel)}
-          </Button>
-        </Box>
-      )}
+
+      <Box display="flex" justifyContent="center">
+        <Button
+          unfocusable
+          variant="text"
+          loading={isCancelling}
+          onClick={onCancel}
+        >
+          {formatMessage(generic.buttonCancel)}
+        </Button>
+      </Box>
     </Box>
   )
 }

--- a/apps/payments/components/BankTransferPendingScreen/BankTransferPendingScreen.tsx
+++ b/apps/payments/components/BankTransferPendingScreen/BankTransferPendingScreen.tsx
@@ -1,0 +1,102 @@
+import {
+  Box,
+  Button,
+  Hidden,
+  LoadingDots,
+  Text,
+} from '@island.is/island-ui/core'
+import { useLocale } from '@island.is/localization'
+import { PaymentsBankTransferPendingStatus } from '@island.is/api/schema'
+
+import { BankTransferQrCode } from '../BankTransferQrCode/BankTransferQrCode'
+import { bankTransfer, generic } from '../../messages'
+
+interface BankTransferPendingScreenProps {
+  // Pending sub-status; SCA_REQUIRED renders the QR/deep-link UI, anything else the waiting UI.
+  pendingStatus?: PaymentsBankTransferPendingStatus | null
+  // The provider SCA URL. May be absent — arrives later via polling if at all.
+  scaRedirectUrl?: string
+  isCancelling: boolean
+  onCancel: () => void
+}
+
+/**
+ * Body of the bank-transfer pending screen.
+ *
+ * sca_required + URL → desktop: QR code; mobile: open-banking-app button.
+ * sca_required without URL → "check your phone" message.
+ * processing (SCA complete / not yet required) → waiting message.
+ */
+export const BankTransferPendingScreen = ({
+  pendingStatus,
+  scaRedirectUrl,
+  isCancelling,
+  onCancel,
+}: BankTransferPendingScreenProps) => {
+  const { formatMessage } = useLocale()
+
+  const showSca =
+    pendingStatus === PaymentsBankTransferPendingStatus.sca_required && !!scaRedirectUrl
+
+  return (
+    <Box
+      display="flex"
+      flexDirection="column"
+      rowGap={[3, 4]}
+      paddingY={[2, 3]}
+    >
+      {showSca ? (
+        <>
+          {/* Desktop: the payer scans the SCA URL with their phone. */}
+          <Hidden below="md">
+            <BankTransferQrCode url={scaRedirectUrl} />
+          </Hidden>
+          {/* Mobile: deep link to banking app. */}
+          <Hidden above="sm">
+            <Box display="flex" flexDirection="column" rowGap={[2, 3]}>
+              <Button
+                fluid
+                unfocusable
+                onClick={() => window.location.assign(scaRedirectUrl)}
+              >
+                {formatMessage(bankTransfer.openBankingApp)}
+              </Button>
+              <Text textAlign="center">
+                {formatMessage(bankTransfer.openBankingAppInstruction)}
+              </Text>
+            </Box>
+          </Hidden>
+        </>
+      ) : (
+        <Box
+          display="flex"
+          flexDirection="column"
+          alignItems="center"
+          rowGap={[2, 3]}
+        >
+          <LoadingDots />
+          <Text textAlign="center">
+            {formatMessage(
+              pendingStatus === PaymentsBankTransferPendingStatus.sca_required
+                ? bankTransfer.checkPhone
+                : bankTransfer.waitingForAuthorization,
+            )}
+          </Text>
+        </Box>
+      )}
+      {/* No cancel while processing: the payer has initiated/approved payment, so settlement may be in flight */}
+      {pendingStatus !== PaymentsBankTransferPendingStatus.processing && (
+        <Box display="flex" justifyContent="center">
+          <Button
+            unfocusable
+            variant="text"
+            loading={isCancelling}
+            onClick={onCancel}
+          >
+            {formatMessage(generic.buttonCancel)}
+          </Button>
+        </Box>
+      )}
+    </Box>
+  )
+}

--- a/apps/payments/components/BankTransferPendingScreen/BankTransferPendingScreen.tsx
+++ b/apps/payments/components/BankTransferPendingScreen/BankTransferPendingScreen.tsx
@@ -9,15 +9,13 @@ import { useLocale } from '@island.is/localization'
 import { PaymentsBankTransferPendingStatus } from '@island.is/api/schema'
 
 import { BankTransferQrCode } from '../BankTransferQrCode/BankTransferQrCode'
-import { bankTransfer, generic } from '../../messages'
+import { bankTransfer } from '../../messages'
 
 interface BankTransferPendingScreenProps {
   // Pending sub-status; SCA_REQUIRED renders the QR/deep-link UI, anything else the waiting UI.
   pendingStatus?: PaymentsBankTransferPendingStatus | null
   // The provider SCA URL. May be absent — arrives later via polling if at all.
   scaRedirectUrl?: string
-  isCancelling: boolean
-  onCancel: () => void
 }
 
 /**
@@ -26,18 +24,21 @@ interface BankTransferPendingScreenProps {
  * sca_required + URL → desktop: QR code; mobile: open-banking-app button.
  * sca_required without URL → "check your phone" message.
  * processing (SCA complete / not yet required) → waiting message.
+ *
+ * Payments that enter this screen can not be cancelled by Blikk. User must do it in their banking app.
  */
 export const BankTransferPendingScreen = ({
   pendingStatus,
   scaRedirectUrl,
-  isCancelling,
-  onCancel,
 }: BankTransferPendingScreenProps) => {
   const { formatMessage } = useLocale()
 
   const showSca =
     pendingStatus === PaymentsBankTransferPendingStatus.sca_required &&
     !!scaRedirectUrl
+
+  const isScaOutstanding =
+    pendingStatus === PaymentsBankTransferPendingStatus.sca_required
 
   return (
     <Box
@@ -86,16 +87,11 @@ export const BankTransferPendingScreen = ({
         </Box>
       )}
 
-      <Box display="flex" justifyContent="center">
-        <Button
-          unfocusable
-          variant="text"
-          loading={isCancelling}
-          onClick={onCancel}
-        >
-          {formatMessage(generic.buttonCancel)}
-        </Button>
-      </Box>
+      {isScaOutstanding && (
+        <Text variant="small" color="dark400" textAlign="center">
+          {formatMessage(bankTransfer.cancelInBankAppNote)}
+        </Text>
+      )}
     </Box>
   )
 }

--- a/apps/payments/components/BankTransferQrCode/BankTransferQrCode.tsx
+++ b/apps/payments/components/BankTransferQrCode/BankTransferQrCode.tsx
@@ -1,0 +1,50 @@
+import { QRCodeSVG } from 'qrcode.react'
+
+import { Box, Text } from '@island.is/island-ui/core'
+import { theme } from '@island.is/island-ui/theme'
+import { useLocale } from '@island.is/localization'
+
+import { bankTransfer } from '../../messages'
+
+interface BankTransferQrCodeProps {
+  // The raw provider SCA URL, encoded verbatim into the QR code.
+  url: string
+}
+
+const QR_CODE_SIZE = 200
+
+/**
+ * The SCA QR code shown on the desktop pending screen — the payer scans it with
+ * their phone to open the banking app.
+ */
+export const BankTransferQrCode = ({ url }: BankTransferQrCodeProps) => {
+  const { formatMessage } = useLocale()
+
+  return (
+    <Box
+      display="flex"
+      flexDirection="column"
+      alignItems="center"
+      rowGap={[2, 3]}
+    >
+      <Box
+        background="white"
+        border="standard"
+        borderColor="blue200"
+        borderRadius="large"
+        padding={2}
+        display="flex"
+        justifyContent="center"
+      >
+        <QRCodeSVG
+          value={url}
+          size={QR_CODE_SIZE}
+          fgColor={theme.color.blue400}
+        />
+      </Box>
+      <Text variant="h4" textAlign="center">
+        {formatMessage(bankTransfer.scanQrInstruction)}
+      </Text>
+    </Box>
+  )
+}

--- a/apps/payments/graphql/mutations.graphql.ts
+++ b/apps/payments/graphql/mutations.graphql.ts
@@ -73,6 +73,7 @@ export const CreateBankTransferMutation = gql`
       providerPaymentId
       scaRedirectUrl
       expiresAt
+      onboardingRequired
     }
   }
 `
@@ -82,6 +83,9 @@ export const VerifyBankTransferMutation = gql`
     paymentsVerifyBankTransfer(input: $input) {
       status
       message
+      pendingStatus
+      scaRedirectUrl
+      failureReason
     }
   }
 `

--- a/apps/payments/graphql/queries.graphql.ts
+++ b/apps/payments/graphql/queries.graphql.ts
@@ -36,6 +36,7 @@ export const GetPaymentFlow = gql`
       lastBankTransferFailure
       bankTransferScaRedirectUrl
       bankTransferExpiresAt
+      bankTransferPendingStatus
     }
   }
 `

--- a/apps/payments/hooks/useBankTransferPayment.ts
+++ b/apps/payments/hooks/useBankTransferPayment.ts
@@ -49,11 +49,11 @@ export const useBankTransferPayment = ({
           },
         })
 
-        const scaRedirectUrl =
-          response.data?.paymentsCreateBankTransfer?.scaRedirectUrl
+        const created = response.data?.paymentsCreateBankTransfer
+        const scaRedirectUrl = created?.scaRedirectUrl
 
-        // Interactive SCA → redirect.
-        if (scaRedirectUrl) {
+        // Redirect if onboarding is required.
+        if (created?.onboardingRequired && scaRedirectUrl) {
           if (!isHttpsUrl(scaRedirectUrl)) {
             onPaymentError({
               code: BankTransferErrorCode.FailedToCreateBankTransfer,
@@ -64,7 +64,7 @@ export const useBankTransferPayment = ({
           return
         }
 
-        // No SCA redirect URL → reload so SSR lands on the dedicated waiting screen.
+        // Reload to land on the dedicated pending screen.
         router.reload()
       } catch (e: unknown) {
         const detail = findProblemInApolloError(e as ApolloError)?.detail

--- a/apps/payments/hooks/useBankTransferStatusPolling.ts
+++ b/apps/payments/hooks/useBankTransferStatusPolling.ts
@@ -33,12 +33,16 @@ interface UseBankTransferStatusPollingProps {
 }
 
 const POLL_INTERVALS_MS = [500, 1000, 2000, 3000, 5000]
+// Slower steady state once the SCA URL is on screen.
+const SCA_WAIT_POLL_MS = 15 * 1000
 const TIMEOUT_GRACE_MS = 30 * 1000 // 30 seconds
 // Matches the prod Blikk TTL (600s). Used only when `expiresAt` is missing.
 const FALLBACK_HARD_TIMEOUT_MS = 10 * 60 * 1000 // 10 minutes
 
-const nextInterval = (attempt: number) =>
-  POLL_INTERVALS_MS[Math.min(attempt, POLL_INTERVALS_MS.length - 1)]
+const nextInterval = (attempt: number, isAwaitingSca: boolean) =>
+  isAwaitingSca
+    ? SCA_WAIT_POLL_MS
+    : POLL_INTERVALS_MS[Math.min(attempt, POLL_INTERVALS_MS.length - 1)]
 
 const terminalStatusToErrorCode = (
   status: PaymentsBankTransferStatus,
@@ -117,6 +121,7 @@ export const useBankTransferStatusPolling = ({
     let cancelled = false
     let timeoutId: ReturnType<typeof setTimeout> | null = null
     let attempt = 0
+    let isAwaitingSca = false
     const startedAt = Date.now()
     const hardTimeoutMs = computeHardTimeoutMs(expiresAt)
 
@@ -177,7 +182,13 @@ export const useBankTransferStatusPolling = ({
           pendingStatus: verifyResult?.pendingStatus,
           scaRedirectUrl: verifyResult?.scaRedirectUrl,
         })
-        timeoutId = setTimeout(poll, nextInterval(attempt))
+        // Decay to the slow interval while the payer acts on the SCA UI; back to fast once the
+        // status moves on (processing — settlement typically resolves within seconds).
+        isAwaitingSca =
+          verifyResult?.pendingStatus ===
+            PaymentsBankTransferPendingStatus.sca_required &&
+          !!verifyResult?.scaRedirectUrl
+        timeoutId = setTimeout(poll, nextInterval(attempt, isAwaitingSca))
         attempt++
       } catch (e) {
         if (cancelled) {
@@ -190,7 +201,7 @@ export const useBankTransferStatusPolling = ({
           return
         }
         // Transient network/server hiccup — retry with backoff.
-        timeoutId = setTimeout(poll, nextInterval(attempt))
+        timeoutId = setTimeout(poll, nextInterval(attempt, isAwaitingSca))
         attempt++
       }
     }

--- a/apps/payments/hooks/useBankTransferStatusPolling.ts
+++ b/apps/payments/hooks/useBankTransferStatusPolling.ts
@@ -1,12 +1,21 @@
 import type { ApolloError } from '@apollo/client'
 import { useEffect, useRef } from 'react'
 
-import { PaymentsBankTransferStatus } from '@island.is/api/schema'
+import {
+  PaymentsBankTransferFailureReason,
+  PaymentsBankTransferStatus,
+  PaymentsBankTransferPendingStatus,
+} from '@island.is/api/schema'
 import { BankTransferErrorCode } from '@island.is/shared/constants'
 import { findProblemInApolloError } from '@island.is/shared/problem'
 
 import { useVerifyBankTransferMutation } from '../graphql/mutations.graphql.generated'
 import { PaymentError } from '../utils/error/error'
+
+export interface BankTransferStatusUpdate {
+  pendingStatus?: PaymentsBankTransferPendingStatus | null
+  scaRedirectUrl?: string | null
+}
 
 /**
  * Polls `paymentsVerifyBankTransfer` until the attempt reaches a terminal state.
@@ -19,9 +28,11 @@ interface UseBankTransferStatusPollingProps {
   expiresAt?: Date | string | null
   onSuccess: () => void
   onFailure: (error: PaymentError) => void
+  // Non-terminal sub-status updates..
+  onStatusUpdate?: (update: BankTransferStatusUpdate) => void
 }
 
-const POLL_INTERVALS_MS = [1000, 2000, 4000, 8000, 15000]
+const POLL_INTERVALS_MS = [500, 1000, 2000, 3000, 5000]
 const TIMEOUT_GRACE_MS = 30 * 1000 // 30 seconds
 // Matches the prod Blikk TTL (600s). Used only when `expiresAt` is missing.
 const FALLBACK_HARD_TIMEOUT_MS = 10 * 60 * 1000 // 10 minutes
@@ -39,6 +50,22 @@ const terminalStatusToErrorCode = (
       return BankTransferErrorCode.BankTransferCancelled
     default:
       return BankTransferErrorCode.BankTransferGenericError
+  }
+}
+
+const terminalFailureToErrorCode = (
+  status: PaymentsBankTransferStatus,
+  failureReason?: PaymentsBankTransferFailureReason | null,
+): BankTransferErrorCode => {
+  switch (failureReason) {
+    case PaymentsBankTransferFailureReason.expired:
+      return BankTransferErrorCode.BankTransferExpired
+    case PaymentsBankTransferFailureReason.rejected:
+      return BankTransferErrorCode.BankTransferRejected
+    case PaymentsBankTransferFailureReason.cancelled:
+      return BankTransferErrorCode.BankTransferCancelled
+    default:
+      return terminalStatusToErrorCode(status)
   }
 }
 
@@ -64,18 +91,23 @@ export const useBankTransferStatusPolling = ({
   expiresAt,
   onSuccess,
   onFailure,
+  onStatusUpdate,
 }: UseBankTransferStatusPollingProps) => {
   const [verifyBankTransferMutation] = useVerifyBankTransferMutation()
 
   // Latest-value refs so callback identity changes don't restart the effect.
   const onSuccessRef = useRef(onSuccess)
   const onFailureRef = useRef(onFailure)
+  const onStatusUpdateRef = useRef(onStatusUpdate)
   useEffect(() => {
     onSuccessRef.current = onSuccess
   }, [onSuccess])
   useEffect(() => {
     onFailureRef.current = onFailure
   }, [onFailure])
+  useEffect(() => {
+    onStatusUpdateRef.current = onStatusUpdate
+  }, [onStatusUpdate])
 
   useEffect(() => {
     if (!enabled || !paymentFlowId) {
@@ -114,13 +146,13 @@ export const useBankTransferStatusPolling = ({
         const result = await verifyBankTransferMutation({
           variables: { input: { paymentFlowId } },
         })
-
         // if the request was cancelled, stop polling
         if (cancelled) {
           return
         }
 
-        const status = result.data?.paymentsVerifyBankTransfer?.status
+        const verifyResult = result.data?.paymentsVerifyBankTransfer
+        const status = verifyResult?.status
         if (status === PaymentsBankTransferStatus.success) {
           stop()
           onSuccessRef.current()
@@ -132,10 +164,19 @@ export const useBankTransferStatusPolling = ({
           status === PaymentsBankTransferStatus.cancelled
         ) {
           stop()
-          onFailureRef.current({ code: terminalStatusToErrorCode(status) })
+          onFailureRef.current({
+            code: terminalFailureToErrorCode(
+              status,
+              verifyResult?.failureReason,
+            ),
+          })
           return
         }
-        // PENDING — schedule the next poll.
+        // PENDING — surface sub-status changes (e.g. a fresh SCA URL) and schedule the next poll.
+        onStatusUpdateRef.current?.({
+          pendingStatus: verifyResult?.pendingStatus,
+          scaRedirectUrl: verifyResult?.scaRedirectUrl,
+        })
         timeoutId = setTimeout(poll, nextInterval(attempt))
         attempt++
       } catch (e) {

--- a/apps/payments/hooks/useBankTransferStatusPolling.ts
+++ b/apps/payments/hooks/useBankTransferStatusPolling.ts
@@ -34,7 +34,7 @@ interface UseBankTransferStatusPollingProps {
 
 const POLL_INTERVALS_MS = [500, 1000, 2000, 3000, 5000]
 // Slower steady state once the SCA URL is on screen.
-const SCA_WAIT_POLL_MS = 15 * 1000
+const SCA_WAIT_POLL_MS = 10 * 1000
 const TIMEOUT_GRACE_MS = 30 * 1000 // 30 seconds
 // Matches the prod Blikk TTL (600s). Used only when `expiresAt` is missing.
 const FALLBACK_HARD_TIMEOUT_MS = 10 * 60 * 1000 // 10 minutes

--- a/apps/payments/hooks/usePaymentOrchestration.ts
+++ b/apps/payments/hooks/usePaymentOrchestration.ts
@@ -40,6 +40,8 @@ const deriveInitialBankTransferError = (
       return { code: BankTransferErrorCode.BankTransferRejected }
     case PaymentsBankTransferFailureReason.cancelled:
       return { code: BankTransferErrorCode.BankTransferCancelled }
+    case PaymentsBankTransferFailureReason.expired:
+      return { code: BankTransferErrorCode.BankTransferExpired }
     default:
       return { code: BankTransferErrorCode.BankTransferGenericError }
   }

--- a/apps/payments/messages/bankTransfer.ts
+++ b/apps/payments/messages/bankTransfer.ts
@@ -68,6 +68,13 @@ export const bankTransfer = defineMessages({
     description:
       'Error toast shown when the cancel-bank-transfer mutation fails (non-already-paid)',
   },
+  cancelRefusedProcessingToast: {
+    id: 'payments:bankTransfer.cancelRefusedProcessingToast',
+    defaultMessage:
+      'Ekki er hægt að hætta við — greiðslan er þegar í vinnslu hjá bankanum.',
+    description:
+      'Error toast shown when the cancel is refused because the payer has already initiated/approved the payment and settlement may be in flight. EN: "The payment cannot be cancelled — your bank is already processing it."',
+  },
   scanQrInstruction: {
     id: 'payments:bankTransfer.scanQrInstruction',
     defaultMessage: 'Skannaðu þennan QR-kóða með símanum þínum.',
@@ -86,11 +93,11 @@ export const bankTransfer = defineMessages({
     description:
       'Supporting text under the open-banking-app button on the mobile pending screen. EN: "Open your banking app to approve payment."',
   },
-  waitingForAuthorization: {
-    id: 'payments:bankTransfer.waitingForAuthorization',
+  waitingForAuthorisation: {
+    id: 'payments:bankTransfer.waitingForAuthorisation',
     defaultMessage: 'Beðið eftir heimild',
     description:
-      'Waiting message under the loading dots while SCA is complete/not yet required and we poll for terminal status. EN: "Waiting for authorization..."',
+      'Waiting message under the loading dots while SCA is complete/not yet required and we poll for terminal status. EN: "Waiting for authorisation..."',
   },
   checkPhone: {
     id: 'payments:bankTransfer.checkPhone',

--- a/apps/payments/messages/bankTransfer.ts
+++ b/apps/payments/messages/bankTransfer.ts
@@ -68,12 +68,11 @@ export const bankTransfer = defineMessages({
     description:
       'Error toast shown when the cancel-bank-transfer mutation fails (non-already-paid)',
   },
-  cancelRefusedProcessingToast: {
-    id: 'payments:bankTransfer.cancelRefusedProcessingToast',
-    defaultMessage:
-      'Ekki er hægt að hætta við — greiðslan er þegar í vinnslu hjá bankanum.',
+  cancelInBankAppNote: {
+    id: 'payments:bankTransfer.cancelInBankAppNote',
+    defaultMessage: 'Þú getur hafnað greiðslubeiðninni í bankaappinu þínu.',
     description:
-      'Error toast shown when the cancel is refused because the payer has already initiated/approved the payment and settlement may be in flight. EN: "The payment cannot be cancelled — your bank is already processing it."',
+      'Static note under the SCA QR / open-banking-app screen telling the payer how to back out, since the payment cannot be cancelled from here once SCA is under way. EN: "Changed your mind? You can decline the payment request in your banking app."',
   },
   scanQrInstruction: {
     id: 'payments:bankTransfer.scanQrInstruction',

--- a/apps/payments/messages/bankTransfer.ts
+++ b/apps/payments/messages/bankTransfer.ts
@@ -68,6 +68,37 @@ export const bankTransfer = defineMessages({
     description:
       'Error toast shown when the cancel-bank-transfer mutation fails (non-already-paid)',
   },
+  scanQrInstruction: {
+    id: 'payments:bankTransfer.scanQrInstruction',
+    defaultMessage: 'Skannaðu þennan QR-kóða með símanum þínum.',
+    description:
+      'Bold heading under the SCA QR code on the desktop pending screen. EN: "Scan the QR code"',
+  },
+  openBankingApp: {
+    id: 'payments:bankTransfer.openBankingApp',
+    defaultMessage: 'Opna bankaapp',
+    description:
+      'Primary CTA on the mobile pending screen that opens the SCA deep link in the banking app. EN: "Open banking app"',
+  },
+  openBankingAppInstruction: {
+    id: 'payments:bankTransfer.openBankingAppInstruction',
+    defaultMessage: 'Opnaðu bankaappið þitt til að staðfesta greiðslu.',
+    description:
+      'Supporting text under the open-banking-app button on the mobile pending screen. EN: "Open your banking app to approve payment."',
+  },
+  waitingForAuthorization: {
+    id: 'payments:bankTransfer.waitingForAuthorization',
+    defaultMessage: 'Beðið eftir heimild',
+    description:
+      'Waiting message under the loading dots while SCA is complete/not yet required and we poll for terminal status. EN: "Waiting for authorization..."',
+  },
+  checkPhone: {
+    id: 'payments:bankTransfer.checkPhone',
+    defaultMessage:
+      'Athugaðu hvort tilkynning frá bankanum þínum hafi borist í símann þinn',
+    description:
+      'Waiting message when SCA is required but there is no SCA URL (back-channel SCA). EN: "Please check your phone for a banking app notification"',
+  },
 })
 
 export const bankTransferSuccess = defineMessages({
@@ -140,13 +171,13 @@ export const bankTransferError = defineMessages({
   expired: {
     id: 'payments:bankTransferError.expired',
     defaultMessage:
-      'Tími til að ljúka millifærslunni rann út. Reyndu aftur til að halda áfram.',
+      'Tími til að ljúka millifærslunni rann út. Vinsamlegast reynið aftur.',
     description:
       'Error shown when the bank-transfer attempt timed out before completing',
   },
   expiredTitle: {
     id: 'payments:bankTransferError.expiredTitle',
-    defaultMessage: 'Millifærsla rann út á tíma',
+    defaultMessage: 'Tíminn rann út',
     description:
       'Header on the standard error view for a bank-transfer that expired before completing',
   },

--- a/apps/payments/pages/[locale]/[paymentFlowId]/index.tsx
+++ b/apps/payments/pages/[locale]/[paymentFlowId]/index.tsx
@@ -31,6 +31,7 @@ import {
 import { CardPayment } from '../../../components/CardPayment/CardPayment'
 import { InvoicePayment } from '../../../components/InvoicePayment/InvoicePayment'
 import { BankTransferPayment } from '../../../components/BankTransferPayment/BankTransferPayment'
+import { BankTransferPendingScreen } from '../../../components/BankTransferPendingScreen/BankTransferPendingScreen'
 import { ALLOWED_LOCALES, Locale, isHttpsUrl } from '../../../utils'
 import { getConfigcatClient } from '../../../clients/configcat'
 import {
@@ -58,7 +59,10 @@ import { PaymentReceipt } from '../../../components/PaymentReceipt'
 import { ThreeDSecure } from '../../../components/ThreeDSecure/ThreeDSecure'
 import { InvoiceReceipt } from '../../../components/InvoiceReceipt'
 import { usePaymentOrchestration } from '../../../hooks/usePaymentOrchestration'
-import { useBankTransferStatusPolling } from '../../../hooks/useBankTransferStatusPolling'
+import {
+  BankTransferStatusUpdate,
+  useBankTransferStatusPolling,
+} from '../../../hooks/useBankTransferStatusPolling'
 import { useCancelBankTransfer } from '../../../hooks/useCancelBankTransfer'
 import { withLocale } from '../../../i18n/withLocale'
 
@@ -275,6 +279,10 @@ function PaymentPage({
   })
   const router = useRouter()
 
+  // Sub-status updates observed while polling, overrides the SSR snapshot from paymentsGetFlow.
+  const [liveBankTransfer, setLiveBankTransfer] =
+    useState<BankTransferStatusUpdate | null>(null)
+
   // Bank-transfer polling runs only on the dedicated waiting screen (reached via SSR after submit).
   useBankTransferStatusPolling({
     paymentFlowId: paymentFlow?.id,
@@ -285,6 +293,7 @@ function PaymentPage({
     // Success needs a reload to land on the receipt screen
     onSuccess: () => router.reload(),
     onFailure: (error) => setPaymentError(error),
+    onStatusUpdate: setLiveBankTransfer,
   })
 
   const { cancelBankTransfer, isCancelling } = useCancelBankTransfer({
@@ -383,11 +392,13 @@ function PaymentPage({
   )
 
   const paymentStatus = paymentFlow?.paymentStatus
-  const bankTransferScaRedirectUrl = isHttpsUrl(
-    paymentFlow?.bankTransferScaRedirectUrl,
-  )
-    ? paymentFlow?.bankTransferScaRedirectUrl ?? undefined
+  const rawScaRedirectUrl =
+    liveBankTransfer?.scaRedirectUrl ?? paymentFlow?.bankTransferScaRedirectUrl
+  const bankTransferScaRedirectUrl = isHttpsUrl(rawScaRedirectUrl)
+    ? rawScaRedirectUrl ?? undefined
     : undefined
+  const bankTransferPendingStatus =
+    liveBankTransfer?.pendingStatus ?? paymentFlow?.bankTransferPendingStatus
 
   const isPaid = paymentStatus === PaymentsGetFlowPaymentStatus.paid
   const isInvoicePending =
@@ -410,37 +421,12 @@ function PaymentPage({
           />
         }
         bodySlot={
-          <Box display="flex" flexDirection="column" rowGap={[2, 3]}>
-            <AlertMessage
-              type="warning"
-              message={formatMessage(
-                bankTransferScaRedirectUrl
-                  ? bankTransfer.waiting
-                  : bankTransfer.finishInBankApp,
-              )}
-            />
-            {bankTransferScaRedirectUrl && (
-              <Button
-                fluid
-                unfocusable
-                onClick={() =>
-                  window.location.assign(bankTransferScaRedirectUrl)
-                }
-              >
-                {formatMessage(bankTransfer.continuePayment)}
-              </Button>
-            )}
-            <Box display="flex" justifyContent="center">
-              <Button
-                unfocusable
-                variant="text"
-                loading={isCancelling}
-                onClick={handleCancelBankTransfer}
-              >
-                {formatMessage(generic.buttonCancel)}
-              </Button>
-            </Box>
-          </Box>
+          <BankTransferPendingScreen
+            pendingStatus={bankTransferPendingStatus}
+            scaRedirectUrl={bankTransferScaRedirectUrl}
+            isCancelling={isCancelling}
+            onCancel={handleCancelBankTransfer}
+          />
         }
       />
     )

--- a/apps/payments/pages/[locale]/[paymentFlowId]/index.tsx
+++ b/apps/payments/pages/[locale]/[paymentFlowId]/index.tsx
@@ -296,7 +296,9 @@ function PaymentPage({
     onStatusUpdate: setLiveBankTransfer,
   })
 
-  const { cancelBankTransfer, isCancelling } = useCancelBankTransfer({
+  // Retained for the error screen's "start again" flow (onErrorBack); the pending screen no longer
+  // exposes a cancel control — see BankTransferPendingScreen.
+  const { cancelBankTransfer } = useCancelBankTransfer({
     paymentFlowId: paymentFlow?.id,
   })
 
@@ -305,30 +307,6 @@ function PaymentPage({
   const isAlreadyPaidError = (e: ApolloError | undefined) =>
     findProblemInApolloError(e)?.detail ===
     PaymentServiceCode.PaymentFlowAlreadyPaid
-
-  const handleCancelBankTransfer = async () => {
-    try {
-      await cancelBankTransfer()
-      router.reload()
-    } catch (e) {
-      if (isAlreadyPaidError(e)) {
-        router.reload()
-        return
-      }
-      // The backend refuses the cancel once the payer has initiated/approved the payment —
-      // settlement may be in flight, so tell them the bank is processing rather than "retry".
-      const isRefusedInProgress =
-        findProblemInApolloError(e)?.detail ===
-        BankTransferErrorCode.BankTransferAlreadyInProgress
-      toast.error(
-        formatMessage(
-          isRefusedInProgress
-            ? bankTransfer.cancelRefusedProcessingToast
-            : bankTransfer.cancelFailedToast,
-        ),
-      )
-    }
-  }
 
   const [isStartingAgain, setIsStartingAgain] = useState(false)
 
@@ -435,8 +413,6 @@ function PaymentPage({
           <BankTransferPendingScreen
             pendingStatus={bankTransferPendingStatus}
             scaRedirectUrl={bankTransferScaRedirectUrl}
-            isCancelling={isCancelling}
-            onCancel={handleCancelBankTransfer}
           />
         }
       />

--- a/apps/payments/pages/[locale]/[paymentFlowId]/index.tsx
+++ b/apps/payments/pages/[locale]/[paymentFlowId]/index.tsx
@@ -315,7 +315,18 @@ function PaymentPage({
         router.reload()
         return
       }
-      toast.error(formatMessage(bankTransfer.cancelFailedToast))
+      // The backend refuses the cancel once the payer has initiated/approved the payment —
+      // settlement may be in flight, so tell them the bank is processing rather than "retry".
+      const isRefusedInProgress =
+        findProblemInApolloError(e)?.detail ===
+        BankTransferErrorCode.BankTransferAlreadyInProgress
+      toast.error(
+        formatMessage(
+          isRefusedInProgress
+            ? bankTransfer.cancelRefusedProcessingToast
+            : bankTransfer.cancelFailedToast,
+        ),
+      )
     }
   }
 

--- a/apps/services/payments/infra/payments.ts
+++ b/apps/services/payments/infra/payments.ts
@@ -45,6 +45,9 @@ const env = {
     staging: '300', // 5 minutes
     prod: '600', // 10 minutes
   },
+  // Origin of the Blikk onboarding app: a DRAFT payment whose scaRedirectUrl points here
+  // requires payer onboarding before SCA (the FE redirects there instead of rendering SCA).
+  BLIKK_ONBOARDING_URL: 'https://light.blikk.tech',
 }
 
 // common database configuration

--- a/apps/services/payments/src/app/bankTransferPayment/README.md
+++ b/apps/services/payments/src/app/bankTransferPayment/README.md
@@ -61,14 +61,21 @@ sequenceDiagram
     SVC->>B: POST /ecom/v3/payments/direct-debtor (amount, items, expiresAt, callbackUrl, debtorExternalId, debtorBban)
     B-->>SVC: { id, status, scaRedirectUrl? }
     SVC->>SVC: persist row (PENDING), emit payment_started
-    SVC-->>FE: { providerPaymentId, scaRedirectUrl, expiresAt }
+    SVC-->>FE: { providerPaymentId, scaRedirectUrl, expiresAt, onboardingRequired }
 
-    alt Interactive SCA (scaRedirectUrl present)
-        FE->>U: redirect to scaRedirectUrl
-        U->>Bank: authenticate & approve
-        Bank-->>FE: redirect back to flow page (SSR → waiting screen)
-    else Back-channel SCA (scaRedirectUrl empty)
-        FE->>FE: reload → SSR waiting screen ("Finish the payment with your bank app")
+    alt Onboarding required (DRAFT + onboarding URL)
+        FE->>U: redirect to scaRedirectUrl (provider onboarding)
+    else Everything else
+        FE->>FE: reload → SSR pending screen (bankTransferPendingStatus drives the UI)
+    end
+
+    alt sca_required + URL (incl. DRAFT with a non-onboarding URL)
+        FE->>U: desktop: QR code of scaRedirectUrl / mobile: "Opna bankaapp" button
+        U->>Bank: scan / open link, authenticate & approve
+    else sca_required without URL (back-channel)
+        FE->>U: "check your phone for a banking-app notification"
+    else processing (PENDING / SCA_COMPLETE / DRAFT without URL)
+        FE->>U: loading dots + "Beðið eftir heimild..."
     end
 
     par Webhook (primary)
@@ -141,20 +148,35 @@ local hook state.
    banner normally, swapping to a **`default` waiting** banner while polling is in flight
    (`isWaiting`). Submit button label is `bankTransfer.confirm`; it is disabled/loading while
    polling so the payer can't double-submit.
-2. **Interactive SCA redirect.** On submit, if `create` returned a non-empty `scaRedirectUrl`,
-   the FE does `window.location.assign(scaRedirectUrl)`. An empty URL means back-channel SCA
-   (approve in the bank app) — the FE `router.reload()`s so SSR lands on the waiting screen.
-3. **Waiting screen** (`paymentStatus === bank_transfer_pending`). A dedicated page-card with a
-   waiting alert and a **Cancel** button. The FE polls `verify` in the background and reloads on a
-   terminal result. The alert depends on whether a redirect URL is present:
+2. **Submit → pending screen (no SCA redirect).** On submit, the FE `router.reload()`s so SSR
+   lands on the pending screen — SCA is rendered **inline** there, not via redirect. The single
+   exception is provider **onboarding**: when `create` returns `onboardingRequired: true`
+   (a `DRAFT` payment whose `scaRedirectUrl` points at the provider onboarding app), the FE does
+   `window.location.assign(scaRedirectUrl)`.
+3. **Pending screen** (`paymentStatus === bank_transfer_pending`), rendered by
+   [`BankTransferPendingScreen`](../../../../../../apps/payments/components/BankTransferPendingScreen/BankTransferPendingScreen.tsx).
+   The FE polls `verify` in the background and reloads on a terminal result. What renders is
+   driven by the provider-neutral `bankTransferPendingStatus` sub-status (from the `getPaymentFlow`
+   overlay at SSR, live-updated by the `verify` poll response) **combined with** the SCA URL —
+   never by the URL alone:
 
-   - **Interactive** (`bankTransferScaRedirectUrl` present): `default` alert + a **Continue payment**
-     button that re-opens the SCA URL (for a payer who bounced).
-   - **Back-channel** (no redirect URL): `warning` alert "Finish the payment with your bank app",
-     **no** Continue button — only Cancel.
+   - **`sca_required` + URL**: desktop (≥ `md`) shows a QR code encoding the raw SCA URL
+     ([`BankTransferQrCode`](../../../../../../apps/payments/components/BankTransferQrCode/BankTransferQrCode.tsx));
+     mobile shows an **"Opna bankaapp"** button that opens the URL directly. `DRAFT` with a
+     non-onboarding SCA URL also maps here — a DRAFT only advances once the payer initiates,
+     so the QR shows immediately after create instead of flickering dots→QR.
+   - **`sca_required` without URL** (back-channel): "check your phone for a banking-app
+     notification" message.
+   - **`processing`** (`PENDING`/`SCA_COMPLETE`/`DRAFT` without a usable URL): loading dots +
+     "Beðið eftir heimild..."
+   - A **Cancel** button on all variants.
 
-   This screen is reached via **SSR**: returning from an interactive SCA redirect, or — for
-   back-channel — the `router.reload()` the FE issues right after a redirect-less `create`.
+   A back-channel create has no SCA URL at first; when Blikk mints one on the
+   `DRAFT → SCA_REQUIRED` transition, `verify`/`getBankTransferStatus` persist it on the row and
+   the poll response carries it to the FE, so the QR/deep link appears mid-poll without a reload.
+
+   This screen is reached via **SSR**: the `router.reload()` the FE issues right after `create`
+   (or returning from the onboarding redirect).
 
 4. **Error screen** (`paymentError` set to a bank-transfer code). Title/message come from
    [`paymentErrorToTitleAndMessage`](../../../../../../apps/payments/utils/error/error.ts). The
@@ -257,10 +279,19 @@ payments with no matching `bank_transfer_payment` row that outlive the TTL.
 (failed screen) buttons.
 
 - A **settled** attempt cannot be cancelled → `PaymentFlowAlreadyPaid`.
-- For a still-`pending`, non-expired attempt we ask Blikk to cancel **first**. Blikk only honours
-  a cancel while the payment is in `DRAFT`; a payment the payer already took to the bank (past
-  `DRAFT`) makes the Blikk cancel throw, and we **refuse to soft-delete** rather than orphan a
-  possibly-live settlement. A `404` from Blikk is tolerated (nothing live to orphan).
+- For a still-`pending`, non-expired attempt, what happens depends on the (refreshed) raw status —
+  Blikk only honours a cancel while the payment is in `DRAFT`:
+  - **`DRAFT`**: best-effort Blikk cancel, then soft-delete. A `DRAFT` cannot settle, so any
+    failure of the Blikk cancel (404 gone, 405 refused, network) is swallowed — the payment
+    lapses via the TTL we sent Blikk on create.
+  - **`SCA_REQUIRED`**: the payer has **not approved yet** and Blikk cannot cancel past `DRAFT` —
+    abandon locally (soft-delete) and let the provider payment lapse via its TTL. _Known window:_
+    a payer who already scanned the QR could still approve in their banking app before the TTL;
+    that settlement's webhook/verify would find no active row (same bounded window as the
+    expired-row lazy discard).
+  - **`PENDING` / `SCA_COMPLETE`** (payer initiated/approved — settlement may be in flight):
+    **refuse** with `BankTransferAlreadyInProgress` rather than orphan a possibly-live
+    settlement; verify/webhook/TTL keep tracking it.
 - The local soft-delete is conditional on `lastKnownStatus`, so a concurrent finalize that flips
   the row to SUCCESS wins the race (and we surface `PaymentFlowAlreadyPaid`).
 - `payment_cancelled` is emitted **only** for an active-`pending` user cancel; terminal-failed

--- a/apps/services/payments/src/app/bankTransferPayment/README.md
+++ b/apps/services/payments/src/app/bankTransferPayment/README.md
@@ -169,7 +169,8 @@ local hook state.
      notification" message.
    - **`processing`** (`PENDING`/`SCA_COMPLETE`/`DRAFT` without a usable URL): loading dots +
      "Beðið eftir heimild..."
-   - A **Cancel** button on all variants.
+   - A **Cancel** button on all variants — the backend refuses once the payer has
+     initiated/approved (`BankTransferAlreadyInProgress`), surfaced as a dedicated toast.
 
    A back-channel create has no SCA URL at first; when Blikk mints one on the
    `DRAFT → SCA_REQUIRED` transition, `verify`/`getBankTransferStatus` persist it on the row and
@@ -279,19 +280,21 @@ payments with no matching `bank_transfer_payment` row that outlive the TTL.
 (failed screen) buttons.
 
 - A **settled** attempt cannot be cancelled → `PaymentFlowAlreadyPaid`.
-- For a still-`pending`, non-expired attempt, what happens depends on the (refreshed) raw status —
-  Blikk only honours a cancel while the payment is in `DRAFT`:
-  - **`DRAFT`**: best-effort Blikk cancel, then soft-delete. A `DRAFT` cannot settle, so any
-    failure of the Blikk cancel (404 gone, 405 refused, network) is swallowed — the payment
-    lapses via the TTL we sent Blikk on create.
-  - **`SCA_REQUIRED`**: the payer has **not approved yet** and Blikk cannot cancel past `DRAFT` —
-    abandon locally (soft-delete) and let the provider payment lapse via its TTL. _Known window:_
-    a payer who already scanned the QR could still approve in their banking app before the TTL;
-    that settlement's webhook/verify would find no active row (same bounded window as the
-    expired-row lazy discard).
-  - **`PENDING` / `SCA_COMPLETE`** (payer initiated/approved — settlement may be in flight):
-    **refuse** with `BankTransferAlreadyInProgress` rather than orphan a possibly-live
-    settlement; verify/webhook/TTL keep tracking it.
+- Cancelling a still-`pending` attempt requires a **fresh** Blikk status — never the cached one,
+  which could be a stale `DRAFT` the payer has since taken to the bank. If the refresh fails,
+  the cancel throws `FailedToFetchBankTransfer` (retryable; the FE shows the cancel-failed
+  toast). With the fresh status in hand, two rules (skipped for an expired row — its TTL already
+  elapsed, nothing to cancel):
+  - **`DRAFT` / `SCA_REQUIRED`** (payer has **not approved**): one best-effort Blikk cancel —
+    Blikk only honours it for `DRAFT`, so any failure (404 gone, 405 refused, network) is
+    swallowed — then soft-delete; the provider payment lapses via the TTL we sent Blikk on
+    create. _Known window:_ a payer who already scanned the QR could still approve in their
+    banking app before the TTL; that settlement's webhook/verify would find no active row (same
+    bounded window as the expired-row lazy discard).
+  - **`PENDING` / `SCA_COMPLETE` / unknown** (payer initiated/approved — settlement may be in
+    flight): **refuse** with `BankTransferAlreadyInProgress` rather than orphan a possibly-live
+    settlement; verify/webhook/TTL keep tracking it. The FE surfaces this as a dedicated
+    "the bank is already processing it" toast.
 - The local soft-delete is conditional on `lastKnownStatus`, so a concurrent finalize that flips
   the row to SUCCESS wins the race (and we surface `PaymentFlowAlreadyPaid`).
 - `payment_cancelled` is emitted **only** for an active-`pending` user cancel; terminal-failed

--- a/apps/services/payments/src/app/bankTransferPayment/bankTransfer.config.ts
+++ b/apps/services/payments/src/app/bankTransferPayment/bankTransfer.config.ts
@@ -5,6 +5,7 @@ import { defineConfig } from '@island.is/nest/config'
 const schema = z.object({
   /** TTL in seconds passed as `expireAt` to Blikk on create. Also gates our row's freshness. */
   paymentTtlSeconds: z.number().int().positive(),
+  onboardingOrigin: z.string().url(),
 })
 
 export type BankTransferModuleConfigType = z.infer<typeof schema>
@@ -21,6 +22,10 @@ export const BankTransferModuleConfig = defineConfig({
         Number.isFinite(paymentTtlSeconds) && paymentTtlSeconds > 0
           ? paymentTtlSeconds
           : 300,
+      onboardingOrigin: env.required(
+        'BLIKK_ONBOARDING_URL',
+        'https://light.blikk.tech',
+      ),
     }
   },
 })

--- a/apps/services/payments/src/app/bankTransferPayment/bankTransfer.service.spec.ts
+++ b/apps/services/payments/src/app/bankTransferPayment/bankTransfer.service.spec.ts
@@ -992,7 +992,7 @@ describe('BankTransferService', () => {
       expect(result).toEqual({ ok: true })
     })
 
-    it('best-effort cancels on Blikk and abandons locally when the payment is SCA_REQUIRED (payer has not approved)', async () => {
+    it('cancels on Blikk and soft-deletes when SCA_REQUIRED and Blikk honours the cancel', async () => {
       bankTransferPaymentModel.findOne.mockResolvedValue({
         ...baseRow,
         lastKnownStatus: 'SCA_REQUIRED',
@@ -1001,11 +1001,10 @@ describe('BankTransferService', () => {
         id: 'prov-1',
         status: 'SCA_REQUIRED',
       })
+      // Default cancelPayment mock resolves (2xx) — Blikk confirmed the cancel.
 
       const result = await service.cancel({ paymentFlowId: 'flow-1' })
 
-      // Blikk only honours cancels for DRAFT, so this call is best-effort (its refusal is
-      // swallowed) — an unapproved payment lapses via its TTL either way.
       expect(blikkClient.cancelPayment).toHaveBeenCalledWith('prov-1')
       expect(bankTransferPaymentModel.update).toHaveBeenCalledWith(
         { isDeleted: true },
@@ -1018,6 +1017,33 @@ describe('BankTransferService', () => {
         },
       )
       expect(result).toEqual({ ok: true })
+    })
+
+    it('refuses and keeps the row live when SCA_REQUIRED and Blikk refuses the cancel', async () => {
+      bankTransferPaymentModel.findOne.mockResolvedValue({
+        ...baseRow,
+        lastKnownStatus: 'SCA_REQUIRED',
+      })
+      blikkClient.getPayment.mockResolvedValue({
+        id: 'prov-1',
+        status: 'SCA_REQUIRED',
+      })
+      // Blikk only honours cancels for DRAFT — a live SCA session yields a non-2xx (e.g. 409).
+      blikkClient.cancelPayment.mockRejectedValue(
+        new BlikkClientError('conflict', 409),
+      )
+
+      await expect(service.cancel({ paymentFlowId: 'flow-1' })).rejects.toThrow(
+        BankTransferErrorCode.BankTransferCannotCancel,
+      )
+
+      expect(blikkClient.cancelPayment).toHaveBeenCalledWith('prov-1')
+      // The still-live attempt must NOT be soft-deleted, and no payment_cancelled event fires.
+      expect(bankTransferPaymentModel.update).not.toHaveBeenCalledWith(
+        { isDeleted: true },
+        expect.anything(),
+      )
+      expect(paymentFlowService.logPaymentFlowUpdate).not.toHaveBeenCalled()
     })
 
     it.each<[string]>([['PENDING'], ['SCA_COMPLETE']])(
@@ -1185,22 +1211,40 @@ describe('BankTransferService', () => {
       expect(result).toEqual({ ok: true })
     })
 
-    // The Blikk cancel is best-effort for a DRAFT payment: a DRAFT cannot settle, so a missing
-    // payment (404) or a refused cancel (e.g. 405) must not block the user — the payment lapses
-    // via its TTL.
-    it.each<[string, number | undefined]>([
-      ['404 not-found', 404],
+    // A 404 means the payment is already gone at Blikk (it lapsed) — safe to discard locally.
+    it('soft-deletes a DRAFT payment when the Blikk cancel returns 404 not-found (already gone)', async () => {
+      bankTransferPaymentModel.findOne.mockResolvedValue({
+        ...baseRow,
+        lastKnownStatus: 'DRAFT',
+      })
+      blikkClient.getPayment.mockResolvedValue({ id: 'prov-1', status: 'DRAFT' })
+      blikkClient.cancelPayment.mockRejectedValue(
+        new BlikkClientError('gone', 404),
+      )
+
+      const result = await service.cancel({ paymentFlowId: 'flow-1' })
+
+      expect(blikkClient.cancelPayment).toHaveBeenCalledWith('prov-1')
+      expect(bankTransferPaymentModel.update).toHaveBeenCalledWith(
+        { isDeleted: true },
+        {
+          where: { id: 'corr-1', isDeleted: false, lastKnownStatus: 'DRAFT' },
+        },
+      )
+      expect(result).toEqual({ ok: true })
+    })
+
+    // Any other non-2xx means Blikk still holds the session — refuse, keep the row live.
+    it.each<[string, number]>([
       ['405 method-not-allowed', 405],
       ['409 conflict', 409],
-      ['network failure', undefined],
     ])(
-      'still soft-deletes a DRAFT payment when the Blikk cancel fails with %s',
+      'refuses and keeps the row live when the Blikk cancel returns %s',
       async (_label, status) => {
         bankTransferPaymentModel.findOne.mockResolvedValue({
           ...baseRow,
           lastKnownStatus: 'DRAFT',
         })
-        // Refresh: Blikk still DRAFT.
         blikkClient.getPayment.mockResolvedValue({
           id: 'prov-1',
           status: 'DRAFT',
@@ -1209,26 +1253,40 @@ describe('BankTransferService', () => {
           new BlikkClientError('refused', status),
         )
 
-        const result = await service.cancel({ paymentFlowId: 'flow-1' })
+        await expect(
+          service.cancel({ paymentFlowId: 'flow-1' }),
+        ).rejects.toThrow(BankTransferErrorCode.BankTransferCannotCancel)
 
         expect(blikkClient.cancelPayment).toHaveBeenCalledWith('prov-1')
-        expect(logger.warn).toHaveBeenCalledWith(
-          expect.stringContaining('Best-effort Blikk cancel failed'),
-          expect.objectContaining({ status }),
-        )
-        expect(bankTransferPaymentModel.update).toHaveBeenCalledWith(
+        expect(bankTransferPaymentModel.update).not.toHaveBeenCalledWith(
           { isDeleted: true },
-          {
-            where: {
-              id: 'corr-1',
-              isDeleted: false,
-              lastKnownStatus: 'DRAFT',
-            },
-          },
+          expect.anything(),
         )
-        expect(result).toEqual({ ok: true })
+        expect(paymentFlowService.logPaymentFlowUpdate).not.toHaveBeenCalled()
       },
     )
+
+    // A network failure leaves the provider state unknown — never discard on a guess.
+    it('throws FailedToFetchBankTransfer and keeps the row live when the Blikk cancel hits a network failure', async () => {
+      bankTransferPaymentModel.findOne.mockResolvedValue({
+        ...baseRow,
+        lastKnownStatus: 'DRAFT',
+      })
+      blikkClient.getPayment.mockResolvedValue({ id: 'prov-1', status: 'DRAFT' })
+      blikkClient.cancelPayment.mockRejectedValue(
+        new BlikkClientError('network down', undefined),
+      )
+
+      await expect(service.cancel({ paymentFlowId: 'flow-1' })).rejects.toThrow(
+        BankTransferErrorCode.FailedToFetchBankTransfer,
+      )
+
+      expect(bankTransferPaymentModel.update).not.toHaveBeenCalledWith(
+        { isDeleted: true },
+        expect.anything(),
+      )
+      expect(paymentFlowService.logPaymentFlowUpdate).not.toHaveBeenCalled()
+    })
 
     it('refreshes from Blikk before discarding an expired PENDING row, but does NOT call the Blikk cancel', async () => {
       bankTransferPaymentModel.findOne.mockResolvedValue({

--- a/apps/services/payments/src/app/bankTransferPayment/bankTransfer.service.spec.ts
+++ b/apps/services/payments/src/app/bankTransferPayment/bankTransfer.service.spec.ts
@@ -26,6 +26,7 @@ import { BankTransferPayment } from './models/bankTransferPayment.model'
 
 const config: ConfigType<typeof BankTransferModuleConfig> = {
   paymentTtlSeconds: 300,
+  onboardingOrigin: 'https://light.blikk.tech',
   isConfigured: true,
 }
 
@@ -755,6 +756,9 @@ describe('BankTransferService', () => {
         expect(result.status).toBe(status)
         // The expiry-aware failure reason passes through (fresh row → 1:1 with the status).
         expect(result.failureReason).toBe(failureReason)
+        // Pending-only fields must not leak onto a terminal response.
+        expect(result.pendingStatus).toBeUndefined()
+        expect(result.scaRedirectUrl).toBeUndefined()
       },
     )
 
@@ -989,7 +993,7 @@ describe('BankTransferService', () => {
       expect(result).toEqual({ ok: true })
     })
 
-    it('skips the Blikk cancel and abandons locally when the payment is SCA_REQUIRED (payer has not approved)', async () => {
+    it('best-effort cancels on Blikk and abandons locally when the payment is SCA_REQUIRED (payer has not approved)', async () => {
       bankTransferPaymentModel.findOne.mockResolvedValue({
         ...baseRow,
         lastKnownStatus: 'SCA_REQUIRED',
@@ -1001,8 +1005,9 @@ describe('BankTransferService', () => {
 
       const result = await service.cancel({ paymentFlowId: 'flow-1' })
 
-      // Blikk cannot cancel past DRAFT — no provider call; the payment lapses via its TTL.
-      expect(blikkClient.cancelPayment).not.toHaveBeenCalled()
+      // Blikk only honours cancels for DRAFT, so this call is best-effort (its refusal is
+      // swallowed) — an unapproved payment lapses via its TTL either way.
+      expect(blikkClient.cancelPayment).toHaveBeenCalledWith('prov-1')
       expect(bankTransferPaymentModel.update).toHaveBeenCalledWith(
         { isDeleted: true },
         {
@@ -1132,49 +1137,29 @@ describe('BankTransferService', () => {
       },
     )
 
-    it('falls through to the Blikk cancel on cached DRAFT state when the refresh fails (network)', async () => {
-      bankTransferPaymentModel.findOne.mockResolvedValue({
-        ...baseRow,
-        lastKnownStatus: 'DRAFT',
-      })
-      // Refresh fails — swallowed by refreshFromBlikkOrWarn.
-      blikkClient.getPayment.mockRejectedValue(
-        new BlikkClientError('ECONNRESET'),
-      )
-      // Cancel succeeds, so the cancel proceeds to soft-delete.
+    // Cancelling on cached state could soft-delete a payment that has since gone live at Blikk
+    // (a stale DRAFT the payer just took to the bank), so a pending cancel requires a fresh
+    // provider status — the error is retryable and the FE surfaces the cancel-failed toast.
+    it.each<[string]>([['DRAFT'], ['PENDING']])(
+      'throws FailedToFetchBankTransfer and touches nothing when the refresh fails on a cached %s row',
+      async (cachedRawStatus) => {
+        bankTransferPaymentModel.findOne.mockResolvedValue({
+          ...baseRow,
+          lastKnownStatus: cachedRawStatus,
+        })
+        blikkClient.getPayment.mockRejectedValue(
+          new BlikkClientError('ECONNRESET'),
+        )
 
-      const result = await service.cancel({ paymentFlowId: 'flow-1' })
+        await expect(
+          service.cancel({ paymentFlowId: 'flow-1' }),
+        ).rejects.toThrow(BankTransferErrorCode.FailedToFetchBankTransfer)
 
-      expect(blikkClient.getPayment).toHaveBeenCalledWith('prov-1')
-      expect(blikkClient.cancelPayment).toHaveBeenCalledWith('prov-1')
-
-      // Cached DRAFT soft-delete uses the cached lastKnownStatus race-guard.
-      expect(bankTransferPaymentModel.update).toHaveBeenCalledWith(
-        { isDeleted: true },
-        {
-          where: {
-            id: 'corr-1',
-            isDeleted: false,
-            lastKnownStatus: 'DRAFT',
-          },
-        },
-      )
-      expect(result).toEqual({ ok: true })
-    })
-
-    it('refuses the cancel on cached PENDING state when the refresh fails (cannot rule out settlement)', async () => {
-      bankTransferPaymentModel.findOne.mockResolvedValue(baseRow)
-      blikkClient.getPayment.mockRejectedValue(
-        new BlikkClientError('ECONNRESET'),
-      )
-
-      await expect(service.cancel({ paymentFlowId: 'flow-1' })).rejects.toThrow(
-        BankTransferErrorCode.BankTransferAlreadyInProgress,
-      )
-
-      expect(blikkClient.cancelPayment).not.toHaveBeenCalled()
-      expect(bankTransferPaymentModel.update).not.toHaveBeenCalled()
-    })
+        expect(blikkClient.cancelPayment).not.toHaveBeenCalled()
+        expect(bankTransferPaymentModel.update).not.toHaveBeenCalled()
+        expect(paymentFlowService.logPaymentFlowUpdate).not.toHaveBeenCalled()
+      },
+    )
 
     it('skips the Blikk calls but still soft-deletes a terminal-failed row, without emitting payment_cancelled', async () => {
       bankTransferPaymentModel.findOne.mockResolvedValue({

--- a/apps/services/payments/src/app/bankTransferPayment/bankTransfer.service.spec.ts
+++ b/apps/services/payments/src/app/bankTransferPayment/bankTransfer.service.spec.ts
@@ -1217,7 +1217,10 @@ describe('BankTransferService', () => {
         ...baseRow,
         lastKnownStatus: 'DRAFT',
       })
-      blikkClient.getPayment.mockResolvedValue({ id: 'prov-1', status: 'DRAFT' })
+      blikkClient.getPayment.mockResolvedValue({
+        id: 'prov-1',
+        status: 'DRAFT',
+      })
       blikkClient.cancelPayment.mockRejectedValue(
         new BlikkClientError('gone', 404),
       )
@@ -1272,7 +1275,10 @@ describe('BankTransferService', () => {
         ...baseRow,
         lastKnownStatus: 'DRAFT',
       })
-      blikkClient.getPayment.mockResolvedValue({ id: 'prov-1', status: 'DRAFT' })
+      blikkClient.getPayment.mockResolvedValue({
+        id: 'prov-1',
+        status: 'DRAFT',
+      })
       blikkClient.cancelPayment.mockRejectedValue(
         new BlikkClientError('network down', undefined),
       )

--- a/apps/services/payments/src/app/bankTransferPayment/bankTransfer.service.spec.ts
+++ b/apps/services/payments/src/app/bankTransferPayment/bankTransfer.service.spec.ts
@@ -14,7 +14,11 @@ import { PaymentMethod, PaymentStatus } from '../../types'
 import { PaymentFlowModuleConfig } from '../paymentFlow/paymentFlow.config'
 import { PaymentFlowService } from '../paymentFlow/paymentFlow.service'
 import { PaymentFulfillment } from '../paymentFlow/models/paymentFulfillment.model'
-import { BankTransferStatus } from './bankTransfer.types'
+import {
+  BankTransferFailureReason,
+  BankTransferStatus,
+  BankTransferPendingStatus,
+} from './bankTransfer.types'
 import { BankTransferService } from './bankTransfer.service'
 import { BankTransferModuleConfig } from './bankTransfer.config'
 import { BankTransferLocale } from './dtos/createBankTransfer.input'
@@ -173,7 +177,27 @@ describe('BankTransferService', () => {
         status: BankTransferStatus.PENDING,
         scaRedirectUrl: 'https://stage.blikk.tech/sca/provider-123',
         message: undefined,
+        // DRAFT with a regular SCA URL is a normal create — not onboarding.
+        onboardingRequired: false,
       })
+    })
+
+    it('flags onboardingRequired for a DRAFT payment whose SCA URL points at the onboarding app', async () => {
+      blikkClient.createPayment.mockResolvedValue({
+        id: 'provider-123',
+        status: 'DRAFT',
+        scaRedirectUrl: 'https://light.blikk.tech/onboarding/provider-123',
+        message: '',
+      })
+
+      const result = await service.createBankTransferPayment({
+        amount: 14000,
+        currency: 'ISK',
+        paymentFlowId: 'flow-1',
+        correlationId: 'btp-onboard',
+      })
+
+      expect(result.onboardingRequired).toBe(true)
     })
 
     it('maps a BlikkClientError to FailedToCreateBankTransfer', async () => {
@@ -251,23 +275,11 @@ describe('BankTransferService', () => {
         status: BankTransferStatus.PENDING,
         scaRedirectUrl: 'https://blikk/sca',
         message: undefined,
+        onboardingRequired: false,
       })
 
     beforeEach(() => {
       bankTransferPaymentModel.findOne.mockResolvedValue(null)
-    })
-
-    it('passes the payer national id and bank account number to the provider create', async () => {
-      const blikkSpy = mockBlikkCreate()
-
-      await service.create(createInput)
-
-      expect(blikkSpy).toHaveBeenCalledTimes(1)
-      expect(blikkSpy.mock.calls[0][0]).toMatchObject({
-        // payerNationalId from the getPaymentFlowDetails mock above.
-        debtorExternalId: '1234567890',
-        bankAccountNumber: '123456789012',
-      })
     })
 
     it('throws PaymentFlowAlreadyPaid when the flow is already PAID', async () => {
@@ -325,6 +337,7 @@ describe('BankTransferService', () => {
           providerPaymentId: 'prov-1',
           scaRedirectUrl: 'https://blikk/sca',
           expiresAt: expect.any(Date),
+          onboardingRequired: false,
         })
       },
     )
@@ -449,7 +462,8 @@ describe('BankTransferService', () => {
 
       const result = await service.create(createInput)
 
-      // Provider call gets the correct URLs/amount and a per-attempt correlationId (NOT paymentFlowId).
+      // Provider call gets the correct URLs/amount/payer details and a per-attempt
+      // correlationId (NOT paymentFlowId).
       expect(blikkSpy).toHaveBeenCalledTimes(1)
       const blikkArg = blikkSpy.mock.calls[0][0]
       expect(blikkArg).toMatchObject({
@@ -458,6 +472,9 @@ describe('BankTransferService', () => {
         currency: 'ISK',
         callbackUrl: 'https://island.is/greida/api/bank-transfer/callback',
         partnerRedirectUrl: 'https://island.is/greida/is/flow-1',
+        // payerNationalId from the getPaymentFlowDetails mock; BBAN from the input.
+        debtorExternalId: '1234567890',
+        bankAccountNumber: '123456789012',
       })
       expect(blikkArg.correlationId).not.toBe('flow-1')
       expect(blikkArg.expiresAt).toBeGreaterThan(Math.floor(Date.now() / 1000))
@@ -491,11 +508,14 @@ describe('BankTransferService', () => {
         metadata: { providerPaymentId: 'prov-1' },
       })
 
-      // expiresAt on the response matches the row (which is the same value we sent Blikk).
+      // expiresAt on the response matches the row (which is the same value we sent Blikk),
+      // and onboardingRequired passes through from the provider result (true-case covered
+      // in the createBankTransferPayment describe).
       expect(result).toEqual({
         providerPaymentId: 'prov-1',
         scaRedirectUrl: 'https://blikk/sca',
         expiresAt: rowArg.expiresAt,
+        onboardingRequired: false,
       })
     })
 
@@ -626,12 +646,11 @@ describe('BankTransferService', () => {
         message,
       })
 
-    it('looks up the active row by providerPaymentId', async () => {
+    it('looks up the active row by providerPaymentId, falling back to paymentFlowId', async () => {
       bankTransferPaymentModel.findOne.mockResolvedValue(activeRow)
       mockGetPayment(BankTransferStatus.PENDING, 'PENDING')
 
       await service.verify({ providerPaymentId: 'prov-1' })
-
       expect(bankTransferPaymentModel.findOne).toHaveBeenCalledWith({
         where: {
           provider: 'blikk',
@@ -639,29 +658,21 @@ describe('BankTransferService', () => {
           isDeleted: false,
         },
       })
-    })
-
-    it('looks up the active row by paymentFlowId when providerPaymentId is absent', async () => {
-      bankTransferPaymentModel.findOne.mockResolvedValue(activeRow)
-      mockGetPayment(BankTransferStatus.PENDING, 'PENDING')
 
       await service.verify({ paymentFlowId: 'flow-1' })
-
       expect(bankTransferPaymentModel.findOne).toHaveBeenCalledWith({
         where: { paymentFlowId: 'flow-1', isDeleted: false },
       })
     })
 
-    it('throws BankTransferNotFound when no row is found', async () => {
+    it('throws BankTransferNotFound when no row is found or no lookup key is provided', async () => {
       bankTransferPaymentModel.findOne.mockResolvedValue(null)
-
       await expect(service.verify({ paymentFlowId: 'flow-1' })).rejects.toThrow(
         BankTransferErrorCode.BankTransferNotFound,
       )
-    })
 
-    it('throws BankTransferNotFound when no lookup key is provided', async () => {
       // No findOne call — findActiveBankTransferPayment returns null without keys.
+      bankTransferPaymentModel.findOne.mockClear()
       await expect(service.verify({})).rejects.toThrow(
         BankTransferErrorCode.BankTransferNotFound,
       )
@@ -698,13 +709,21 @@ describe('BankTransferService', () => {
       expect(result.status).toBe(BankTransferStatus.SUCCESS)
     })
 
-    it.each<[BankTransferStatus, string]>([
-      [BankTransferStatus.ERROR, 'ERROR'],
-      [BankTransferStatus.REJECTED, 'REJECTED'],
-      [BankTransferStatus.CANCELLED, 'CANCELLED'],
+    it.each<[BankTransferStatus, string, BankTransferFailureReason]>([
+      [BankTransferStatus.ERROR, 'ERROR', BankTransferFailureReason.ERROR],
+      [
+        BankTransferStatus.REJECTED,
+        'REJECTED',
+        BankTransferFailureReason.REJECTED,
+      ],
+      [
+        BankTransferStatus.CANCELLED,
+        'CANCELLED',
+        BankTransferFailureReason.CANCELLED,
+      ],
     ])(
       'persists lastKnownStatus and emits payment_failed when the provider reports %s (row stays alive for BANK_TRANSFER_FAILED rendering)',
-      async (status, rawStatus) => {
+      async (status, rawStatus, failureReason) => {
         bankTransferPaymentModel.findOne.mockResolvedValue(activeRow)
         mockGetPayment(status, rawStatus, 'provider detail')
 
@@ -734,6 +753,8 @@ describe('BankTransferService', () => {
           },
         })
         expect(result.status).toBe(status)
+        // The expiry-aware failure reason passes through (fresh row → 1:1 with the status).
+        expect(result.failureReason).toBe(failureReason)
       },
     )
 
@@ -770,6 +791,123 @@ describe('BankTransferService', () => {
       expect(result.status).toBe(BankTransferStatus.PENDING)
     })
 
+    it('returns the pending sub-status and the fresh SCA URL from the provider', async () => {
+      bankTransferPaymentModel.findOne.mockResolvedValue(activeRow)
+      jest.spyOn(service, 'getPayment').mockResolvedValue({
+        providerPaymentId: 'prov-1',
+        rawStatus: 'SCA_REQUIRED',
+        status: BankTransferStatus.PENDING,
+        scaRedirectUrl: 'https://blikk/sca/fresh',
+      })
+
+      const result = await service.verify({ paymentFlowId: 'flow-1' })
+
+      expect(result).toEqual({
+        status: BankTransferStatus.PENDING,
+        message: undefined,
+        pendingStatus: BankTransferPendingStatus.SCA_REQUIRED,
+        scaRedirectUrl: 'https://blikk/sca/fresh',
+      })
+      // A pending attempt carries no failure reason. (The raw-status → pendingStatus
+      // mapping itself is table-tested in bankTransfer.utils.spec.ts.)
+      expect(result.failureReason).toBeUndefined()
+    })
+
+    it('reports sca_required for a DRAFT payment whose row already carries the SCA URL (no dots→QR flicker after create)', async () => {
+      bankTransferPaymentModel.findOne.mockResolvedValue({
+        ...activeRow,
+        lastKnownStatus: 'DRAFT',
+        scaRedirectUrl: 'https://stage.blikk.tech/sca/prov-1',
+      })
+      // Blikk GET repeats DRAFT and omits the URL — the row's creation-time URL is the fallback.
+      mockGetPayment(BankTransferStatus.PENDING, 'DRAFT')
+
+      const result = await service.verify({ paymentFlowId: 'flow-1' })
+
+      expect(result.pendingStatus).toBe(BankTransferPendingStatus.SCA_REQUIRED)
+      expect(result.scaRedirectUrl).toBe('https://stage.blikk.tech/sca/prov-1')
+    })
+
+    it('persists a newly minted SCA URL alongside the raw-status drift (back-channel create → SCA_REQUIRED)', async () => {
+      bankTransferPaymentModel.findOne.mockResolvedValue({
+        ...activeRow,
+        lastKnownStatus: 'DRAFT',
+        scaRedirectUrl: null,
+      })
+      jest.spyOn(service, 'getPayment').mockResolvedValue({
+        providerPaymentId: 'prov-1',
+        rawStatus: 'SCA_REQUIRED',
+        status: BankTransferStatus.PENDING,
+        scaRedirectUrl: 'https://blikk/sca/late',
+      })
+
+      await service.verify({ paymentFlowId: 'flow-1' })
+
+      expect(bankTransferPaymentModel.update).toHaveBeenCalledWith(
+        {
+          lastKnownStatus: 'SCA_REQUIRED',
+          scaRedirectUrl: 'https://blikk/sca/late',
+        },
+        {
+          where: { id: 'corr-1', isDeleted: false, lastKnownStatus: 'DRAFT' },
+        },
+      )
+    })
+
+    it('persists an SCA URL that appears without a raw-status change', async () => {
+      bankTransferPaymentModel.findOne.mockResolvedValue({
+        ...activeRow,
+        lastKnownStatus: 'SCA_REQUIRED',
+        scaRedirectUrl: null,
+      })
+      jest.spyOn(service, 'getPayment').mockResolvedValue({
+        providerPaymentId: 'prov-1',
+        rawStatus: 'SCA_REQUIRED',
+        status: BankTransferStatus.PENDING,
+        scaRedirectUrl: 'https://blikk/sca/late',
+      })
+
+      await service.verify({ paymentFlowId: 'flow-1' })
+
+      expect(bankTransferPaymentModel.update).toHaveBeenCalledWith(
+        {
+          lastKnownStatus: 'SCA_REQUIRED',
+          scaRedirectUrl: 'https://blikk/sca/late',
+        },
+        {
+          where: {
+            id: 'corr-1',
+            isDeleted: false,
+            lastKnownStatus: 'SCA_REQUIRED',
+          },
+        },
+      )
+    })
+
+    it('does not overwrite an already-persisted SCA URL', async () => {
+      bankTransferPaymentModel.findOne.mockResolvedValue({
+        ...activeRow,
+        lastKnownStatus: 'DRAFT',
+        scaRedirectUrl: 'https://blikk/sca/original',
+      })
+      jest.spyOn(service, 'getPayment').mockResolvedValue({
+        providerPaymentId: 'prov-1',
+        rawStatus: 'SCA_REQUIRED',
+        status: BankTransferStatus.PENDING,
+        scaRedirectUrl: 'https://blikk/sca/other',
+      })
+
+      await service.verify({ paymentFlowId: 'flow-1' })
+
+      // Only the status drift is persisted — the creation-time URL stays.
+      expect(bankTransferPaymentModel.update).toHaveBeenCalledWith(
+        { lastKnownStatus: 'SCA_REQUIRED' },
+        {
+          where: { id: 'corr-1', isDeleted: false, lastKnownStatus: 'DRAFT' },
+        },
+      )
+    })
+
     it('does not write or notify when the provider returns the same non-terminal status', async () => {
       bankTransferPaymentModel.findOne.mockResolvedValue({
         ...activeRow,
@@ -783,6 +921,20 @@ describe('BankTransferService', () => {
       expect(paymentFlowService.logPaymentFlowUpdate).not.toHaveBeenCalled()
       expect(result.status).toBe(BankTransferStatus.PENDING)
     })
+
+    it('reports failureReason expired when the provider ERROR lands on a row past its TTL', async () => {
+      bankTransferPaymentModel.findOne.mockResolvedValue({
+        ...activeRow,
+        expiresAt: new Date(Date.now() - 60 * 1000),
+      })
+      mockGetPayment(BankTransferStatus.ERROR, 'ERROR', 'expired')
+
+      const result = await service.verify({ paymentFlowId: 'flow-1' })
+
+      expect(result.status).toBe(BankTransferStatus.ERROR)
+      expect(result.failureReason).toBe(BankTransferFailureReason.EXPIRED)
+    })
+
   })
 
   describe('cancel', () => {
@@ -808,12 +960,15 @@ describe('BankTransferService', () => {
       expect(blikkClient.cancelPayment).not.toHaveBeenCalled()
     })
 
-    it('refreshes then cancels on Blikk and soft-deletes the row when PENDING + fresh and Blikk still says PENDING', async () => {
-      bankTransferPaymentModel.findOne.mockResolvedValue(baseRow)
-      // Authoritative refresh — Blikk confirms still PENDING.
+    it('refreshes then cancels on Blikk and soft-deletes the row when the payment is still DRAFT', async () => {
+      bankTransferPaymentModel.findOne.mockResolvedValue({
+        ...baseRow,
+        lastKnownStatus: 'DRAFT',
+      })
+      // Authoritative refresh — Blikk confirms still DRAFT (payer has not initiated).
       blikkClient.getPayment.mockResolvedValue({
         id: 'prov-1',
-        status: 'PENDING',
+        status: 'DRAFT',
       })
 
       const result = await service.cancel({ paymentFlowId: 'flow-1' })
@@ -827,12 +982,65 @@ describe('BankTransferService', () => {
           where: {
             id: 'corr-1',
             isDeleted: false,
-            lastKnownStatus: 'PENDING',
+            lastKnownStatus: 'DRAFT',
           },
         },
       )
       expect(result).toEqual({ ok: true })
     })
+
+    it('skips the Blikk cancel and abandons locally when the payment is SCA_REQUIRED (payer has not approved)', async () => {
+      bankTransferPaymentModel.findOne.mockResolvedValue({
+        ...baseRow,
+        lastKnownStatus: 'SCA_REQUIRED',
+      })
+      blikkClient.getPayment.mockResolvedValue({
+        id: 'prov-1',
+        status: 'SCA_REQUIRED',
+      })
+
+      const result = await service.cancel({ paymentFlowId: 'flow-1' })
+
+      // Blikk cannot cancel past DRAFT — no provider call; the payment lapses via its TTL.
+      expect(blikkClient.cancelPayment).not.toHaveBeenCalled()
+      expect(bankTransferPaymentModel.update).toHaveBeenCalledWith(
+        { isDeleted: true },
+        {
+          where: {
+            id: 'corr-1',
+            isDeleted: false,
+            lastKnownStatus: 'SCA_REQUIRED',
+          },
+        },
+      )
+      expect(result).toEqual({ ok: true })
+    })
+
+    it.each<[string]>([['PENDING'], ['SCA_COMPLETE']])(
+      'refuses the cancel when the payment is %s (payer initiated/approved — settlement may be in flight)',
+      async (rawStatus) => {
+        bankTransferPaymentModel.findOne.mockResolvedValue({
+          ...baseRow,
+          lastKnownStatus: rawStatus,
+        })
+        blikkClient.getPayment.mockResolvedValue({
+          id: 'prov-1',
+          status: rawStatus,
+        })
+
+        await expect(
+          service.cancel({ paymentFlowId: 'flow-1' }),
+        ).rejects.toThrow(BankTransferErrorCode.BankTransferAlreadyInProgress)
+
+        expect(blikkClient.cancelPayment).not.toHaveBeenCalled()
+        // The live payment must NOT be soft-deleted, and no payment_cancelled event fires.
+        expect(bankTransferPaymentModel.update).not.toHaveBeenCalledWith(
+          { isDeleted: true },
+          expect.anything(),
+        )
+        expect(paymentFlowService.logPaymentFlowUpdate).not.toHaveBeenCalled()
+      },
+    )
 
     // Closes the cancel-vs-settlement race: if Blikk has settled but the webhook
     // hasn't reached us yet, the cached PENDING row would silently soft-delete a
@@ -924,8 +1132,11 @@ describe('BankTransferService', () => {
       },
     )
 
-    it('falls through to the Blikk cancel on cached state when the refresh fails (network)', async () => {
-      bankTransferPaymentModel.findOne.mockResolvedValue(baseRow)
+    it('falls through to the Blikk cancel on cached DRAFT state when the refresh fails (network)', async () => {
+      bankTransferPaymentModel.findOne.mockResolvedValue({
+        ...baseRow,
+        lastKnownStatus: 'DRAFT',
+      })
       // Refresh fails — swallowed by refreshFromBlikkOrWarn.
       blikkClient.getPayment.mockRejectedValue(
         new BlikkClientError('ECONNRESET'),
@@ -937,21 +1148,35 @@ describe('BankTransferService', () => {
       expect(blikkClient.getPayment).toHaveBeenCalledWith('prov-1')
       expect(blikkClient.cancelPayment).toHaveBeenCalledWith('prov-1')
 
-      // Cached PENDING soft-delete uses the cached lastKnownStatus race-guard.
+      // Cached DRAFT soft-delete uses the cached lastKnownStatus race-guard.
       expect(bankTransferPaymentModel.update).toHaveBeenCalledWith(
         { isDeleted: true },
         {
           where: {
             id: 'corr-1',
             isDeleted: false,
-            lastKnownStatus: 'PENDING',
+            lastKnownStatus: 'DRAFT',
           },
         },
       )
       expect(result).toEqual({ ok: true })
     })
 
-    it('skips the Blikk call but still soft-deletes the row when the row is already terminal-failed', async () => {
+    it('refuses the cancel on cached PENDING state when the refresh fails (cannot rule out settlement)', async () => {
+      bankTransferPaymentModel.findOne.mockResolvedValue(baseRow)
+      blikkClient.getPayment.mockRejectedValue(
+        new BlikkClientError('ECONNRESET'),
+      )
+
+      await expect(service.cancel({ paymentFlowId: 'flow-1' })).rejects.toThrow(
+        BankTransferErrorCode.BankTransferAlreadyInProgress,
+      )
+
+      expect(blikkClient.cancelPayment).not.toHaveBeenCalled()
+      expect(bankTransferPaymentModel.update).not.toHaveBeenCalled()
+    })
+
+    it('skips the Blikk calls but still soft-deletes a terminal-failed row, without emitting payment_cancelled', async () => {
       bankTransferPaymentModel.findOne.mockResolvedValue({
         ...baseRow,
         lastKnownStatus: 'REJECTED',
@@ -971,80 +1196,55 @@ describe('BankTransferService', () => {
           },
         },
       )
+      // The row already emitted payment_failed when it was finalized.
+      expect(paymentFlowService.logPaymentFlowUpdate).not.toHaveBeenCalled()
       expect(result).toEqual({ ok: true })
     })
 
-    it('soft-deletes the row when the Blikk cancel returns 404 (nothing live to orphan)', async () => {
-      bankTransferPaymentModel.findOne.mockResolvedValue(baseRow)
-      // Refresh: Blikk still PENDING.
-      blikkClient.getPayment.mockResolvedValue({
-        id: 'prov-1',
-        status: 'PENDING',
-      })
-      // Cancel: 404 — the payment is unknown to Blikk, nothing live to orphan.
-      blikkClient.cancelPayment.mockRejectedValue(
-        new BlikkClientError('not found', 404),
-      )
+    // The Blikk cancel is best-effort for a DRAFT payment: a DRAFT cannot settle, so a missing
+    // payment (404) or a refused cancel (e.g. 405) must not block the user — the payment lapses
+    // via its TTL.
+    it.each<[string, number | undefined]>([
+      ['404 not-found', 404],
+      ['405 method-not-allowed', 405],
+      ['409 conflict', 409],
+      ['network failure', undefined],
+    ])(
+      'still soft-deletes a DRAFT payment when the Blikk cancel fails with %s',
+      async (_label, status) => {
+        bankTransferPaymentModel.findOne.mockResolvedValue({
+          ...baseRow,
+          lastKnownStatus: 'DRAFT',
+        })
+        // Refresh: Blikk still DRAFT.
+        blikkClient.getPayment.mockResolvedValue({
+          id: 'prov-1',
+          status: 'DRAFT',
+        })
+        blikkClient.cancelPayment.mockRejectedValue(
+          new BlikkClientError('refused', status),
+        )
 
-      const result = await service.cancel({ paymentFlowId: 'flow-1' })
+        const result = await service.cancel({ paymentFlowId: 'flow-1' })
 
-      expect(bankTransferPaymentModel.update).toHaveBeenCalledWith(
-        { isDeleted: true },
-        {
-          where: {
-            id: 'corr-1',
-            isDeleted: false,
-            lastKnownStatus: 'PENDING',
+        expect(blikkClient.cancelPayment).toHaveBeenCalledWith('prov-1')
+        expect(logger.warn).toHaveBeenCalledWith(
+          expect.stringContaining('Best-effort Blikk cancel failed'),
+          expect.objectContaining({ status }),
+        )
+        expect(bankTransferPaymentModel.update).toHaveBeenCalledWith(
+          { isDeleted: true },
+          {
+            where: {
+              id: 'corr-1',
+              isDeleted: false,
+              lastKnownStatus: 'DRAFT',
+            },
           },
-        },
-      )
-      expect(result).toEqual({ ok: true })
-    })
-
-    // Blikk only cancels DRAFT payments; a non-2xx (other than 404) means the payment is past DRAFT /
-    // live. Soft-deleting it would hide a possible settlement from the webhook/polling backstop and
-    // orphan the money, so we refuse the cancel instead.
-    it('throws and does NOT soft-delete when the Blikk cancel returns a non-2xx (payment is live)', async () => {
-      bankTransferPaymentModel.findOne.mockResolvedValue(baseRow)
-      // Refresh: Blikk still PENDING.
-      blikkClient.getPayment.mockResolvedValue({
-        id: 'prov-1',
-        status: 'PENDING',
-      })
-      // Cancel: 409 — Blikk refuses to cancel a payment that is no longer in DRAFT.
-      blikkClient.cancelPayment.mockRejectedValue(
-        new BlikkClientError('conflict', 409),
-      )
-
-      await expect(service.cancel({ paymentFlowId: 'flow-1' })).rejects.toThrow(
-        BankTransferErrorCode.BankTransferAlreadyInProgress,
-      )
-
-      expect(blikkClient.cancelPayment).toHaveBeenCalledWith('prov-1')
-      // The live payment must NOT be soft-deleted, and no payment_cancelled event fires.
-      expect(bankTransferPaymentModel.update).not.toHaveBeenCalled()
-      expect(paymentFlowService.logPaymentFlowUpdate).not.toHaveBeenCalled()
-    })
-
-    it('throws and does NOT soft-delete when the Blikk cancel request fails (network)', async () => {
-      bankTransferPaymentModel.findOne.mockResolvedValue(baseRow)
-      // Refresh: Blikk still PENDING.
-      blikkClient.getPayment.mockResolvedValue({
-        id: 'prov-1',
-        status: 'PENDING',
-      })
-      // Cancel: network failure (no HTTP status) — we can't confirm the cancel, so fail safe.
-      blikkClient.cancelPayment.mockRejectedValue(
-        new BlikkClientError('ECONNRESET'),
-      )
-
-      await expect(service.cancel({ paymentFlowId: 'flow-1' })).rejects.toThrow(
-        BankTransferErrorCode.BankTransferAlreadyInProgress,
-      )
-
-      expect(bankTransferPaymentModel.update).not.toHaveBeenCalled()
-      expect(paymentFlowService.logPaymentFlowUpdate).not.toHaveBeenCalled()
-    })
+        )
+        expect(result).toEqual({ ok: true })
+      },
+    )
 
     it('refreshes from Blikk before discarding an expired PENDING row, but does NOT call the Blikk cancel', async () => {
       bankTransferPaymentModel.findOne.mockResolvedValue({
@@ -1073,6 +1273,8 @@ describe('BankTransferService', () => {
           },
         },
       )
+      // Only active (non-expired) cancels emit payment_cancelled.
+      expect(paymentFlowService.logPaymentFlowUpdate).not.toHaveBeenCalled()
       expect(result).toEqual({ ok: true })
     })
 
@@ -1107,11 +1309,14 @@ describe('BankTransferService', () => {
       expect(bankTransferPaymentModel.update).not.toHaveBeenCalled()
     })
 
-    it('emits payment_cancelled when cancelling an active PENDING row', async () => {
-      bankTransferPaymentModel.findOne.mockResolvedValue(baseRow)
+    it('emits payment_cancelled when cancelling an active DRAFT row', async () => {
+      bankTransferPaymentModel.findOne.mockResolvedValue({
+        ...baseRow,
+        lastKnownStatus: 'DRAFT',
+      })
       blikkClient.getPayment.mockResolvedValue({
         id: 'prov-1',
-        status: 'PENDING',
+        status: 'DRAFT',
       })
 
       await service.cancel({ paymentFlowId: 'flow-1' })
@@ -1131,41 +1336,6 @@ describe('BankTransferService', () => {
       )
     })
 
-    it('does not emit when cancelling a terminal-failed row', async () => {
-      bankTransferPaymentModel.findOne.mockResolvedValue({
-        ...baseRow,
-        lastKnownStatus: 'REJECTED',
-      })
-
-      await service.cancel({ paymentFlowId: 'flow-1' })
-
-      expect(paymentFlowService.logPaymentFlowUpdate).not.toHaveBeenCalled()
-    })
-
-    it('does not emit when cancelling an expired PENDING row', async () => {
-      bankTransferPaymentModel.findOne.mockResolvedValue({
-        ...baseRow,
-        expiresAt: new Date(Date.now() - 10 * 60 * 1000),
-      })
-
-      await service.cancel({ paymentFlowId: 'flow-1' })
-
-      expect(paymentFlowService.logPaymentFlowUpdate).not.toHaveBeenCalled()
-    })
-
-    it('does not emit when the soft-delete affects no rows (race loss)', async () => {
-      bankTransferPaymentModel.findOne.mockResolvedValue(baseRow)
-      bankTransferPaymentModel.update.mockResolvedValueOnce([0])
-      blikkClient.getPayment.mockResolvedValue({
-        id: 'prov-1',
-        status: 'PENDING',
-      })
-
-      await service.cancel({ paymentFlowId: 'flow-1' })
-
-      expect(paymentFlowService.logPaymentFlowUpdate).not.toHaveBeenCalled()
-    })
-
     it('throws PaymentFlowAlreadyPaid and does not soft-delete when the row is already SUCCESS', async () => {
       bankTransferPaymentModel.findOne.mockResolvedValue({
         ...baseRow,
@@ -1183,13 +1353,14 @@ describe('BankTransferService', () => {
     })
 
     it('throws PaymentFlowAlreadyPaid when the row flips to SUCCESS between refresh and soft-delete (race)', async () => {
+      const draftRow = { ...baseRow, lastKnownStatus: 'DRAFT' }
       bankTransferPaymentModel.findOne
-        .mockResolvedValueOnce(baseRow)
-        .mockResolvedValueOnce({ ...baseRow, lastKnownStatus: 'SUCCESS' })
+        .mockResolvedValueOnce(draftRow)
+        .mockResolvedValueOnce({ ...draftRow, lastKnownStatus: 'SUCCESS' })
       bankTransferPaymentModel.update.mockResolvedValueOnce([0])
       blikkClient.getPayment.mockResolvedValue({
         id: 'prov-1',
-        status: 'PENDING',
+        status: 'DRAFT',
       })
 
       await expect(service.cancel({ paymentFlowId: 'flow-1' })).rejects.toThrow(
@@ -1199,18 +1370,20 @@ describe('BankTransferService', () => {
       expect(paymentFlowService.logPaymentFlowUpdate).not.toHaveBeenCalled()
     })
 
-    it('returns { ok: true } when the soft-delete races against a concurrent cancel (idempotent)', async () => {
+    it('returns { ok: true } without emitting when the soft-delete races against a concurrent cancel (idempotent)', async () => {
+      const draftRow = { ...baseRow, lastKnownStatus: 'DRAFT' }
       bankTransferPaymentModel.findOne
-        .mockResolvedValueOnce(baseRow)
-        .mockResolvedValueOnce({ ...baseRow, isDeleted: true })
+        .mockResolvedValueOnce(draftRow)
+        .mockResolvedValueOnce({ ...draftRow, isDeleted: true })
       bankTransferPaymentModel.update.mockResolvedValueOnce([0])
       blikkClient.getPayment.mockResolvedValue({
         id: 'prov-1',
-        status: 'PENDING',
+        status: 'DRAFT',
       })
 
       const result = await service.cancel({ paymentFlowId: 'flow-1' })
 
+      // Zero affected rows → the other writer won; no payment_cancelled from this call.
       expect(result).toEqual({ ok: true })
       expect(paymentFlowService.logPaymentFlowUpdate).not.toHaveBeenCalled()
     })
@@ -1297,6 +1470,59 @@ describe('BankTransferService', () => {
         updatedAt: baseRow.modified,
         bankTransferScaRedirectUrl: 'https://blikk/sca',
         bankTransferExpiresAt: baseRow.expiresAt,
+        bankTransferPendingStatus: BankTransferPendingStatus.SCA_REQUIRED,
+      })
+    })
+
+    it('surfaces sca_required right after create (DRAFT + SCA URL) so SSR renders the QR without a flicker', async () => {
+      bankTransferPaymentModel.findOne.mockResolvedValue({
+        ...baseRow,
+        lastKnownStatus: 'DRAFT',
+      })
+      mockGetPayment(BankTransferStatus.PENDING, 'DRAFT')
+
+      const result = await service.getBankTransferStatus('flow-1')
+
+      expect(result).toMatchObject({
+        paymentStatus: PaymentStatus.BANK_TRANSFER_PENDING,
+        bankTransferScaRedirectUrl: 'https://blikk/sca',
+        bankTransferPendingStatus: BankTransferPendingStatus.SCA_REQUIRED,
+      })
+    })
+
+    it('surfaces a freshly minted SCA URL from the refresh when the row has none yet', async () => {
+      bankTransferPaymentModel.findOne.mockResolvedValue({
+        ...baseRow,
+        scaRedirectUrl: null,
+      })
+      jest.spyOn(service, 'getPayment').mockResolvedValue({
+        providerPaymentId: 'prov-1',
+        rawStatus: 'SCA_REQUIRED',
+        status: BankTransferStatus.PENDING,
+        scaRedirectUrl: 'https://blikk/sca/late',
+      })
+
+      const result = await service.getBankTransferStatus('flow-1')
+
+      // Persisted for later reads…
+      expect(bankTransferPaymentModel.update).toHaveBeenCalledWith(
+        {
+          lastKnownStatus: 'SCA_REQUIRED',
+          scaRedirectUrl: 'https://blikk/sca/late',
+        },
+        {
+          where: {
+            id: 'corr-1',
+            isDeleted: false,
+            lastKnownStatus: 'PENDING',
+          },
+        },
+      )
+      // …and surfaced immediately (the in-memory row predates the persist).
+      expect(result).toMatchObject({
+        paymentStatus: PaymentStatus.BANK_TRANSFER_PENDING,
+        bankTransferScaRedirectUrl: 'https://blikk/sca/late',
+        bankTransferPendingStatus: BankTransferPendingStatus.SCA_REQUIRED,
       })
     })
 
@@ -1402,6 +1628,24 @@ describe('BankTransferService', () => {
       },
     )
 
+    it('surfaces lastBankTransferFailure expired when the refresh reports ERROR on a row past its TTL', async () => {
+      // Cached PENDING + expired: the refresh runs before any discard, and Blikk reports the
+      // lapsed TTL as a plain ERROR — the overlay derives it as `expired` for the failed screen.
+      bankTransferPaymentModel.findOne.mockResolvedValue({
+        ...baseRow,
+        expiresAt: new Date(Date.now() - 60 * 1000),
+      })
+      mockGetPayment(BankTransferStatus.ERROR, 'ERROR', 'expired')
+
+      const result = await service.getBankTransferStatus('flow-1')
+
+      expect(result).toEqual({
+        paymentStatus: PaymentStatus.BANK_TRANSFER_FAILED,
+        updatedAt: baseRow.modified,
+        lastBankTransferFailure: BankTransferFailureReason.EXPIRED,
+      })
+    })
+
     it('does not fire payment_failed when the race-guarded persist affects zero rows (concurrent verify won)', async () => {
       bankTransferPaymentModel.findOne.mockResolvedValue(baseRow)
       bankTransferPaymentModel.update.mockResolvedValue([0])
@@ -1430,6 +1674,8 @@ describe('BankTransferService', () => {
         updatedAt: baseRow.modified,
         bankTransferScaRedirectUrl: 'https://blikk/sca',
         bankTransferExpiresAt: baseRow.expiresAt,
+        // Cached raw status is PENDING → processing.
+        bankTransferPendingStatus: BankTransferPendingStatus.PROCESSING,
       })
       expect(logger.warn).toHaveBeenCalled()
     })

--- a/apps/services/payments/src/app/bankTransferPayment/bankTransfer.service.spec.ts
+++ b/apps/services/payments/src/app/bankTransferPayment/bankTransfer.service.spec.ts
@@ -938,7 +938,6 @@ describe('BankTransferService', () => {
       expect(result.status).toBe(BankTransferStatus.ERROR)
       expect(result.failureReason).toBe(BankTransferFailureReason.EXPIRED)
     })
-
   })
 
   describe('cancel', () => {

--- a/apps/services/payments/src/app/bankTransferPayment/bankTransfer.service.ts
+++ b/apps/services/payments/src/app/bankTransferPayment/bankTransfer.service.ts
@@ -208,29 +208,32 @@ export class BankTransferService {
     const result = await this.getPayment(row.providerPaymentId)
     await this.finalizeFromBlikkResult(row, result)
 
+    const isPending = result.status === BankTransferStatus.PENDING
     const scaRedirectUrl =
       result.scaRedirectUrl ?? row.scaRedirectUrl ?? undefined
 
     return {
       status: result.status,
       message: result.message,
-      pendingStatus: mapRawStatusToBankTransferPendingStatus(
-        result.rawStatus,
-        scaRedirectUrl,
-      ),
-      scaRedirectUrl,
+      pendingStatus: isPending
+        ? mapRawStatusToBankTransferPendingStatus(
+            result.rawStatus,
+            scaRedirectUrl,
+            this.config.onboardingOrigin,
+          )
+        : undefined,
+      scaRedirectUrl: isPending ? scaRedirectUrl : undefined,
       failureReason:
         deriveBankTransferFailureReason(result.status, row) ?? undefined,
     }
   }
 
   /**
-   * Cancels the active bank-transfer attempt for a flow. Blikk only cancels DRAFT payments, so:
-   * DRAFT → best-effort provider cancel; SCA_REQUIRED (payer has not approved yet) → abandon
-   * locally and let the provider payment lapse via its TTL;
-   * PENDING/SCA_COMPLETE (payer initiated/approved — settlement may be in flight) → refuse.
-   * The local row is soft-deleted for DRAFT / SCA_REQUIRED / terminal / expired attempts.
-   * Idempotent.
+   * Cancels the active bank-transfer attempt for a flow. Two rules, applied to a *fresh* provider
+   * status (throws retryably when Blikk is unreachable — we never cancel on cached state):
+   * payer initiated/approved (PENDING/SCA_COMPLETE — settlement may be in flight) → refuse;
+   * payer has not approved (DRAFT/SCA_REQUIRED) → best-effort provider cancel, abandon locally.
+   * The local row is soft-deleted for not-approved / terminal / expired attempts. Idempotent.
    */
   async cancel(
     input: CancelBankTransferInput,
@@ -261,30 +264,24 @@ export class BankTransferService {
       // Authoritative refresh BEFORE any destructive action — including for an expired row. A
       // transfer that settled just before expiry whose callback was lost must be finalized, not
       // discarded, or the payer could pay a second time. (Same refresh-before-discard guard as
-      // getBankTransferStatus.)
-      const refreshed = await this.refreshFromBlikkOrWarn(row)
-      if (refreshed) {
-        await this.finalizeFromBlikkResult(row, refreshed)
-        if (refreshed.status === BankTransferStatus.SUCCESS) {
-          throw new BadRequestException(
-            PaymentServiceCode.PaymentFlowAlreadyPaid,
-          )
-        }
-        mappedStatus = refreshed.status
-        lastKnownStatus = refreshed.rawStatus
+      // getBankTransferStatus.) Throws FailedToFetchBankTransfer when Blikk is unreachable —
+      // cancelling on cached state could soft-delete a payment that has since gone live.
+      const refreshed = await this.getPayment(row.providerPaymentId)
+      await this.finalizeFromBlikkResult(row, refreshed)
+      if (refreshed.status === BankTransferStatus.SUCCESS) {
+        throw new BadRequestException(PaymentServiceCode.PaymentFlowAlreadyPaid)
       }
-      // Blikk only cancels DRAFT payments, so what happens next depends on how far the attempt
-      // got (skipped entirely for an expired row — its TTL already elapsed, nothing to cancel):
-      // - DRAFT: best-effort provider cancel. A DRAFT cannot settle, so a refused/failed cancel
-      //   is safe to ignore — the payment lapses via the TTL we sent Blikk on create.
-      // - SCA_REQUIRED: the payer has not approved yet and Blikk cannot cancel past DRAFT —
-      //   abandon locally and let the provider payment lapse via its TTL.
+      mappedStatus = refreshed.status
+      lastKnownStatus = refreshed.rawStatus
+
+      // Skipped entirely for an expired row — its TTL already elapsed, nothing to cancel:
+      // - DRAFT/SCA_REQUIRED: the payer has not approved. Best-effort provider cancel (Blikk
+      //   only honours it for DRAFT), then abandon locally — an unapproved payment cannot
+      //   settle and lapses via the TTL we sent Blikk on create.
       // - Anything else (PENDING, SCA_COMPLETE, unknown): the payer has initiated/approved, so
       //   settlement may be in flight — refuse, and let verify/webhook/TTL keep tracking it.
       if (mappedStatus === BankTransferStatus.PENDING && !isRowExpired(row)) {
-        if (lastKnownStatus === 'DRAFT') {
-          await this.cancelBlikkPayment(row.providerPaymentId, logPrefix)
-        } else if (lastKnownStatus !== 'SCA_REQUIRED') {
+        if (lastKnownStatus !== 'DRAFT' && lastKnownStatus !== 'SCA_REQUIRED') {
           this.logger.warn(
             `${logPrefix}Cancel refused — payment may be settling`,
             { lastKnownStatus },
@@ -293,6 +290,7 @@ export class BankTransferService {
             BankTransferErrorCode.BankTransferAlreadyInProgress,
           )
         }
+        await this.cancelBlikkPayment(row.providerPaymentId, logPrefix)
       }
     }
 
@@ -429,6 +427,7 @@ export class BankTransferService {
         bankTransferPendingStatus: mapRawStatusToBankTransferPendingStatus(
           refreshed?.rawStatus ?? row.lastKnownStatus,
           scaRedirectUrl,
+          this.config.onboardingOrigin,
         ),
       }
     }
@@ -852,10 +851,11 @@ export class BankTransferService {
   }
 
   /**
-   * Best-effort Blikk cancel — only ever called for a DRAFT payment (Blikk cancels DRAFT only,
-   * and past-DRAFT statuses are handled in `cancel` before this point). A DRAFT cannot settle,
-   * so any failure here (404 gone, refused, network) is safe to swallow: the payment simply
-   * lapses via the TTL we sent Blikk on create.
+   * Best-effort Blikk cancel — only ever called for a freshly confirmed DRAFT/SCA_REQUIRED
+   * payment (past-approval statuses are refused in `cancel` before this point). An unapproved
+   * payment cannot settle, so any failure here (404 gone, refused — Blikk only honours cancels
+   * for DRAFT, network) is safe to swallow: the payment simply lapses via the TTL we sent
+   * Blikk on create.
    */
   private async cancelBlikkPayment(
     providerPaymentId: string,
@@ -923,6 +923,7 @@ export class BankTransferService {
       onboardingRequired: isOnboardingRequired(
         data.status,
         data.scaRedirectUrl || undefined,
+        this.config.onboardingOrigin,
       ),
     }
   }

--- a/apps/services/payments/src/app/bankTransferPayment/bankTransfer.service.ts
+++ b/apps/services/payments/src/app/bankTransferPayment/bankTransfer.service.ts
@@ -275,9 +275,10 @@ export class BankTransferService {
       lastKnownStatus = refreshed.rawStatus
 
       // Skipped entirely for an expired row — its TTL already elapsed, nothing to cancel:
-      // - DRAFT/SCA_REQUIRED: the payer has not approved. Best-effort provider cancel (Blikk
-      //   only honours it for DRAFT), then abandon locally — an unapproved payment cannot
-      //   settle and lapses via the TTL we sent Blikk on create.
+      // - DRAFT/SCA_REQUIRED: the payer has not approved. Ask Blikk to cancel and let its response
+      //   decide — we only discard locally if Blikk confirms the cancel (Blikk only honours it for
+      //   DRAFT). If Blikk refuses, the SCA session is still live and could settle, so we keep the
+      //   row and tell the payer to decline it in their banking app.
       // - Anything else (PENDING, SCA_COMPLETE, unknown): the payer has initiated/approved, so
       //   settlement may be in flight — refuse, and let verify/webhook/TTL keep tracking it.
       if (mappedStatus === BankTransferStatus.PENDING && !isRowExpired(row)) {
@@ -290,7 +291,16 @@ export class BankTransferService {
             BankTransferErrorCode.BankTransferAlreadyInProgress,
           )
         }
-        await this.cancelBlikkPayment(row.providerPaymentId, logPrefix)
+
+        const cancelled = await this.cancelBlikkPayment(
+          row.providerPaymentId,
+          logPrefix,
+        )
+        if (!cancelled) {
+          throw new BadRequestException(
+            BankTransferErrorCode.BankTransferCannotCancel,
+          )
+        }
       }
     }
 
@@ -851,25 +861,38 @@ export class BankTransferService {
   }
 
   /**
-   * Best-effort Blikk cancel — only ever called for a freshly confirmed DRAFT/SCA_REQUIRED
-   * payment (past-approval statuses are refused in `cancel` before this point). An unapproved
-   * payment cannot settle, so any failure here (404 gone, refused — Blikk only honours cancels
-   * for DRAFT, network) is safe to swallow: the payment simply lapses via the TTL we sent
-   * Blikk on create.
+   * Asks Blikk to cancel the payment and reports whether the attempt may be safely discarded
+   * locally. Blikk's response is authoritative — we never soft-delete a live SCA session it still
+   * holds, because the payer can still approve it and settle. Only called for a freshly confirmed
+   * DRAFT/SCA_REQUIRED payment (past-approval statuses are refused in `cancel` before this point).
    */
   private async cancelBlikkPayment(
     providerPaymentId: string,
     logPrefix: string,
-  ): Promise<void> {
+  ): Promise<boolean> {
     try {
       await this.blikkClient.cancelPayment(providerPaymentId)
+      return true
     } catch (e) {
+      if (e instanceof BlikkClientError) {
+        if (e.status === 404) {
+          return true
+        }
+        if (e.status !== undefined) {
+          this.logger.warn(
+            `${logPrefix}Blikk refused to cancel — SCA session still live`,
+            { providerPaymentId, status: e.status },
+          )
+          return false
+        }
+      }
+
       this.logger.warn(
-        `${logPrefix}Best-effort Blikk cancel failed — payment lapses via its TTL`,
-        {
-          providerPaymentId,
-          status: e instanceof BlikkClientError ? e.status : undefined,
-        },
+        `${logPrefix}Could not reach Blikk to cancel — leaving attempt live`,
+        { providerPaymentId },
+      )
+      throw new BadRequestException(
+        BankTransferErrorCode.FailedToFetchBankTransfer,
       )
     }
   }

--- a/apps/services/payments/src/app/bankTransferPayment/bankTransfer.service.ts
+++ b/apps/services/payments/src/app/bankTransferPayment/bankTransfer.service.ts
@@ -47,13 +47,15 @@ import {
 } from './dtos'
 import { BankTransferPayment } from './models/bankTransferPayment.model'
 import {
+  deriveBankTransferFailureReason,
   generateBankTransferChargeFJSPayload,
   isBankTransferFailureStatus,
   isBlikkStatus,
+  isOnboardingRequired,
   isRowExpired,
   mapBlikkStatusToBankTransferStatus,
+  mapRawStatusToBankTransferPendingStatus,
   rowLogPrefix,
-  toBankTransferFailureReason,
   toBlikkItem,
 } from './bankTransfer.utils'
 
@@ -180,6 +182,7 @@ export class BankTransferService {
       providerPaymentId: providerResult.providerPaymentId,
       scaRedirectUrl: providerResult.scaRedirectUrl,
       expiresAt,
+      onboardingRequired: providerResult.onboardingRequired,
     }
   }
 
@@ -205,14 +208,28 @@ export class BankTransferService {
     const result = await this.getPayment(row.providerPaymentId)
     await this.finalizeFromBlikkResult(row, result)
 
-    return { status: result.status, message: result.message }
+    const scaRedirectUrl =
+      result.scaRedirectUrl ?? row.scaRedirectUrl ?? undefined
+
+    return {
+      status: result.status,
+      message: result.message,
+      pendingStatus: mapRawStatusToBankTransferPendingStatus(
+        result.rawStatus,
+        scaRedirectUrl,
+      ),
+      scaRedirectUrl,
+      failureReason:
+        deriveBankTransferFailureReason(result.status, row) ?? undefined,
+    }
   }
 
   /**
-   * Cancels the active bank-transfer attempt for a flow. For a still-PENDING attempt we ask Blikk to
-   * cancel first; Blikk only honours this while the payment is in DRAFT, so a payment the user already
-   * took to the bank makes the Blikk cancel throw and we refuse the cancel. Soft-deletes the local row only once the
-   * payment is confirmed cancelled / already terminal / expired.
+   * Cancels the active bank-transfer attempt for a flow. Blikk only cancels DRAFT payments, so:
+   * DRAFT → best-effort provider cancel; SCA_REQUIRED (payer has not approved yet) → abandon
+   * locally and let the provider payment lapse via its TTL;
+   * PENDING/SCA_COMPLETE (payer initiated/approved — settlement may be in flight) → refuse.
+   * The local row is soft-deleted for DRAFT / SCA_REQUIRED / terminal / expired attempts.
    * Idempotent.
    */
   async cancel(
@@ -256,11 +273,26 @@ export class BankTransferService {
         mappedStatus = refreshed.status
         lastKnownStatus = refreshed.rawStatus
       }
-      // Only DELETE on Blikk while the attempt is still PENDING and not expired. Throws if Blikk
-      // refuses to cancel (payment past DRAFT / live) — we let that propagate so we never soft-delete
-      // a live payment. An expired row is past its TTL, so there is nothing to cancel Blikk-side.
+      // Blikk only cancels DRAFT payments, so what happens next depends on how far the attempt
+      // got (skipped entirely for an expired row — its TTL already elapsed, nothing to cancel):
+      // - DRAFT: best-effort provider cancel. A DRAFT cannot settle, so a refused/failed cancel
+      //   is safe to ignore — the payment lapses via the TTL we sent Blikk on create.
+      // - SCA_REQUIRED: the payer has not approved yet and Blikk cannot cancel past DRAFT —
+      //   abandon locally and let the provider payment lapse via its TTL.
+      // - Anything else (PENDING, SCA_COMPLETE, unknown): the payer has initiated/approved, so
+      //   settlement may be in flight — refuse, and let verify/webhook/TTL keep tracking it.
       if (mappedStatus === BankTransferStatus.PENDING && !isRowExpired(row)) {
-        await this.cancelBlikkPayment(row.providerPaymentId, logPrefix)
+        if (lastKnownStatus === 'DRAFT') {
+          await this.cancelBlikkPayment(row.providerPaymentId, logPrefix)
+        } else if (lastKnownStatus !== 'SCA_REQUIRED') {
+          this.logger.warn(
+            `${logPrefix}Cancel refused — payment may be settling`,
+            { lastKnownStatus },
+          )
+          throw new BadRequestException(
+            BankTransferErrorCode.BankTransferAlreadyInProgress,
+          )
+        }
       }
     }
 
@@ -327,10 +359,11 @@ export class BankTransferService {
 
     const isExpired = isRowExpired(row)
     let mapped = mapBlikkStatusToBankTransferStatus(row.lastKnownStatus)
+    let refreshed: BankTransferPaymentResult | null = null
 
     // PENDING → ask Blikk for the authoritative state.
     if (mapped === BankTransferStatus.PENDING) {
-      const refreshed = await this.refreshFromBlikkOrWarn(row)
+      refreshed = await this.refreshFromBlikkOrWarn(row)
 
       if (refreshed) {
         await this.finalizeFromBlikkResult(row, refreshed)
@@ -346,7 +379,8 @@ export class BankTransferService {
             paymentStatus: PaymentStatus.BANK_TRANSFER_FAILED,
             updatedAt: row.modified,
             lastBankTransferFailure:
-              toBankTransferFailureReason(refreshed.status) ?? undefined,
+              deriveBankTransferFailureReason(refreshed.status, row) ??
+              undefined,
           }
         }
 
@@ -384,18 +418,26 @@ export class BankTransferService {
     }
 
     if (mapped === BankTransferStatus.PENDING) {
+      // Prefer the just-refreshed URL — the in-memory row predates any persist above.
+      const scaRedirectUrl =
+        refreshed?.scaRedirectUrl ?? row.scaRedirectUrl ?? undefined
       return {
         paymentStatus: PaymentStatus.BANK_TRANSFER_PENDING,
         updatedAt: row.modified,
-        bankTransferScaRedirectUrl: row.scaRedirectUrl ?? undefined,
+        bankTransferScaRedirectUrl: scaRedirectUrl,
         bankTransferExpiresAt: row.expiresAt,
+        bankTransferPendingStatus: mapRawStatusToBankTransferPendingStatus(
+          refreshed?.rawStatus ?? row.lastKnownStatus,
+          scaRedirectUrl,
+        ),
       }
     }
 
     return {
       paymentStatus: PaymentStatus.BANK_TRANSFER_FAILED,
       updatedAt: row.modified,
-      lastBankTransferFailure: toBankTransferFailureReason(mapped) ?? undefined,
+      lastBankTransferFailure:
+        deriveBankTransferFailureReason(mapped, row) ?? undefined,
     }
   }
 
@@ -717,10 +759,18 @@ export class BankTransferService {
       // On failure, finalize the bank transfer failure.
     } else if (isBankTransferFailureStatus(refreshed.status)) {
       await this.finalizeBankTransferFailure(row, refreshed)
-      // On PENDING with raw-status drift, update the lastKnownStatus.
-    } else if (refreshed.rawStatus !== row.lastKnownStatus) {
+      // On PENDING with raw-status drift (or a newly minted SCA URL), update the row.
+    } else if (
+      refreshed.rawStatus !== row.lastKnownStatus ||
+      (refreshed.scaRedirectUrl && !row.scaRedirectUrl)
+    ) {
       await this.bankTransferPaymentModel.update(
-        { lastKnownStatus: refreshed.rawStatus },
+        {
+          lastKnownStatus: refreshed.rawStatus,
+          ...(refreshed.scaRedirectUrl && !row.scaRedirectUrl
+            ? { scaRedirectUrl: refreshed.scaRedirectUrl }
+            : {}),
+        },
         {
           where: {
             id: row.id,
@@ -802,10 +852,10 @@ export class BankTransferService {
   }
 
   /**
-   * Cancels the Blikk payment. Blikk only cancels payments still in DRAFT; a payment the user has
-   * already taken to the bank (past DRAFT) yields a non-2xx, surfaced as a `BlikkClientError`. We
-   * tolerate a 404 (nothing live to orphan) but otherwise refuse to soft-delete so the still-live
-   * payment stays trackable by verify/webhook/TTL.
+   * Best-effort Blikk cancel — only ever called for a DRAFT payment (Blikk cancels DRAFT only,
+   * and past-DRAFT statuses are handled in `cancel` before this point). A DRAFT cannot settle,
+   * so any failure here (404 gone, refused, network) is safe to swallow: the payment simply
+   * lapses via the TTL we sent Blikk on create.
    */
   private async cancelBlikkPayment(
     providerPaymentId: string,
@@ -814,18 +864,12 @@ export class BankTransferService {
     try {
       await this.blikkClient.cancelPayment(providerPaymentId)
     } catch (e) {
-      if (e instanceof BlikkClientError && e.status === 404) {
-        this.logger.warn(`${logPrefix}Blikk cancel target not found (404)`, {
+      this.logger.warn(
+        `${logPrefix}Best-effort Blikk cancel failed — payment lapses via its TTL`,
+        {
           providerPaymentId,
-        })
-        return
-      }
-      this.logger.warn(`${logPrefix}Blikk cancel refused — payment is live`, {
-        providerPaymentId,
-        status: e instanceof BlikkClientError ? e.status : undefined,
-      })
-      throw new BadRequestException(
-        BankTransferErrorCode.BankTransferAlreadyInProgress,
+          status: e instanceof BlikkClientError ? e.status : undefined,
+        },
       )
     }
   }
@@ -876,6 +920,10 @@ export class BankTransferService {
       // Empty string means back-channel SCA (no redirect) — surface as undefined.
       scaRedirectUrl: data.scaRedirectUrl || undefined,
       message: data.message || undefined,
+      onboardingRequired: isOnboardingRequired(
+        data.status,
+        data.scaRedirectUrl || undefined,
+      ),
     }
   }
 }

--- a/apps/services/payments/src/app/bankTransferPayment/bankTransfer.types.ts
+++ b/apps/services/payments/src/app/bankTransferPayment/bankTransfer.types.ts
@@ -14,6 +14,16 @@ export enum BankTransferFailureReason {
   REJECTED = 'rejected',
   CANCELLED = 'cancelled',
   ERROR = 'error',
+  // Derived, not a raw provider value: an ERROR observed on a row past its TTL.
+  EXPIRED = 'expired',
+}
+
+/** Provider-neutral sub-status of a pending attempt. */
+export enum BankTransferPendingStatus {
+  // SCA is outstanding — show a QR code (desktop) / open-banking-app button (mobile).
+  SCA_REQUIRED = 'sca_required',
+  // SCA complete or not yet required — show a waiting-for-confirmation message.
+  PROCESSING = 'processing',
 }
 
 export interface CreateBankTransferPaymentInput {
@@ -39,6 +49,9 @@ export interface BankTransferPaymentResult {
   // Empty / undefined = back-channel SCA, no redirect.
   scaRedirectUrl?: string
   message?: string
+  // True when the payer must complete provider onboarding before SCA can proceed —
+  // the one case where the FE still redirects to scaRedirectUrl.
+  onboardingRequired?: boolean
 }
 
 /** Bank-transfer overlay folded into GetPaymentFlow when the base status is UNPAID. */
@@ -52,4 +65,5 @@ export interface BankTransferStatusOverlay {
   lastBankTransferFailure?: BankTransferFailureReason
   // Row TTL; drives the FE polling hard timeout.
   bankTransferExpiresAt?: Date
+  bankTransferPendingStatus?: BankTransferPendingStatus
 }

--- a/apps/services/payments/src/app/bankTransferPayment/bankTransfer.utils.spec.ts
+++ b/apps/services/payments/src/app/bankTransferPayment/bankTransfer.utils.spec.ts
@@ -80,9 +80,9 @@ describe('isOnboardingRequired', () => {
   })
 
   it('is false for an unparsable SCA URL', () => {
-    expect(
-      isOnboardingRequired('DRAFT', 'not a url', onboardingOrigin),
-    ).toBe(false)
+    expect(isOnboardingRequired('DRAFT', 'not a url', onboardingOrigin)).toBe(
+      false,
+    )
   })
 
   it('is false for a DRAFT payment without an SCA URL (back-channel)', () => {

--- a/apps/services/payments/src/app/bankTransferPayment/bankTransfer.utils.spec.ts
+++ b/apps/services/payments/src/app/bankTransferPayment/bankTransfer.utils.spec.ts
@@ -1,0 +1,85 @@
+import {
+  BankTransferFailureReason,
+  BankTransferStatus,
+  BankTransferPendingStatus,
+} from './bankTransfer.types'
+import {
+  deriveBankTransferFailureReason,
+  isOnboardingRequired,
+  mapRawStatusToBankTransferPendingStatus,
+} from './bankTransfer.utils'
+
+describe('mapRawStatusToBankTransferPendingStatus', () => {
+  const scaUrl = 'https://stage.blikk.tech/sca/p-1'
+
+  it.each<[string, string | undefined, BankTransferPendingStatus]>([
+    ['SCA_REQUIRED', scaUrl, BankTransferPendingStatus.SCA_REQUIRED],
+    ['SCA_REQUIRED', undefined, BankTransferPendingStatus.SCA_REQUIRED],
+    // DRAFT only advances once the payer initiates — with an SCA URL present the payer
+    // must act, so it renders the SCA UI (prevents a dots→QR flicker right after create).
+    ['DRAFT', scaUrl, BankTransferPendingStatus.SCA_REQUIRED],
+    ['DRAFT', undefined, BankTransferPendingStatus.PROCESSING],
+    // …but an onboarding URL is handled via redirect, not the SCA UI.
+    ['DRAFT', 'https://light.blikk.tech/onboarding/p-1', BankTransferPendingStatus.PROCESSING],
+    ['PENDING', scaUrl, BankTransferPendingStatus.PROCESSING],
+    ['SCA_COMPLETE', scaUrl, BankTransferPendingStatus.PROCESSING],
+    // Unknown statuses fall back to processing (keep polling, no SCA UI).
+    ['WAT', scaUrl, BankTransferPendingStatus.PROCESSING],
+  ])('maps %s (url: %s) to %s', (rawStatus, url, expected) => {
+    expect(mapRawStatusToBankTransferPendingStatus(rawStatus, url)).toBe(expected)
+  })
+})
+
+describe('isOnboardingRequired', () => {
+  it('is true for a DRAFT payment whose SCA URL points at the onboarding app', () => {
+    expect(
+      isOnboardingRequired('DRAFT', 'https://light.blikk.tech/onboarding/p-1'),
+    ).toBe(true)
+  })
+
+  it('is false for a DRAFT payment with a regular SCA URL', () => {
+    expect(
+      isOnboardingRequired('DRAFT', 'https://stage.blikk.tech/sca/p-1'),
+    ).toBe(false)
+  })
+
+  it('is false for a DRAFT payment without an SCA URL (back-channel)', () => {
+    expect(isOnboardingRequired('DRAFT', undefined)).toBe(false)
+  })
+
+  it('is false for non-DRAFT statuses regardless of the URL', () => {
+    expect(
+      isOnboardingRequired(
+        'SCA_REQUIRED',
+        'https://light.blikk.tech/onboarding/p-1',
+      ),
+    ).toBe(false)
+  })
+})
+
+describe('deriveBankTransferFailureReason', () => {
+  const fresh = { expiresAt: new Date(Date.now() + 5 * 60 * 1000) }
+  const expired = { expiresAt: new Date(Date.now() - 60 * 1000) }
+
+  it.each<
+    [BankTransferStatus, { expiresAt: Date }, BankTransferFailureReason | null]
+  >([
+    // Blikk reports a lapsed TTL as a plain ERROR — expiry is derived from the row.
+    [BankTransferStatus.ERROR, expired, BankTransferFailureReason.EXPIRED],
+    [BankTransferStatus.ERROR, fresh, BankTransferFailureReason.ERROR],
+    // REJECTED/CANCELLED are explicit acts and keep their reasons even past the TTL.
+    [BankTransferStatus.REJECTED, expired, BankTransferFailureReason.REJECTED],
+    [BankTransferStatus.REJECTED, fresh, BankTransferFailureReason.REJECTED],
+    [
+      BankTransferStatus.CANCELLED,
+      expired,
+      BankTransferFailureReason.CANCELLED,
+    ],
+    [BankTransferStatus.CANCELLED, fresh, BankTransferFailureReason.CANCELLED],
+    // Non-failures have no reason.
+    [BankTransferStatus.SUCCESS, expired, null],
+    [BankTransferStatus.PENDING, expired, null],
+  ])('derives %s on %o as %s', (status, row, expectedReason) => {
+    expect(deriveBankTransferFailureReason(status, row)).toBe(expectedReason)
+  })
+})

--- a/apps/services/payments/src/app/bankTransferPayment/bankTransfer.utils.spec.ts
+++ b/apps/services/payments/src/app/bankTransferPayment/bankTransfer.utils.spec.ts
@@ -9,6 +9,8 @@ import {
   mapRawStatusToBankTransferPendingStatus,
 } from './bankTransfer.utils'
 
+const onboardingOrigin = 'https://light.blikk.tech'
+
 describe('mapRawStatusToBankTransferPendingStatus', () => {
   const scaUrl = 'https://stage.blikk.tech/sca/p-1'
 
@@ -20,31 +22,73 @@ describe('mapRawStatusToBankTransferPendingStatus', () => {
     ['DRAFT', scaUrl, BankTransferPendingStatus.SCA_REQUIRED],
     ['DRAFT', undefined, BankTransferPendingStatus.PROCESSING],
     // …but an onboarding URL is handled via redirect, not the SCA UI.
-    ['DRAFT', 'https://light.blikk.tech/onboarding/p-1', BankTransferPendingStatus.PROCESSING],
+    [
+      'DRAFT',
+      'https://light.blikk.tech/onboarding/p-1',
+      BankTransferPendingStatus.PROCESSING,
+    ],
     ['PENDING', scaUrl, BankTransferPendingStatus.PROCESSING],
     ['SCA_COMPLETE', scaUrl, BankTransferPendingStatus.PROCESSING],
     // Unknown statuses fall back to processing (keep polling, no SCA UI).
     ['WAT', scaUrl, BankTransferPendingStatus.PROCESSING],
   ])('maps %s (url: %s) to %s', (rawStatus, url, expected) => {
-    expect(mapRawStatusToBankTransferPendingStatus(rawStatus, url)).toBe(expected)
+    expect(
+      mapRawStatusToBankTransferPendingStatus(rawStatus, url, onboardingOrigin),
+    ).toBe(expected)
   })
 })
 
 describe('isOnboardingRequired', () => {
-  it('is true for a DRAFT payment whose SCA URL points at the onboarding app', () => {
+  it('is true for a DRAFT payment whose SCA URL points at the onboarding origin', () => {
     expect(
-      isOnboardingRequired('DRAFT', 'https://light.blikk.tech/onboarding/p-1'),
+      isOnboardingRequired(
+        'DRAFT',
+        'https://light.blikk.tech/onboarding/p-1',
+        onboardingOrigin,
+      ),
     ).toBe(true)
   })
 
   it('is false for a DRAFT payment with a regular SCA URL', () => {
     expect(
-      isOnboardingRequired('DRAFT', 'https://stage.blikk.tech/sca/p-1'),
+      isOnboardingRequired(
+        'DRAFT',
+        'https://stage.blikk.tech/sca/p-1',
+        onboardingOrigin,
+      ),
+    ).toBe(false)
+  })
+
+  it('compares origins, not substrings — the onboarding host elsewhere in the URL must not match', () => {
+    expect(
+      isOnboardingRequired(
+        'DRAFT',
+        'https://stage.blikk.tech/sca/p-1?return=light.blikk.tech',
+        onboardingOrigin,
+      ),
+    ).toBe(false)
+  })
+
+  it('follows the configured origin, not a hardcoded host', () => {
+    expect(
+      isOnboardingRequired(
+        'DRAFT',
+        'https://onboarding.example.is/p-1',
+        'https://onboarding.example.is',
+      ),
+    ).toBe(true)
+  })
+
+  it('is false for an unparsable SCA URL', () => {
+    expect(
+      isOnboardingRequired('DRAFT', 'not a url', onboardingOrigin),
     ).toBe(false)
   })
 
   it('is false for a DRAFT payment without an SCA URL (back-channel)', () => {
-    expect(isOnboardingRequired('DRAFT', undefined)).toBe(false)
+    expect(isOnboardingRequired('DRAFT', undefined, onboardingOrigin)).toBe(
+      false,
+    )
   })
 
   it('is false for non-DRAFT statuses regardless of the URL', () => {
@@ -52,6 +96,7 @@ describe('isOnboardingRequired', () => {
       isOnboardingRequired(
         'SCA_REQUIRED',
         'https://light.blikk.tech/onboarding/p-1',
+        onboardingOrigin,
       ),
     ).toBe(false)
   })

--- a/apps/services/payments/src/app/bankTransferPayment/bankTransfer.utils.ts
+++ b/apps/services/payments/src/app/bankTransferPayment/bankTransfer.utils.ts
@@ -7,6 +7,7 @@ import { BlikkItem } from '@island.is/clients/blikk'
 import {
   BankTransferFailureReason,
   BankTransferStatus,
+  BankTransferPendingStatus,
 } from './bankTransfer.types'
 import { BankTransferPayment } from './models/bankTransferPayment.model'
 import { CatalogItemWithQuantity } from '../../types/charges'
@@ -48,6 +49,34 @@ export const mapBlikkStatusToBankTransferStatus = (
     default:
       return BankTransferStatus.PENDING
   }
+}
+
+/** True when Blikk signals the payer must complete onboarding first. */
+export const isOnboardingRequired = (
+  rawStatus: string,
+  scaRedirectUrl?: string,
+): boolean =>
+  rawStatus === 'DRAFT' && !!scaRedirectUrl?.includes('light.blikk.tech')
+
+/** Map a raw Blikk status onto the pending sub-status. */
+export const mapRawStatusToBankTransferPendingStatus = (
+  status: string,
+  scaRedirectUrl?: string,
+): BankTransferPendingStatus => {
+  if (status === 'SCA_REQUIRED') {
+    return BankTransferPendingStatus.SCA_REQUIRED
+  }
+
+  // If the payment is a DRAFT and has a non-onboarding SCA URL, return SCA_REQUIRED.
+  if (
+    status === 'DRAFT' &&
+    scaRedirectUrl &&
+    !isOnboardingRequired(status, scaRedirectUrl)
+  ) {
+    return BankTransferPendingStatus.SCA_REQUIRED
+  }
+
+  return BankTransferPendingStatus.PROCESSING
 }
 
 export const toBlikkItem = (item: CatalogItemWithQuantity): BlikkItem => ({
@@ -111,6 +140,15 @@ export const toBankTransferFailureReason = (
       return null
   }
 }
+
+export const deriveBankTransferFailureReason = (
+  status: BankTransferStatus,
+  row: Pick<BankTransferPayment, 'expiresAt'>,
+): BankTransferFailureReason | null =>
+  // Blikk reports a lapsed TTL as a plain ERROR — expiry is derived from the row.
+  status === BankTransferStatus.ERROR && isRowExpired(row)
+    ? BankTransferFailureReason.EXPIRED
+    : toBankTransferFailureReason(status)
 
 /** Builds a PAID FJS charge payload for a settled bank transfer; carries the provider id in `RRN`. */
 export const generateBankTransferChargeFJSPayload = ({

--- a/apps/services/payments/src/app/bankTransferPayment/bankTransfer.utils.ts
+++ b/apps/services/payments/src/app/bankTransferPayment/bankTransfer.utils.ts
@@ -51,17 +51,27 @@ export const mapBlikkStatusToBankTransferStatus = (
   }
 }
 
-/** True when Blikk signals the payer must complete onboarding first. */
+/** True when Blikk signals the payer must complete onboarding first: a DRAFT payment whose SCA URL points at the configured onboarding app. Compares parsed origins — an unparsable URL is never onboarding. */
 export const isOnboardingRequired = (
   rawStatus: string,
-  scaRedirectUrl?: string,
-): boolean =>
-  rawStatus === 'DRAFT' && !!scaRedirectUrl?.includes('light.blikk.tech')
+  scaRedirectUrl: string | undefined,
+  onboardingOrigin: string,
+): boolean => {
+  if (rawStatus !== 'DRAFT' || !scaRedirectUrl) {
+    return false
+  }
+  try {
+    return new URL(scaRedirectUrl).origin === new URL(onboardingOrigin).origin
+  } catch {
+    return false
+  }
+}
 
 /** Map a raw Blikk status onto the pending sub-status. */
 export const mapRawStatusToBankTransferPendingStatus = (
   status: string,
-  scaRedirectUrl?: string,
+  scaRedirectUrl: string | undefined,
+  onboardingOrigin: string,
 ): BankTransferPendingStatus => {
   if (status === 'SCA_REQUIRED') {
     return BankTransferPendingStatus.SCA_REQUIRED
@@ -71,7 +81,7 @@ export const mapRawStatusToBankTransferPendingStatus = (
   if (
     status === 'DRAFT' &&
     scaRedirectUrl &&
-    !isOnboardingRequired(status, scaRedirectUrl)
+    !isOnboardingRequired(status, scaRedirectUrl, onboardingOrigin)
   ) {
     return BankTransferPendingStatus.SCA_REQUIRED
   }

--- a/apps/services/payments/src/app/bankTransferPayment/dtos/createBankTransfer.response.ts
+++ b/apps/services/payments/src/app/bankTransferPayment/dtos/createBankTransfer.response.ts
@@ -1,5 +1,5 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger'
-import { IsDate, IsOptional, IsString } from 'class-validator'
+import { IsBoolean, IsDate, IsOptional, IsString } from 'class-validator'
 
 export class CreateBankTransferResponse {
   @IsString()
@@ -15,4 +15,13 @@ export class CreateBankTransferResponse {
   @IsDate()
   @ApiProperty()
   readonly expiresAt!: Date
+
+  @IsOptional()
+  @IsBoolean()
+  @ApiPropertyOptional({
+    description:
+      'True when the payer must complete onboarding before SCA can proceed. ' +
+      'The frontend should redirect to scaRedirectUrl in this case only.',
+  })
+  readonly onboardingRequired?: boolean
 }

--- a/apps/services/payments/src/app/bankTransferPayment/dtos/verifyBankTransfer.response.ts
+++ b/apps/services/payments/src/app/bankTransferPayment/dtos/verifyBankTransfer.response.ts
@@ -1,7 +1,11 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger'
 import { IsEnum, IsOptional, IsString } from 'class-validator'
 
-import { BankTransferStatus } from '../bankTransfer.types'
+import {
+  BankTransferFailureReason,
+  BankTransferStatus,
+  BankTransferPendingStatus,
+} from '../bankTransfer.types'
 
 /** Status snapshot from verify. Server-side settlement is already triggered on SUCCESS. */
 export class VerifyBankTransferResponse {
@@ -13,4 +17,20 @@ export class VerifyBankTransferResponse {
   @IsString()
   @ApiPropertyOptional()
   readonly message?: string
+
+  // Pending sub-status; Controls if the UI should show the SCA (QR/deep link) or waiting UI.
+  @IsOptional()
+  @IsEnum(BankTransferPendingStatus)
+  @ApiPropertyOptional({ enum: BankTransferPendingStatus })
+  readonly pendingStatus?: BankTransferPendingStatus
+
+  @IsOptional()
+  @IsString()
+  @ApiPropertyOptional()
+  readonly scaRedirectUrl?: string
+
+  @IsOptional()
+  @IsEnum(BankTransferFailureReason)
+  @ApiPropertyOptional({ enum: BankTransferFailureReason })
+  readonly failureReason?: BankTransferFailureReason
 }

--- a/apps/services/payments/src/app/paymentFlow/dtos/getPaymentFlow.dto.ts
+++ b/apps/services/payments/src/app/paymentFlow/dtos/getPaymentFlow.dto.ts
@@ -13,7 +13,10 @@ import {
   PaymentFlowEventType,
   PaymentFlowEventReason,
 } from '../../../types'
-import { BankTransferFailureReason } from '../../bankTransferPayment/bankTransfer.types'
+import {
+  BankTransferFailureReason,
+  BankTransferPendingStatus,
+} from '../../bankTransferPayment/bankTransfer.types'
 import { PageInfoDto } from '@island.is/nest/pagination'
 
 export class PaymentFlowEventDTO {
@@ -238,6 +241,14 @@ export class GetPaymentFlowDTO {
   @IsOptional()
   @IsDate()
   bankTransferExpiresAt?: Date
+
+  @ApiPropertyOptional({
+    description: 'Populated only when paymentStatus is bank_transfer_pending',
+    enum: BankTransferPendingStatus,
+  })
+  @IsOptional()
+  @IsEnum(BankTransferPendingStatus)
+  bankTransferPendingStatus?: BankTransferPendingStatus
 }
 
 export class GetPaymentFlowsPaginatedDTO {

--- a/apps/services/payments/src/app/paymentFlow/paymentFlow.controller.ts
+++ b/apps/services/payments/src/app/paymentFlow/paymentFlow.controller.ts
@@ -99,6 +99,7 @@ export class PaymentFlowController {
       bankTransferScaRedirectUrl: overlay.bankTransferScaRedirectUrl,
       lastBankTransferFailure: overlay.lastBankTransferFailure,
       bankTransferExpiresAt: overlay.bankTransferExpiresAt,
+      bankTransferPendingStatus: overlay.bankTransferPendingStatus,
     }
   }
 

--- a/charts/islandis-services/services-payments-worker/values.cronjob.dev.yaml
+++ b/charts/islandis-services/services-payments-worker/values.cronjob.dev.yaml
@@ -26,6 +26,7 @@ command:
 enabled: true
 env:
   BLIKK_API_BASE_URL: 'https://stage.blikk.tech'
+  BLIKK_ONBOARDING_URL: 'https://light.blikk.tech'
   BLIKK_PAYMENT_TTL_SECONDS: '300'
   CODE_OWNER: 'aranja'
   DB_HOST: 'postgres-applications.internal'

--- a/charts/islandis-services/services-payments-worker/values.cronjob.prod.yaml
+++ b/charts/islandis-services/services-payments-worker/values.cronjob.prod.yaml
@@ -26,6 +26,7 @@ command:
 enabled: true
 env:
   BLIKK_API_BASE_URL: 'https://api.blikk.tech'
+  BLIKK_ONBOARDING_URL: 'https://light.blikk.tech'
   BLIKK_PAYMENT_TTL_SECONDS: '600'
   CODE_OWNER: 'aranja'
   DB_HOST: 'postgres-applications.internal'

--- a/charts/islandis-services/services-payments-worker/values.cronjob.staging.yaml
+++ b/charts/islandis-services/services-payments-worker/values.cronjob.staging.yaml
@@ -26,6 +26,7 @@ command:
 enabled: true
 env:
   BLIKK_API_BASE_URL: 'https://stage.blikk.tech'
+  BLIKK_ONBOARDING_URL: 'https://light.blikk.tech'
   BLIKK_PAYMENT_TTL_SECONDS: '300'
   CODE_OWNER: 'aranja'
   DB_HOST: 'postgres-applications.internal'

--- a/charts/islandis-services/services-payments/values.dev.yaml
+++ b/charts/islandis-services/services-payments/values.dev.yaml
@@ -20,6 +20,7 @@ name: 'services-payments'
 enabled: true
 env:
   BLIKK_API_BASE_URL: 'https://stage.blikk.tech'
+  BLIKK_ONBOARDING_URL: 'https://light.blikk.tech'
   BLIKK_PAYMENT_TTL_SECONDS: '300'
   DB_EXTENSIONS: 'uuid-ossp'
   DB_HOST: 'postgres-applications.internal'

--- a/charts/islandis-services/services-payments/values.prod.yaml
+++ b/charts/islandis-services/services-payments/values.prod.yaml
@@ -20,6 +20,7 @@ name: 'services-payments'
 enabled: true
 env:
   BLIKK_API_BASE_URL: 'https://api.blikk.tech'
+  BLIKK_ONBOARDING_URL: 'https://light.blikk.tech'
   BLIKK_PAYMENT_TTL_SECONDS: '600'
   DB_EXTENSIONS: 'uuid-ossp'
   DB_HOST: 'postgres-applications.internal'

--- a/charts/islandis-services/services-payments/values.staging.yaml
+++ b/charts/islandis-services/services-payments/values.staging.yaml
@@ -20,6 +20,7 @@ name: 'services-payments'
 enabled: true
 env:
   BLIKK_API_BASE_URL: 'https://stage.blikk.tech'
+  BLIKK_ONBOARDING_URL: 'https://light.blikk.tech'
   BLIKK_PAYMENT_TTL_SECONDS: '300'
   DB_EXTENSIONS: 'uuid-ossp'
   DB_HOST: 'postgres-applications.internal'

--- a/charts/islandis/values.dev.yaml
+++ b/charts/islandis/values.dev.yaml
@@ -3331,6 +3331,7 @@ services-payments:
   enabled: true
   env:
     BLIKK_API_BASE_URL: 'https://stage.blikk.tech'
+    BLIKK_ONBOARDING_URL: 'https://light.blikk.tech'
     BLIKK_PAYMENT_TTL_SECONDS: '300'
     DB_EXTENSIONS: 'uuid-ossp'
     DB_HOST: 'postgres-applications.internal'
@@ -3482,6 +3483,7 @@ services-payments-worker:
   enabled: true
   env:
     BLIKK_API_BASE_URL: 'https://stage.blikk.tech'
+    BLIKK_ONBOARDING_URL: 'https://light.blikk.tech'
     BLIKK_PAYMENT_TTL_SECONDS: '300'
     CODE_OWNER: 'aranja'
     DB_HOST: 'postgres-applications.internal'

--- a/charts/islandis/values.prod.yaml
+++ b/charts/islandis/values.prod.yaml
@@ -3266,6 +3266,7 @@ services-payments:
   enabled: true
   env:
     BLIKK_API_BASE_URL: 'https://api.blikk.tech'
+    BLIKK_ONBOARDING_URL: 'https://light.blikk.tech'
     BLIKK_PAYMENT_TTL_SECONDS: '600'
     DB_EXTENSIONS: 'uuid-ossp'
     DB_HOST: 'postgres-applications.internal'
@@ -3417,6 +3418,7 @@ services-payments-worker:
   enabled: true
   env:
     BLIKK_API_BASE_URL: 'https://api.blikk.tech'
+    BLIKK_ONBOARDING_URL: 'https://light.blikk.tech'
     BLIKK_PAYMENT_TTL_SECONDS: '600'
     CODE_OWNER: 'aranja'
     DB_HOST: 'postgres-applications.internal'

--- a/charts/islandis/values.staging.yaml
+++ b/charts/islandis/values.staging.yaml
@@ -3062,6 +3062,7 @@ services-payments:
   enabled: true
   env:
     BLIKK_API_BASE_URL: 'https://stage.blikk.tech'
+    BLIKK_ONBOARDING_URL: 'https://light.blikk.tech'
     BLIKK_PAYMENT_TTL_SECONDS: '300'
     DB_EXTENSIONS: 'uuid-ossp'
     DB_HOST: 'postgres-applications.internal'
@@ -3213,6 +3214,7 @@ services-payments-worker:
   enabled: true
   env:
     BLIKK_API_BASE_URL: 'https://stage.blikk.tech'
+    BLIKK_ONBOARDING_URL: 'https://light.blikk.tech'
     BLIKK_PAYMENT_TTL_SECONDS: '300'
     CODE_OWNER: 'aranja'
     DB_HOST: 'postgres-applications.internal'

--- a/libs/api/domains/payments/src/lib/dto/createBankTransfer.response.ts
+++ b/libs/api/domains/payments/src/lib/dto/createBankTransfer.response.ts
@@ -19,4 +19,11 @@ export class CreateBankTransferResponse {
       'When this attempt expires (the TTL we shared with Blikk). The FE polling loop derives its hard timeout from this.',
   })
   expiresAt!: Date
+
+  @Field(() => Boolean, {
+    nullable: true,
+    description:
+      'True when the payer must complete onboarding before SCA can proceed. Redirect to scaRedirectUrl in this case only.',
+  })
+  onboardingRequired?: boolean
 }

--- a/libs/api/domains/payments/src/lib/dto/getPaymentFlow.response.ts
+++ b/libs/api/domains/payments/src/lib/dto/getPaymentFlow.response.ts
@@ -1,6 +1,7 @@
 import { Field, ObjectType, ID, registerEnumType } from '@nestjs/graphql'
 import { GraphQLJSON } from 'graphql-type-json'
 import {
+  GetPaymentFlowDTOBankTransferPendingStatusEnum,
   GetPaymentFlowDTOLastBankTransferFailureEnum,
   GetPaymentFlowDTOPaymentStatusEnum,
 } from '@island.is/clients/payments'
@@ -12,6 +13,10 @@ registerEnumType(GetPaymentFlowDTOPaymentStatusEnum, {
 
 registerEnumType(GetPaymentFlowDTOLastBankTransferFailureEnum, {
   name: 'PaymentsBankTransferFailureReason',
+})
+
+registerEnumType(GetPaymentFlowDTOBankTransferPendingStatusEnum, {
+  name: 'PaymentsBankTransferPendingStatus',
 })
 
 @ObjectType('PaymentsGetPaymentFlowResponse')
@@ -88,6 +93,13 @@ export class GetPaymentFlowResponse {
       'Populated only when paymentStatus is bank_transfer_pending. Timestamp at which the in-flight attempt expires (matches the TTL we shared with Blikk on create). The FE polling loop derives its hard timeout from this.',
   })
   bankTransferExpiresAt?: Date
+
+  @Field(() => GetPaymentFlowDTOBankTransferPendingStatusEnum, {
+    nullable: true,
+    description:
+      'Populated only when paymentStatus is bank_transfer_pending. sca_required: the payer must complete SCA — render bankTransferScaRedirectUrl as a QR code (desktop) or deep link (mobile). processing: waiting for bank confirmation.',
+  })
+  bankTransferPendingStatus?: GetPaymentFlowDTOBankTransferPendingStatusEnum
 }
 
 @ObjectType('PaymentsGetPaymentFlowAdminResponse')

--- a/libs/api/domains/payments/src/lib/dto/verifyBankTransfer.response.ts
+++ b/libs/api/domains/payments/src/lib/dto/verifyBankTransfer.response.ts
@@ -1,6 +1,10 @@
 import { Field, ObjectType, registerEnumType } from '@nestjs/graphql'
 
-import { VerifyBankTransferResponseStatusEnum } from '@island.is/clients/payments'
+import {
+  GetPaymentFlowDTOBankTransferPendingStatusEnum,
+  GetPaymentFlowDTOLastBankTransferFailureEnum,
+  VerifyBankTransferResponseStatusEnum,
+} from '@island.is/clients/payments'
 
 registerEnumType(VerifyBankTransferResponseStatusEnum, {
   name: 'PaymentsBankTransferStatus',
@@ -13,4 +17,25 @@ export class VerifyBankTransferResponse {
 
   @Field(() => String, { nullable: true })
   message?: string
+
+  @Field(() => GetPaymentFlowDTOBankTransferPendingStatusEnum, {
+    nullable: true,
+    description:
+      'Pending sub-status. sca_required: the payer must complete SCA — render scaRedirectUrl as a QR code (desktop) or deep link (mobile). processing: waiting for bank confirmation.',
+  })
+  pendingStatus?: GetPaymentFlowDTOBankTransferPendingStatusEnum
+
+  @Field(() => String, {
+    nullable: true,
+    description:
+      'Fresh SCA URL from the provider — may only appear once the payment reaches sca_required (back-channel creates have none initially).',
+  })
+  scaRedirectUrl?: string
+
+  @Field(() => GetPaymentFlowDTOLastBankTransferFailureEnum, {
+    nullable: true,
+    description:
+      'Expiry-aware reason for a terminal failure (an ERROR past the attempt TTL is reported as "expired"); absent for non-failure statuses.',
+  })
+  failureReason?: GetPaymentFlowDTOLastBankTransferFailureEnum
 }

--- a/libs/api/domains/payments/src/lib/payments.service.ts
+++ b/libs/api/domains/payments/src/lib/payments.service.ts
@@ -13,6 +13,8 @@ import {
   GetPaymentFlowDTOLastBankTransferFailureEnum,
   GetPaymentFlowDTOPaymentStatusEnum,
   CreateBankTransferInputLocaleEnum,
+  VerifyBankTransferResponsePendingStatusEnum,
+  VerifyBankTransferResponseFailureReasonEnum,
 } from '@island.is/clients/payments'
 
 import { VerifyCardInput } from './dto/verifyCard.input'
@@ -35,6 +37,44 @@ import { VerifyBankTransferInput } from './dto/verifyBankTransfer.input'
 import { VerifyBankTransferResponse } from './dto/verifyBankTransfer.response'
 import { CancelBankTransferInput } from './dto/cancelBankTransfer.input'
 import { CancelBankTransferResponse } from './dto/cancelBankTransfer.response'
+
+const toRegisteredPendingStatus = (
+  pendingStatus?: VerifyBankTransferResponsePendingStatusEnum,
+): GetPaymentFlowDTOBankTransferPendingStatusEnum | undefined => {
+  switch (pendingStatus) {
+    case undefined:
+      return undefined
+    case VerifyBankTransferResponsePendingStatusEnum.sca_required:
+      return GetPaymentFlowDTOBankTransferPendingStatusEnum.sca_required
+    case VerifyBankTransferResponsePendingStatusEnum.processing:
+      return GetPaymentFlowDTOBankTransferPendingStatusEnum.processing
+    default: {
+      const exhaustive: never = pendingStatus
+      return exhaustive
+    }
+  }
+}
+
+const toRegisteredFailureReason = (
+  failureReason?: VerifyBankTransferResponseFailureReasonEnum,
+): GetPaymentFlowDTOLastBankTransferFailureEnum | undefined => {
+  switch (failureReason) {
+    case undefined:
+      return undefined
+    case VerifyBankTransferResponseFailureReasonEnum.rejected:
+      return GetPaymentFlowDTOLastBankTransferFailureEnum.rejected
+    case VerifyBankTransferResponseFailureReasonEnum.cancelled:
+      return GetPaymentFlowDTOLastBankTransferFailureEnum.cancelled
+    case VerifyBankTransferResponseFailureReasonEnum.error:
+      return GetPaymentFlowDTOLastBankTransferFailureEnum.error
+    case VerifyBankTransferResponseFailureReasonEnum.expired:
+      return GetPaymentFlowDTOLastBankTransferFailureEnum.expired
+    default: {
+      const exhaustive: never = failureReason
+      return exhaustive
+    }
+  }
+}
 
 @Injectable()
 export class PaymentsService {
@@ -154,12 +194,8 @@ export class PaymentsService {
 
     return {
       ...response,
-      pendingStatus: response.pendingStatus as unknown as
-        | GetPaymentFlowDTOBankTransferPendingStatusEnum
-        | undefined,
-      failureReason: response.failureReason as unknown as
-        | GetPaymentFlowDTOLastBankTransferFailureEnum
-        | undefined,
+      pendingStatus: toRegisteredPendingStatus(response.pendingStatus),
+      failureReason: toRegisteredFailureReason(response.failureReason),
     }
   }
 

--- a/libs/api/domains/payments/src/lib/payments.service.ts
+++ b/libs/api/domains/payments/src/lib/payments.service.ts
@@ -9,6 +9,8 @@ import {
   PaymentsApi,
   VerificationStatusResponse,
   VerificationCallbackInput,
+  GetPaymentFlowDTOBankTransferPendingStatusEnum,
+  GetPaymentFlowDTOLastBankTransferFailureEnum,
   GetPaymentFlowDTOPaymentStatusEnum,
   CreateBankTransferInputLocaleEnum,
 } from '@island.is/clients/payments'
@@ -146,9 +148,19 @@ export class PaymentsService {
   async verifyBankTransfer(
     verifyBankTransferInput: VerifyBankTransferInput,
   ): Promise<VerifyBankTransferResponse> {
-    return this.paymentsApi.bankTransferControllerVerify({
+    const response = await this.paymentsApi.bankTransferControllerVerify({
       verifyBankTransferInput,
     })
+
+    return {
+      ...response,
+      pendingStatus: response.pendingStatus as unknown as
+        | GetPaymentFlowDTOBankTransferPendingStatusEnum
+        | undefined,
+      failureReason: response.failureReason as unknown as
+        | GetPaymentFlowDTOLastBankTransferFailureEnum
+        | undefined,
+    }
   }
 
   async cancelBankTransfer(

--- a/libs/clients/payments/src/index.ts
+++ b/libs/clients/payments/src/index.ts
@@ -18,6 +18,8 @@ export {
   GetPaymentFlowStatusDTOPaymentStatusEnum,
   CreateBankTransferInputLocaleEnum,
   VerifyBankTransferResponseStatusEnum,
+  VerifyBankTransferResponsePendingStatusEnum,
+  VerifyBankTransferResponseFailureReasonEnum,
   GetPaymentFlowDTOLastBankTransferFailureEnum,
   GetPaymentFlowDTOBankTransferPendingStatusEnum,
 } from '../gen/fetch'

--- a/libs/clients/payments/src/index.ts
+++ b/libs/clients/payments/src/index.ts
@@ -19,4 +19,5 @@ export {
   CreateBankTransferInputLocaleEnum,
   VerifyBankTransferResponseStatusEnum,
   GetPaymentFlowDTOLastBankTransferFailureEnum,
+  GetPaymentFlowDTOBankTransferPendingStatusEnum,
 } from '../gen/fetch'

--- a/libs/shared/constants/src/lib/paymentErrorCodes.ts
+++ b/libs/shared/constants/src/lib/paymentErrorCodes.ts
@@ -77,6 +77,7 @@ export enum BankTransferErrorCode {
   MissingBankAccountNumber = 'MissingBankAccountNumber',
   FailedToFetchBankTransfer = 'FailedToFetchBankTransfer',
   BankTransferAlreadyInProgress = 'BankTransferAlreadyInProgress',
+  BankTransferCannotCancel = 'BankTransferCannotCancel',
   BankTransferNotFound = 'BankTransferNotFound',
   UnknownBankTransferError = 'UnknownBankTransferError',
   BankTransferRejected = 'BankTransferRejected',

--- a/package.json
+++ b/package.json
@@ -263,6 +263,7 @@
     "powerbi-models": "1.15.2",
     "prom-client": "14.1.0",
     "pubsub-js": "1.8.0",
+    "qrcode.react": "4.2.0",
     "react": "18.3.1",
     "react-alice-carousel": "1.19.3",
     "react-animate-height": "3.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -35507,6 +35507,7 @@ __metadata:
     prettier: "npm:2.6.2"
     prom-client: "npm:14.1.0"
     pubsub-js: "npm:1.8.0"
+    qrcode.react: "npm:4.2.0"
     react: "npm:18.3.1"
     react-alice-carousel: "npm:1.19.3"
     react-animate-height: "npm:3.1.2"
@@ -44608,6 +44609,15 @@ __metadata:
   version: 1.1.3
   resolution: "pvutils@npm:1.1.3"
   checksum: 10/e5201b8f78ece68eae414a938c844bc45fb3f0de298178eed1775a217eedfd897c4346e5e54f410bb4d7466e09ceb262e85f20fd64239b8bb2595f14c52fa95e
+  languageName: node
+  linkType: hard
+
+"qrcode.react@npm:4.2.0":
+  version: 4.2.0
+  resolution: "qrcode.react@npm:4.2.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+  checksum: 10/665036d88b160e6d5de4e24d101bc63bd2b76712802e874bbffe56c6b6e5fe50c63f02c3cba2975b2e2b555c1f1e112cbb42987f8cb3a626ce2d17023cfde6ac
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What

- Render the bank-transfer SCA (strong customer authentication) step inline on the pending screen: a new `BankTransferPendingScreen` shows the SCA link as a scannable QR code (`qrcode.react`) alongside an open-in-app button, instead of only redirecting.
- Surface a non-terminal `pendingStatus` (`sca_required`, `onboarding_required`, `processing`) and `scaRedirectUrl` through the verify/status endpoints, GraphQL layer, and client DTOs so the web app can react to sub-status changes while the attempt is still pending.
- Derive a structured `failureReason` (expired / rejected / cancelled) for terminal failures and map it to the matching frontend error codes.
- Adjust status polling: faster initial intervals, decay to a slow 15s interval while the payer is acting on the SCA UI, and pick back up once the status moves on.
- Rework `cancel` to always refresh the provider state first (never cancel on cached state), refuse cancels once the payer has initiated/approved (settlement may be in flight), and treat the provider-side cancel of unapproved DRAFT/SCA_REQUIRED payments as best-effort.
- Persist a newly minted SCA URL onto the local row when the provider returns one after creation, and detect onboarding-required SCA URLs via a configurable `onboardingOrigin` (new env var wired through infra/chart values).

## Why

- Redirecting away for SCA loses the payment context; showing the QR code inline lets the payer approve on their phone while the pending screen keeps polling and completes the flow automatically.
- The frontend needs pending sub-status and a fresh SCA URL to know what UI to show (QR vs. onboarding vs. processing) without inventing state client-side.
- Distinct failure reasons give the payer an accurate message (expired vs. rejected vs. cancelled) instead of a generic failure.
- The previous cancel logic could act on stale local state; refreshing first and refusing past-approval cancels prevents soft-deleting a payment that may be settling.
- Slow polling during SCA avoids hammering the verify endpoint while the payer is busy in their banking app.

## Screenshots / Gifs

N/A

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated bank-transfer pending screen with SCA support (desktop QR code and mobile deep link) and contextual waiting/check-phone messaging.
  * Added live pending updates, including surfaced SCA/onboarding-required details.
* **Bug Fixes**
  * Improved redirect vs reload behavior and polling cadence when SCA/deep links are involved.
  * Enhanced failure handling, including expired status detection and richer failure reasons.
  * Refined cancellation rules and “already in progress” outcomes, with clearer user messaging.
* **Documentation**
  * Updated bank-transfer payment documentation for the new FE/SCA/cancellation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->