### PR TITLE
fix(payments): send required 3DS data and handle incomplete verification callbacks

### DIFF
--- a/apps/payments/components/CardPayment/CardPayment.tsx
+++ b/apps/payments/components/CardPayment/CardPayment.tsx
@@ -11,6 +11,7 @@ import { validateCardCVC, validateCardExpiry } from './CardPayment.utils'
 const APPLE_PAY_BUTTON_ID = 'apple-pay-button'
 
 interface CardPaymentInput {
+  cardholderName: string
   card: string
   cardExpiry: string
   cardCVC: string
@@ -84,6 +85,30 @@ export const CardPayment = ({
         </>
       )}
       <Box display="flex" flexDirection="column" rowGap={[2, 3]}>
+        <Controller
+          name={'cardholderName'}
+          control={control}
+          rules={{
+            required: formatMessage(cardValidationError.cardholderName),
+            validate: (value) => {
+              if (value.trim().length < 2) {
+                return formatMessage(cardValidationError.cardholderNameTooShort)
+              }
+              return true
+            },
+          }}
+          render={({ field }) => (
+            <Input
+              {...field}
+              backgroundColor="blue"
+              label={formatMessage(card.cardholderName)}
+              placeholder={formatMessage(card.cardholderNamePlaceholder)}
+              size="sm"
+              maxLength={45}
+              errorMessage={formState.errors.cardholderName?.message}
+            />
+          )}
+        />
         <Controller
           name={'card'}
           control={control}

--- a/apps/payments/hooks/useCardPayment.ts
+++ b/apps/payments/hooks/useCardPayment.ts
@@ -15,6 +15,7 @@ import {
   useGetVerificationStatusLazyQuery,
 } from '../graphql/queries.graphql.generated'
 import { findProblemInApolloError } from '@island.is/shared/problem'
+import { getBrowserInfo } from '../utils/browserInfo'
 import { PaymentError } from '../utils/error/error'
 import { ApolloError } from '@apollo/client'
 
@@ -26,6 +27,7 @@ interface UseCardPaymentProps {
 }
 
 interface CardPaymentData {
+  cardholderName: string
   number: string
   expiryMonth: number
   expiryYear: number
@@ -180,6 +182,10 @@ export const useCardPayment = ({
           expiryMonth: cardData.expiryMonth,
           expiryYear: cardData.expiryYear,
           paymentFlowId: paymentFlow.id,
+          // 3-D Secure authentication data: who the cardholder is and the
+          // browser environment the authentication happens in.
+          cardholderName: cardData.cardholderName,
+          browserInfo: getBrowserInfo(),
         })
 
         if (!verifyCardResponse.isSuccess) {

--- a/apps/payments/hooks/usePaymentOrchestration.ts
+++ b/apps/payments/hooks/usePaymentOrchestration.ts
@@ -126,8 +126,9 @@ export const usePaymentOrchestration = ({
 
       try {
         if (selectedPaymentMethod === 'card') {
-          const { card, cardExpiry, cardCVC } = data
+          const { cardholderName, card, cardExpiry, cardCVC } = data
           if (
+            !cardholderName ||
             !card ||
             !cardExpiry ||
             typeof cardExpiry !== 'string' ||
@@ -139,6 +140,7 @@ export const usePaymentOrchestration = ({
           }
           const [month, year] = cardExpiry.split('/')
           await cardPayment.processCardPayment({
+            cardholderName,
             number: card,
             expiryMonth: Number(month),
             expiryYear: Number(year),

--- a/apps/payments/messages/3ds.ts
+++ b/apps/payments/messages/3ds.ts
@@ -11,4 +11,15 @@ export const threeDSecure = defineMessages({
     defaultMessage: 'Hinkraðu á meðan við klárum greiðslu',
     description: 'Please wait while we finish the payment',
   },
+  failedTitle: {
+    id: 'payments:threeDSecure.failedTitle',
+    defaultMessage: 'Greiðslan tókst ekki',
+    description: 'Shown when the card payment / 3DS step did not complete',
+  },
+  failedMessage: {
+    id: 'payments:threeDSecure.failedMessage',
+    defaultMessage:
+      'Ekki tókst að ljúka greiðslunni. Reyndu aftur eða veldu annan greiðslumáta.',
+    description: 'Shown in the 3DS iframe when the payment did not complete',
+  },
 })

--- a/apps/payments/messages/card.ts
+++ b/apps/payments/messages/card.ts
@@ -6,6 +6,16 @@ export const card = defineMessages({
     defaultMessage: 'Greiðslukort',
     description: 'Title for card payment method',
   },
+  cardholderName: {
+    id: 'payments:card.cardholderName',
+    defaultMessage: 'Nafn korthafa',
+    description: 'Cardholder name',
+  },
+  cardholderNamePlaceholder: {
+    id: 'payments:card.cardholderNamePlaceholder',
+    defaultMessage: 'Nafn eins og það birtist á korti',
+    description: 'Cardholder name placeholder (name as printed on the card)',
+  },
   cardNumber: {
     id: 'payments:card.cardNumber',
     defaultMessage: 'Kortanúmer',
@@ -106,6 +116,16 @@ export const cardValidationError = defineMessages({
     id: 'payments:validationError.card.cardCVCTooShortError',
     defaultMessage: 'Öryggiskóði er of stuttur',
     description: 'Card CVC is too short',
+  },
+  cardholderName: {
+    id: 'payments:validationError.card.cardholderNameError',
+    defaultMessage: 'Nafn korthafa er nauðsynlegt',
+    description: 'Cardholder name is required',
+  },
+  cardholderNameTooShort: {
+    id: 'payments:validationError.card.cardholderNameTooShortError',
+    defaultMessage: 'Nafn korthafa er of stutt',
+    description: 'Cardholder name is too short',
   },
 })
 

--- a/apps/payments/pages/3ds/index.tsx
+++ b/apps/payments/pages/3ds/index.tsx
@@ -1,3 +1,5 @@
+import { GetServerSideProps } from 'next'
+
 import { LoadingDots, Text } from '@island.is/island-ui/core'
 import { useLocale } from '@island.is/localization'
 
@@ -5,8 +7,25 @@ import { PaymentCompleteIcon } from '../../components/PaymentCompleteIcon'
 import { threeDSecure } from '../../messages'
 import { withLocale } from '../../i18n/withLocale'
 
+interface ThreeDSecurePageProps {
+  hasFailed: boolean
+}
+
+export const getServerSideProps: GetServerSideProps<
+  ThreeDSecurePageProps
+> = async (context) => {
+  // The card verification callback redirects here with `?status=failed` when the ACS
+  // returned an incomplete or invalid result. Resolve it on the server so the failure
+  // state never briefly renders the success screen during hydration.
+  return {
+    props: {
+      hasFailed: context.query.status === 'failed',
+    },
+  }
+}
+
 // eslint-disable-next-line func-style
-function ThreeDSecureSuccessPage() {
+function ThreeDSecurePage({ hasFailed }: ThreeDSecurePageProps) {
   const { formatMessage } = useLocale()
 
   return (
@@ -23,18 +42,29 @@ function ThreeDSecureSuccessPage() {
         width: '100%',
       }}
     >
-      <PaymentCompleteIcon />
-
-      <Text as="h1" variant="h1" marginTop={2}>
-        {formatMessage(threeDSecure.title)}
-      </Text>
-      <Text marginTop={1} marginBottom={4}>
-        {formatMessage(threeDSecure.pleaseWait)}
-      </Text>
-
-      <LoadingDots />
+      {hasFailed ? (
+        <>
+          <Text as="h1" variant="h1" marginTop={2}>
+            {formatMessage(threeDSecure.failedTitle)}
+          </Text>
+          <Text marginTop={1} marginBottom={4}>
+            {formatMessage(threeDSecure.failedMessage)}
+          </Text>
+        </>
+      ) : (
+        <>
+          <PaymentCompleteIcon />
+          <Text as="h1" variant="h1" marginTop={2}>
+            {formatMessage(threeDSecure.title)}
+          </Text>
+          <Text marginTop={1} marginBottom={4}>
+            {formatMessage(threeDSecure.pleaseWait)}
+          </Text>
+          <LoadingDots />
+        </>
+      )}
     </div>
   )
 }
 
-export default withLocale(ThreeDSecureSuccessPage)
+export default withLocale(ThreeDSecurePage)

--- a/apps/payments/pages/[locale]/[paymentFlowId]/index.tsx
+++ b/apps/payments/pages/[locale]/[paymentFlowId]/index.tsx
@@ -253,6 +253,7 @@ function PaymentPage({
     mode: 'onBlur',
     reValidateMode: 'onChange',
     defaultValues: {
+      cardholderName: '',
       card: '',
       cardExpiry: '',
       cardCVC: '',

--- a/apps/payments/pages/api/card/callback.ts
+++ b/apps/payments/pages/api/card/callback.ts
@@ -12,6 +12,13 @@ import {
   VerificationCallbackDocument,
 } from '../../../graphql/mutations.graphql.generated'
 
+// The 3-D Secure ACS posts the verification result here as
+// application/x-www-form-urlencoded. `cavv` and `TDS2.dsTransID` are only present on a
+// completed authentication (mdStatus success). A schema miss therefore signals an
+// incomplete or invalid callback — a declined/attempted/abandoned authentication, but
+// possibly also a malformed request or a changed provider contract. In every case it is
+// a return-flow outcome, not a server crash: throwing renders a broken 500 page inside
+// the ACS iframe and blocks the payer, so we redirect to the failure screen instead.
 const VerificationCallbackSchema = z.object({
   xid: z.string().min(1, 'xid is required'),
   mdStatus: z.string().min(1, 'mdStatus status is required'),
@@ -20,24 +27,61 @@ const VerificationCallbackSchema = z.object({
   ['TDS2.dsTransID']: z.string().min(1, 'TDS2.dsTransID is required'),
 })
 
+// POST/Redirect/GET back to the (GET) result page. 303 (not 307) so the browser issues a
+// GET and the sensitive 3DS callback fields are not re-posted to the page route.
+const SUCCESS_REDIRECT = '/greida/3ds'
+const FAILURE_REDIRECT = '/greida/3ds?status=failed'
+
 export default async function cardVerificationCallbackHandler(
   req: NextApiRequest,
-  res: NextApiResponse<any>,
+  res: NextApiResponse<unknown>,
 ) {
   if (req.method !== 'POST') {
     return res.status(400).json({ error: 'Method not allowed' })
   }
 
-  const contentType = req.headers['content-type']
+  // The ACS may append parameters, e.g. `application/x-www-form-urlencoded; charset=UTF-8`,
+  // so match on the media type rather than requiring exact equality.
+  const contentType = req.headers['content-type'] ?? ''
 
-  if (contentType !== 'application/x-www-form-urlencoded') {
-    return res.status(400).json({ error: 'Invalid content-type' })
+  if (!contentType.startsWith('application/x-www-form-urlencoded')) {
+    console.error('Card verification callback: unexpected content-type', {
+      contentType: contentType.split(';')[0] || null,
+    })
+    return res.redirect(303, FAILURE_REDIRECT)
   }
 
-  const parsed = VerificationCallbackSchema.parse(req.body)
+  const parsed = VerificationCallbackSchema.safeParse(req.body)
 
-  const { xid, mdStatus, MD, cavv } = parsed
-  const dsTransId = parsed['TDS2.dsTransID']
+  if (!parsed.success) {
+    // The callback was incomplete or invalid (declined/attempted/abandoned auth, a
+    // malformed request, or a changed provider contract). Log booleans + mdStatus only
+    // (never the raw 3DS payload or cardholder data) so the outcome can be triaged, then
+    // send the payer to the failure screen instead of crashing.
+    const body = (req.body ?? {}) as Record<string, unknown>
+    const isPresent = (key: string) => {
+      const value = body[key]
+      return typeof value === 'string' && value.length > 0
+    }
+    const requiredFields = ['xid', 'mdStatus', 'MD', 'cavv', 'TDS2.dsTransID']
+
+    console.error(
+      'Card verification callback: incomplete or invalid callback',
+      {
+        mdStatus: typeof body.mdStatus === 'string' ? body.mdStatus : null,
+        hasXid: isPresent('xid'),
+        hasMd: isPresent('MD'),
+        hasCavv: isPresent('cavv'),
+        hasDsTransId: isPresent('TDS2.dsTransID'),
+        missingFields: requiredFields.filter((key) => !isPresent(key)),
+      },
+    )
+
+    return res.redirect(303, FAILURE_REDIRECT)
+  }
+
+  const { xid, mdStatus, MD, cavv } = parsed.data
+  const dsTransId = parsed.data['TDS2.dsTransID']
 
   const client = initApollo()
 
@@ -71,18 +115,19 @@ export default async function cardVerificationCallbackHandler(
     })
 
     if (errors) {
-      return res.status(503).json({ error: 'Unknown error occured' })
+      console.error(
+        'Card verification callback: verify mutation returned errors',
+      )
+      return res.redirect(303, FAILURE_REDIRECT)
     }
 
-    return res.redirect(307, `/greida/3ds`)
+    return res.redirect(303, SUCCESS_REDIRECT)
   } catch (e) {
     const problem = findProblemInApolloError(e)
-
-    if (problem?.detail) {
-      return res.status(400).json({ error: problem.detail })
-    }
-
-    console.error(e)
-    return res.status(503).json({ error: 'Unknown error occured' })
+    console.error('Card verification callback: verify mutation failed', {
+      detail:
+        problem?.detail ?? (e instanceof Error ? e.message : 'unknown error'),
+    })
+    return res.redirect(303, FAILURE_REDIRECT)
   }
 }

--- a/apps/payments/specs/cardCallback.spec.ts
+++ b/apps/payments/specs/cardCallback.spec.ts
@@ -1,0 +1,134 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+
+import initApollo from '../graphql/client'
+import handler from '../pages/api/card/callback'
+
+jest.mock('../graphql/client', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}))
+
+jest.mock('next/config', () => () => ({
+  serverRuntimeConfig: { verificationCallbackSigningSecret: 'test-secret' },
+}))
+
+jest.mock('jsonwebtoken', () => ({
+  sign: jest.fn(() => 'signed-token'),
+}))
+
+jest.mock('../graphql/mutations.graphql.generated', () => ({
+  VerificationCallbackDocument: 'VerificationCallbackDocument',
+}))
+
+const SUCCESS_REDIRECT = '/greida/3ds'
+const FAILURE_REDIRECT = '/greida/3ds?status=failed'
+const FORM_CONTENT_TYPE = 'application/x-www-form-urlencoded'
+
+// A completed 3-D Secure authentication returns the cryptogram fields.
+const completedAuthBody = {
+  xid: 'xid-1',
+  mdStatus: 'Y',
+  MD: 'md-1',
+  cavv: 'cavv-1',
+  'TDS2.dsTransID': 'ds-1',
+}
+
+const mockMutate = jest.fn()
+
+const createRes = () => {
+  const res = {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn().mockReturnThis(),
+    redirect: jest.fn().mockReturnThis(),
+  }
+  return res as unknown as NextApiResponse & typeof res
+}
+
+const createReq = (overrides: Partial<NextApiRequest> = {}) =>
+  ({
+    method: 'POST',
+    headers: { 'content-type': FORM_CONTENT_TYPE },
+    body: completedAuthBody,
+    ...overrides,
+  } as unknown as NextApiRequest)
+
+describe('card verification callback handler', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    ;(initApollo as unknown as jest.Mock).mockReturnValue({
+      mutate: mockMutate,
+    })
+    mockMutate.mockResolvedValue({ errors: undefined })
+    jest.spyOn(console, 'error').mockImplementation(() => undefined)
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('verifies a completed authentication and redirects to the success page with 303', async () => {
+    const res = createRes()
+
+    await handler(createReq(), res)
+
+    expect(mockMutate).toHaveBeenCalledTimes(1)
+    expect(res.redirect).toHaveBeenCalledWith(303, SUCCESS_REDIRECT)
+  })
+
+  it('accepts a content-type that includes charset parameters', async () => {
+    const res = createRes()
+
+    await handler(
+      createReq({
+        headers: { 'content-type': `${FORM_CONTENT_TYPE}; charset=UTF-8` },
+      }),
+      res,
+    )
+
+    expect(mockMutate).toHaveBeenCalledTimes(1)
+    expect(res.redirect).toHaveBeenCalledWith(303, SUCCESS_REDIRECT)
+  })
+
+  it('redirects to the failure page (303) without verifying when cavv/dsTransID are missing', async () => {
+    const res = createRes()
+
+    // The ACS returned a non-authenticated result: mdStatus present, no cryptogram.
+    await handler(
+      createReq({ body: { xid: 'xid-1', mdStatus: 'N', MD: 'md-1' } }),
+      res,
+    )
+
+    expect(mockMutate).not.toHaveBeenCalled()
+    expect(res.redirect).toHaveBeenCalledWith(303, FAILURE_REDIRECT)
+  })
+
+  it('redirects to the failure page when the verification mutation returns errors', async () => {
+    mockMutate.mockResolvedValue({ errors: [{ message: 'boom' }] })
+    const res = createRes()
+
+    await handler(createReq(), res)
+
+    expect(res.redirect).toHaveBeenCalledWith(303, FAILURE_REDIRECT)
+  })
+
+  it('redirects to the failure page on an unexpected content-type', async () => {
+    const res = createRes()
+
+    await handler(
+      createReq({ headers: { 'content-type': 'application/json' } }),
+      res,
+    )
+
+    expect(mockMutate).not.toHaveBeenCalled()
+    expect(res.redirect).toHaveBeenCalledWith(303, FAILURE_REDIRECT)
+  })
+
+  it('rejects non-POST requests with a 400 and does not redirect', async () => {
+    const res = createRes()
+
+    await handler(createReq({ method: 'GET' }), res)
+
+    expect(res.status).toHaveBeenCalledWith(400)
+    expect(res.redirect).not.toHaveBeenCalled()
+  })
+})

--- a/apps/payments/utils/browserInfo.ts
+++ b/apps/payments/utils/browserInfo.ts
@@ -1,0 +1,30 @@
+import { PaymentsVerifyCardBrowserInfoInput } from '@island.is/api/schema'
+
+/**
+ * Collects the payer's browser environment for EMV 3-D Secure authentication.
+ * These fields are forwarded (together with server-derived connection
+ * information) to the card gateway as the browser data of the authentication
+ * request. Only values observable by the page are collected; nothing here
+ * identifies the payer beyond what every HTTP request already exposes.
+ */
+export const getBrowserInfo = ():
+  | PaymentsVerifyCardBrowserInfoInput
+  | undefined => {
+  if (typeof window === 'undefined' || !window.screen) {
+    return undefined
+  }
+
+  return {
+    screenHeight: window.screen.height,
+    screenWidth: window.screen.width,
+    colorDepth: window.screen.colorDepth,
+    timeZoneOffset: new Date().getTimezoneOffset(),
+    language: navigator.language,
+    // navigator.javaEnabled() is deprecated and returns false in all modern
+    // browsers; report false when it is unavailable.
+    javaEnabled:
+      typeof navigator.javaEnabled === 'function'
+        ? navigator.javaEnabled()
+        : false,
+  }
+}

--- a/apps/services/payments/src/app/cardPayment/cardPayment.service.ts
+++ b/apps/services/payments/src/app/cardPayment/cardPayment.service.ts
@@ -37,6 +37,8 @@ import { CardPaymentModuleConfig } from './cardPayment.config'
 import { paymentGatewayResponseCodes } from './cardPayment.constants'
 import { verifyApplePaySignature } from './applePaySignature'
 import {
+  buildVerificationBrowserData,
+  buildVerificationCardholderData,
   decryptApplePayPaymentToken,
   generateApplePayDecryptedChargeRequestOptions,
   generateApplePayValidationRequestOptions,
@@ -91,6 +93,26 @@ export class CardPaymentService {
     const correlationId = uuid()
 
     const { paymentFlowId } = verifyCardInput
+
+    // Visibility into requests that will go to the gateway without the
+    // documented-required 3DS data (e.g. an older frontend during rollout, or
+    // input the builders had to drop as invalid). Uses the same pure builders
+    // as the outgoing request so the log reflects what is actually sent.
+    const willSendBrowserData = !!buildVerificationBrowserData(
+      verifyCardInput.browserInfo,
+    )
+    const willSendCardholderData = !!buildVerificationCardholderData(
+      verifyCardInput.cardholderName,
+    )
+    if (!willSendBrowserData || !willSendCardholderData) {
+      this.logger.warn(
+        `[${paymentFlowId}] Card verification request sent without full 3DS data`,
+        {
+          hasBrowserData: willSendBrowserData,
+          hasCardholderData: willSendCardholderData,
+        },
+      )
+    }
 
     const md = generateMd({
       correlationId,

--- a/apps/services/payments/src/app/cardPayment/cardPayment.utils.spec.ts
+++ b/apps/services/payments/src/app/cardPayment/cardPayment.utils.spec.ts
@@ -1,9 +1,14 @@
 import crypto from 'crypto'
 
 import {
+  buildVerificationBrowserData,
+  buildVerificationCardholderData,
   decryptApplePayPaymentToken,
   deriveApplePaySymmetricKey,
+  generateVerificationRequestOptions,
 } from './cardPayment.utils'
+import { CardPaymentModuleConfigType } from './cardPayment.config'
+import { VerifyCardInput } from './dtos/verifyCard.input'
 
 const MERCHANT_ID = 'merchant.com.island.test'
 
@@ -186,5 +191,218 @@ describe('deriveApplePaySymmetricKey', () => {
     expect(a.toString('hex')).toBe(b.toString('hex'))
     expect(a.toString('hex')).not.toBe(c.toString('hex'))
     expect(a).toHaveLength(32)
+  })
+})
+
+describe('buildVerificationBrowserData', () => {
+  const validBrowserInfo = {
+    ipAddress: '203.0.113.7',
+    screenHeight: 1080,
+    screenWidth: 1920,
+  }
+
+  it('returns undefined without browser info', () => {
+    expect(buildVerificationBrowserData(undefined)).toBeUndefined()
+  })
+
+  it('returns undefined when a gateway-required member is missing or invalid', () => {
+    expect(
+      buildVerificationBrowserData({ ...validBrowserInfo, ipAddress: '' }),
+    ).toBeUndefined()
+    expect(
+      buildVerificationBrowserData({
+        ...validBrowserInfo,
+        screenHeight: 1080.5,
+      }),
+    ).toBeUndefined()
+    expect(
+      buildVerificationBrowserData({ ...validBrowserInfo, screenWidth: -1 }),
+    ).toBeUndefined()
+    expect(
+      buildVerificationBrowserData({
+        ...validBrowserInfo,
+        screenHeight: 1_000_000,
+      }),
+    ).toBeUndefined()
+  })
+
+  it('returns undefined for values that do not parse as an IP address', () => {
+    expect(
+      buildVerificationBrowserData({
+        ...validBrowserInfo,
+        ipAddress: 'not-an-ip',
+      }),
+    ).toBeUndefined()
+    expect(
+      buildVerificationBrowserData({
+        ...validBrowserInfo,
+        ipAddress: '999.999.1.1',
+      }),
+    ).toBeUndefined()
+  })
+
+  it('accepts IPv6 addresses', () => {
+    expect(
+      buildVerificationBrowserData({
+        ...validBrowserInfo,
+        ipAddress: '2001:db8::1',
+      }),
+    ).toMatchObject({ ip: '2001:db8::1' })
+  })
+
+  it('builds the minimal gateway object from the required members', () => {
+    expect(buildVerificationBrowserData(validBrowserInfo)).toEqual({
+      ip: '203.0.113.7',
+      screenHeight: 1080,
+      screenWidth: 1920,
+      javascriptEnabled: true,
+      javaEnabled: false,
+    })
+  })
+
+  it('passes through valid optional members', () => {
+    expect(
+      buildVerificationBrowserData({
+        ...validBrowserInfo,
+        colorDepth: 24,
+        timeZoneOffset: -60,
+        language: 'en-GB',
+        userAgent: 'Mozilla/5.0',
+        acceptHeader: 'application/json',
+        javaEnabled: true,
+      }),
+    ).toEqual({
+      ip: '203.0.113.7',
+      screenHeight: 1080,
+      screenWidth: 1920,
+      javascriptEnabled: true,
+      javaEnabled: true,
+      colorDepth: 24,
+      timeZoneOffset: -60,
+      language: 'en-GB',
+      userAgent: 'Mozilla/5.0',
+      acceptHeader: 'application/json',
+    })
+  })
+
+  it('omits optional members the gateway would reject instead of remapping them', () => {
+    const result = buildVerificationBrowserData({
+      ...validBrowserInfo,
+      // 30 bits per pixel (e.g. HDR displays) is not an accepted gateway value.
+      colorDepth: 30,
+      timeZoneOffset: 100_000,
+      language: 'not/a/valid/language/tag',
+    })
+
+    expect(result).toEqual({
+      ip: '203.0.113.7',
+      screenHeight: 1080,
+      screenWidth: 1920,
+      javascriptEnabled: true,
+      javaEnabled: false,
+    })
+  })
+})
+
+describe('buildVerificationCardholderData', () => {
+  it('returns undefined for missing or out-of-range names', () => {
+    expect(buildVerificationCardholderData(undefined)).toBeUndefined()
+    expect(buildVerificationCardholderData('')).toBeUndefined()
+    expect(buildVerificationCardholderData('  J  ')).toBeUndefined()
+    // 46 characters: omitted, never truncated into a different name.
+    expect(buildVerificationCardholderData('J'.repeat(46))).toBeUndefined()
+  })
+
+  it('trims and passes through a valid name', () => {
+    expect(buildVerificationCardholderData(' Jón Jónsson ')).toEqual({
+      cardholderName: 'Jón Jónsson',
+    })
+    expect(buildVerificationCardholderData('J'.repeat(45))).toEqual({
+      cardholderName: 'J'.repeat(45),
+    })
+  })
+})
+
+describe('generateVerificationRequestOptions', () => {
+  const paymentApiConfig = {
+    paymentsApiSecret: 'secret',
+    paymentsApiHeaderKey: 'valitorpay-api-version',
+    paymentsApiHeaderValue: '2.0',
+    systemCalling: 'island-is',
+  } as CardPaymentModuleConfigType['paymentGateway']
+
+  const baseInput = {
+    paymentFlowId: 'flow-1',
+    cardNumber: '4111111111111111',
+    expiryMonth: 12,
+    expiryYear: 30,
+  }
+
+  const generate = (verifyCardInput: VerifyCardInput) =>
+    JSON.parse(
+      generateVerificationRequestOptions({
+        verifyCardInput,
+        md: 'test-md',
+        paymentApiConfig,
+        webOrigin: 'https://island.is/greida',
+        amount: 100,
+      }).body as string,
+    )
+
+  it('sends the request without 3DS objects when the client did not supply them', () => {
+    const body = generate(baseInput)
+
+    expect(body).toEqual({
+      cardNumber: '4111111111111111',
+      expirationMonth: 12,
+      expirationYear: 2030,
+      cardholderDeviceType: 'WWW',
+      amount: 10000,
+      currency: 'ISK',
+      authenticationUrl: 'https://island.is/greida/api/card/callback',
+      MD: 'test-md',
+      systemCalling: 'island-is',
+    })
+    expect(body).not.toHaveProperty('browserData')
+    expect(body).not.toHaveProperty('cardHolderData')
+  })
+
+  it('includes browserData and cardHolderData when the client supplied valid 3DS data', () => {
+    const body = generate({
+      ...baseInput,
+      cardholderName: 'Jón Jónsson',
+      browserInfo: {
+        ipAddress: '203.0.113.7',
+        screenHeight: 1080,
+        screenWidth: 1920,
+        language: 'is',
+      },
+    })
+
+    expect(body.browserData).toEqual({
+      ip: '203.0.113.7',
+      screenHeight: 1080,
+      screenWidth: 1920,
+      javascriptEnabled: true,
+      javaEnabled: false,
+      language: 'is',
+    })
+    expect(body.cardHolderData).toEqual({ cardholderName: 'Jón Jónsson' })
+  })
+
+  it('omits invalid 3DS data rather than failing or altering the request base', () => {
+    const body = generate({
+      ...baseInput,
+      cardholderName: 'J',
+      browserInfo: {
+        ipAddress: '',
+        screenHeight: 1080,
+        screenWidth: 1920,
+      },
+    })
+
+    expect(body).not.toHaveProperty('browserData')
+    expect(body).not.toHaveProperty('cardHolderData')
+    expect(body.cardNumber).toBe('4111111111111111')
   })
 })

--- a/apps/services/payments/src/app/cardPayment/cardPayment.utils.ts
+++ b/apps/services/payments/src/app/cardPayment/cardPayment.utils.ts
@@ -1,4 +1,5 @@
 import crypto from 'crypto'
+import { isIP } from 'net'
 import { sign, verify, Algorithm } from 'jsonwebtoken'
 import { z } from 'zod'
 import { Agent } from 'undici'
@@ -9,7 +10,7 @@ import {
 } from '@island.is/clients/charge-fjs-v2'
 
 import { ChargeCardInput } from './dtos/chargeCard.input'
-import { VerifyCardInput } from './dtos/verifyCard.input'
+import { VerifyCardBrowserInfo, VerifyCardInput } from './dtos/verifyCard.input'
 import {
   MdNormalised,
   MdSerialized,
@@ -30,6 +31,96 @@ const MdSerializedSchema = z.object({
 })
 
 const iskToAur = (amount: number) => amount * 100
+
+/**
+ * The payment gateway (EMV 3-D Secure) only accepts these colorDepth values.
+ * Browsers can report other values (e.g. 30 on HDR displays); anything else is
+ * omitted rather than remapped so we never fabricate device data.
+ */
+const ACCEPTED_COLOR_DEPTHS = new Set([1, 4, 8, 15, 16, 24, 32, 48])
+const BROWSER_LANGUAGE_PATTERN = /^[a-zA-Z0-9-]{1,8}$/
+const CARDHOLDER_NAME_MIN_LENGTH = 2
+const CARDHOLDER_NAME_MAX_LENGTH = 45
+const MAX_SCREEN_DIMENSION = 999999
+const MAX_TIME_ZONE_OFFSET = 99999
+
+/**
+ * Builds the EMV 3-D Secure `browserData` object of a gateway CardVerification
+ * request. Returns undefined when any member the gateway documents as required
+ * (ip, screenHeight, screenWidth) is unavailable — a partial object is not
+ * sent. Optional members that do not meet the gateway constraints are dropped;
+ * browser oddities must never fail the verification itself.
+ */
+export const buildVerificationBrowserData = (
+  browserInfo: VerifyCardBrowserInfo | undefined,
+) => {
+  if (!browserInfo) {
+    return undefined
+  }
+
+  const { ipAddress, screenHeight, screenWidth } = browserInfo
+
+  const isValidScreenDimension = (value: number) =>
+    Number.isInteger(value) && value >= 0 && value <= MAX_SCREEN_DIMENSION
+
+  if (
+    !ipAddress ||
+    !isIP(ipAddress) ||
+    !isValidScreenDimension(screenHeight) ||
+    !isValidScreenDimension(screenWidth)
+  ) {
+    return undefined
+  }
+
+  const {
+    colorDepth,
+    timeZoneOffset,
+    language,
+    userAgent,
+    acceptHeader,
+    javaEnabled,
+  } = browserInfo
+
+  return {
+    ip: ipAddress,
+    screenHeight,
+    screenWidth,
+    // This data is collected by our script running in the payer's browser.
+    javascriptEnabled: true,
+    javaEnabled: javaEnabled ?? false,
+    ...(colorDepth !== undefined &&
+      ACCEPTED_COLOR_DEPTHS.has(colorDepth) && { colorDepth }),
+    ...(timeZoneOffset !== undefined &&
+      Number.isInteger(timeZoneOffset) &&
+      Math.abs(timeZoneOffset) <= MAX_TIME_ZONE_OFFSET && { timeZoneOffset }),
+    ...(language !== undefined &&
+      BROWSER_LANGUAGE_PATTERN.test(language) && { language }),
+    ...(userAgent && { userAgent }),
+    ...(acceptHeader && { acceptHeader }),
+  }
+}
+
+/**
+ * Builds the `cardHolderData` object of a gateway CardVerification request.
+ * The gateway requires a 2-45 character name; the frontend enforces the same
+ * limits, so an out-of-range value means a non-compliant client and the object
+ * is omitted (never silently altered) rather than failing the verification.
+ */
+export const buildVerificationCardholderData = (
+  cardholderName: string | undefined,
+) => {
+  const trimmed = cardholderName?.trim()
+
+  if (
+    !trimmed ||
+    trimmed.length < CARDHOLDER_NAME_MIN_LENGTH ||
+    trimmed.length > CARDHOLDER_NAME_MAX_LENGTH
+  ) {
+    return undefined
+  }
+
+  return { cardholderName: trimmed }
+}
 
 export const generateMd = ({
   correlationId,
@@ -64,13 +155,23 @@ export const generateVerificationRequestOptions = ({
   webOrigin: string
   amount: number
 }) => {
-  const { cardNumber, expiryMonth, expiryYear } = verifyCardInput
+  const { cardNumber, expiryMonth, expiryYear, cardholderName, browserInfo } =
+    verifyCardInput
   const {
     paymentsApiSecret,
     paymentsApiHeaderKey,
     paymentsApiHeaderValue,
     systemCalling,
   } = paymentApiConfig
+
+  // The gateway documents browserData and cardHolderData as required members
+  // of a CardVerification request (mandatory since gateway release 2.32).
+  // Sending them with accurate values gives issuers the EMV 3-D Secure data
+  // they need to authenticate the payer. When a client has not supplied the
+  // data (e.g. an older frontend during rollout) the request is sent without
+  // it, matching the previous behaviour of this integration.
+  const browserData = buildVerificationBrowserData(browserInfo)
+  const cardHolderData = buildVerificationCardholderData(cardholderName)
 
   const requestOptions: RequestInit = {
     method: 'POST',
@@ -89,6 +190,8 @@ export const generateVerificationRequestOptions = ({
       authenticationUrl: `${webOrigin}/api/card/callback`,
       MD: md,
       systemCalling,
+      ...(browserData && { browserData }),
+      ...(cardHolderData && { cardHolderData }),
     }),
   }
 

--- a/apps/services/payments/src/app/cardPayment/dtos/verifyCard.input.ts
+++ b/apps/services/payments/src/app/cardPayment/dtos/verifyCard.input.ts
@@ -1,5 +1,110 @@
-import { ApiProperty } from '@nestjs/swagger'
-import { IsNumber, IsString } from 'class-validator'
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger'
+import { Type } from 'class-transformer'
+import {
+  IsBoolean,
+  IsInt,
+  IsNumber,
+  IsOptional,
+  IsString,
+  Max,
+  MaxLength,
+  Min,
+  ValidateNested,
+} from 'class-validator'
+
+/**
+ * Browser environment of the payer, forwarded to the payment gateway as the
+ * EMV 3-D Secure browser data of the authentication request. Screen dimensions
+ * and similar fields are collected in the payer's browser; ip, userAgent and
+ * acceptHeader are derived server-side from the payer's request by the API layer.
+ *
+ * Validation here is deliberately looser than the gateway contract: values that
+ * cannot be forwarded as-is (e.g. an unsupported colorDepth) are normalised or
+ * omitted when the gateway request is built, so an odd browser value can never
+ * fail the verification outright.
+ */
+export class VerifyCardBrowserInfo {
+  @IsInt()
+  @Min(0)
+  @Max(999999)
+  @ApiProperty({
+    description: 'Total height of the payer screen in pixels',
+    type: Number,
+  })
+  screenHeight!: number
+
+  @IsInt()
+  @Min(0)
+  @Max(999999)
+  @ApiProperty({
+    description: 'Total width of the payer screen in pixels',
+    type: Number,
+  })
+  screenWidth!: number
+
+  @IsOptional()
+  @IsInt()
+  @ApiPropertyOptional({
+    description: 'Colour depth of the payer screen in bits per pixel',
+    type: Number,
+  })
+  colorDepth?: number
+
+  @IsOptional()
+  @IsInt()
+  @Min(-99999)
+  @Max(99999)
+  @ApiPropertyOptional({
+    description:
+      'Offset in minutes between UTC and the payer browser local time',
+    type: Number,
+  })
+  timeZoneOffset?: number
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(35)
+  @ApiPropertyOptional({
+    description: 'Browser language tag, e.g. is or en-GB',
+    type: String,
+  })
+  language?: string
+
+  @IsOptional()
+  @IsBoolean()
+  @ApiPropertyOptional({
+    description: 'Whether the payer browser is able to execute Java',
+    type: Boolean,
+  })
+  javaEnabled?: boolean
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(45)
+  @ApiPropertyOptional({
+    description: 'IP address of the payer as seen by the API layer',
+    type: String,
+  })
+  ipAddress?: string
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(2048)
+  @ApiPropertyOptional({
+    description: 'User-agent header of the payer request',
+    type: String,
+  })
+  userAgent?: string
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(2048)
+  @ApiPropertyOptional({
+    description: 'Accept header of the payer request',
+    type: String,
+  })
+  acceptHeader?: string
+}
 
 export class VerifyCardInput {
   @IsString()
@@ -29,4 +134,24 @@ export class VerifyCardInput {
     type: Number,
   })
   expiryYear!: number
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(100)
+  @ApiPropertyOptional({
+    description:
+      'Cardholder name as printed on the card, forwarded to the payment gateway for 3-D Secure authentication',
+    type: String,
+  })
+  cardholderName?: string
+
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => VerifyCardBrowserInfo)
+  @ApiPropertyOptional({
+    description:
+      'Browser environment of the payer, forwarded to the payment gateway for 3-D Secure authentication',
+    type: VerifyCardBrowserInfo,
+  })
+  browserInfo?: VerifyCardBrowserInfo
 }

--- a/apps/services/payments/src/app/cardPayment/dtos/verifyCard.input.ts
+++ b/apps/services/payments/src/app/cardPayment/dtos/verifyCard.input.ts
@@ -18,10 +18,10 @@ import {
  * and similar fields are collected in the payer's browser; ip, userAgent and
  * acceptHeader are derived server-side from the payer's request by the API layer.
  *
- * Validation here is deliberately looser than the gateway contract: values that
- * cannot be forwarded as-is (e.g. an unsupported colorDepth) are normalised or
- * omitted when the gateway request is built, so an odd browser value can never
- * fail the verification outright.
+ * Validation here mirrors what real browsers produce and is deliberately
+ * looser than the gateway contract: values a real browser can report but the
+ * gateway would reject (e.g. an unsupported colorDepth) are omitted when the
+ * gateway request is built rather than failing the verification.
  */
 export class VerifyCardBrowserInfo {
   @IsInt()

--- a/libs/api/domains/payments/src/lib/dto/verifyCard.input.ts
+++ b/libs/api/domains/payments/src/lib/dto/verifyCard.input.ts
@@ -1,4 +1,42 @@
-import { Field, InputType } from '@nestjs/graphql'
+import { Field, InputType, Int } from '@nestjs/graphql'
+
+@InputType('PaymentsVerifyCardBrowserInfoInput')
+export class VerifyCardBrowserInfoInput {
+  @Field(() => Int, {
+    description: 'Total height of the payer screen in pixels',
+  })
+  screenHeight!: number
+
+  @Field(() => Int, {
+    description: 'Total width of the payer screen in pixels',
+  })
+  screenWidth!: number
+
+  @Field(() => Int, {
+    nullable: true,
+    description: 'Colour depth of the payer screen in bits per pixel',
+  })
+  colorDepth?: number
+
+  @Field(() => Int, {
+    nullable: true,
+    description:
+      'Offset in minutes between UTC and the payer browser local time',
+  })
+  timeZoneOffset?: number
+
+  @Field(() => String, {
+    nullable: true,
+    description: 'Browser language tag, e.g. is or en-GB',
+  })
+  language?: string
+
+  @Field(() => Boolean, {
+    nullable: true,
+    description: 'Whether the payer browser is able to execute Java',
+  })
+  javaEnabled?: boolean
+}
 
 @InputType('PaymentsVerifyCardInput')
 export class VerifyCardInput {
@@ -13,4 +51,18 @@ export class VerifyCardInput {
 
   @Field((_) => String)
   paymentFlowId!: string
+
+  @Field(() => String, {
+    nullable: true,
+    description:
+      'Cardholder name as printed on the card, used for 3-D Secure authentication',
+  })
+  cardholderName?: string
+
+  @Field(() => VerifyCardBrowserInfoInput, {
+    nullable: true,
+    description:
+      'Browser environment of the payer, used for 3-D Secure authentication',
+  })
+  browserInfo?: VerifyCardBrowserInfoInput
 }

--- a/libs/api/domains/payments/src/lib/payments.resolver.ts
+++ b/libs/api/domains/payments/src/lib/payments.resolver.ts
@@ -1,8 +1,9 @@
-import { Args, Mutation, Query, Resolver } from '@nestjs/graphql'
+import { Args, Context, Mutation, Query, Resolver } from '@nestjs/graphql'
 import { UseGuards } from '@nestjs/common'
 import { ApolloError } from '@apollo/client'
 
 import { IdsUserGuard, Scopes, ScopesGuard } from '@island.is/auth-nest-tools'
+import type { GraphQLContext } from '@island.is/auth-nest-tools'
 import {
   FeatureFlag,
   FeatureFlagGuard,
@@ -18,6 +19,7 @@ import {
   PaymentFlowAdminResponse,
 } from './dto/getPaymentFlow.response'
 import { PaymentsService } from './payments.service'
+import { getPayerRequestInfo } from './payments.utils'
 import { VerifyCardResponse } from './dto/verifyCard.response'
 import { VerifyCardInput } from './dto/verifyCard.input'
 import { ChargeCardInput } from './dto/chargeCard.input'
@@ -98,9 +100,10 @@ export class PaymentsResolver {
   async verifyCard(
     @Args('input', { type: () => VerifyCardInput })
     input: VerifyCardInput,
+    @Context('req') req: GraphQLContext['req'],
   ): Promise<VerifyCardResponse> {
     try {
-      return this.paymentsService.verifyCard(input)
+      return this.paymentsService.verifyCard(input, getPayerRequestInfo(req))
     } catch (e) {
       throw new ApolloError(e.message)
     }

--- a/libs/api/domains/payments/src/lib/payments.service.ts
+++ b/libs/api/domains/payments/src/lib/payments.service.ts
@@ -18,6 +18,7 @@ import {
 } from '@island.is/clients/payments'
 
 import { VerifyCardInput } from './dto/verifyCard.input'
+import { PayerRequestInfo } from './payments.utils'
 import { VerifyCardResponse } from './dto/verifyCard.response'
 import { ChargeCardInput } from './dto/chargeCard.input'
 import { ChargeCardResponse } from './dto/chargeCard.response'
@@ -102,9 +103,23 @@ export class PaymentsService {
     })
   }
 
-  verifyCard(verifyCardInput: VerifyCardInput): Promise<VerifyCardResponse> {
+  verifyCard(
+    verifyCardInput: VerifyCardInput,
+    payerRequestInfo: PayerRequestInfo,
+  ): Promise<VerifyCardResponse> {
+    const { browserInfo, ...cardInput } = verifyCardInput
+
     return this.paymentsApi.cardPaymentControllerVerify({
-      verifyCardInput,
+      verifyCardInput: {
+        ...cardInput,
+        // ip, userAgent and acceptHeader describe the payer's request as
+        // observed by this API and are derived server-side, never trusted
+        // from client input.
+        browserInfo: browserInfo && {
+          ...browserInfo,
+          ...payerRequestInfo,
+        },
+      },
     })
   }
 
@@ -148,8 +163,13 @@ export class PaymentsService {
   async chargeCard(
     chargeCardInput: ChargeCardInput,
   ): Promise<ChargeCardResponse> {
+    // ChargeCardInput inherits the verification-only 3DS fields from
+    // VerifyCardInput in the GraphQL schema; the payments service charge
+    // endpoint does not accept them.
+    const { cardholderName, browserInfo, ...restInput } = chargeCardInput
+
     const response = await this.paymentsApi.cardPaymentControllerCharge({
-      chargeCardInput,
+      chargeCardInput: restInput,
     })
 
     const { isSuccess, responseCode } = response

--- a/libs/api/domains/payments/src/lib/payments.utils.spec.ts
+++ b/libs/api/domains/payments/src/lib/payments.utils.spec.ts
@@ -1,0 +1,96 @@
+import type { GraphQLContext } from '@island.is/auth-nest-tools'
+
+import { getPayerRequestInfo } from './payments.utils'
+
+type Req = GraphQLContext['req']
+
+const buildReq = ({
+  ip,
+  remoteAddress,
+  headers = {},
+}: {
+  ip?: string
+  remoteAddress?: string
+  headers?: Record<string, string | string[]>
+}): Req =>
+  ({
+    ip,
+    socket: { remoteAddress },
+    headers,
+  } as unknown as Req)
+
+describe('getPayerRequestInfo', () => {
+  it('uses the first x-forwarded-for hop', () => {
+    const req = buildReq({
+      ip: '10.1.2.3',
+      headers: { 'x-forwarded-for': '198.51.100.1, 10.0.0.1' },
+    })
+
+    expect(getPayerRequestInfo(req).ipAddress).toBe('198.51.100.1')
+  })
+
+  it('falls back to the request IP when x-forwarded-for is missing', () => {
+    const req = buildReq({ ip: '203.0.113.7' })
+
+    expect(getPayerRequestInfo(req).ipAddress).toBe('203.0.113.7')
+  })
+
+  it('falls back to the socket address when the request IP is unavailable', () => {
+    const req = buildReq({ remoteAddress: '203.0.113.7' })
+
+    expect(getPayerRequestInfo(req).ipAddress).toBe('203.0.113.7')
+  })
+
+  it('skips candidates that do not parse as an IP', () => {
+    const req = buildReq({
+      ip: '203.0.113.7',
+      headers: { 'x-forwarded-for': 'not-an-ip, 10.0.0.1' },
+    })
+
+    expect(getPayerRequestInfo(req).ipAddress).toBe('203.0.113.7')
+  })
+
+  it('unmaps IPv4-mapped IPv6 addresses', () => {
+    const req = buildReq({ ip: '::ffff:203.0.113.7' })
+
+    expect(getPayerRequestInfo(req).ipAddress).toBe('203.0.113.7')
+  })
+
+  it('accepts IPv6 addresses', () => {
+    const req = buildReq({ ip: '2001:db8::1' })
+
+    expect(getPayerRequestInfo(req).ipAddress).toBe('2001:db8::1')
+  })
+
+  it('omits the IP when no candidate parses as an IP', () => {
+    const garbage = buildReq({
+      headers: { 'x-forwarded-for': 'not-an-ip, also-not-an-ip' },
+    })
+    const empty = buildReq({})
+
+    expect(getPayerRequestInfo(garbage).ipAddress).toBeUndefined()
+    expect(getPayerRequestInfo(empty).ipAddress).toBeUndefined()
+  })
+
+  it('passes headers through and truncates them to the gateway limit', () => {
+    const req = buildReq({
+      headers: {
+        'user-agent': 'a'.repeat(3000),
+        accept: 'text/html,application/xhtml+xml',
+      },
+    })
+
+    const info = getPayerRequestInfo(req)
+
+    expect(info.userAgent).toHaveLength(2048)
+    expect(info.acceptHeader).toBe('text/html,application/xhtml+xml')
+  })
+
+  it('uses the first value of repeated headers', () => {
+    const req = buildReq({
+      headers: { 'user-agent': ['Mozilla/5.0', 'Other/1.0'] },
+    })
+
+    expect(getPayerRequestInfo(req).userAgent).toBe('Mozilla/5.0')
+  })
+})

--- a/libs/api/domains/payments/src/lib/payments.utils.ts
+++ b/libs/api/domains/payments/src/lib/payments.utils.ts
@@ -1,0 +1,65 @@
+import { isIP } from 'net'
+
+import type { GraphQLContext } from '@island.is/auth-nest-tools'
+
+/** Gateway limit for the EMV 3-D Secure userAgent and acceptHeader members. */
+const HEADER_MAX_LENGTH = 2048
+
+/**
+ * Connection information of the payer's own request, forwarded to the payments
+ * service as part of the EMV 3-D Secure browser data.
+ */
+export interface PayerRequestInfo {
+  ipAddress?: string
+  userAgent?: string
+  acceptHeader?: string
+}
+
+const firstHeaderValue = (
+  value: string | string[] | undefined,
+): string | undefined => (Array.isArray(value) ? value[0] : value)
+
+/** Node reports IPv4 peers as IPv4-mapped IPv6 addresses (::ffff:1.2.3.4). */
+const unmapIp = (value: string): string =>
+  value.toLowerCase().startsWith('::ffff:') && isIP(value.slice(7)) === 4
+    ? value.slice(7)
+    : value
+
+/**
+ * Derives the payer's connection information from the incoming GraphQL
+ * request for the EMV 3-D Secure browser data of a card verification.
+ *
+ * The client IP is the first x-forwarded-for hop — where our reverse proxies
+ * record the connecting client (see the trust-proxy note in
+ * infra-nest-server/bootstrap.ts) — falling back to the request/socket
+ * address, matching how other API domains resolve the client IP. Candidates
+ * that do not parse as an IP are skipped; when none qualifies the IP is
+ * omitted rather than sending a malformed value to the gateway. Headers are
+ * truncated to the gateway limit so an oversized header can never fail the
+ * verification. All values are derived server-side, never trusted from
+ * client-supplied GraphQL input.
+ */
+export const getPayerRequestInfo = (
+  req: GraphQLContext['req'],
+): PayerRequestInfo => {
+  const forwardedIp = firstHeaderValue(req.headers['x-forwarded-for'])
+    ?.split(',')[0]
+    ?.trim()
+
+  const ipAddress = [forwardedIp, req.ip, req.socket?.remoteAddress]
+    .filter((candidate): candidate is string => !!candidate)
+    .map(unmapIp)
+    .find((candidate) => isIP(candidate) !== 0)
+
+  return {
+    ipAddress,
+    userAgent: firstHeaderValue(req.headers['user-agent'])?.slice(
+      0,
+      HEADER_MAX_LENGTH,
+    ),
+    acceptHeader: firstHeaderValue(req.headers['accept'])?.slice(
+      0,
+      HEADER_MAX_LENGTH,
+    ),
+  }
+}

--- a/libs/application/core/src/lib/messages.ts
+++ b/libs/application/core/src/lib/messages.ts
@@ -322,7 +322,7 @@ export const coreMessages = defineMessages({
   paymentPendingInvoiceDescription: {
     id: 'application.system:core.payment.pendingInvoiceDescription#markdown',
     defaultMessage:
-      '* Krafa hefur verið stofnuð og verið send í netbanka. \n\n * Til að fá þjónustuna sem sótt er um þarf að greiða kröfuna. \n\n * Verði krafan ekki greidd innan 48 klst (á virkum degi) mun umsóknin verða felld niður.',
+      '* Krafa hefur verið stofnuð og verið send í netbanka. \n\n * Til að fá þjónustuna sem sótt er um þarf að greiða kröfuna. \n\n * Verði krafan ekki greidd innan tveggja virkra daga mun umsóknin verða felld niður.',
     description: 'Description for payment pending invoice',
   },
 })


### PR DESCRIPTION
# ...
https://digitaliceland.zendesk.com/agent/tickets/569451
https://digitaliceland.zendesk.com/agent/tickets/570821

## What

Made in response to the elevated 3DS-return failure rate on card payments (island.is/greida). Contains three changes, plus an invoice copy fix.

### 1. Send the 3-D Secure data the card gateway documents as required (spec-compliance change)

Our `/CardVerification` request to the payment gateway has never included `browserData` or `cardHolderData`. Both are marked `required` in the gateway's v2 OpenAPI spec (verified against prod and UAT — identical), and the gateway release notes state they **became mandatory in release 2.32 (2023-12-13)** (2.37 later made billing data optional; 2.57 explicitly allows name-only cardholder data). The integration has therefore been sending a data-poor EMV 3DS authentication request since it was built.

* **`cardHolderData.cardholderName`** — new "Nafn korthafa" (name on card) field on the card form, entered by the payer. Deliberately *not* derived from registry/FJS data: the payer is not always the cardholder (spouse/company cards), and a mismatched name is bad risk data.
* **`browserData`** — screen size, colour depth, timezone offset, language and Java support collected in the payer's browser; client IP, user-agent and accept header derived **server-side** at the GraphQL API from the payer's own request (first `x-forwarded-for` hop with `req.ip`/socket fallback, the same pattern used elsewhere in API domains; candidates that don't parse as an IP are skipped). The connection fields are never taken from client-supplied GraphQL input.
* **`apps/services/payments`** builds the gateway objects with strict value validation: `colorDepth` only when it exactly matches the gateway's accepted set (e.g. 30-bit HDR values are omitted, never remapped), language only when it matches the gateway pattern, IP only when it parses (`isIP`), name only when 2–45 chars after trim (omitted, never truncated). When builder validation fails — or a client sent no data at all — the gateway object is omitted and the request degrades to today's shape, with a `hasBrowserData`/`hasCardholderData` warning logged so degraded traffic is visible. (DTO-level validation still rejects clearly malformed requests, e.g. non-integer screen dimensions, as 400 — values real browsers do not produce.)

### 2. Handle incomplete 3DS callbacks gracefully (resilience)

Unchanged from the first revision of this PR: the ACS callback previously crashed with an unhandled `ZodError` → HTTP 500 inside the 3DS iframe. Now `safeParse` → structured diagnostics (`mdStatus` + field presence only, never cardholder data) → 303 redirect to an honest failure screen (rendered server-side via `?status=failed`, no success flash).

### 3. Invoice-pending copy

“48 klst” → “tveggja virkra daga”, matching the backend's two-working-day expiry.

## Why

Production incident (Zendesk #569451, #570821): since Jul 15 a meaningful share of card payments fail on 3DS return — the callback arrives without authentication results (`cavv`/`TDS2.dsTransID`), baseline ~1–7/hr rising to ~50/hr, 686 occurrences by Jul 16; ~23% of vehicle-ownership-transfer card attempts on Jul 15 morning reached payment but never completed (<1% baseline). Both Visa and Mastercard are affected, and no island.is deploy correlates with the onset.

**Confirmed:** our CardVerification request omits members the gateway spec marks required, and has since Apr 2025. **Unverified:** whether that gap is what the failing payments are hitting — there is no UAT reproduction or gateway-side evidence for a causal link yet. The `mdStatus` diagnostics added in this PR will show the distribution of authentication outcomes on failing callbacks (`mdStatus ∈ {0, 2–9}` ⇒ not-authenticated, `mdStatus = 1` without `cavv` ⇒ a different contract problem), which distinguishes the candidate explanations without by itself proving causation.

**The remediation impact of part 1 is therefore unverified.** What it verifiably does: brings the integration into compliance with the documented contract and gives issuers accurate EMV 3DS data, with every value either accurate or omitted. Post-deploy failure rates and the `mdStatus` distribution will show whether the incident picture improves; a rate change is supporting evidence, not causal proof.

Not included, deliberately: `billingData` (optional since gateway 2.37; the payer's registry address is not necessarily the cardholder's billing address — wrong optional risk data is worse than absent) and email/phone (recommended but not required; needs a user-profile integration decision). Both are noted as follow-ups pending gateway guidance.

## Rollout note

Deploy order matters for a brief window: **services-payments → api → payments web**. The REST and GraphQL layers strictly validate input, so the new optional fields must be accepted before clients send them. In the other direction old clients degrade gracefully against new services (request keeps today's shape; warning logged).

## Verification

* Gateway spec: prod + UAT v2 swagger both list `CardVerification.required = [amount, authenticationUrl, browserData, cardHolderData, cardholderDeviceType, currency]`, `BrowserData.required = [ip, screenHeight, screenWidth]`, `CardholderData.required = [cardholderName]`.
* `nx test services-payments` — full suite green, incl. 13 new tests for the builders and request body (omission of unsupported colorDepth/overlong names/malformed IPs; degraded request keeps the previous shape).
* `nx test api-domains-payments` — 9 new tests for payer request extraction (XFF-first, fallbacks, isIP validation, header truncation).
* `nx test payments` — 22 passed (incl. the 6 callback tests).
* `tsc --noEmit` clean on payments, services-payments and api-domains-payments; `nx lint` clean on all three; openapi.yaml, generated client, api.graphql and frontend types regenerate cleanly.

## Screenshots / Gifs

New required "Nafn korthafa" input above the card number field on /greida; failure screen unchanged from previous revision.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Fable with GPT 5.6 Sol advisor (Oh My Pi harness)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cardholder name collection and validation during card payments.
  * Enhanced 3-D Secure verification with browser and payer information.
  * Added clear success and failure screens for 3-D Secure authentication.
  * Card verification now redirects reliably to the appropriate result page.

* **Bug Fixes**
  * Improved handling of incomplete, invalid, or failed verification callbacks.
  * Updated invoice payment messaging to reflect a two-business-day deadline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->