### PR TITLE
fix(clients-national-registry): update B2C devFallbacks to new auth provider

### DIFF
--- a/libs/clients/national-registry/v3-applications/src/lib/nationalRegistryV3Applications.config.ts
+++ b/libs/clients/national-registry/v3-applications/src/lib/nationalRegistryV3Applications.config.ts
@@ -19,16 +19,16 @@ export const NationalRegistryV3ApplicationsClientConfig = defineConfig<
     fetchTimeout: env.optionalJSON('XROAD_NATIONAL_REGISTRY_TIMEOUT') ?? 10000,
     clientId: env.required(
       'NATIONAL_REGISTRY_B2C_CLIENT_ID',
-      'b464afdd-056b-406d-b650-6d41733cfeb7',
+      '8f4c5411-9caf-40a1-8764-bbe05fd6de50',
     ),
     clientSecret: env.required('NATIONAL_REGISTRY_B2C_CLIENT_SECRET', ''),
     scope: env.required(
       'NATIONAL_REGISTRY_B2C_APPLICATION_SCOPE',
-      'https://skraidentitydev.onmicrosoft.com/midlunumsoknir/.default',
+      'https://skraiddev.onmicrosoft.com/midlunUmsoknir/.default',
     ),
     endpoint: env.required(
       'NATIONAL_REGISTRY_B2C_ENDPOINT',
-      'https://skraidentitydev.b2clogin.com/skraidentitydev.onmicrosoft.com/b2c_1_midlun_flow/oauth2/v2.0/token',
+      'https://dev.identity.skra.is/dev.identity.skra.is/oauth2/v2.0/token',
     ),
     xRoadServicePath: env.required(
       'NATIONAL_REGISTRY_B2C_APPLICATION_PATH',

--- a/libs/clients/national-registry/v3/src/lib/nationalRegistryV3.config.ts
+++ b/libs/clients/national-registry/v3/src/lib/nationalRegistryV3.config.ts
@@ -19,16 +19,16 @@ export const NationalRegistryV3ClientConfig = defineConfig<
     fetchTimeout: 10000,
     clientId: env.required(
       'NATIONAL_REGISTRY_B2C_CLIENT_ID',
-      'b464afdd-056b-406d-b650-6d41733cfeb7',
+      '8f4c5411-9caf-40a1-8764-bbe05fd6de50',
     ),
     clientSecret: env.required('NATIONAL_REGISTRY_B2C_CLIENT_SECRET', ''),
     scope: env.required(
       'NATIONAL_REGISTRY_B2C_SCOPE',
-      'https://skraidentitydev.onmicrosoft.com/midlun/.default',
+      'https://skraiddev.onmicrosoft.com/midlun/.default',
     ),
     endpoint: env.required(
       'NATIONAL_REGISTRY_B2C_ENDPOINT',
-      'https://skraidentitydev.b2clogin.com/skraidentitydev.onmicrosoft.com/b2c_1_midlun_flow/oauth2/v2.0/token',
+      'https://dev.identity.skra.is/dev.identity.skra.is/oauth2/v2.0/token',
     ),
     xRoadServicePath: env.required(
       'NATIONAL_REGISTRY_B2C_PATH',


### PR DESCRIPTION
# Update national-registry B2C devFallbacks to new auth provider

## What

- Update the dev fallback values in `NationalRegistryV3ClientConfig` and `NationalRegistryV3ApplicationsClientConfig` to Þjóðskrá's new auth provider: client id `8f4c5411-...`, `skraiddev.onmicrosoft.com` scopes, and the `dev.identity.skra.is` token endpoint — matching the values the infra DSL already provides to deployments.

## Why

- Þjóðskrá switched auth providers in the May 2026 credential rotation. Deployments get the new client id/scope/endpoint from `infra/src/dsl/xroad.ts`, but local dev falls back to the config defaults, which still pointed at the old provider (`skraidentitydev`).
- `get-secrets` only fetches the client secret (`/k8s/api/NATIONAL_REGISTRY_B2C_CLIENT_SECRET`), so local dev paired the current secret with the old client id and got `AADB2C90081 invalid_client` from the token endpoint (see the recent #devops_support thread).
- Verified against the dev token endpoint: the current `/k8s/api` secret + these new fallback values returns a token; the old fallbacks + the same secret reproduce the reported error. No secret rotation is needed.

## Screenshots / Gifs

N/A

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated National Registry application configuration defaults to use the correct development identity scope and token endpoint.
  * Corrected client identifier metadata used during environment configuration.
  * Applied the same configuration corrections across National Registry v3 services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->