### PR TITLE
feat(services-payments): use Blikk's scaRedirectUrl (#23246)

### DIFF
--- a/apps/payments/components/BankTransferPendingScreen/BankTransferPendingScreen.tsx
+++ b/apps/payments/components/BankTransferPendingScreen/BankTransferPendingScreen.tsx
@@ -1,4 +1,5 @@
 import {
+  AlertMessage,
   Box,
   Button,
   Hidden,
@@ -88,9 +89,10 @@ export const BankTransferPendingScreen = ({
       )}
 
       {isScaOutstanding && (
-        <Text variant="small" color="dark400" textAlign="center">
-          {formatMessage(bankTransfer.cancelInBankAppNote)}
-        </Text>
+        <AlertMessage
+          type="info"
+          message={formatMessage(bankTransfer.cancelInBankAppNote)}
+        />
       )}
     </Box>
   )

--- a/apps/services/payments/src/app/bankTransferPayment/bankTransfer.service.spec.ts
+++ b/apps/services/payments/src/app/bankTransferPayment/bankTransfer.service.spec.ts
@@ -1492,7 +1492,7 @@ describe('BankTransferService', () => {
       expect(result).toBeNull()
     })
 
-    it('refreshes from Blikk on fresh PENDING and surfaces BANK_TRANSFER_PENDING when still pending', async () => {
+    it('refreshes from Blikk on fresh PENDING; at SCA_REQUIRED it trusts Blikk and surfaces no redirect URL when Blikk omits one', async () => {
       bankTransferPaymentModel.findOne.mockResolvedValue(baseRow)
       const getPaymentSpy = mockGetPayment(
         BankTransferStatus.PENDING,
@@ -1513,10 +1513,12 @@ describe('BankTransferService', () => {
           },
         },
       )
+      // At SCA_REQUIRED Blikk is authoritative for the URL: it omitted one (back-channel SCA), so we
+      // surface none rather than resurrecting the row's creation-time URL.
       expect(result).toEqual({
         paymentStatus: PaymentStatus.BANK_TRANSFER_PENDING,
         updatedAt: baseRow.modified,
-        bankTransferScaRedirectUrl: 'https://blikk/sca',
+        bankTransferScaRedirectUrl: undefined,
         bankTransferExpiresAt: baseRow.expiresAt,
         bankTransferPendingStatus: BankTransferPendingStatus.SCA_REQUIRED,
       })

--- a/apps/services/payments/src/app/bankTransferPayment/bankTransfer.service.ts
+++ b/apps/services/payments/src/app/bankTransferPayment/bankTransfer.service.ts
@@ -210,7 +210,18 @@ export class BankTransferService {
 
     const isPending = result.status === BankTransferStatus.PENDING
     const scaRedirectUrl =
-      result.scaRedirectUrl ?? row.scaRedirectUrl ?? undefined
+      result.rawStatus === 'SCA_REQUIRED'
+        ? result.scaRedirectUrl
+        : result.scaRedirectUrl ?? row.scaRedirectUrl ?? undefined
+
+    // Diagnostic: on a raw Blikk SCA_REQUIRED, record whether Blikk sent its own SCA URL, and whether
+    // we dropped a persisted row URL by trusting Blikk's omission. Booleans only — no URL logged.
+    if (isPending && result.rawStatus === 'SCA_REQUIRED') {
+      this.logger.info(`[${row.paymentFlowId}] SCA_REQUIRED verify`, {
+        blikkSentScaUrl: !!result.scaRedirectUrl,
+        droppedRowUrl: !result.scaRedirectUrl && !!row.scaRedirectUrl,
+      })
+    }
 
     return {
       status: result.status,
@@ -426,9 +437,10 @@ export class BankTransferService {
     }
 
     if (mapped === BankTransferStatus.PENDING) {
-      // Prefer the just-refreshed URL — the in-memory row predates any persist above.
       const scaRedirectUrl =
-        refreshed?.scaRedirectUrl ?? row.scaRedirectUrl ?? undefined
+        refreshed?.rawStatus === 'SCA_REQUIRED'
+          ? refreshed.scaRedirectUrl
+          : refreshed?.scaRedirectUrl ?? row.scaRedirectUrl ?? undefined
       return {
         paymentStatus: PaymentStatus.BANK_TRANSFER_PENDING,
         updatedAt: row.modified,


### PR DESCRIPTION
* feat(payments): trust Blikk SCA URL at SCA_REQUIRED, log status, info box for cancel note

- Stop resurrecting the persisted scaRedirectUrl when Blikk omits it at SCA_REQUIRED (back-channel SCA); keep the fallback for DRAFT/PENDING and when Blikk is unreachable, so the QR does not flicker after create.
- Log Blikk's SCA URL presence on SCA_REQUIRED verify (booleans only) to confirm provider behaviour vs our fallback.
- Render the cancel-in-bank-app note as an AlertMessage info box.

* fix comments

* test(services-payments): expect no SCA URL at SCA_REQUIRED when Blikk omits it

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [x] No AI tools were used in preparing this pull request
- [ ] AI tools were used in preparing this pull request
      Tools used:
