### PR TITLE
feat(services-payments): use Blikk's scaRedirectUrl

### DIFF
--- a/apps/payments/components/BankTransferPendingScreen/BankTransferPendingScreen.tsx
+++ b/apps/payments/components/BankTransferPendingScreen/BankTransferPendingScreen.tsx
@@ -1,4 +1,5 @@
 import {
+  AlertMessage,
   Box,
   Button,
   Hidden,
@@ -88,9 +89,10 @@ export const BankTransferPendingScreen = ({
       )}
 
       {isScaOutstanding && (
-        <Text variant="small" color="dark400" textAlign="center">
-          {formatMessage(bankTransfer.cancelInBankAppNote)}
-        </Text>
+        <AlertMessage
+          type="info"
+          message={formatMessage(bankTransfer.cancelInBankAppNote)}
+        />
       )}
     </Box>
   )

--- a/apps/services/payments/src/app/bankTransferPayment/bankTransfer.service.spec.ts
+++ b/apps/services/payments/src/app/bankTransferPayment/bankTransfer.service.spec.ts
@@ -1492,7 +1492,7 @@ describe('BankTransferService', () => {
       expect(result).toBeNull()
     })
 
-    it('refreshes from Blikk on fresh PENDING and surfaces BANK_TRANSFER_PENDING when still pending', async () => {
+    it('refreshes from Blikk on fresh PENDING; at SCA_REQUIRED it trusts Blikk and surfaces no redirect URL when Blikk omits one', async () => {
       bankTransferPaymentModel.findOne.mockResolvedValue(baseRow)
       const getPaymentSpy = mockGetPayment(
         BankTransferStatus.PENDING,
@@ -1513,10 +1513,12 @@ describe('BankTransferService', () => {
           },
         },
       )
+      // At SCA_REQUIRED Blikk is authoritative for the URL: it omitted one (back-channel SCA), so we
+      // surface none rather than resurrecting the row's creation-time URL.
       expect(result).toEqual({
         paymentStatus: PaymentStatus.BANK_TRANSFER_PENDING,
         updatedAt: baseRow.modified,
-        bankTransferScaRedirectUrl: 'https://blikk/sca',
+        bankTransferScaRedirectUrl: undefined,
         bankTransferExpiresAt: baseRow.expiresAt,
         bankTransferPendingStatus: BankTransferPendingStatus.SCA_REQUIRED,
       })

--- a/apps/services/payments/src/app/bankTransferPayment/bankTransfer.service.ts
+++ b/apps/services/payments/src/app/bankTransferPayment/bankTransfer.service.ts
@@ -209,10 +209,6 @@ export class BankTransferService {
     await this.finalizeFromBlikkResult(row, result)
 
     const isPending = result.status === BankTransferStatus.PENDING
-    // At SCA_REQUIRED, Blikk is authoritative for the SCA URL just as it is for status: an omitted URL
-    // is intentional (SCA moved to the bank-app back-channel), so we surface exactly what the fresh
-    // response carries and never resurrect a persisted one. Before SCA_REQUIRED (DRAFT/PENDING) Blikk's
-    // GET may simply not echo the creation-time URL, so we keep the row's URL to avoid a dots→QR flicker.
     const scaRedirectUrl =
       result.rawStatus === 'SCA_REQUIRED'
         ? result.scaRedirectUrl
@@ -441,9 +437,6 @@ export class BankTransferService {
     }
 
     if (mapped === BankTransferStatus.PENDING) {
-      // At SCA_REQUIRED, trust the fresh Blikk response — an omitted URL is intentional (back-channel
-      // SCA), so surface exactly what it carries. Before SCA_REQUIRED, or when Blikk was unreachable
-      // (no fresh response), keep the last-known row URL to avoid blanking the QR mid-DRAFT.
       const scaRedirectUrl =
         refreshed?.rawStatus === 'SCA_REQUIRED'
           ? refreshed.scaRedirectUrl

--- a/apps/services/payments/src/app/bankTransferPayment/bankTransfer.service.ts
+++ b/apps/services/payments/src/app/bankTransferPayment/bankTransfer.service.ts
@@ -209,8 +209,23 @@ export class BankTransferService {
     await this.finalizeFromBlikkResult(row, result)
 
     const isPending = result.status === BankTransferStatus.PENDING
+    // At SCA_REQUIRED, Blikk is authoritative for the SCA URL just as it is for status: an omitted URL
+    // is intentional (SCA moved to the bank-app back-channel), so we surface exactly what the fresh
+    // response carries and never resurrect a persisted one. Before SCA_REQUIRED (DRAFT/PENDING) Blikk's
+    // GET may simply not echo the creation-time URL, so we keep the row's URL to avoid a dots→QR flicker.
     const scaRedirectUrl =
-      result.scaRedirectUrl ?? row.scaRedirectUrl ?? undefined
+      result.rawStatus === 'SCA_REQUIRED'
+        ? result.scaRedirectUrl
+        : result.scaRedirectUrl ?? row.scaRedirectUrl ?? undefined
+
+    // Diagnostic: on a raw Blikk SCA_REQUIRED, record whether Blikk sent its own SCA URL, and whether
+    // we dropped a persisted row URL by trusting Blikk's omission. Booleans only — no URL logged.
+    if (isPending && result.rawStatus === 'SCA_REQUIRED') {
+      this.logger.info(`[${row.paymentFlowId}] SCA_REQUIRED verify`, {
+        blikkSentScaUrl: !!result.scaRedirectUrl,
+        droppedRowUrl: !result.scaRedirectUrl && !!row.scaRedirectUrl,
+      })
+    }
 
     return {
       status: result.status,
@@ -426,9 +441,13 @@ export class BankTransferService {
     }
 
     if (mapped === BankTransferStatus.PENDING) {
-      // Prefer the just-refreshed URL — the in-memory row predates any persist above.
+      // At SCA_REQUIRED, trust the fresh Blikk response — an omitted URL is intentional (back-channel
+      // SCA), so surface exactly what it carries. Before SCA_REQUIRED, or when Blikk was unreachable
+      // (no fresh response), keep the last-known row URL to avoid blanking the QR mid-DRAFT.
       const scaRedirectUrl =
-        refreshed?.scaRedirectUrl ?? row.scaRedirectUrl ?? undefined
+        refreshed?.rawStatus === 'SCA_REQUIRED'
+          ? refreshed.scaRedirectUrl
+          : refreshed?.scaRedirectUrl ?? row.scaRedirectUrl ?? undefined
       return {
         paymentStatus: PaymentStatus.BANK_TRANSFER_PENDING,
         updatedAt: row.modified,


### PR DESCRIPTION
## What

- Stop resurrecting the persisted `scaRedirectUrl` when Blikk omits it at `SCA_REQUIRED`. The fallback to the row's URL is kept for `DRAFT`/`PENDING` and when Blikk is unreachable.
- Add a booleans-only diagnostic log on `SCA_REQUIRED` verify (`blikkSentScaUrl`, `droppedRowUrl`) to observe provider behaviour vs our fallback.
- Render the cancel-in-bank-app note as an island-ui `AlertMessage` info box on the bank-transfer pending screen.

## Why

- At `SCA_REQUIRED`, Blikk moves SCA to the bank-app back-channel and omits the redirect URL on purpose; serving a stale persisted URL sent payers a QR/deep link they should not get, contradicting the pending screen's "check your phone" state. Blikk is authoritative for the URL there, just as for status.
- The fallback stays for `DRAFT`/`PENDING`, where Blikk's `GET` simply may not echo the creation-time URL yet — dropping it there would flicker the QR back to loading dots after create.
- The log makes the provider-vs-fallback question observable without leaking any URL (booleans + flow id only).
- The cancel note is important guidance once SCA is under way (the payment can no longer be cancelled from our side), so it deserves an info box rather than small grey caption text.


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an informational alert on pending bank transfers explaining when confirmation must be completed in the banking app.

* **Bug Fixes**
  * Improved handling of security verification redirects during bank transfers by using Blikk’s redirect URL only when SCA is required, and otherwise preserving any previously available redirect.
  * Corrected pending-status behavior when SCA is required but Blikk does not provide a redirect URL.
  
* **Tests**
  * Updated/added coverage for the pending SCA-required redirect-omission scenario.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->