### PR TITLE
chore(mileage-registration): Add mileage odometer to main info

### DIFF
--- a/libs/api/domains/vehicles/src/lib/models/getVehicleDetail.model.ts
+++ b/libs/api/domains/vehicles/src/lib/models/getVehicleDetail.model.ts
@@ -49,7 +49,7 @@ export class VehiclesMainInfo {
   availableMileageRegistration?: boolean
 
   @Field({ nullable: true })
-  hasMilesOdometer?: boolean | null
+  hasMilesOdometer?: boolean
 }
 
 @ObjectType()

--- a/libs/api/domains/vehicles/src/lib/models/getVehicleDetail.model.ts
+++ b/libs/api/domains/vehicles/src/lib/models/getVehicleDetail.model.ts
@@ -47,6 +47,9 @@ export class VehiclesMainInfo {
 
   @Field(() => Boolean, { nullable: true })
   availableMileageRegistration?: boolean
+
+  @Field(() => Boolean, { nullable: true })
+  hasMilesOdometer?: boolean | null
 }
 
 @ObjectType()

--- a/libs/api/domains/vehicles/src/lib/models/getVehicleDetail.model.ts
+++ b/libs/api/domains/vehicles/src/lib/models/getVehicleDetail.model.ts
@@ -48,7 +48,7 @@ export class VehiclesMainInfo {
   @Field(() => Boolean, { nullable: true })
   availableMileageRegistration?: boolean
 
-  @Field(() => Boolean, { nullable: true })
+  @Field({ nullable: true })
   hasMilesOdometer?: boolean | null
 }
 

