### PR TITLE
feat(my-pages): Updated client and health conversation detail info added

### DIFF
--- a/libs/api/domains/health-directorate/src/lib/health-directorate.service.ts
+++ b/libs/api/domains/health-directorate/src/lib/health-directorate.service.ts
@@ -3,12 +3,12 @@ import {
   ConversationAttachmentDto,
   ConversationDetailDto,
   ConversationMessageDto,
-  ConversationStatusFilter,
   CreateConversationRequestDto,
   CreateEuPatientConsentDto,
   CreateReplyRequestDto,
   HealthDirectorateHealthService,
   HealthDirectorateVaccinationsService,
+  MessagingRecipientDto,
   OrganDonorDto,
   VaccinationDto,
 } from '@island.is/clients/health-directorate'
@@ -859,6 +859,37 @@ export class HealthDirectorateService {
     return true
   }
 
+  private mapMessagingRecipient(
+    r: MessagingRecipientDto,
+  ): HealthDirectorateHealthConversationRecipient {
+    return {
+      nodeId: r.nodeId,
+      groupId: r.groupId,
+      name: r.name,
+      allowsMessaging: r.allowsMessaging,
+      messagingWindowOpen: r.messagingWindowOpen,
+      messagingWindowClose: r.messagingWindowClose,
+      isCurrentlyWithinWindow: r.isCurrentlyWithinWindow,
+      patientReplyWindowDays: r.patientReplyWindowDays,
+      allowedMessageTypes: r.allowedConversationTypes.map(
+        (t): HealthDirectorateHealthConversationType => ({
+          patientInitiatedTypeCode: t.patientInitiatedTypeCode,
+          title: t.title,
+          description: t.description,
+          isCertificate: t.isCertificate,
+        }),
+      ),
+      canCreateConversation: r.canCreateConversation,
+      conversationBlockedReason: toConversationRecipientBlockedReasonEnum(
+        r.conversationBlockedReason,
+      ),
+      canRequestCertificate: r.canRequestCertificate,
+      certificateBlockedReason: toConversationRecipientBlockedReasonEnum(
+        r.certificateBlockedReason,
+      ),
+    }
+  }
+
   async getHealthConversationRecipients(
     auth: Auth,
     locale: Locale = 'is',
@@ -866,33 +897,6 @@ export class HealthDirectorateService {
     const items = await this.healthApi.getMessagingRecipients(auth, locale)
     if (!items) return null
 
-    return items.map(
-      (r): HealthDirectorateHealthConversationRecipient => ({
-        nodeId: r.nodeId,
-        groupId: r.groupId,
-        name: r.name,
-        allowsMessaging: r.allowsMessaging,
-        messagingWindowOpen: r.messagingWindowOpen,
-        messagingWindowClose: r.messagingWindowClose,
-        isCurrentlyWithinWindow: r.isCurrentlyWithinWindow,
-        patientReplyWindowDays: r.patientReplyWindowDays,
-        allowedMessageTypes: r.allowedConversationTypes.map(
-          (t): HealthDirectorateHealthConversationType => ({
-            patientInitiatedTypeCode: t.patientInitiatedTypeCode,
-            title: t.title,
-            description: t.description,
-            isCertificate: t.isCertificate,
-          }),
-        ),
-        canCreateConversation: r.canCreateConversation,
-        conversationBlockedReason: toConversationRecipientBlockedReasonEnum(
-          r.conversationBlockedReason,
-        ),
-        canRequestCertificate: r.canRequestCertificate,
-        certificateBlockedReason: toConversationRecipientBlockedReasonEnum(
-          r.certificateBlockedReason,
-        ),
-      }),
-    )
+    return items.map((r) => this.mapMessagingRecipient(r))
   }
 }

