### PR TITLE
fix(web): Customs calculator - update state when shortcut gets clicked

### DIFF
--- a/apps/web/components/connected/CustomsCalculator/CustomsCalculator.tsx
+++ b/apps/web/components/connected/CustomsCalculator/CustomsCalculator.tsx
@@ -243,6 +243,19 @@ const CustomsCalculator = ({ slice }: CustomsCalculatorProps) => {
                   if (bottomLevelCategory)
                     setSelectedBottomLevelCategory(bottomLevelCategory)
                   else setSelectedBottomLevelCategory(null)
+
+                  const topLevel =
+                    productCategoriesResponse.data
+                      ?.customsCalculatorProductCategories?.topLevel ?? []
+                  const path =
+                    findCategoryPath(
+                      topLevel as CategoryNode[],
+                      bottomLevelCategory?.id ?? '',
+                    ) ?? []
+                  setSelectedCategory({
+                    current: path.length > 0 ? path[path.length - 1] : null,
+                    breadcrumbs: path.slice(0, -1),
+                  })
                 }}
               >
                 {shortcut.label}


### PR DESCRIPTION
# Customs calculator - update state when shortcut gets clicked

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [x] No AI tools were used in preparing this pull request
- [ ] AI tools were used in preparing this pull request
      Tools used:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Shortcut category selections now correctly update the category breadcrumb trail.
  * The selected category is displayed as the current item, with its parent categories shown in order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->