### PR TITLE
fix(service-portal): Fixing 0 index navigation and re-renders for dynamic routes

### DIFF
--- a/libs/portals/my-pages/core/src/components/Navigation/Navigation.tsx
+++ b/libs/portals/my-pages/core/src/components/Navigation/Navigation.tsx
@@ -162,7 +162,7 @@ export const Navigation: FC<React.PropsWithChildren<NavigationProps>> = ({
   mobileNavigationButtonOpenLabel = 'Open',
   mobileNavigationButtonCloseLabel = 'Close',
 }) => {
-  // First-level accordion ids that match the current route. `items` is
+  // First-level accordion ids that match the current route. 'items' is
   // recomputed whenever the route changes (and when async sub-routes finish loading)
   // so this must stay in sync rather than being seeded only once on mount.
   const activeAccordionIds = useMemo(
@@ -174,8 +174,11 @@ export const Navigation: FC<React.PropsWithChildren<NavigationProps>> = ({
     [items],
   )
 
-  const [activeAccordions, setActiveAccordions] =
-    useState<Array<string>>(activeAccordionIds)
+  const [activeAccordions, setActiveAccordions] = useState<Array<string>>(
+    // In single-accordion mode only one may be open, so seed with the active
+    // route only (last one wins if several match, mirroring toggle behaviour).
+    singleAccordion ? activeAccordionIds.slice(-1) : activeAccordionIds,
+  )
 
   // Expand the accordion for the active route when navigating to a sub-path or
   // when its children finish loading.
@@ -184,13 +187,21 @@ export const Navigation: FC<React.PropsWithChildren<NavigationProps>> = ({
       return
     }
     setActiveAccordions((prev) => {
+      if (singleAccordion) {
+        // Only one accordion may be open; the active route replaces whatever
+        // was open. Return prev unchanged if it already matches to skip a render.
+        const next = activeAccordionIds.slice(-1)
+        return prev.length === next.length && prev[0] === next[0] ? prev : next
+      }
+      // Additive: open the active accordion(s) without closing ones the user
+      // opened manually.
       const missing = activeAccordionIds.filter((id) => !prev.includes(id))
       return missing.length ? [...prev, ...missing] : prev
     })
     // This useEffect would fire every re-render since activeAccordionIds
     // is a new array every render, Using join() so it only runs when content changes
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [activeAccordionIds.join('|')])
+  }, [activeAccordionIds.join('|'), singleAccordion])
 
   const color = colorSchemeColors[colorScheme]['color']
   const activeColor = colorSchemeColors[colorScheme]['activeColor']

--- a/libs/portals/my-pages/core/src/components/Navigation/Navigation.tsx
+++ b/libs/portals/my-pages/core/src/components/Navigation/Navigation.tsx
@@ -16,6 +16,7 @@ import React, {
   ReactElement,
   ReactNode,
   useEffect,
+  useMemo,
   useState,
 } from 'react'
 import AnimateHeight from 'react-animate-height'
@@ -161,27 +162,35 @@ export const Navigation: FC<React.PropsWithChildren<NavigationProps>> = ({
   mobileNavigationButtonOpenLabel = 'Open',
   mobileNavigationButtonCloseLabel = 'Close',
 }) => {
-  const [activeAccordions, setActiveAccordions] = useState<Array<string>>(
-    () => {
-      const initialActivePathIndex = items?.findIndex(
-        (item) => item.active && item.accordion,
-      )
-
-      if (initialActivePathIndex > 0) {
-        //first level only
-        return [
-          `1-${items?.findIndex(
-            (item) =>
-              item.active &&
-              item.accordion &&
-              item.items?.some((child) => child.active),
-          )}`,
-        ]
-      }
-
-      return []
-    },
+  // First-level accordion ids that match the current route. `items` is
+  // recomputed whenever the route changes (and when async sub-routes finish loading)
+  // so this must stay in sync rather than being seeded only once on mount.
+  const activeAccordionIds = useMemo(
+    () =>
+      (items ?? [])
+        .map((item, index) => ({ item, index }))
+        .filter(({ item }) => item.accordion && item.active)
+        .map(({ index }) => `1-${index}`),
+    [items],
   )
+
+  const [activeAccordions, setActiveAccordions] =
+    useState<Array<string>>(activeAccordionIds)
+
+  // Expand the accordion for the active route when navigating to a sub-path or
+  // when its children finish loading.
+  useEffect(() => {
+    if (activeAccordionIds.length === 0) {
+      return
+    }
+    setActiveAccordions((prev) => {
+      const missing = activeAccordionIds.filter((id) => !prev.includes(id))
+      return missing.length ? [...prev, ...missing] : prev
+    })
+    // This useEffect would fire every re-render since activeAccordionIds
+    // is a new array every render, Using join() so it only runs when content changes
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeAccordionIds.join('|')])
 
   const color = colorSchemeColors[colorScheme]['color']
   const activeColor = colorSchemeColors[colorScheme]['activeColor']


### PR DESCRIPTION
Navigation would not expand automatically on item on index 0, additionally it could not automatically expand on dynamic routes

## Before

https://github.com/user-attachments/assets/c7caacce-2d46-4130-b9c1-ad51de76028c

## After

https://github.com/user-attachments/assets/cd16f05d-fdf2-454a-8de6-3dca11ca5084

Attach a link to issue if relevant

## What

Specify what you're trying to achieve

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [X] AI tools were used in preparing this pull request
      Tools used: Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Navigation accordions now remain synchronized as navigation items and routes change, including deeper sub-route updates.
  * Active accordion state updates more reliably when items are updated, avoiding stale or incorrect expanded sections (with improved behavior for single vs. multi accordion modes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->