### PR TITLE
feat(web): Verdict list - Change onClick to be a Link instead

### DIFF
--- a/apps/web/screens/Verdicts/VerdictsList.tsx
+++ b/apps/web/screens/Verdicts/VerdictsList.tsx
@@ -1397,7 +1397,7 @@ const VerdictsList: CustomScreen<VerdictsListProps> = (props) => {
                           <Button
                             size="small"
                             variant="text"
-                            icon="download"
+                            icon="open"
                             iconType="outline"
                             colorScheme="light"
                             unfocusable={true}

--- a/apps/web/screens/Verdicts/VerdictsList.tsx
+++ b/apps/web/screens/Verdicts/VerdictsList.tsx
@@ -1389,23 +1389,22 @@ const VerdictsList: CustomScreen<VerdictsListProps> = (props) => {
                       />
                       {formatMessage(m.listPage.downloadGuideUrl).trim()
                         .length > 0 && (
-                        <Button
-                          size="small"
-                          variant="text"
-                          icon="download"
-                          iconType="outline"
-                          colorScheme="light"
-                          onClick={() => {
-                            const fileUrl = formatMessage(
-                              m.listPage.downloadGuideUrl,
-                            )
-                            const link = document.createElement('a')
-                            link.href = fileUrl
-                            link.click()
-                          }}
+                        <LinkV2
+                          href={formatMessage(m.listPage.downloadGuideUrl)}
+                          pureChildren={true}
+                          newTab={true}
                         >
-                          {formatMessage(m.listPage.downloadGuide)}
-                        </Button>
+                          <Button
+                            size="small"
+                            variant="text"
+                            icon="download"
+                            iconType="outline"
+                            colorScheme="light"
+                            unfocusable={true}
+                          >
+                            {formatMessage(m.listPage.downloadGuide)}
+                          </Button>
+                        </LinkV2>
                       )}
                     </Inline>
                     {Boolean(description?.trim()) && (


### PR DESCRIPTION
# Verdict list - Change onClick to be a Link instead

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [x] No AI tools were used in preparing this pull request
- [ ] AI tools were used in preparing this pull request
      Tools used:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the “download guide” navigation for more reliable link behavior.
  * Updated the control to open the download guide in a new tab.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->