### PR TITLE
feat: add child safety section

### DIFF
--- a/libs/application/template-api-modules/src/lib/modules/templates/national-agency-for-children-and-families/child-protection-notification/child-protection-notification.service.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/national-agency-for-children-and-families/child-protection-notification/child-protection-notification.service.ts
@@ -29,6 +29,12 @@ export class ChildProtectionNotificationService extends BaseTemplateApiService {
     )
   }
 
+  async getUrgencyAssessments({ auth }: TemplateApiModuleActionProps) {
+    return await this.nationalAgencyForChildrenAndFamiliesClientService.getUrgencyAssessments(
+      auth,
+    )
+  }
+
   async createApplication() {
     // TODO: Implement this
     await new Promise((resolve) => setTimeout(resolve, 2000))

--- a/libs/application/templates/national-agency-for-children-and-families/child-protection-notification/src/dataProviders/index.ts
+++ b/libs/application/templates/national-agency-for-children-and-families/child-protection-notification/src/dataProviders/index.ts
@@ -22,3 +22,9 @@ export const ProtectiveFactorsApi = defineTemplateApi({
   externalDataId: 'protectiveFactors',
   namespace: ApplicationTypes.CHILD_PROTECTION_NOTIFICATION,
 })
+
+export const UrgencyAssessmentsApi = defineTemplateApi({
+  action: 'getUrgencyAssessments',
+  externalDataId: 'urgencyAssessments',
+  namespace: ApplicationTypes.CHILD_PROTECTION_NOTIFICATION,
+})

--- a/libs/application/templates/national-agency-for-children-and-families/child-protection-notification/src/forms/adultProcurationForm/index.ts
+++ b/libs/application/templates/national-agency-for-children-and-families/child-protection-notification/src/forms/adultProcurationForm/index.ts
@@ -3,6 +3,7 @@ import { FormModes } from '@island.is/application/types'
 import { childInfoManualSection } from '../shared/childInfoManualSection'
 import { parentsSection } from '../shared/parentsSection'
 import { protectiveFactorsSection } from '../shared/protectiveFactorsSection'
+import { childSafetySection } from '../shared/childSafetySection'
 import { overviewSection } from './overviewSection'
 
 export const AdultProcurationForm = buildForm({
@@ -14,6 +15,7 @@ export const AdultProcurationForm = buildForm({
     childInfoManualSection,
     parentsSection,
     protectiveFactorsSection,
+    childSafetySection,
     overviewSection,
   ],
 })

--- a/libs/application/templates/national-agency-for-children-and-families/child-protection-notification/src/forms/adultProcurationForm/overviewSection.ts
+++ b/libs/application/templates/national-agency-for-children-and-families/child-protection-notification/src/forms/adultProcurationForm/overviewSection.ts
@@ -102,6 +102,9 @@ export const overviewSection = buildSection({
           items: getProtectiveFactorsItems,
           hideIfEmpty: true,
         }),
+
+        // TODO: Add overview.childSafety field once slider is implemented and API is ready
+
         buildSubmitField({
           id: 'submit',
           refetchApplicationAfterSubmit: true,

--- a/libs/application/templates/national-agency-for-children-and-families/child-protection-notification/src/forms/prerequisitesForm/externalDataSubSection.ts
+++ b/libs/application/templates/national-agency-for-children-and-families/child-protection-notification/src/forms/prerequisitesForm/externalDataSubSection.ts
@@ -8,6 +8,7 @@ import {
   CategoriesApi,
   IdentityApiProvider,
   ProtectiveFactorsApi,
+  UrgencyAssessmentsApi,
 } from '../../dataProviders'
 import { prerequisitesMessages } from '../../lib/messages'
 
@@ -37,6 +38,9 @@ export const externalDataSubSection = buildSubSection({
         }),
         buildDataProviderItem({
           provider: ProtectiveFactorsApi,
+        }),
+        buildDataProviderItem({
+          provider: UrgencyAssessmentsApi,
         }),
       ],
     }),

--- a/libs/application/templates/national-agency-for-children-and-families/child-protection-notification/src/forms/shared/childSafetySection.ts
+++ b/libs/application/templates/national-agency-for-children-and-families/child-protection-notification/src/forms/shared/childSafetySection.ts
@@ -1,0 +1,35 @@
+import {
+  buildDescriptionField,
+  buildMultiField,
+  buildSection,
+} from '@island.is/application/core'
+import { childSafetyMessages } from '../../lib/messages'
+import { isUnborn } from '../../utils/conditionUtils'
+
+export const childSafetySection = buildSection({
+  id: 'childSafetySection',
+  title: childSafetyMessages.shared.sectionTitle,
+  children: [
+    buildMultiField({
+      id: 'childSafety',
+      title: childSafetyMessages.shared.sectionTitle,
+      description: childSafetyMessages.shared.description,
+      children: [
+        buildDescriptionField({
+          id: 'childSafety.question',
+          title: ({ answers }) =>
+            isUnborn(answers)
+              ? childSafetyMessages.unborn.sliderQuestion
+              : childSafetyMessages.shared.sliderQuestion,
+          titleVariant: 'h4',
+          doesNotRequireAnswer: true,
+          space: 2,
+        }),
+        // TODO: Add urgency level slider
+        // TODO: Add info card (alertType: 'default') showing urgency assessment label + description from urgencyAssessments API
+        // TODO: Add warning alert (alertType: 'warning') when slider value is 0-2
+        // Data: urgencyAssessments from UrgencyAssessmentsApi (externalData), childSafetyUrgencyLevel in answers/dataSchema
+      ],
+    }),
+  ],
+})

--- a/libs/application/templates/national-agency-for-children-and-families/child-protection-notification/src/lib/ChildProtectionNotificationTemplate.ts
+++ b/libs/application/templates/national-agency-for-children-and-families/child-protection-notification/src/lib/ChildProtectionNotificationTemplate.ts
@@ -21,6 +21,7 @@ import {
   CategoriesApi,
   IdentityApiProvider,
   ProtectiveFactorsApi,
+  UrgencyAssessmentsApi,
 } from '../dataProviders'
 import {
   overviewMessages,
@@ -76,6 +77,7 @@ const template: ApplicationTemplate<
                   IdentityApiProvider,
                   CategoriesApi,
                   ProtectiveFactorsApi,
+                  UrgencyAssessmentsApi,
                 ],
                 delete: true,
               }),
