### PR TITLE
feat(application-system): Changing from generic 'þínar umsóknir to name of application'

### DIFF
--- a/apps/application-system/form/src/routes/Applications.tsx
+++ b/apps/application-system/form/src/routes/Applications.tsx
@@ -3,6 +3,7 @@ import React, { FC, useEffect, useState } from 'react'
 import { useParams, useLocation, useNavigate } from 'react-router-dom'
 import { useMutation } from '@apollo/client'
 import isEmpty from 'lodash/isEmpty'
+import isObject from 'lodash/isObject'
 import {
   CREATE_APPLICATION,
   APPLICATION_CARDS,
@@ -31,10 +32,13 @@ import {
 } from '@island.is/shared/problem'
 import { getApplicationTemplateByTypeId } from '@island.is/application/template-loader'
 import {
+  Application,
   ApplicationCard,
   ApplicationContext,
   ApplicationStateSchema,
+  ApplicationStatus,
   ApplicationTemplate,
+  ApplicationTypes,
 } from '@island.is/application/types'
 import { EventObject } from 'xstate'
 import { Organization } from '@island.is/shared/types'
@@ -42,6 +46,20 @@ import { Organization } from '@island.is/shared/types'
 type UseParams = {
   slug: string
 }
+
+const mockApplicationFromTypeId = (typeId: ApplicationTypes): Application => ({
+  id: '',
+  state: '',
+  applicant: '',
+  assignees: [],
+  applicantActors: [],
+  typeId,
+  modified: new Date(),
+  created: new Date(),
+  answers: {},
+  externalData: {},
+  status: ApplicationStatus.IN_PROGRESS,
+})
 
 export const Applications: FC<React.PropsWithChildren<unknown>> = () => {
   const { slug } = useParams() as UseParams
@@ -203,6 +221,23 @@ export const Applications: FC<React.PropsWithChildren<unknown>> = () => {
       : template.allowMultipleApplicationsInDraft ||
         numberOfApplicationsInDraft < 1
 
+  const getTemplateName = () => {
+    if (typeof template.name === 'function') {
+      const returnValue = template.name(mockApplicationFromTypeId(type))
+      if (
+        isObject(returnValue) &&
+        'value' in returnValue &&
+        'name' in returnValue
+      ) {
+        return formatMessage(returnValue.name, {
+          value: returnValue.value,
+        })
+      }
+      return formatMessage(returnValue)
+    }
+    return formatMessage(template.name)
+  }
+
   return (
     <Page>
       <GridContainer>
@@ -218,7 +253,7 @@ export const Applications: FC<React.PropsWithChildren<unknown>> = () => {
               <Text variant="h1">
                 {template.applicationText
                   ? formatMessage(template.applicationText)
-                  : formatMessage(coreMessages.applications)}
+                  : getTemplateName()}
               </Text>
               {shouldRenderNewApplicationButton ? (
                 <Box marginTop={[2, 0]}>


### PR DESCRIPTION
Changing the title from "Þínar umsóknir" to the name of the application for the overview screen per application (Request from Vésteinn)

## Before
<img width="1429" height="492" alt="image" src="https://github.com/user-attachments/assets/15a1e2c7-211b-4d23-b671-1eef3f174ff7" />


## After
<img width="1414" height="497" alt="image" src="https://github.com/user-attachments/assets/b637407c-8054-4e08-923d-b7d67b60804b" />



Attach a link to issue if relevant

## What

Specify what you're trying to achieve

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [X] AI tools were used in preparing this pull request
      Tools used: Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Application pages now display titles based on the selected application template.
  * Templates can provide either fixed names or dynamically generated, formatted titles.
* **Bug Fixes**
  * Improved title handling for templates with different naming formats, ensuring a suitable title is shown in all supported cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->