### PR TITLE
feat(web): Verdict list - Guide download button and links to courts

### DIFF
--- a/apps/web/screens/Verdicts/VerdictsList.css.ts
+++ b/apps/web/screens/Verdicts/VerdictsList.css.ts
@@ -1,5 +1,7 @@
 import { style } from '@vanilla-extract/css'
 
+import { theme } from '@island.is/island-ui/theme'
+
 export const searchInput = style({
   maxWidth: '774px',
 })
@@ -21,4 +23,21 @@ export const logo = style({
 
 export const verdictsWebsiteLink = style({
   fontSize: '14px',
+})
+
+export const verdictsWebsiteLinksDropdown = style({
+  position: 'absolute',
+  top: '100%',
+  left: 0,
+  right: 0,
+  zIndex: 10,
+  marginTop: theme.spacing[1],
+  backgroundColor: theme.color.white,
+  boxShadow: theme.shadows.strong,
+  borderRadius: theme.border.radius.large,
+})
+
+export const verdictsWebsiteLinksDropdownToggle = style({
+  width: 'fit-content',
+  gap: '4px',
 })

--- a/apps/web/screens/Verdicts/VerdictsList.css.ts
+++ b/apps/web/screens/Verdicts/VerdictsList.css.ts
@@ -18,3 +18,7 @@ export const logo = style({
   height: '162px',
   width: 'auto',
 })
+
+export const verdictsWebsiteLink = style({
+  fontSize: '14px',
+})

--- a/apps/web/screens/Verdicts/VerdictsList.tsx
+++ b/apps/web/screens/Verdicts/VerdictsList.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useIntl } from 'react-intl'
-import { useDebounce } from 'react-use'
+import { useClickAway, useDebounce } from 'react-use'
 import cn from 'classnames'
 import isEqual from 'lodash/isEqual'
 import {
@@ -22,6 +22,7 @@ import {
   GridContainer,
   GridRow,
   Hidden,
+  Icon,
   type IconMapIcon,
   Inline,
   LinkV2,
@@ -999,6 +1000,106 @@ const Filters = ({
   )
 }
 
+const VerdictsWebsiteLinks = ({
+  links,
+  layout = 'grid',
+  showEyebrow = true,
+}: {
+  links: { label: string; href: string }[]
+  layout?: 'grid' | 'stack'
+  showEyebrow?: boolean
+}) => {
+  const { formatMessage } = useIntl()
+
+  if (links.length === 0) {
+    return null
+  }
+
+  return (
+    <Stack space={1}>
+      {showEyebrow && (
+        <Text variant="eyebrow">
+          {formatMessage(m.listPage.verdictsWebsiteEyebrow)}
+        </Text>
+      )}
+      {layout === 'grid' ? (
+        <GridRow rowGap={2}>
+          {links.map((link) => (
+            <GridColumn key={link.href}>
+              <LinkV2
+                underlineVisibility="always"
+                underline="small"
+                color="blue400"
+                href={link.href}
+              >
+                <span className={styles.verdictsWebsiteLink}>{link.label}</span>
+              </LinkV2>
+            </GridColumn>
+          ))}
+        </GridRow>
+      ) : (
+        <Stack space={2}>
+          {links.map((link) => (
+            <LinkV2
+              key={link.href}
+              underlineVisibility="always"
+              underline="small"
+              color="blue400"
+              href={link.href}
+            >
+              <span className={styles.verdictsWebsiteLink}>{link.label}</span>
+            </LinkV2>
+          ))}
+        </Stack>
+      )}
+    </Stack>
+  )
+}
+
+const VerdictsWebsiteLinksDropdown = ({
+  links,
+}: {
+  links: { label: string; href: string }[]
+}) => {
+  const { formatMessage } = useIntl()
+  const [isOpen, setIsOpen] = useState(false)
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  useClickAway(containerRef, (ev) => {
+    if (ev.type !== 'touchstart') setIsOpen(false)
+  })
+
+  if (links.length === 0) return null
+
+  return (
+    <Hidden above="md">
+      <div ref={containerRef} style={{ position: 'relative' }}>
+        <Box
+          display="flex"
+          alignItems="flexStart"
+          cursor="pointer"
+          onClick={() => setIsOpen((open) => !open)}
+          className={styles.verdictsWebsiteLinksDropdownToggle}
+        >
+          <Text variant="eyebrow">
+            {formatMessage(m.listPage.verdictsWebsiteEyebrow)}
+          </Text>
+          <Icon size="small" icon={isOpen ? 'chevronUp' : 'chevronDown'} />
+        </Box>
+        {isOpen && (
+          <Box className={styles.verdictsWebsiteLinksDropdown} padding={3}>
+            <VerdictsWebsiteLinks
+              links={links}
+              layout="stack"
+              showEyebrow={false}
+            />
+          </Box>
+        )}
+      </div>
+    </Hidden>
+  )
+}
+
 const VerdictsList: CustomScreen<VerdictsListProps> = (props) => {
   const {
     queryState,
@@ -1260,9 +1361,14 @@ const VerdictsList: CustomScreen<VerdictsListProps> = (props) => {
                   span={['1/1', '1/1', '1/1', '8/12', '8/12']}
                 >
                   <Stack space={2}>
-                    <Text variant="h1" as="h1">
-                      {heading}
-                    </Text>
+                    <Stack space={1}>
+                      <VerdictsWebsiteLinksDropdown
+                        links={verdictsWebsiteLinks}
+                      />
+                      <Text variant="h1" as="h1">
+                        {heading}
+                      </Text>
+                    </Stack>
                     <Inline space={4}>
                       <Webreader
                         readClass="rs_read"
@@ -1818,29 +1924,7 @@ const VerdictsList: CustomScreen<VerdictsListProps> = (props) => {
                       span={['0', '0', '0', '3/12', '3/12']}
                       hiddenBelow="lg"
                     >
-                      {verdictsWebsiteLinks.length > 0 && (
-                        <Stack space={1}>
-                          <Text variant="eyebrow">
-                            {formatMessage(m.listPage.verdictsWebsiteEyebrow)}
-                          </Text>
-                          <GridRow rowGap={2}>
-                            {verdictsWebsiteLinks.map((link) => (
-                              <GridColumn key={link.href}>
-                                <LinkV2
-                                  underlineVisibility="always"
-                                  underline="small"
-                                  color="blue400"
-                                  href={link.href}
-                                >
-                                  <span className={styles.verdictsWebsiteLink}>
-                                    {link.label}
-                                  </span>
-                                </LinkV2>
-                              </GridColumn>
-                            ))}
-                          </GridRow>
-                        </Stack>
-                      )}
+                      <VerdictsWebsiteLinks links={verdictsWebsiteLinks} />
                     </GridColumn>
                   </GridRow>
                 </GridColumn>

--- a/apps/web/screens/Verdicts/VerdictsList.tsx
+++ b/apps/web/screens/Verdicts/VerdictsList.tsx
@@ -1078,7 +1078,16 @@ const CourtWebsiteLinksDropdown = ({
           display="flex"
           alignItems="flexStart"
           cursor="pointer"
+          tabIndex={0}
+          role="button"
+          aria-expanded={isOpen}
           onClick={() => setIsOpen((open) => !open)}
+          onKeyDown={(ev) => {
+            if (ev.key === 'Enter' || ev.key === ' ') {
+              ev.preventDefault()
+              setIsOpen((open) => !open)
+            }
+          }}
           className={styles.verdictsWebsiteLinksDropdownToggle}
         >
           <Text variant="eyebrow">

--- a/apps/web/screens/Verdicts/VerdictsList.tsx
+++ b/apps/web/screens/Verdicts/VerdictsList.tsx
@@ -24,6 +24,7 @@ import {
   Hidden,
   type IconMapIcon,
   Inline,
+  LinkV2,
   Select,
   Stack,
   Tag,
@@ -46,6 +47,7 @@ import {
   type WebVerdictKeyword,
   type WebVerdictsInput,
 } from '@island.is/web/graphql/schema'
+import { useI18n } from '@island.is/web/i18n'
 import { useDateUtils } from '@island.is/web/i18n/useDateUtils'
 import { withMainLayout } from '@island.is/web/layouts/main'
 import { CustomNextError } from '@island.is/web/units/errors'
@@ -1218,6 +1220,30 @@ const VerdictsList: CustomScreen<VerdictsListProps> = (props) => {
 
   const description = formatMessage(m.listPage.description)
 
+  const verdictsWebsiteLinks: { label: string; href: string }[] = customPageData
+    ?.configJson?.verdictsWebsiteLinks ?? [
+    {
+      label: 'Hæstiréttur',
+      href: '/s/haestirettur',
+    },
+    {
+      label: 'Endurupptökudómar',
+      href: '/s/endurupptokudomar',
+    },
+    {
+      label: 'Landsréttur',
+      href: '/s/landsrettur',
+    },
+    {
+      label: 'Dómstólasýslan',
+      href: '/s/domstolasyslan',
+    },
+    {
+      label: 'Héraðsdómstólar',
+      href: '/s/haeradsdomstolar',
+    },
+  ]
+
   return (
     <Box>
       <HeadWithSocialSharing title={customPageData?.ogTitle ?? heading}>
@@ -1238,11 +1264,33 @@ const VerdictsList: CustomScreen<VerdictsListProps> = (props) => {
                     <Text variant="h1" as="h1">
                       {heading}
                     </Text>
-                    <Webreader
-                      readClass="rs_read"
-                      marginBottom={0}
-                      marginTop={0}
-                    />
+                    <Inline space={4}>
+                      <Webreader
+                        readClass="rs_read"
+                        marginBottom={0}
+                        marginTop={0}
+                      />
+                      {formatMessage(m.listPage.downloadGuideUrl).trim()
+                        .length > 0 && (
+                        <Button
+                          size="small"
+                          variant="text"
+                          icon="download"
+                          iconType="outline"
+                          colorScheme="light"
+                          onClick={() => {
+                            const fileUrl = formatMessage(
+                              m.listPage.downloadGuideUrl,
+                            )
+                            const link = document.createElement('a')
+                            link.href = fileUrl
+                            link.click()
+                          }}
+                        >
+                          {formatMessage(m.listPage.downloadGuide)}
+                        </Button>
+                      )}
+                    </Inline>
                     {Boolean(description?.trim()) && (
                       <Text variant="intro">{description}</Text>
                     )}
@@ -1273,198 +1321,67 @@ const VerdictsList: CustomScreen<VerdictsListProps> = (props) => {
                   offset={['0', '0', '0', '1/12', '1/12']}
                   span={['1/1', '1/1', '1/1', '11/12', '11/12']}
                 >
-                  <Stack space={3}>
-                    <Box className={styles.searchInput}>
-                      <DebouncedInput
-                        debounceTimeInMs={DEBOUNCE_TIME_IN_MS}
-                        key={renderKey}
-                        value={queryState[QueryParam.SEARCH_TERM]}
-                        loading={loading}
-                        onChange={(value) => {
-                          updateQueryState(QueryParam.SEARCH_TERM, value)
-                        }}
-                        name="verdict-search-input"
-                        icon={{ name: 'search', type: 'outline' }}
-                        backgroundColor="blue"
-                        tooltip={formatMessage(m.listPage.searchInputTooltip)}
-                        label={formatMessage(m.listPage.searchInputLabel)}
-                        placeholder={formatMessage(
-                          m.listPage.searchInputPlaceholder,
-                        )}
-                        size="md"
-                      />
-                    </Box>
-                    <Hidden above="xs">
-                      <Select
-                        key={renderKey}
-                        options={courtTags}
-                        value={courtTags.filter((tag) => {
-                          if (tag.value === ALL_COURTS_TAG) {
-                            return (
-                              selectedCourts.length === 0 &&
-                              selectedDistrictCourts.length === 0
-                            )
-                          }
-                          if (tag.value === DEFAULT_DISTRICT_COURT_TAG) {
-                            return isDistrictCourtPanelVisible
-                          }
-                          return selectedCourts.includes(tag.value)
-                        })}
-                        isSearchable={false}
-                        isClearable={false}
-                        isMulti={true}
-                        label={formatMessage(m.listPage.courtSelectLabel)}
-                        onChange={(options) => {
-                          const prevCourts = queryState[QueryParam.COURT] ?? []
-                          const prevDistrict =
-                            queryState[QueryParam.DISTRICT_COURTS] ?? []
-                          const lastOption = options[options.length - 1]
-                          if (
-                            !lastOption ||
-                            lastOption.value === ALL_COURTS_TAG
-                          ) {
-                            if (
-                              shouldResetCaseFiltersOnCourtsChange(
-                                prevCourts,
-                                prevDistrict,
-                                [],
-                                [],
-                              )
-                            ) {
-                              updateQueryState(QueryParam.CASE_CATEGORIES, null)
-                              updateQueryState(QueryParam.CASE_TYPES, null)
-                              updateRenderKey()
-                            }
-                            updateQueryState(QueryParam.COURT, [])
-                            updateQueryState(QueryParam.DISTRICT_COURTS, null)
-                            return
-                          }
-                          const nextValues = options
-                            .map((option) => option.value)
-                            .filter((value) => value !== ALL_COURTS_TAG)
-                          const resolved = resolveExclusiveMainCourtSelection(
-                            nextValues,
-                            lastOption,
-                            prevDistrict.length,
-                          )
-                          const nextDistrictCourts =
-                            resolved.clearDistrictCourts
-                              ? []
-                              : resolved.courts.includes(
-                                  DEFAULT_DISTRICT_COURT_TAG,
+                  <GridRow rowGap={2}>
+                    <GridColumn span={['1/1', '1/1', '1/1', '8/12', '8/12']}>
+                      <Stack space={3}>
+                        <Box className={styles.searchInput}>
+                          <DebouncedInput
+                            debounceTimeInMs={DEBOUNCE_TIME_IN_MS}
+                            key={renderKey}
+                            value={queryState[QueryParam.SEARCH_TERM]}
+                            loading={loading}
+                            onChange={(value) => {
+                              updateQueryState(QueryParam.SEARCH_TERM, value)
+                            }}
+                            name="verdict-search-input"
+                            icon={{ name: 'search', type: 'outline' }}
+                            backgroundColor="blue"
+                            tooltip={formatMessage(
+                              m.listPage.searchInputTooltip,
+                            )}
+                            label={formatMessage(m.listPage.searchInputLabel)}
+                            placeholder={formatMessage(
+                              m.listPage.searchInputPlaceholder,
+                            )}
+                            size="md"
+                          />
+                        </Box>
+                        <Hidden above="xs">
+                          <Select
+                            key={renderKey}
+                            options={courtTags}
+                            value={courtTags.filter((tag) => {
+                              if (tag.value === ALL_COURTS_TAG) {
+                                return (
+                                  selectedCourts.length === 0 &&
+                                  selectedDistrictCourts.length === 0
                                 )
-                              ? prevDistrict
-                              : []
-                          if (
-                            shouldResetCaseFiltersOnCourtsChange(
-                              prevCourts,
-                              prevDistrict,
-                              resolved.courts,
-                              nextDistrictCourts,
-                            )
-                          ) {
-                            updateQueryState(QueryParam.CASE_CATEGORIES, null)
-                            updateQueryState(QueryParam.CASE_TYPES, null)
-                            updateRenderKey()
-                          }
-                          updateQueryState(
-                            QueryParam.COURT,
-                            (previousState) => ({
-                              ...previousState,
-                              [QueryParam.COURT]: resolved.courts,
-                              [QueryParam.DISTRICT_COURTS]: nextDistrictCourts,
-                            }),
-                          )
-                        }}
-                        size="sm"
-                        backgroundColor="blue"
-                      />
-                    </Hidden>
-                    <Hidden below="sm">
-                      <Inline alignY="center" space={2}>
-                        {courtTags.map((tag) => {
-                          const isActive =
-                            tag.value === ALL_COURTS_TAG
-                              ? selectedCourts.length === 0 &&
-                                selectedDistrictCourts.length === 0
-                              : tag.value === DEFAULT_DISTRICT_COURT_TAG
-                              ? isDistrictCourtPanelVisible
-                              : selectedCourts.includes(tag.value)
-                          return (
-                            <Tag
-                              key={tag.value}
-                              active={isActive}
-                              focusVisibleOnly={true}
-                              onClick={() => {
-                                const prevCourts =
-                                  queryState[QueryParam.COURT] ?? []
-                                const prevDistrict =
-                                  queryState[QueryParam.DISTRICT_COURTS] ?? []
-                                if (tag.value === ALL_COURTS_TAG) {
-                                  if (
-                                    shouldResetCaseFiltersOnCourtsChange(
-                                      prevCourts,
-                                      prevDistrict,
-                                      [],
-                                      [],
-                                    )
-                                  ) {
-                                    updateQueryState(
-                                      QueryParam.CASE_CATEGORIES,
-                                      null,
-                                    )
-                                    updateQueryState(
-                                      QueryParam.CASE_TYPES,
-                                      null,
-                                    )
-                                    updateRenderKey()
-                                  }
-                                  updateQueryState(QueryParam.COURT, [])
-                                  updateQueryState(
-                                    QueryParam.DISTRICT_COURTS,
-                                    null,
-                                  )
-                                  return
-                                }
-                                const nextCourtsState = (() => {
-                                  const isSelected = prevCourts.includes(
-                                    tag.value,
-                                  )
-                                  let nextCourts = isSelected
-                                    ? prevCourts.filter(
-                                        (court) => court !== tag.value,
-                                      )
-                                    : [...prevCourts, tag.value]
-                                  let nextDistrictCourts =
-                                    isSelected &&
-                                    tag.value === DEFAULT_DISTRICT_COURT_TAG
-                                      ? []
-                                      : prevDistrict
-
-                                  if (!isSelected) {
-                                    if (
-                                      tag.value === DEFAULT_DISTRICT_COURT_TAG
-                                    ) {
-                                      nextCourts =
-                                        stripHigherCourtTags(nextCourts)
-                                    } else if (isHigherCourtTag(tag.value)) {
-                                      nextCourts =
-                                        stripDistrictCourtTag(nextCourts)
-                                      nextDistrictCourts = []
-                                    }
-                                  }
-
-                                  return {
-                                    nextCourts,
-                                    nextDistrictCourts,
-                                  }
-                                })()
+                              }
+                              if (tag.value === DEFAULT_DISTRICT_COURT_TAG) {
+                                return isDistrictCourtPanelVisible
+                              }
+                              return selectedCourts.includes(tag.value)
+                            })}
+                            isSearchable={false}
+                            isClearable={false}
+                            isMulti={true}
+                            label={formatMessage(m.listPage.courtSelectLabel)}
+                            onChange={(options) => {
+                              const prevCourts =
+                                queryState[QueryParam.COURT] ?? []
+                              const prevDistrict =
+                                queryState[QueryParam.DISTRICT_COURTS] ?? []
+                              const lastOption = options[options.length - 1]
+                              if (
+                                !lastOption ||
+                                lastOption.value === ALL_COURTS_TAG
+                              ) {
                                 if (
                                   shouldResetCaseFiltersOnCourtsChange(
                                     prevCourts,
                                     prevDistrict,
-                                    nextCourtsState.nextCourts,
-                                    nextCourtsState.nextDistrictCourts,
+                                    [],
+                                    [],
                                   )
                                 ) {
                                   updateQueryState(
@@ -1474,137 +1391,169 @@ const VerdictsList: CustomScreen<VerdictsListProps> = (props) => {
                                   updateQueryState(QueryParam.CASE_TYPES, null)
                                   updateRenderKey()
                                 }
+                                updateQueryState(QueryParam.COURT, [])
                                 updateQueryState(
-                                  QueryParam.COURT,
-                                  (previousState) => ({
-                                    ...previousState,
-                                    [QueryParam.COURT]:
-                                      nextCourtsState.nextCourts,
-                                    [QueryParam.DISTRICT_COURTS]:
-                                      nextCourtsState.nextDistrictCourts,
-                                  }),
+                                  QueryParam.DISTRICT_COURTS,
+                                  null,
                                 )
-                              }}
-                            >
-                              <Box
-                                flexDirection="row"
-                                alignItems="center"
-                                justifyContent="center"
-                              >
-                                {tag.label}
-                                {isActive && tag.value !== ALL_COURTS_TAG && (
-                                  <span
-                                    className={styles.crossmark}
-                                    aria-hidden="true"
-                                  >
-                                    &#10005;
-                                  </span>
-                                )}
-                              </Box>
-                            </Tag>
-                          )
-                        })}
-                      </Inline>
-                    </Hidden>
-                    {isDistrictCourtPanelVisible && (
-                      <>
-                        <Hidden below="sm">
-                          <Inline alignY="center" space={2}>
-                            <Tag
-                              key={DEFAULT_DISTRICT_COURT_TAG}
-                              focusVisibleOnly={true}
-                              active={
-                                selectedCourts.includes(
-                                  DEFAULT_DISTRICT_COURT_TAG,
-                                ) && selectedDistrictCourts.length === 0
+                                return
                               }
-                              onClick={() => {
-                                if (selectedDistrictCourts.length === 0) return
-                                updateQueryState(
-                                  QueryParam.COURT,
-                                  (previousState) => {
-                                    const previousCourts =
-                                      previousState[QueryParam.COURT]
-                                    const baseCourts = previousCourts.includes(
+                              const nextValues = options
+                                .map((option) => option.value)
+                                .filter((value) => value !== ALL_COURTS_TAG)
+                              const resolved =
+                                resolveExclusiveMainCourtSelection(
+                                  nextValues,
+                                  lastOption,
+                                  prevDistrict.length,
+                                )
+                              const nextDistrictCourts =
+                                resolved.clearDistrictCourts
+                                  ? []
+                                  : resolved.courts.includes(
                                       DEFAULT_DISTRICT_COURT_TAG,
                                     )
-                                      ? previousCourts
-                                      : [
-                                          ...previousCourts,
-                                          DEFAULT_DISTRICT_COURT_TAG,
-                                        ]
-                                    const nextCourts =
-                                      stripHigherCourtTags(baseCourts)
-                                    return {
-                                      ...previousState,
-                                      [QueryParam.COURT]: nextCourts,
-                                      [QueryParam.DISTRICT_COURTS]: [],
-                                    }
-                                  },
+                                  ? prevDistrict
+                                  : []
+                              if (
+                                shouldResetCaseFiltersOnCourtsChange(
+                                  prevCourts,
+                                  prevDistrict,
+                                  resolved.courts,
+                                  nextDistrictCourts,
                                 )
-                              }}
-                            >
-                              {formatMessage(m.listPage.showAllDistrictCourts)}
-                            </Tag>
-                            {districtCourtTags.map((tag) => {
-                              const isActive = selectedDistrictCourts.includes(
-                                tag.value,
+                              ) {
+                                updateQueryState(
+                                  QueryParam.CASE_CATEGORIES,
+                                  null,
+                                )
+                                updateQueryState(QueryParam.CASE_TYPES, null)
+                                updateRenderKey()
+                              }
+                              updateQueryState(
+                                QueryParam.COURT,
+                                (previousState) => ({
+                                  ...previousState,
+                                  [QueryParam.COURT]: resolved.courts,
+                                  [QueryParam.DISTRICT_COURTS]:
+                                    nextDistrictCourts,
+                                }),
                               )
+                            }}
+                            size="sm"
+                            backgroundColor="blue"
+                          />
+                        </Hidden>
+                        <Hidden below="sm">
+                          <Inline alignY="center" space={2}>
+                            {courtTags.map((tag) => {
+                              const isActive =
+                                tag.value === ALL_COURTS_TAG
+                                  ? selectedCourts.length === 0 &&
+                                    selectedDistrictCourts.length === 0
+                                  : tag.value === DEFAULT_DISTRICT_COURT_TAG
+                                  ? isDistrictCourtPanelVisible
+                                  : selectedCourts.includes(tag.value)
                               return (
                                 <Tag
                                   key={tag.value}
                                   active={isActive}
                                   focusVisibleOnly={true}
                                   onClick={() => {
-                                    updateQueryState(
-                                      QueryParam.DISTRICT_COURTS,
-                                      (previousState) => {
-                                        const previousDistrictCourts =
-                                          previousState[
-                                            QueryParam.DISTRICT_COURTS
-                                          ]
-                                        const previousCourts =
-                                          previousState[QueryParam.COURT]
-                                        const withDistrictTag =
-                                          previousCourts.includes(
-                                            DEFAULT_DISTRICT_COURT_TAG,
+                                    const prevCourts =
+                                      queryState[QueryParam.COURT] ?? []
+                                    const prevDistrict =
+                                      queryState[QueryParam.DISTRICT_COURTS] ??
+                                      []
+                                    if (tag.value === ALL_COURTS_TAG) {
+                                      if (
+                                        shouldResetCaseFiltersOnCourtsChange(
+                                          prevCourts,
+                                          prevDistrict,
+                                          [],
+                                          [],
+                                        )
+                                      ) {
+                                        updateQueryState(
+                                          QueryParam.CASE_CATEGORIES,
+                                          null,
+                                        )
+                                        updateQueryState(
+                                          QueryParam.CASE_TYPES,
+                                          null,
+                                        )
+                                        updateRenderKey()
+                                      }
+                                      updateQueryState(QueryParam.COURT, [])
+                                      updateQueryState(
+                                        QueryParam.DISTRICT_COURTS,
+                                        null,
+                                      )
+                                      return
+                                    }
+                                    const nextCourtsState = (() => {
+                                      const isSelected = prevCourts.includes(
+                                        tag.value,
+                                      )
+                                      let nextCourts = isSelected
+                                        ? prevCourts.filter(
+                                            (court) => court !== tag.value,
                                           )
-                                            ? previousCourts
-                                            : [
-                                                ...previousCourts,
-                                                DEFAULT_DISTRICT_COURT_TAG,
-                                              ]
-                                        const nextCourts =
-                                          stripHigherCourtTags(withDistrictTag)
+                                        : [...prevCourts, tag.value]
+                                      let nextDistrictCourts =
+                                        isSelected &&
+                                        tag.value === DEFAULT_DISTRICT_COURT_TAG
+                                          ? []
+                                          : prevDistrict
 
+                                      if (!isSelected) {
                                         if (
-                                          previousDistrictCourts.includes(
-                                            tag.value,
-                                          )
+                                          tag.value ===
+                                          DEFAULT_DISTRICT_COURT_TAG
                                         ) {
-                                          const updatedDistrictCourts =
-                                            previousDistrictCourts.filter(
-                                              (districtCourt) =>
-                                                districtCourt !== tag.value,
-                                            )
-
-                                          return {
-                                            ...previousState,
-                                            [QueryParam.COURT]: nextCourts,
-                                            [QueryParam.DISTRICT_COURTS]:
-                                              updatedDistrictCourts,
-                                          }
+                                          nextCourts =
+                                            stripHigherCourtTags(nextCourts)
+                                        } else if (
+                                          isHigherCourtTag(tag.value)
+                                        ) {
+                                          nextCourts =
+                                            stripDistrictCourtTag(nextCourts)
+                                          nextDistrictCourts = []
                                         }
+                                      }
 
-                                        return {
-                                          ...previousState,
-                                          [QueryParam.COURT]: nextCourts,
-                                          [QueryParam.DISTRICT_COURTS]:
-                                            previousDistrictCourts.concat(
-                                              tag.value,
-                                            ),
-                                        }
-                                      },
+                                      return {
+                                        nextCourts,
+                                        nextDistrictCourts,
+                                      }
+                                    })()
+                                    if (
+                                      shouldResetCaseFiltersOnCourtsChange(
+                                        prevCourts,
+                                        prevDistrict,
+                                        nextCourtsState.nextCourts,
+                                        nextCourtsState.nextDistrictCourts,
+                                      )
+                                    ) {
+                                      updateQueryState(
+                                        QueryParam.CASE_CATEGORIES,
+                                        null,
+                                      )
+                                      updateQueryState(
+                                        QueryParam.CASE_TYPES,
+                                        null,
+                                      )
+                                      updateRenderKey()
+                                    }
+                                    updateQueryState(
+                                      QueryParam.COURT,
+                                      (previousState) => ({
+                                        ...previousState,
+                                        [QueryParam.COURT]:
+                                          nextCourtsState.nextCourts,
+                                        [QueryParam.DISTRICT_COURTS]:
+                                          nextCourtsState.nextDistrictCourts,
+                                      }),
                                     )
                                   }}
                                 >
@@ -1614,7 +1563,7 @@ const VerdictsList: CustomScreen<VerdictsListProps> = (props) => {
                                     justifyContent="center"
                                   >
                                     {tag.label}
-                                    {isActive && (
+                                    {isActive && tag.value !== ALL_COURTS_TAG && (
                                       <span
                                         className={styles.crossmark}
                                         aria-hidden="true"
@@ -1628,110 +1577,273 @@ const VerdictsList: CustomScreen<VerdictsListProps> = (props) => {
                             })}
                           </Inline>
                         </Hidden>
-                        <Hidden above="xs">
-                          <Select
-                            key={renderKey}
-                            options={districtCourtTagsForSelect}
-                            label={formatMessage(
-                              m.listPage.districtCourtSelectLabel,
-                            )}
-                            isSearchable={false}
-                            isClearable={false}
-                            value={districtCourtTagsForSelect.filter((tag) => {
-                              if (selectedDistrictCourts.length > 0) {
-                                return selectedDistrictCourts.includes(
-                                  tag.value,
-                                )
-                              }
-                              return (
-                                selectedCourts.includes(
-                                  DEFAULT_DISTRICT_COURT_TAG,
-                                ) && tag.value === DEFAULT_DISTRICT_COURT_TAG
-                              )
-                            })}
-                            onChange={(options) => {
-                              if (options.length === 0) {
-                                updateQueryState(
-                                  QueryParam.COURT,
-                                  (previousState) => ({
-                                    ...previousState,
-                                    [QueryParam.COURT]: previousState[
-                                      QueryParam.COURT
-                                    ].filter(
-                                      (court) =>
-                                        court !== DEFAULT_DISTRICT_COURT_TAG,
-                                    ),
-                                    [QueryParam.DISTRICT_COURTS]: [],
-                                  }),
-                                )
-                                return
-                              }
-                              if (
-                                options[options.length - 1]?.value ===
-                                DEFAULT_DISTRICT_COURT_TAG
-                              ) {
-                                updateQueryState(
-                                  QueryParam.COURT,
-                                  (previousState) => {
-                                    const previousCourts =
-                                      previousState[QueryParam.COURT]
-                                    const baseCourts = previousCourts.includes(
+                        {isDistrictCourtPanelVisible && (
+                          <>
+                            <Hidden below="sm">
+                              <Inline alignY="center" space={2}>
+                                <Tag
+                                  key={DEFAULT_DISTRICT_COURT_TAG}
+                                  focusVisibleOnly={true}
+                                  active={
+                                    selectedCourts.includes(
                                       DEFAULT_DISTRICT_COURT_TAG,
-                                    )
-                                      ? previousCourts
-                                      : [
-                                          ...previousCourts,
-                                          DEFAULT_DISTRICT_COURT_TAG,
-                                        ]
-                                    const nextCourts =
-                                      stripHigherCourtTags(baseCourts)
-                                    return {
-                                      ...previousState,
-                                      [QueryParam.COURT]: nextCourts,
-                                      [QueryParam.DISTRICT_COURTS]: [],
-                                    }
-                                  },
-                                )
-                              } else {
-                                updateQueryState(
-                                  QueryParam.DISTRICT_COURTS,
-                                  (previousState) => {
-                                    const previousCourts =
-                                      previousState[QueryParam.COURT]
-                                    const withDistrictTag =
-                                      previousCourts.includes(
-                                        DEFAULT_DISTRICT_COURT_TAG,
-                                      )
-                                        ? previousCourts
-                                        : [
-                                            ...previousCourts,
+                                    ) && selectedDistrictCourts.length === 0
+                                  }
+                                  onClick={() => {
+                                    if (selectedDistrictCourts.length === 0)
+                                      return
+                                    updateQueryState(
+                                      QueryParam.COURT,
+                                      (previousState) => {
+                                        const previousCourts =
+                                          previousState[QueryParam.COURT]
+                                        const baseCourts =
+                                          previousCourts.includes(
                                             DEFAULT_DISTRICT_COURT_TAG,
-                                          ]
-                                    const nextCourts =
-                                      stripHigherCourtTags(withDistrictTag)
-                                    return {
-                                      ...previousState,
-                                      [QueryParam.COURT]: nextCourts,
-                                      [QueryParam.DISTRICT_COURTS]: options
-                                        .map((option) => option.value)
-                                        .filter(
-                                          (value) =>
-                                            value !==
+                                          )
+                                            ? previousCourts
+                                            : [
+                                                ...previousCourts,
+                                                DEFAULT_DISTRICT_COURT_TAG,
+                                              ]
+                                        const nextCourts =
+                                          stripHigherCourtTags(baseCourts)
+                                        return {
+                                          ...previousState,
+                                          [QueryParam.COURT]: nextCourts,
+                                          [QueryParam.DISTRICT_COURTS]: [],
+                                        }
+                                      },
+                                    )
+                                  }}
+                                >
+                                  {formatMessage(
+                                    m.listPage.showAllDistrictCourts,
+                                  )}
+                                </Tag>
+                                {districtCourtTags.map((tag) => {
+                                  const isActive =
+                                    selectedDistrictCourts.includes(tag.value)
+                                  return (
+                                    <Tag
+                                      key={tag.value}
+                                      active={isActive}
+                                      focusVisibleOnly={true}
+                                      onClick={() => {
+                                        updateQueryState(
+                                          QueryParam.DISTRICT_COURTS,
+                                          (previousState) => {
+                                            const previousDistrictCourts =
+                                              previousState[
+                                                QueryParam.DISTRICT_COURTS
+                                              ]
+                                            const previousCourts =
+                                              previousState[QueryParam.COURT]
+                                            const withDistrictTag =
+                                              previousCourts.includes(
+                                                DEFAULT_DISTRICT_COURT_TAG,
+                                              )
+                                                ? previousCourts
+                                                : [
+                                                    ...previousCourts,
+                                                    DEFAULT_DISTRICT_COURT_TAG,
+                                                  ]
+                                            const nextCourts =
+                                              stripHigherCourtTags(
+                                                withDistrictTag,
+                                              )
+
+                                            if (
+                                              previousDistrictCourts.includes(
+                                                tag.value,
+                                              )
+                                            ) {
+                                              const updatedDistrictCourts =
+                                                previousDistrictCourts.filter(
+                                                  (districtCourt) =>
+                                                    districtCourt !== tag.value,
+                                                )
+
+                                              return {
+                                                ...previousState,
+                                                [QueryParam.COURT]: nextCourts,
+                                                [QueryParam.DISTRICT_COURTS]:
+                                                  updatedDistrictCourts,
+                                              }
+                                            }
+
+                                            return {
+                                              ...previousState,
+                                              [QueryParam.COURT]: nextCourts,
+                                              [QueryParam.DISTRICT_COURTS]:
+                                                previousDistrictCourts.concat(
+                                                  tag.value,
+                                                ),
+                                            }
+                                          },
+                                        )
+                                      }}
+                                    >
+                                      <Box
+                                        flexDirection="row"
+                                        alignItems="center"
+                                        justifyContent="center"
+                                      >
+                                        {tag.label}
+                                        {isActive && (
+                                          <span
+                                            className={styles.crossmark}
+                                            aria-hidden="true"
+                                          >
+                                            &#10005;
+                                          </span>
+                                        )}
+                                      </Box>
+                                    </Tag>
+                                  )
+                                })}
+                              </Inline>
+                            </Hidden>
+                            <Hidden above="xs">
+                              <Select
+                                key={renderKey}
+                                options={districtCourtTagsForSelect}
+                                label={formatMessage(
+                                  m.listPage.districtCourtSelectLabel,
+                                )}
+                                isSearchable={false}
+                                isClearable={false}
+                                value={districtCourtTagsForSelect.filter(
+                                  (tag) => {
+                                    if (selectedDistrictCourts.length > 0) {
+                                      return selectedDistrictCourts.includes(
+                                        tag.value,
+                                      )
+                                    }
+                                    return (
+                                      selectedCourts.includes(
+                                        DEFAULT_DISTRICT_COURT_TAG,
+                                      ) &&
+                                      tag.value === DEFAULT_DISTRICT_COURT_TAG
+                                    )
+                                  },
+                                )}
+                                onChange={(options) => {
+                                  if (options.length === 0) {
+                                    updateQueryState(
+                                      QueryParam.COURT,
+                                      (previousState) => ({
+                                        ...previousState,
+                                        [QueryParam.COURT]: previousState[
+                                          QueryParam.COURT
+                                        ].filter(
+                                          (court) =>
+                                            court !==
                                             DEFAULT_DISTRICT_COURT_TAG,
                                         ),
-                                    }
-                                  },
-                                )
-                              }
-                            }}
-                            size="sm"
-                            backgroundColor="blue"
-                            isMulti={true}
-                          />
-                        </Hidden>
-                      </>
-                    )}
-                  </Stack>
+                                        [QueryParam.DISTRICT_COURTS]: [],
+                                      }),
+                                    )
+                                    return
+                                  }
+                                  if (
+                                    options[options.length - 1]?.value ===
+                                    DEFAULT_DISTRICT_COURT_TAG
+                                  ) {
+                                    updateQueryState(
+                                      QueryParam.COURT,
+                                      (previousState) => {
+                                        const previousCourts =
+                                          previousState[QueryParam.COURT]
+                                        const baseCourts =
+                                          previousCourts.includes(
+                                            DEFAULT_DISTRICT_COURT_TAG,
+                                          )
+                                            ? previousCourts
+                                            : [
+                                                ...previousCourts,
+                                                DEFAULT_DISTRICT_COURT_TAG,
+                                              ]
+                                        const nextCourts =
+                                          stripHigherCourtTags(baseCourts)
+                                        return {
+                                          ...previousState,
+                                          [QueryParam.COURT]: nextCourts,
+                                          [QueryParam.DISTRICT_COURTS]: [],
+                                        }
+                                      },
+                                    )
+                                  } else {
+                                    updateQueryState(
+                                      QueryParam.DISTRICT_COURTS,
+                                      (previousState) => {
+                                        const previousCourts =
+                                          previousState[QueryParam.COURT]
+                                        const withDistrictTag =
+                                          previousCourts.includes(
+                                            DEFAULT_DISTRICT_COURT_TAG,
+                                          )
+                                            ? previousCourts
+                                            : [
+                                                ...previousCourts,
+                                                DEFAULT_DISTRICT_COURT_TAG,
+                                              ]
+                                        const nextCourts =
+                                          stripHigherCourtTags(withDistrictTag)
+                                        return {
+                                          ...previousState,
+                                          [QueryParam.COURT]: nextCourts,
+                                          [QueryParam.DISTRICT_COURTS]: options
+                                            .map((option) => option.value)
+                                            .filter(
+                                              (value) =>
+                                                value !==
+                                                DEFAULT_DISTRICT_COURT_TAG,
+                                            ),
+                                        }
+                                      },
+                                    )
+                                  }
+                                }}
+                                size="sm"
+                                backgroundColor="blue"
+                                isMulti={true}
+                              />
+                            </Hidden>
+                          </>
+                        )}
+                      </Stack>
+                    </GridColumn>
+                    <GridColumn
+                      offset={['0', '0', '0', '1/12', '1/12']}
+                      span={['0', '0', '0', '3/12', '3/12']}
+                      hiddenBelow="lg"
+                    >
+                      {verdictsWebsiteLinks.length > 0 && (
+                        <Stack space={1}>
+                          <Text variant="eyebrow">
+                            {formatMessage(m.listPage.verdictsWebsiteEyebrow)}
+                          </Text>
+                          <GridRow rowGap={2}>
+                            {verdictsWebsiteLinks.map((link) => (
+                              <GridColumn key={link.href}>
+                                <LinkV2
+                                  underlineVisibility="always"
+                                  underline="small"
+                                  color="blue400"
+                                  href={link.href}
+                                >
+                                  <span className={styles.verdictsWebsiteLink}>
+                                    {link.label}
+                                  </span>
+                                </LinkV2>
+                              </GridColumn>
+                            ))}
+                          </GridRow>
+                        </Stack>
+                      )}
+                    </GridColumn>
+                  </GridRow>
                 </GridColumn>
               </GridRow>
             </Stack>

--- a/apps/web/screens/Verdicts/VerdictsList.tsx
+++ b/apps/web/screens/Verdicts/VerdictsList.tsx
@@ -47,7 +47,6 @@ import {
   type WebVerdictKeyword,
   type WebVerdictsInput,
 } from '@island.is/web/graphql/schema'
-import { useI18n } from '@island.is/web/i18n'
 import { useDateUtils } from '@island.is/web/i18n/useDateUtils'
 import { withMainLayout } from '@island.is/web/layouts/main'
 import { CustomNextError } from '@island.is/web/units/errors'

--- a/apps/web/screens/Verdicts/VerdictsList.tsx
+++ b/apps/web/screens/Verdicts/VerdictsList.tsx
@@ -1000,7 +1000,7 @@ const Filters = ({
   )
 }
 
-const VerdictsWebsiteLinks = ({
+const CourtWebsiteLinks = ({
   links,
   layout = 'grid',
   showEyebrow = true,
@@ -1056,7 +1056,7 @@ const VerdictsWebsiteLinks = ({
   )
 }
 
-const VerdictsWebsiteLinksDropdown = ({
+const CourtWebsiteLinksDropdown = ({
   links,
 }: {
   links: { label: string; href: string }[]
@@ -1088,7 +1088,7 @@ const VerdictsWebsiteLinksDropdown = ({
         </Box>
         {isOpen && (
           <Box className={styles.verdictsWebsiteLinksDropdown} padding={3}>
-            <VerdictsWebsiteLinks
+            <CourtWebsiteLinks
               links={links}
               layout="stack"
               showEyebrow={false}
@@ -1320,8 +1320,8 @@ const VerdictsList: CustomScreen<VerdictsListProps> = (props) => {
 
   const description = formatMessage(m.listPage.description)
 
-  const verdictsWebsiteLinks: { label: string; href: string }[] = customPageData
-    ?.configJson?.verdictsWebsiteLinks ?? [
+  const courtWebsiteLinks: { label: string; href: string }[] = customPageData
+    ?.configJson?.courtWebsiteLinks ?? [
     {
       label: 'Hæstiréttur',
       href: '/s/haestirettur',
@@ -1334,13 +1334,18 @@ const VerdictsList: CustomScreen<VerdictsListProps> = (props) => {
       label: 'Landsréttur',
       href: '/s/landsrettur',
     },
+
+    {
+      label: 'Héraðsdómstólar',
+      href: '/s/haeradsdomstolar',
+    },
     {
       label: 'Dómstólasýslan',
       href: '/s/domstolasyslan',
     },
     {
-      label: 'Héraðsdómstólar',
-      href: '/s/haeradsdomstolar',
+      label: 'Dómstólar',
+      href: '/s/domstolar',
     },
   ]
 
@@ -1362,9 +1367,7 @@ const VerdictsList: CustomScreen<VerdictsListProps> = (props) => {
                 >
                   <Stack space={2}>
                     <Stack space={1}>
-                      <VerdictsWebsiteLinksDropdown
-                        links={verdictsWebsiteLinks}
-                      />
+                      <CourtWebsiteLinksDropdown links={courtWebsiteLinks} />
                       <Text variant="h1" as="h1">
                         {heading}
                       </Text>
@@ -1924,7 +1927,7 @@ const VerdictsList: CustomScreen<VerdictsListProps> = (props) => {
                       span={['0', '0', '0', '3/12', '3/12']}
                       hiddenBelow="lg"
                     >
-                      <VerdictsWebsiteLinks links={verdictsWebsiteLinks} />
+                      <CourtWebsiteLinks links={courtWebsiteLinks} />
                     </GridColumn>
                   </GridRow>
                 </GridColumn>

--- a/apps/web/screens/Verdicts/translations.strings.ts
+++ b/apps/web/screens/Verdicts/translations.strings.ts
@@ -2,6 +2,22 @@ import { defineMessages } from 'react-intl'
 
 export const m = {
   listPage: defineMessages({
+    downloadGuide: {
+      id: 'web.verdicts:listPage.downloadGuide',
+      defaultMessage: 'Sjá leiðbeiningar',
+      description: 'Leiðbeiningar',
+    },
+    downloadGuideUrl: {
+      id: 'web.verdicts:listPage.downloadGuideUrl',
+      defaultMessage:
+        'https://assets.ctfassets.net/8k0h54kbe6bj/22bf80wWmp3j4htA1VbUWx/5d68b57f4607c529c763aef15539a9a8/a1c00c4f-d788-4e16-a946-a4db394f9159.docx',
+      description: 'Hlekkur á leiðbeiningarskjal',
+    },
+    verdictsWebsiteEyebrow: {
+      id: 'web.verdicts:listPage.verdictsWebsiteEyebrow',
+      defaultMessage: 'Vefsvæði dómstólanna',
+      description: 'Vefsvæði dómstólanna',
+    },
     caseContactAccordionLabel: {
       id: 'web.verdicts:listPage.caseContactAccordionLabel',
       defaultMessage: 'Málsaðili',


### PR DESCRIPTION
# Verdict list - Guide download button and links to courts

<img width="1368" height="482" alt="Screenshot 2026-07-09 at 14 37 51" src="https://github.com/user-attachments/assets/db964101-d1fd-48c6-aeaa-8040958c6a05" />

<img width="366" height="475" alt="Screenshot 2026-07-09 at 14 38 15" src="https://github.com/user-attachments/assets/633921c0-c1f1-45dd-8ac1-0b6f5869b64c" />


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [x] No AI tools were used in preparing this pull request
- [ ] AI tools were used in preparing this pull request
      Tools used:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a verdicts website links area to the verdicts page header, including a compact dropdown on smaller screens.
  * Enabled configurable verdicts website links with a built-in fallback when no custom links are available.
  * Added localized text for a download guide link and a label for the verdicts website links section.
* **Bug Fixes**
  * Improved the court and district court filter layout while preserving existing filter behavior across desktop and mobile views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->