--- a/libs/api/domains/vehicles/src/lib/utils/basicVehicleInformationMapper.ts
+++ b/libs/api/domains/vehicles/src/lib/utils/basicVehicleInformationMapper.ts
@@ -66,6 +66,7 @@ export const basicVehicleInformationMapper = (
       requiresMileageRegistration: data.requiresMileageRegistration,
       canRegisterMileage: data.canRegisterMileage,
       availableMileageRegistration: data.availableMileageRegistration,
+      hasMilesOdometer: data.vehicleHasMilesOdometer,
     },
     basicInfo: {
       model: data.make,

--- a/libs/api/domains/vehicles/src/lib/utils/basicVehicleInformationMapper.ts
+++ b/libs/api/domains/vehicles/src/lib/utils/basicVehicleInformationMapper.ts
@@ -66,7 +66,7 @@ export const basicVehicleInformationMapper = (
       requiresMileageRegistration: data.requiresMileageRegistration,
       canRegisterMileage: data.canRegisterMileage,
       availableMileageRegistration: data.availableMileageRegistration,
-      hasMilesOdometer: data.vehicleHasMilesOdometer,
+      hasMilesOdometer: data.vehicleHasMilesOdometer ?? undefined,
     },
     basicInfo: {
       model: data.make,

--- a/libs/portals/my-pages/assets/src/screens/VehicleDetail/VehicleDetail.graphql
+++ b/libs/portals/my-pages/assets/src/screens/VehicleDetail/VehicleDetail.graphql
@@ -16,6 +16,7 @@ query GetUsersVehiclesDetail($input: GetVehicleDetailInput!) {
       requiresMileageRegistration
       canRegisterMileage
       availableMileageRegistration
+      hasMilesOdometer
     }
     basicInfo {
       model

--- a/libs/portals/my-pages/assets/src/screens/VehicleDetail/VehicleDetail.tsx
+++ b/libs/portals/my-pages/assets/src/screens/VehicleDetail/VehicleDetail.tsx
@@ -366,7 +366,7 @@ const VehicleDetail = () => {
               label={formatMessage(messages.lastKnownOdometerStatus)}
               content={displayWithUnit(
                 data.vehiclesDetail.latestMileageRegistration,
-                'km',
+                mainInfo?.hasMilesOdometer ? 'mi' : 'km',
                 true,
               )}
               loading={loading}

--- a/libs/portals/my-pages/assets/src/screens/VehicleMileage/VehicleDetail.graphql
+++ b/libs/portals/my-pages/assets/src/screens/VehicleMileage/VehicleDetail.graphql
@@ -37,6 +37,7 @@ query getCo2($input: VehiclesListInputV3!) {
     vehicleList {
       vehicleId
       co2
+      hasMilesOdometer
     }
   }
 }

--- a/libs/portals/my-pages/assets/src/screens/VehicleMileage/VehicleMileage.tsx
+++ b/libs/portals/my-pages/assets/src/screens/VehicleMileage/VehicleMileage.tsx
@@ -158,6 +158,7 @@ const VehicleMileage = () => {
 
   const hasMilesOdometer =
     co2?.vehiclesListV3?.vehicleList?.[0]?.hasMilesOdometer
+  const unit: 'mi' | 'km' = hasMilesOdometer ? 'mi' : 'km'
 
   const details = data?.vehicleMileageDetails?.data
   const hasData = details && details?.length > 0
@@ -285,7 +286,7 @@ const VehicleMileage = () => {
                     name="odometerStatus"
                     required
                     type="number"
-                    suffix=" km"
+                    suffix={' ' + unit}
                     thousandSeparator
                     decimalScale={0}
                     backgroundColor="blue"
@@ -424,7 +425,7 @@ const VehicleMileage = () => {
                             <Table.Data align="right">
                               {displayWithUnit(
                                 item.mileageNumber,
-                                hasMilesOdometer ? 'mi' : 'km',
+                                unit,
                                 true,
                               )}
                             </Table.Data>
@@ -450,7 +451,7 @@ const VehicleMileage = () => {
                     }}
                     yAxis={{
                       datakey: 'mileage',
-                      label: 'Km.',
+                      label: unit === 'mi' ? 'Mi.' : 'Km.',
                     }}
                     tooltip={{
                       labels: {

--- a/libs/portals/my-pages/assets/src/screens/VehicleMileage/VehicleMileage.tsx
+++ b/libs/portals/my-pages/assets/src/screens/VehicleMileage/VehicleMileage.tsx
@@ -156,6 +156,9 @@ const VehicleMileage = () => {
       },
     })
 
+  const hasMilesOdometer =
+    co2?.vehiclesListV3?.vehicleList?.[0]?.hasMilesOdometer
+
   const details = data?.vehicleMileageDetails?.data
   const hasData = details && details?.length > 0
   const isFormEditable = data?.vehicleMileageDetails?.editing
@@ -419,7 +422,11 @@ const VehicleMileage = () => {
                               {item.originCode}
                             </Table.Data>
                             <Table.Data align="right">
-                              {displayWithUnit(item.mileageNumber, 'km', true)}
+                              {displayWithUnit(
+                                item.mileageNumber,
+                                hasMilesOdometer ? 'mi' : 'km',
+                                true,
+                              )}
                             </Table.Data>
                           </Table.Row>
                         ))}

--- a/libs/portals/my-pages/assets/src/screens/VehicleMileage/VehicleMileage.tsx
+++ b/libs/portals/my-pages/assets/src/screens/VehicleMileage/VehicleMileage.tsx
@@ -423,11 +423,7 @@ const VehicleMileage = () => {
                               {item.originCode}
                             </Table.Data>
                             <Table.Data align="right">
-                              {displayWithUnit(
-                                item.mileageNumber,
-                                unit,
-                                true,
-                              )}
+                              {displayWithUnit(item.mileageNumber, unit, true)}
                             </Table.Data>
                           </Table.Row>
                         ))}


### PR DESCRIPTION
## What

* Adds hasMilesOdometer to the vehicles `MainInfo` object.
* Integreate mi display in vehicle detail as well.

## Why

* App needs hasMilesOdometer

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: claude code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `hasMilesOdometer` to vehicle detail and mileage data.
  - Vehicle detail now displays the odometer unit as **mi** (miles) or **km** (kilometers).
  - Vehicle mileage charts and tables now use the correct unit consistently (**Mi.**/**Km.**).

- **Bug Fixes**
  - Fixed mileage and odometer displays that previously always showed kilometers across vehicle detail and mileage overview screens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->