### PR TITLE
fix(services-auth): Deflake delegation-api specs by stubbing background indexing

### DIFF
--- a/apps/services/auth/delegation-api/src/app/delegations/test/me-delegations.access-outgoing.spec.ts
+++ b/apps/services/auth/delegation-api/src/app/delegations/test/me-delegations.access-outgoing.spec.ts
@@ -12,6 +12,7 @@ import {
   CreateDelegationDTO,
   Delegation,
   DelegationScope,
+  DelegationsIndexService,
   Domain,
   NamesService,
   PatchDelegationDTO,
@@ -68,6 +69,16 @@ describe.each(Object.keys(accessOutgoingTestCases))(
       jest
         .spyOn(namesService, 'getUserName')
         .mockResolvedValue(faker.name.findName())
+
+      // Stub fire-and-forget indexing so stray queries don't outlive the suite
+      // and hit the shared test database while it is being recreated.
+      const delegationIndexService = app.get(DelegationsIndexService)
+      jest
+        .spyOn(delegationIndexService, 'indexDelegations')
+        .mockImplementation()
+      jest
+        .spyOn(delegationIndexService, 'indexCustomDelegations')
+        .mockImplementation()
 
       factory = new FixtureFactory(app)
       domains = await Promise.all(

--- a/apps/services/auth/delegation-api/src/app/delegations/test/me-delegations.filters.spec.ts
+++ b/apps/services/auth/delegation-api/src/app/delegations/test/me-delegations.filters.spec.ts
@@ -4,6 +4,7 @@ import request from 'supertest'
 import {
   CreateDelegationDTO,
   Delegation,
+  DelegationsIndexService,
   DelegationValidity,
   PatchDelegationDTO,
 } from '@island.is/auth-api-lib'
@@ -39,6 +40,14 @@ describe('MeDelegationsController filters', () => {
     })
     server = request(app.getHttpServer())
     factory = new FixtureFactory(app)
+
+    // Stub fire-and-forget indexing so stray queries don't outlive the suite
+    // and hit the shared test database while it is being recreated.
+    const delegationIndexService = app.get(DelegationsIndexService)
+    jest.spyOn(delegationIndexService, 'indexDelegations').mockImplementation()
+    jest
+      .spyOn(delegationIndexService, 'indexCustomDelegations')
+      .mockImplementation()
 
     await Promise.all(
       Object.values(testDomains).map((domain) => factory.createDomain(domain)),
@@ -459,6 +468,14 @@ describe('MeDelegationController company filters', () => {
     })
     server = request(app.getHttpServer())
     factory = new FixtureFactory(app)
+
+    // Stub fire-and-forget indexing so stray queries don't outlive the suite
+    // and hit the shared test database while it is being recreated.
+    const delegationIndexService = app.get(DelegationsIndexService)
+    jest.spyOn(delegationIndexService, 'indexDelegations').mockImplementation()
+    jest
+      .spyOn(delegationIndexService, 'indexCustomDelegations')
+      .mockImplementation()
 
     await Promise.all(
       Object.values(testDomains).map((domain) => factory.createDomain(domain)),


### PR DESCRIPTION
## What

Stub the fire-and-forget delegation indexing methods (`indexDelegations`, `indexCustomDelegations`) in the two delegation-api test suites that hit delegation endpoints without asserting on indexing:

- `me-delegations.filters.spec.ts` (both describe blocks)
- `me-delegations.access-outgoing.spec.ts`

This mirrors the existing pattern in `me-delegations.access-incoming.spec.ts`.

## Why

The delegation services fire indexing as unawaited background promises (`void this.delegationIndexService.indexCustomDelegations(...)` in `delegations-outgoing.service.ts`, `void this.delegationsIndexService.indexDelegations(user)` in `delegations-incoming.service.ts`). All test suites share a single Postgres database, and every suite setup runs `sequelize.sync({ force: true })`, dropping and recreating all tables.

When a background indexing promise outlives its suite, it can query `delegation_index` while the next suite is recreating tables, producing an unhandled rejection:

```
● Test suite failed to run
    relation "delegation_index" does not exist
```

This failed CI on an unrelated PR today (all 300 tests passed, but the suite was marked failed). Reviewed all other services-auth specs for the same exposure: ids-api mocks `indexDelegations` globally in its test setup, admin-api and personal-representative specs already stub their index methods, and the remaining suites only reach awaited index calls — so these two suites were the only gap.

Verified locally: full `services-auth-delegation-api` test suite passes.

## Screenshots / Gifs

N/A — test-only change.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved delegation-related test reliability by preventing background indexing from running during test execution.
  * Reduced the chance of stray database queries interfering with shared test state, especially while the test environment is being recreated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->