--- a/libs/api/domains/health-directorate/src/lib/health-directorate.service.ts
+++ b/libs/api/domains/health-directorate/src/lib/health-directorate.service.ts
@@ -33,7 +33,6 @@ import { PermitInput } from './dto/permit.input'
 import { HealthDirectorateResponse } from './dto/response.dto'
 import {
   mapAppointmentStatus,
-  mapMessagingRecipient,
   toAppointmentAssigneeTypeEnum,
   toAppointmentLinkTypeEnum,
   toAppointmentModalityEnum,
@@ -41,10 +40,13 @@ import {
   mapStatusIdToColor,
   mapReferralStatusValueToStatus,
   mapVaccinationStatus,
+} from './mappers/basicInformationMapper'
+import {
+  mapMessagingRecipient,
   toConversationDirectionEnum,
   toConversationReplyBlockedReasonEnum,
   toConversationStatusFilter,
-} from './mappers/basicInformationMapper'
+} from './mappers/conversationMapper'
 import {
   mapDelegationStatus,
   mapDispensationItem,

--- a/libs/api/domains/health-directorate/src/lib/health-directorate.service.ts
+++ b/libs/api/domains/health-directorate/src/lib/health-directorate.service.ts
@@ -8,7 +8,6 @@ import {
   CreateReplyRequestDto,
   HealthDirectorateHealthService,
   HealthDirectorateVaccinationsService,
-  MessagingRecipientDto,
   OrganDonorDto,
   VaccinationDto,
 } from '@island.is/clients/health-directorate'
@@ -34,6 +33,7 @@ import { PermitInput } from './dto/permit.input'
 import { HealthDirectorateResponse } from './dto/response.dto'
 import {
   mapAppointmentStatus,
+  mapMessagingRecipient,
   toAppointmentAssigneeTypeEnum,
   toAppointmentLinkTypeEnum,
   toAppointmentModalityEnum,
@@ -42,7 +42,6 @@ import {
   mapReferralStatusValueToStatus,
   mapVaccinationStatus,
   toConversationDirectionEnum,
-  toConversationRecipientBlockedReasonEnum,
   toConversationReplyBlockedReasonEnum,
   toConversationStatusFilter,
 } from './mappers/basicInformationMapper'
@@ -88,7 +87,6 @@ import { HealthDirectorateHealthConversation } from './models/healthConversation
 import { HealthDirectorateHealthConversationAttachment } from './models/healthConversationAttachment.model'
 import { HealthDirectorateHealthConversationDetail } from './models/healthConversationDetail.model'
 import { HealthDirectorateHealthConversationEntry } from './models/healthConversationEntry.model'
-import { HealthDirectorateHealthConversationType } from './models/healthConversationType.model'
 import { HealthDirectorateHealthConversationRecipient } from './models/healthConversationRecipient.model'
 
 @Injectable()
@@ -859,37 +857,6 @@ export class HealthDirectorateService {
     return true
   }
 
-  private mapMessagingRecipient(
-    r: MessagingRecipientDto,
-  ): HealthDirectorateHealthConversationRecipient {
-    return {
-      nodeId: r.nodeId,
-      groupId: r.groupId,
-      name: r.name,
-      allowsMessaging: r.allowsMessaging,
-      messagingWindowOpen: r.messagingWindowOpen,
-      messagingWindowClose: r.messagingWindowClose,
-      isCurrentlyWithinWindow: r.isCurrentlyWithinWindow,
-      patientReplyWindowDays: r.patientReplyWindowDays,
-      allowedMessageTypes: r.allowedConversationTypes.map(
-        (t): HealthDirectorateHealthConversationType => ({
-          patientInitiatedTypeCode: t.patientInitiatedTypeCode,
-          title: t.title,
-          description: t.description,
-          isCertificate: t.isCertificate,
-        }),
-      ),
-      canCreateConversation: r.canCreateConversation,
-      conversationBlockedReason: toConversationRecipientBlockedReasonEnum(
-        r.conversationBlockedReason,
-      ),
-      canRequestCertificate: r.canRequestCertificate,
-      certificateBlockedReason: toConversationRecipientBlockedReasonEnum(
-        r.certificateBlockedReason,
-      ),
-    }
-  }
-
   async getHealthConversationRecipients(
     auth: Auth,
     locale: Locale = 'is',
@@ -897,6 +864,6 @@ export class HealthDirectorateService {
     const items = await this.healthApi.getMessagingRecipients(auth, locale)
     if (!items) return null
 
-    return items.map((r) => this.mapMessagingRecipient(r))
+    return items.map(mapMessagingRecipient)
   }
 }

--- a/libs/api/domains/health-directorate/src/lib/health-directorate.service.ts
+++ b/libs/api/domains/health-directorate/src/lib/health-directorate.service.ts
@@ -42,6 +42,8 @@ import {
   mapReferralStatusValueToStatus,
   mapVaccinationStatus,
   toConversationDirectionEnum,
+  toConversationRecipientBlockedReasonEnum,
+  toConversationReplyBlockedReasonEnum,
   toConversationStatusFilter,
 } from './mappers/basicInformationMapper'
 import {
@@ -755,6 +757,9 @@ export class HealthDirectorateService {
       isStarred: c.isStarred,
       isArchived: c.isArchived,
       patientCanReply: c.patientCanReply,
+      replyBlockedReason: toConversationReplyBlockedReasonEnum(
+        c.replyBlockedReason,
+      ),
       isRead: !c.unread,
       messages: c.messages.map((m) => this.mapConversationEntry(m, c.id)),
     }
@@ -878,6 +883,14 @@ export class HealthDirectorateService {
             description: t.description,
             isCertificate: t.isCertificate,
           }),
+        ),
+        canCreateConversation: r.canCreateConversation,
+        conversationBlockedReason: toConversationRecipientBlockedReasonEnum(
+          r.conversationBlockedReason,
+        ),
+        canRequestCertificate: r.canRequestCertificate,
+        certificateBlockedReason: toConversationRecipientBlockedReasonEnum(
+          r.certificateBlockedReason,
         ),
       }),
     )

--- a/libs/api/domains/health-directorate/src/lib/mappers/basicInformationMapper.ts
+++ b/libs/api/domains/health-directorate/src/lib/mappers/basicInformationMapper.ts
@@ -1,22 +1,12 @@
 import {
-  ConversationReplyBlockedReason,
-  ConversationStatusFilter,
   DiseaseVaccinationDtoVaccinationStatusEnum,
-  MessagingRecipientDto,
-  RecipientCreateBlockedReason,
   UserVisibleAppointmentStatuses,
 } from '@island.is/clients/health-directorate'
-import { HealthDirectorateHealthConversationRecipient } from '../models/healthConversationRecipient.model'
-import { HealthDirectorateHealthConversationType } from '../models/healthConversationType.model'
 import {
   AppointmentAssigneeTypeEnum,
   AppointmentLinkTypeEnum,
   AppointmentModalityEnum,
   AppointmentStatusEnum,
-  HealthConversationDirectionEnum,
-  HealthConversationRecipientBlockedReasonEnum,
-  HealthConversationReplyBlockedReasonEnum,
-  HealthConversationStatusFilterEnum,
   ReferralStatusEnum,
   VaccinationStatusEnum,
   WaitlistStatusTagColorEnum,
@@ -174,95 +164,3 @@ export const mapReferralStatusValueToStatus = (
   }
 }
 