@@ -100,6 +102,7 @@ const template: ApplicationTemplate<
                 IdentityApiProvider,
                 CategoriesApi,
                 ProtectiveFactorsApi,
+                UrgencyAssessmentsApi,
               ],
               delete: true,
             },

--- a/libs/application/templates/national-agency-for-children-and-families/child-protection-notification/src/lib/dataSchema.ts
+++ b/libs/application/templates/national-agency-for-children-and-families/child-protection-notification/src/lib/dataSchema.ts
@@ -196,6 +196,7 @@ export const dataSchema = z.object({
   serviceProvider: serviceProviderSchema,
   child: childSchema.optional(),
   parents: parentsSchema.optional(),
+  childSafetyUrgencyLevel: z.string().optional(),
   protectiveFactors: z
     .record(z.unknown())
     .optional()

--- a/libs/application/templates/national-agency-for-children-and-families/child-protection-notification/src/lib/messages/childSafety.ts
+++ b/libs/application/templates/national-agency-for-children-and-families/child-protection-notification/src/lib/messages/childSafety.ts
@@ -1,0 +1,30 @@
+import { defineMessages } from 'react-intl'
+
+export const childSafetyMessages = {
+  shared: defineMessages({
+    sectionTitle: {
+      id: 'cpn.application:childSafety.shared.sectionTitle',
+      defaultMessage: 'Öryggi barns',
+    },
+    description: {
+      id: 'cpn.application:childSafety.shared.description',
+      defaultMessage:
+        'Tilkynning til barnaverndar felur ekki sjálfkrafa í sér að opnað verði barnaverndarmál. Barnavernd tekur samt allar tilkynningar alvarlega, tekur þær til skoðunar, bregst við og virkjar viðeigandi fagaðila eða úrræði til stuðnings foreldri og barni eftir því sem við á. Við biðjum þig hér að veita okkur upplýsingar sem hjálpa okkur að ákvarða viðeigandi viðbrögð í framhaldi af þessari tilkynningu.',
+    },
+    sliderQuestion: {
+      id: 'cpn.application:childSafety.shared.sliderQuestion',
+      defaultMessage: 'Hversu öruggt telur þú barnið vera núna?',
+    },
+    warningText: {
+      id: 'cpn.application:childSafety.shared.warningText',
+      defaultMessage: 'Ef barnið er í bráðri hættu, hringdu í 112',
+    },
+  }),
+  unborn: defineMessages({
+    sliderQuestion: {
+      id: 'cpn.application:childSafety.unborn.sliderQuestion',
+      defaultMessage:
+        'Hversu öruggt telur þú verðandi foreldri og ófætt barn vera núna?',
+    },
+  }),
+}

--- a/libs/application/templates/national-agency-for-children-and-families/child-protection-notification/src/lib/messages/index.ts
+++ b/libs/application/templates/national-agency-for-children-and-families/child-protection-notification/src/lib/messages/index.ts
@@ -1,6 +1,7 @@
 export * from './child'
 export * from './parents'
 export * from './protectiveFactors'
+export * from './childSafety'
 export * from './shared'
 export * from './prerequisites'
 export * from './error'

--- a/libs/application/templates/national-agency-for-children-and-families/child-protection-notification/src/utils/getApplicationAnswers.ts
+++ b/libs/application/templates/national-agency-for-children-and-families/child-protection-notification/src/utils/getApplicationAnswers.ts
@@ -178,6 +178,11 @@ export const getApplicationAnswers = (answers: Application['answers']) => {
     Record<string, Record<string, string[]>>
   >(answers, 'protectiveFactors')
 
+  const childSafetyUrgencyLevel = getValueViaPath<string>(
+    answers,
+    'childSafetyUrgencyLevel',
+  )
+
   return {
     serviceProviderService,
     serviceProviderServiceType,
@@ -215,5 +220,6 @@ export const getApplicationAnswers = (answers: Application['answers']) => {
     parent1,
     parent2,
     protectiveFactors,
+    childSafetyUrgencyLevel,
   }
 }

--- a/libs/application/templates/national-agency-for-children-and-families/child-protection-notification/src/utils/getApplicationExternalData.ts
+++ b/libs/application/templates/national-agency-for-children-and-families/child-protection-notification/src/utils/getApplicationExternalData.ts
@@ -1,6 +1,9 @@
 import { getValueViaPath } from '@island.is/application/core'
 import { Application } from '@island.is/application/types'
-import { ProtectiveFactorSectionDto } from '@island.is/clients/national-agency-for-children-and-families'
+import {
+  DropDownDto,
+  ProtectiveFactorSectionDto,
+} from '@island.is/clients/national-agency-for-children-and-families'
 import { Category } from './types'
 
 export const getApplicationExternalData = (
@@ -50,6 +53,10 @@ export const getApplicationExternalData = (
       'protectiveFactors.data',
     ) ?? []
 
+  const urgencyAssessments =
+    getValueViaPath<DropDownDto[]>(externalData, 'urgencyAssessments.data') ??
+    []
+
   return {
     applicantName,
     applicantNationalId,
@@ -60,5 +67,6 @@ export const getApplicationExternalData = (
     actorNationalId,
     categories,
     protectiveFactorSections,
+    urgencyAssessments,
   }
 }

--- a/libs/application/templates/national-agency-for-children-and-families/child-protection-notification/src/utils/getOverviewItems.ts
+++ b/libs/application/templates/national-agency-for-children-and-families/child-protection-notification/src/utils/getOverviewItems.ts
@@ -553,6 +553,10 @@ export const getParent2Items = (
   return buildParentItems(parent2, parentsKnowsNationalIds)
 }
 
+// TODO: Add getChildSafetyItems once slider is implemented and API is ready
+// keyText: isUnborn ? childSafetyMessages.unborn.sliderQuestion : childSafetyMessages.shared.sliderQuestion
+// valueText: urgencyAssessments.find(a => a.value === childSafetyUrgencyLevel)?.label ?? childSafetyUrgencyLevel
+
 export const getProtectiveFactorsItems = (
   answers: FormValue,
   externalData: ExternalData,

--- a/libs/clients/national-agency-for-children-and-families/src/lib/nationalAgencyForChildrenAndFamiliesClient.service.ts
+++ b/libs/clients/national-agency-for-children-and-families/src/lib/nationalAgencyForChildrenAndFamiliesClient.service.ts
@@ -1,6 +1,7 @@
 import { Auth, AuthMiddleware, type User } from '@island.is/auth-nest-tools'
 import { Injectable } from '@nestjs/common'
 import {
+  DropDownDto,
   ExternalCategoryResponse,
   ExternalDropdownApi,
   ProtectiveFactorSectionDto,
@@ -23,5 +24,11 @@ export class NationalAgencyForChildrenAndFamiliesClientService {
     return await this.externalDropdownApiWithAuth(
       user,
     ).externalProtectiveFactors()
+  }
+
+  async getUrgencyAssessments(user: User): Promise<DropDownDto[]> {
+    return await this.externalDropdownApiWithAuth(
+      user,
+    ).externalUrgencyAssessments()
   }
 }


### PR DESCRIPTION
Adds the child safety section to the notification form. The section shows the introductory text and the question about urgency level.

Pending — waiting on designer/API maintainers input:

The urgency level slider, info card, and warning alert are not implemented yet. The required data API (UrgencyAssessmentsApi) is already scaffolded in externalData.

What needs to be implemented once design decisions are confirmed:
- Urgency level slider (childSafetyUrgencyLevel answer field + dataSchema entry)
- Info card showing the urgency assessment label and description from UrgencyAssessmentsApi
- Warning alert shown when slider value is 0–2

See the TODO comments in childSafetySection.ts for the full context.

https://dit-iceland.atlassian.net/browse/SIA-23?atlOrigin=eyJpIjoiNGRmNzcyZGJmZjdjNDNjM2E1NTg0NTNiMTRlODcyNDUiLCJwIjoiaiJ9
## What

Specify what you're trying to achieve

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude code
