### PR TITLE
feat(web): Default conversation field id for zendesk chat

### DIFF
--- a/apps/contentful-apps/components/WebChat/ZendeskSection.tsx
+++ b/apps/contentful-apps/components/WebChat/ZendeskSection.tsx
@@ -74,6 +74,11 @@ export const ZendeskSection = ({ sdk, value, updateValue }: SectionProps) => {
                       }))
                     }}
                   />
+                  <FormControl.HelpText>
+                    This is the ticket ID that will be used to track the chat
+                    url. If left blank, the chat will be tracked by the default
+                    ticket ID
+                  </FormControl.HelpText>
                 </Flex>
                 <Flex flexDirection="column">
                   <FormControl.Label>

--- a/apps/web/components/WebChat/WebChat.tsx
+++ b/apps/web/components/WebChat/WebChat.tsx
@@ -27,12 +27,17 @@ const WebChat = ({ webChat, pushUp, renderFallback }: WebChatProps) => {
       chatBubbleTitle,
     } = webChat.webChatConfiguration.zendesk ?? {}
     if (!snippetUrl) return renderFallback?.() ?? null
+
+    let ticketId: string = urlTrackingTicketId ?? ''
+    if (ticketId.length > 0 && ticketId.trim() === '') ticketId = ''
+    else if (!ticketId.trim()) ticketId = '36130758325906'
+
     return (
       <ZendeskChatPanel
         snippetUrl={snippetUrl}
         pushUp={pushUp}
         chatBubbleVariant={chatBubbleVariant || 'circle'}
-        urlTrackingTicketId={urlTrackingTicketId}
+        urlTrackingTicketId={ticketId}
         chatBubbleTitle={chatBubbleTitle}
       />
     )

--- a/apps/web/components/WebChat/WebChat.tsx
+++ b/apps/web/components/WebChat/WebChat.tsx
@@ -31,6 +31,7 @@ const WebChat = ({ webChat, pushUp, renderFallback }: WebChatProps) => {
     let ticketId: string = urlTrackingTicketId ?? ''
     if (ticketId.length > 0 && ticketId.trim() === '') ticketId = ''
     else if (!ticketId.trim()) ticketId = '36130758325906'
+    else ticketId = ticketId.trim()
 
     return (
       <ZendeskChatPanel


### PR DESCRIPTION
# Default conversation field id for zendesk chat

The conversationFields id is used to track the chat url which for example can set the correct response language of the chatbot. This PR sets a default id (but still allowing for overrides in the cms).

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [x] No AI tools were used in preparing this pull request
- [ ] AI tools were used in preparing this pull request
      Tools used:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added help text to the “Zendesk URL Ticket ID” field to clarify how ticket IDs are used for tracking chat URLs and when the default applies.

- **Bug Fixes**
  - Improved Zendesk chat URL tracking by normalizing the ticket ID (handles missing values, trims whitespace, and applies the default when the result is empty).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->