-export const toConversationDirectionEnum = (
-  direction: string,
-): HealthConversationDirectionEnum => {
-  switch (direction) {
-    case 'PATIENT':
-      return HealthConversationDirectionEnum.PATIENT
-    case 'STAFF':
-      return HealthConversationDirectionEnum.STAFF
-    case 'SYSTEM':
-      return HealthConversationDirectionEnum.SYSTEM
-    default:
-      return HealthConversationDirectionEnum.SYSTEM
-  }
-}
-
-export const toConversationStatusFilter = (
-  status: HealthConversationStatusFilterEnum,
-): ConversationStatusFilter => {
-  switch (status) {
-    case HealthConversationStatusFilterEnum.ACTIVE:
-      return ConversationStatusFilter.ACTIVE
-    case HealthConversationStatusFilterEnum.ARCHIVED:
-      return ConversationStatusFilter.ARCHIVED
-    case HealthConversationStatusFilterEnum.ALL:
-      return ConversationStatusFilter.ALL
-  }
-}
-
-export const toConversationReplyBlockedReasonEnum = (
-  reason?: ConversationReplyBlockedReason,
-): HealthConversationReplyBlockedReasonEnum | undefined => {
-  switch (reason) {
-    case ConversationReplyBlockedReason.MISSING_RECIPIENT:
-      return HealthConversationReplyBlockedReasonEnum.MISSING_RECIPIENT
-    case ConversationReplyBlockedReason.REPLIES_DISABLED:
-      return HealthConversationReplyBlockedReasonEnum.REPLIES_DISABLED
-    case ConversationReplyBlockedReason.NO_REPLY_GROUP:
-      return HealthConversationReplyBlockedReasonEnum.NO_REPLY_GROUP
-    case ConversationReplyBlockedReason.MESSAGING_NOT_ALLOWED:
-      return HealthConversationReplyBlockedReasonEnum.MESSAGING_NOT_ALLOWED
-    case ConversationReplyBlockedReason.OUTSIDE_MESSAGING_WINDOW:
-      return HealthConversationReplyBlockedReasonEnum.OUTSIDE_MESSAGING_WINDOW
-    case ConversationReplyBlockedReason.REPLY_WINDOW_EXPIRED:
-      return HealthConversationReplyBlockedReasonEnum.REPLY_WINDOW_EXPIRED
-    default:
-      return undefined
-  }
-}
-
-export const mapMessagingRecipient = (
-  r: MessagingRecipientDto,
-): HealthDirectorateHealthConversationRecipient => ({
-  nodeId: r.nodeId,
-  groupId: r.groupId,
-  name: r.name,
-  allowsMessaging: r.allowsMessaging,
-  messagingWindowOpen: r.messagingWindowOpen,
-  messagingWindowClose: r.messagingWindowClose,
-  isCurrentlyWithinWindow: r.isCurrentlyWithinWindow,
-  patientReplyWindowDays: r.patientReplyWindowDays,
-  allowedMessageTypes: r.allowedConversationTypes.map(
-    (t): HealthDirectorateHealthConversationType => ({
-      patientInitiatedTypeCode: t.patientInitiatedTypeCode,
-      title: t.title,
-      description: t.description,
-      isCertificate: t.isCertificate,
-    }),
-  ),
-  canCreateConversation: r.canCreateConversation,
-  conversationBlockedReason: toConversationRecipientBlockedReasonEnum(
-    r.conversationBlockedReason,
-  ),
-  canRequestCertificate: r.canRequestCertificate,
-  certificateBlockedReason: toConversationRecipientBlockedReasonEnum(
-    r.certificateBlockedReason,
-  ),
-})
-
-export const toConversationRecipientBlockedReasonEnum = (
-  reason?: RecipientCreateBlockedReason,
-): HealthConversationRecipientBlockedReasonEnum | undefined => {
-  switch (reason) {
-    case RecipientCreateBlockedReason.MESSAGING_NOT_ALLOWED:
-      return HealthConversationRecipientBlockedReasonEnum.MESSAGING_NOT_ALLOWED
-    case RecipientCreateBlockedReason.OUTSIDE_MESSAGING_WINDOW:
-      return HealthConversationRecipientBlockedReasonEnum.OUTSIDE_MESSAGING_WINDOW
-    case RecipientCreateBlockedReason.NO_ALLOWED_TYPES:
-      return HealthConversationRecipientBlockedReasonEnum.NO_ALLOWED_TYPES
-    default:
-      return undefined
-  }
-}

--- a/libs/api/domains/health-directorate/src/lib/mappers/basicInformationMapper.ts
+++ b/libs/api/domains/health-directorate/src/lib/mappers/basicInformationMapper.ts
@@ -1,6 +1,8 @@
 import {
+  ConversationReplyBlockedReason,
   ConversationStatusFilter,
   DiseaseVaccinationDtoVaccinationStatusEnum,
+  RecipientCreateBlockedReason,
   UserVisibleAppointmentStatuses,
 } from '@island.is/clients/health-directorate'
 import {
@@ -9,6 +11,8 @@ import {
   AppointmentModalityEnum,
   AppointmentStatusEnum,
   HealthConversationDirectionEnum,
+  HealthConversationRecipientBlockedReasonEnum,
+  HealthConversationReplyBlockedReasonEnum,
   HealthConversationStatusFilterEnum,
   ReferralStatusEnum,
   VaccinationStatusEnum,
@@ -192,5 +196,41 @@ export const toConversationStatusFilter = (
       return ConversationStatusFilter.ARCHIVED
     case HealthConversationStatusFilterEnum.ALL:
       return ConversationStatusFilter.ALL
+  }
+}
+
+export const toConversationReplyBlockedReasonEnum = (
+  reason?: ConversationReplyBlockedReason,
+): HealthConversationReplyBlockedReasonEnum | undefined => {
+  switch (reason) {
+    case ConversationReplyBlockedReason.MISSING_RECIPIENT:
+      return HealthConversationReplyBlockedReasonEnum.MISSING_RECIPIENT
+    case ConversationReplyBlockedReason.REPLIES_DISABLED:
+      return HealthConversationReplyBlockedReasonEnum.REPLIES_DISABLED
+    case ConversationReplyBlockedReason.NO_REPLY_GROUP:
+      return HealthConversationReplyBlockedReasonEnum.NO_REPLY_GROUP
+    case ConversationReplyBlockedReason.MESSAGING_NOT_ALLOWED:
+      return HealthConversationReplyBlockedReasonEnum.MESSAGING_NOT_ALLOWED
+    case ConversationReplyBlockedReason.OUTSIDE_MESSAGING_WINDOW:
+      return HealthConversationReplyBlockedReasonEnum.OUTSIDE_MESSAGING_WINDOW
+    case ConversationReplyBlockedReason.REPLY_WINDOW_EXPIRED:
+      return HealthConversationReplyBlockedReasonEnum.REPLY_WINDOW_EXPIRED
+    default:
+      return undefined
+  }
+}
+
+export const toConversationRecipientBlockedReasonEnum = (
+  reason?: RecipientCreateBlockedReason,
+): HealthConversationRecipientBlockedReasonEnum | undefined => {
+  switch (reason) {
+    case RecipientCreateBlockedReason.MESSAGING_NOT_ALLOWED:
+      return HealthConversationRecipientBlockedReasonEnum.MESSAGING_NOT_ALLOWED
+    case RecipientCreateBlockedReason.OUTSIDE_MESSAGING_WINDOW:
+      return HealthConversationRecipientBlockedReasonEnum.OUTSIDE_MESSAGING_WINDOW
+    case RecipientCreateBlockedReason.NO_ALLOWED_TYPES:
+      return HealthConversationRecipientBlockedReasonEnum.NO_ALLOWED_TYPES
+    default:
+      return undefined
   }
 }

--- a/libs/api/domains/health-directorate/src/lib/mappers/basicInformationMapper.ts
+++ b/libs/api/domains/health-directorate/src/lib/mappers/basicInformationMapper.ts
@@ -2,9 +2,12 @@ import {
   ConversationReplyBlockedReason,
   ConversationStatusFilter,
   DiseaseVaccinationDtoVaccinationStatusEnum,
+  MessagingRecipientDto,
   RecipientCreateBlockedReason,
   UserVisibleAppointmentStatuses,
 } from '@island.is/clients/health-directorate'
+import { HealthDirectorateHealthConversationRecipient } from '../models/healthConversationRecipient.model'
+import { HealthDirectorateHealthConversationType } from '../models/healthConversationType.model'
 import {
   AppointmentAssigneeTypeEnum,
   AppointmentLinkTypeEnum,
@@ -219,6 +222,35 @@ export const toConversationReplyBlockedReasonEnum = (
       return undefined
   }
 }
+
+export const mapMessagingRecipient = (
+  r: MessagingRecipientDto,
+): HealthDirectorateHealthConversationRecipient => ({
+  nodeId: r.nodeId,
+  groupId: r.groupId,
+  name: r.name,
+  allowsMessaging: r.allowsMessaging,
+  messagingWindowOpen: r.messagingWindowOpen,
+  messagingWindowClose: r.messagingWindowClose,
+  isCurrentlyWithinWindow: r.isCurrentlyWithinWindow,
+  patientReplyWindowDays: r.patientReplyWindowDays,
+  allowedMessageTypes: r.allowedConversationTypes.map(
+    (t): HealthDirectorateHealthConversationType => ({
+      patientInitiatedTypeCode: t.patientInitiatedTypeCode,
+      title: t.title,
+      description: t.description,
+      isCertificate: t.isCertificate,
+    }),
+  ),
+  canCreateConversation: r.canCreateConversation,
+  conversationBlockedReason: toConversationRecipientBlockedReasonEnum(
+    r.conversationBlockedReason,
+  ),
+  canRequestCertificate: r.canRequestCertificate,
+  certificateBlockedReason: toConversationRecipientBlockedReasonEnum(
+    r.certificateBlockedReason,
+  ),
+})
 
 export const toConversationRecipientBlockedReasonEnum = (
   reason?: RecipientCreateBlockedReason,

--- a/libs/api/domains/health-directorate/src/lib/mappers/basicInformationMapper.ts
+++ b/libs/api/domains/health-directorate/src/lib/mappers/basicInformationMapper.ts
@@ -163,4 +163,3 @@ export const mapReferralStatusValueToStatus = (
       return ReferralStatusEnum.Unknown
   }
 }
-

--- a/libs/api/domains/health-directorate/src/lib/mappers/conversationMapper.ts
+++ b/libs/api/domains/health-directorate/src/lib/mappers/conversationMapper.ts
@@ -1,0 +1,107 @@
+import {
+  ConversationReplyBlockedReason,
+  ConversationStatusFilter,
+  MessagingRecipientDto,
+  RecipientCreateBlockedReason,
+} from '@island.is/clients/health-directorate'
+import {
+  HealthConversationDirectionEnum,
+  HealthConversationRecipientBlockedReasonEnum,
+  HealthConversationReplyBlockedReasonEnum,
+  HealthConversationStatusFilterEnum,
+} from '../models/enums'
+import { HealthDirectorateHealthConversationRecipient } from '../models/healthConversationRecipient.model'
+import { HealthDirectorateHealthConversationType } from '../models/healthConversationType.model'
+
+export const toConversationDirectionEnum = (
+  direction: string,
+): HealthConversationDirectionEnum => {
+  switch (direction) {
+    case 'PATIENT':
+      return HealthConversationDirectionEnum.PATIENT
+    case 'STAFF':
+      return HealthConversationDirectionEnum.STAFF
+    case 'SYSTEM':
+      return HealthConversationDirectionEnum.SYSTEM
+    default:
+      return HealthConversationDirectionEnum.SYSTEM
+  }
+}
+
+export const toConversationStatusFilter = (
+  status: HealthConversationStatusFilterEnum,
+): ConversationStatusFilter => {
+  switch (status) {
+    case HealthConversationStatusFilterEnum.ACTIVE:
+      return ConversationStatusFilter.ACTIVE
+    case HealthConversationStatusFilterEnum.ARCHIVED:
+      return ConversationStatusFilter.ARCHIVED
+    case HealthConversationStatusFilterEnum.ALL:
+      return ConversationStatusFilter.ALL
+  }
+}
+
+export const toConversationReplyBlockedReasonEnum = (
+  reason?: ConversationReplyBlockedReason,
+): HealthConversationReplyBlockedReasonEnum | undefined => {
+  switch (reason) {
+    case ConversationReplyBlockedReason.MISSING_RECIPIENT:
+      return HealthConversationReplyBlockedReasonEnum.MISSING_RECIPIENT
+    case ConversationReplyBlockedReason.REPLIES_DISABLED:
+      return HealthConversationReplyBlockedReasonEnum.REPLIES_DISABLED
+    case ConversationReplyBlockedReason.NO_REPLY_GROUP:
+      return HealthConversationReplyBlockedReasonEnum.NO_REPLY_GROUP
+    case ConversationReplyBlockedReason.MESSAGING_NOT_ALLOWED:
+      return HealthConversationReplyBlockedReasonEnum.MESSAGING_NOT_ALLOWED
+    case ConversationReplyBlockedReason.OUTSIDE_MESSAGING_WINDOW:
+      return HealthConversationReplyBlockedReasonEnum.OUTSIDE_MESSAGING_WINDOW
+    case ConversationReplyBlockedReason.REPLY_WINDOW_EXPIRED:
+      return HealthConversationReplyBlockedReasonEnum.REPLY_WINDOW_EXPIRED
+    default:
+      return undefined
+  }
+}
+
+export const toConversationRecipientBlockedReasonEnum = (
+  reason?: RecipientCreateBlockedReason,
+): HealthConversationRecipientBlockedReasonEnum | undefined => {
+  switch (reason) {
+    case RecipientCreateBlockedReason.MESSAGING_NOT_ALLOWED:
+      return HealthConversationRecipientBlockedReasonEnum.MESSAGING_NOT_ALLOWED
+    case RecipientCreateBlockedReason.OUTSIDE_MESSAGING_WINDOW:
+      return HealthConversationRecipientBlockedReasonEnum.OUTSIDE_MESSAGING_WINDOW
+    case RecipientCreateBlockedReason.NO_ALLOWED_TYPES:
+      return HealthConversationRecipientBlockedReasonEnum.NO_ALLOWED_TYPES
+    default:
+      return undefined
+  }
+}
+
+export const mapMessagingRecipient = (
+  r: MessagingRecipientDto,
+): HealthDirectorateHealthConversationRecipient => ({
+  nodeId: r.nodeId,
+  groupId: r.groupId,
+  name: r.name,
+  allowsMessaging: r.allowsMessaging,
+  messagingWindowOpen: r.messagingWindowOpen,
+  messagingWindowClose: r.messagingWindowClose,
+  isCurrentlyWithinWindow: r.isCurrentlyWithinWindow,
+  patientReplyWindowDays: r.patientReplyWindowDays,
+  allowedMessageTypes: r.allowedConversationTypes.map(
+    (t): HealthDirectorateHealthConversationType => ({
+      patientInitiatedTypeCode: t.patientInitiatedTypeCode,
+      title: t.title,
+      description: t.description,
+      isCertificate: t.isCertificate,
+    }),
+  ),
+  canCreateConversation: r.canCreateConversation,
+  conversationBlockedReason: toConversationRecipientBlockedReasonEnum(
+    r.conversationBlockedReason,
+  ),
+  canRequestCertificate: r.canRequestCertificate,
+  certificateBlockedReason: toConversationRecipientBlockedReasonEnum(
+    r.certificateBlockedReason,
+  ),
+})

--- a/libs/api/domains/health-directorate/src/lib/models/enums.ts
+++ b/libs/api/domains/health-directorate/src/lib/models/enums.ts
@@ -165,3 +165,24 @@ export enum HealthConversationStatusFilterEnum {
 registerEnumType(HealthConversationStatusFilterEnum, {
   name: 'HealthDirectorateHealthConversationStatusFilter',
 })
+
+export enum HealthConversationReplyBlockedReasonEnum {
+  MISSING_RECIPIENT = 'MISSING_RECIPIENT',
+  REPLIES_DISABLED = 'REPLIES_DISABLED',
+  NO_REPLY_GROUP = 'NO_REPLY_GROUP',
+  MESSAGING_NOT_ALLOWED = 'MESSAGING_NOT_ALLOWED',
+  OUTSIDE_MESSAGING_WINDOW = 'OUTSIDE_MESSAGING_WINDOW',
+  REPLY_WINDOW_EXPIRED = 'REPLY_WINDOW_EXPIRED',
+}
+registerEnumType(HealthConversationReplyBlockedReasonEnum, {
+  name: 'HealthDirectorateHealthConversationReplyBlockedReason',
+})
+
+export enum HealthConversationRecipientBlockedReasonEnum {
+  MESSAGING_NOT_ALLOWED = 'MESSAGING_NOT_ALLOWED',
+  OUTSIDE_MESSAGING_WINDOW = 'OUTSIDE_MESSAGING_WINDOW',
+  NO_ALLOWED_TYPES = 'NO_ALLOWED_TYPES',
+}
+registerEnumType(HealthConversationRecipientBlockedReasonEnum, {
+  name: 'HealthDirectorateHealthConversationRecipientBlockedReason',
+})

--- a/libs/api/domains/health-directorate/src/lib/models/enums.ts
+++ b/libs/api/domains/health-directorate/src/lib/models/enums.ts
@@ -167,21 +167,21 @@ registerEnumType(HealthConversationStatusFilterEnum, {
 })
 
 export enum HealthConversationReplyBlockedReasonEnum {
-  MISSING_RECIPIENT = 'MISSING_RECIPIENT',
-  REPLIES_DISABLED = 'REPLIES_DISABLED',
-  NO_REPLY_GROUP = 'NO_REPLY_GROUP',
-  MESSAGING_NOT_ALLOWED = 'MESSAGING_NOT_ALLOWED',
-  OUTSIDE_MESSAGING_WINDOW = 'OUTSIDE_MESSAGING_WINDOW',
-  REPLY_WINDOW_EXPIRED = 'REPLY_WINDOW_EXPIRED',
+  MISSING_RECIPIENT = 'missingRecipient',
+  REPLIES_DISABLED = 'repliesDisabled',
+  NO_REPLY_GROUP = 'noReplyGroup',
+  MESSAGING_NOT_ALLOWED = 'messagingNotAllowed',
+  OUTSIDE_MESSAGING_WINDOW = 'outsideMessagingWindow',
+  REPLY_WINDOW_EXPIRED = 'replyWindowExpired',
 }
 registerEnumType(HealthConversationReplyBlockedReasonEnum, {
   name: 'HealthDirectorateHealthConversationReplyBlockedReason',
 })
 
 export enum HealthConversationRecipientBlockedReasonEnum {
-  MESSAGING_NOT_ALLOWED = 'MESSAGING_NOT_ALLOWED',
-  OUTSIDE_MESSAGING_WINDOW = 'OUTSIDE_MESSAGING_WINDOW',
-  NO_ALLOWED_TYPES = 'NO_ALLOWED_TYPES',
+  MESSAGING_NOT_ALLOWED = 'messagingNotAllowed',
+  OUTSIDE_MESSAGING_WINDOW = 'outsideMessagingWindow',
+  NO_ALLOWED_TYPES = 'noAllowedTypes',
 }
 registerEnumType(HealthConversationRecipientBlockedReasonEnum, {
   name: 'HealthDirectorateHealthConversationRecipientBlockedReason',

--- a/libs/api/domains/health-directorate/src/lib/models/healthConversationDetail.model.ts
+++ b/libs/api/domains/health-directorate/src/lib/models/healthConversationDetail.model.ts
@@ -9,13 +9,15 @@ export class HealthDirectorateHealthConversationDetail extends HealthDirectorate
   startDate?: Date
 
   @Field({
-    description: 'Whether the patient can reply to this conversation right now.',
+    description:
+      'Whether the patient can reply to this conversation right now.',
   })
   patientCanReply!: boolean
 
   @Field(() => HealthConversationReplyBlockedReasonEnum, {
     nullable: true,
-    description: 'Why replying is blocked. Only set when patientCanReply is false.',
+    description:
+      'Why replying is blocked. Only set when patientCanReply is false.',
   })
   replyBlockedReason?: HealthConversationReplyBlockedReasonEnum
 

--- a/libs/api/domains/health-directorate/src/lib/models/healthConversationDetail.model.ts
+++ b/libs/api/domains/health-directorate/src/lib/models/healthConversationDetail.model.ts
@@ -1,4 +1,5 @@
 import { Field, GraphQLISODateTime, ObjectType } from '@nestjs/graphql'
+import { HealthConversationReplyBlockedReasonEnum } from './enums'
 import { HealthDirectorateHealthConversation } from './healthConversation.model'
 import { HealthDirectorateHealthConversationEntry } from './healthConversationEntry.model'
 
@@ -8,11 +9,15 @@ export class HealthDirectorateHealthConversationDetail extends HealthDirectorate
   startDate?: Date
 
   @Field({
-    nullable: true,
-    description:
-      'Whether the patient can reply. Null means no staff decision yet — replies are allowed unless explicitly false.',
+    description: 'Whether the patient can reply to this conversation right now.',
   })
-  patientCanReply?: boolean
+  patientCanReply!: boolean
+
+  @Field(() => HealthConversationReplyBlockedReasonEnum, {
+    nullable: true,
+    description: 'Why replying is blocked. Only set when patientCanReply is false.',
+  })
+  replyBlockedReason?: HealthConversationReplyBlockedReasonEnum
 
   @Field(() => [HealthDirectorateHealthConversationEntry])
   messages!: HealthDirectorateHealthConversationEntry[]

--- a/libs/api/domains/health-directorate/src/lib/models/healthConversationRecipient.model.ts
+++ b/libs/api/domains/health-directorate/src/lib/models/healthConversationRecipient.model.ts
@@ -1,4 +1,5 @@
 import { Field, Int, ObjectType } from '@nestjs/graphql'
+import { HealthConversationRecipientBlockedReasonEnum } from './enums'
 import { HealthDirectorateHealthConversationType } from './healthConversationType.model'
 
 @ObjectType()
@@ -35,4 +36,30 @@ export class HealthDirectorateHealthConversationRecipient {
 
   @Field(() => [HealthDirectorateHealthConversationType])
   allowedMessageTypes!: HealthDirectorateHealthConversationType[]
+
+  @Field({
+    description:
+      'Whether the patient can start a new conversation with this recipient right now.',
+  })
+  canCreateConversation!: boolean
+
+  @Field(() => HealthConversationRecipientBlockedReasonEnum, {
+    nullable: true,
+    description:
+      'Why starting a conversation is blocked. Only set when canCreateConversation is false.',
+  })
+  conversationBlockedReason?: HealthConversationRecipientBlockedReasonEnum
+
+  @Field({
+    description:
+      'Whether the patient can request a certificate from this recipient right now.',
+  })
+  canRequestCertificate!: boolean
+
+  @Field(() => HealthConversationRecipientBlockedReasonEnum, {
+    nullable: true,
+    description:
+      'Why requesting a certificate is blocked. Only set when canRequestCertificate is false.',
+  })
+  certificateBlockedReason?: HealthConversationRecipientBlockedReasonEnum
 }

--- a/libs/clients/health-directorate/src/index.ts
+++ b/libs/clients/health-directorate/src/index.ts
@@ -51,11 +51,13 @@ export {
   ConversationBaseDto,
   ConversationDetailDto,
   ConversationMessageDto,
+  ConversationReplyBlockedReason,
   ConversationStatusFilter,
   CreateConversationRequestDto,
   CreateReplyRequestDto,
   DispensationHistoryItemDto,
   MessagingRecipientDto,
+  RecipientCreateBlockedReason,
   UserVisibleAppointmentStatuses,
   OrganDonorDto,
 } from './lib/clients/health'

--- a/libs/clients/health-directorate/src/lib/clients/health/clientConfig.json
+++ b/libs/clients/health-directorate/src/lib/clients/health/clientConfig.json
@@ -1744,7 +1744,8 @@
     },
     "/v1/me/appointments": {
       "get": {
-        "description": "Get user's appointments (summary)",
+        "deprecated": true,
+        "description": "Get user's appointments (summary). Deprecated – use v2, which returns a paginated envelope.",
         "operationId": "MeAppointmentController_getPatientAppointments_v1",
         "parameters": [
           {
@@ -1781,6 +1782,111 @@
                   "items": {
                     "$ref": "#/components/schemas/AppointmentBaseDto"
                   }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpProblemResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpProblemResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpProblemResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpProblemResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": ["Appointments"]
+      }
+    },
+    "/v2/me/appointments": {
+      "get": {
+        "description": "Get user's appointments (summary), paginated",
+        "operationId": "MeAppointmentController_getPatientAppointmentsV2_v2",
+        "parameters": [
+          {
+            "name": "status",
+            "required": false,
+            "in": "query",
+            "description": "Filter appointments by status. Can include multiple statuses (comma-separated).",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/UserVisibleAppointmentStatuses"
+              }
+            }
+          },
+          {
+            "name": "fromStartTime",
+            "required": false,
+            "in": "query",
+            "description": "Filter appointments to only include those starting at or after this time.",
+            "schema": {
+              "format": "date-time",
+              "example": "2024-01-15T10:30:00.000Z",
+              "type": "string"
+            }
+          },
+          {
+            "name": "page",
+            "required": true,
+            "in": "query",
+            "description": "1-based page number.",
+            "schema": {
+              "minimum": 1,
+              "type": "number"
+            }
+          },
+          {
+            "name": "pageSize",
+            "required": true,
+            "in": "query",
+            "description": "Number of items per page (max 100).",
+            "schema": {
+              "minimum": 1,
+              "maximum": 100,
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedAppointmentsDto"
                 }
               }
             }
@@ -5984,7 +6090,7 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["ROLE", "ROOM", "EQUIPMENT", "SERVICE", "OTHER", "TEAM"],
+            "enum": ["ROLE", "ROOM", "EQUIPMENT", "SERVICE", "OTHER"],
             "description": "Assignee type. PERSON assignees are surfaced under practitioners, not here."
           },
           "name": {
@@ -6054,6 +6160,52 @@
           "practitioners",
           "assignees"
         ]
+      },
+      "PaginationDto": {
+        "type": "object",
+        "properties": {
+          "page": {
+            "type": "number"
+          },
+          "pageSize": {
+            "type": "number"
+          },
+          "totalResults": {
+            "type": "number"
+          },
+          "totalPages": {
+            "type": "number"
+          },
+          "hasNext": {
+            "type": "boolean"
+          },
+          "hasPrevious": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "page",
+          "pageSize",
+          "totalResults",
+          "totalPages",
+          "hasNext",
+          "hasPrevious"
+        ]
+      },
+      "PaginatedAppointmentsDto": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AppointmentBaseDto"
+            }
+          },
+          "pagination": {
+            "$ref": "#/components/schemas/PaginationDto"
+          }
+        },
+        "required": ["data", "pagination"]
       },
       "OpeningHoursSlotDto": {
         "type": "object",
@@ -6484,6 +6636,80 @@
           "unread"
         ]
       },
+      "ConversationReplyBlockedReason": {
+        "type": "string",
+        "enum": [
+          "MISSING_RECIPIENT",
+          "REPLIES_DISABLED",
+          "NO_REPLY_GROUP",
+          "MESSAGING_NOT_ALLOWED",
+          "OUTSIDE_MESSAGING_WINDOW",
+          "REPLY_WINDOW_EXPIRED"
+        ],
+        "description": "Why replying is blocked. Only set when patientCanReply is false."
+      },
+      "MessageType": {
+        "type": "string",
+        "enum": ["TEXT", "VIDEO", "SEGMENTED"],
+        "description": "What kind of message this is. VIDEO → use `videoConversation`; SEGMENTED → use `contentSegments`; TEXT → use `messageTextContent`."
+      },
+      "VideoConversationDto": {
+        "type": "object",
+        "properties": {
+          "url": {
+            "type": "string",
+            "description": "Video-call join link. Carries a `pin` query param."
+          },
+          "description": {
+            "type": "string"
+          },
+          "appointmentDate": {
+            "type": "string",
+            "description": "Local ISO datetime with no timezone offset. Iceland is UTC year-round — interpret as UTC, do not shift."
+          },
+          "appointmentHostName": {
+            "type": "string"
+          },
+          "isCanceled": {
+            "type": "boolean"
+          },
+          "isEdited": {
+            "type": "boolean"
+          }
+        },
+        "required": ["url", "isCanceled", "isEdited"]
+      },
+      "ContentSegmentType": {
+        "type": "string",
+        "enum": ["TEXT", "LINK"],
+        "description": "Segment kind. `TEXT` carries `text`; `LINK` carries `label` + `href`."
+      },
+      "ContentSegmentDto": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "description": "Segment kind. `TEXT` carries `text`; `LINK` carries `label` + `href`.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ContentSegmentType"
+              }
+            ]
+          },
+          "text": {
+            "type": "string",
+            "description": "Set on `text` segments."
+          },
+          "label": {
+            "type": "string",
+            "description": "Anchor text; set on `link` segments."
+          },
+          "href": {
+            "type": "string",
+            "description": "Sanitized https href; set on `link` segments."
+          }
+        },
+        "required": ["type"]
+      },
       "ConversationAttachmentDto": {
         "type": "object",
         "properties": {
@@ -6515,8 +6741,31 @@
             "format": "date-time",
             "type": "string"
           },
+          "messageType": {
+            "description": "What kind of message this is. VIDEO → use `videoConversation`; SEGMENTED → use `contentSegments`; TEXT → use `messageTextContent`.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/MessageType"
+              }
+            ]
+          },
           "messageTextContent": {
             "type": "string"
+          },
+          "videoConversation": {
+            "description": "Structured video-call card. Present when `messageType` is `VIDEO` and the payload parsed; `messageTextContent` is omitted for video messages.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/VideoConversationDto"
+              }
+            ]
+          },
+          "contentSegments": {
+            "description": "Ordered text/link segments. Present when `messageType` is `SEGMENTED`.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ContentSegmentDto"
+            }
           },
           "senderGroupName": {
             "type": "string"
@@ -6524,7 +6773,7 @@
           "certificateId": {
             "type": "string",
             "format": "uuid",
-            "description": "Set when this message has an issued certificate attached. FE follows this id to the certificate download endpoint."
+            "description": "Set when this message has an issued certificate attached."
           },
           "requiresPayment": {
             "type": "boolean",
@@ -6545,7 +6794,13 @@
             }
           }
         },
-        "required": ["id", "direction", "messageSentAt", "attachments"]
+        "required": [
+          "id",
+          "direction",
+          "messageSentAt",
+          "messageType",
+          "attachments"
+        ]
       },
       "ConversationDetailDto": {
         "type": "object",
@@ -6590,7 +6845,15 @@
           },
           "patientCanReply": {
             "type": "boolean",
-            "description": "Whether the patient is allowed to reply on this conversation. Null when no staff has set it yet — replies are allowed unless explicitly false."
+            "description": "Whether the patient can reply to this conversation right now."
+          },
+          "replyBlockedReason": {
+            "description": "Why replying is blocked. Only set when patientCanReply is false.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ConversationReplyBlockedReason"
+              }
+            ]
           },
           "unread": {
             "type": "boolean",
@@ -6610,6 +6873,7 @@
           "hasAttachment",
           "isStarred",
           "isArchived",
+          "patientCanReply",
           "unread",
           "messages"
         ]
@@ -6713,6 +6977,15 @@
         },
         "required": ["patientInitiatedTypeCode", "title", "isCertificate"]
       },
+      "RecipientCreateBlockedReason": {
+        "type": "string",
+        "enum": [
+          "MESSAGING_NOT_ALLOWED",
+          "OUTSIDE_MESSAGING_WINDOW",
+          "NO_ALLOWED_TYPES"
+        ],
+        "description": "Why starting a conversation is blocked. Only set when canCreateConversation is false."
+      },
       "MessagingRecipientDto": {
         "type": "object",
         "properties": {
@@ -6749,6 +7022,30 @@
             "items": {
               "$ref": "#/components/schemas/AllowedConversationTypeDto"
             }
+          },
+          "canCreateConversation": {
+            "type": "boolean",
+            "description": "Whether the patient can start a new conversation with this recipient right now."
+          },
+          "conversationBlockedReason": {
+            "description": "Why starting a conversation is blocked. Only set when canCreateConversation is false.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RecipientCreateBlockedReason"
+              }
+            ]
+          },
+          "canRequestCertificate": {
+            "type": "boolean",
+            "description": "Whether the patient can request a certificate from this recipient right now."
+          },
+          "certificateBlockedReason": {
+            "description": "Why requesting a certificate is blocked. Only set when canRequestCertificate is false.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RecipientCreateBlockedReason"
+              }
+            ]
           }
         },
         "required": [
@@ -6760,7 +7057,9 @@
           "messagingWindowClose",
           "isCurrentlyWithinWindow",
           "patientReplyWindowDays",
-          "allowedConversationTypes"
+          "allowedConversationTypes",
+          "canCreateConversation",
+          "canRequestCertificate"
         ]
       },
       "PaymentDto": {
@@ -6794,7 +7093,7 @@
       },
       "CertificateTypeCode": {
         "type": "string",
-        "enum": ["work", "school"],
+        "enum": ["WORK", "SCHOOL"],
         "description": "Certificate type code."
       },
       "CreateCertificateRequestDto": {


### PR DESCRIPTION
## What

Updated health service client and pulled added health conversation info up to the domain layer

## Why

We will need it for changes in upcoming features

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new paginated appointments endpoint (v2) with `page` and `pageSize`.
  * Expanded conversation/messaging details with blocked-reason information for whether patients can reply and which messaging recipients are allowed.
  * Added recipient capability flags (e.g., create conversation / request certificate) alongside corresponding blocked reasons.

* **Bug Fixes**
  * Improved conversation detail responses by including the appropriate reply-blocked reason when replies are unavailable.

* **Changes**
  * Enhanced messaging payloads with `messageType` and richer content variants (text, video, and segmented content).
  * Marked v1 appointments as deprecated in favor of v2; standardized certificate type codes to uppercase.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->