### PR TITLE
feat(application-system): Add singleExpand and startExpanded properties to AccordionFormField

### DIFF
--- a/libs/application/core/src/lib/fieldBuilders.ts
+++ b/libs/application/core/src/lib/fieldBuilders.ts
@@ -1250,6 +1250,7 @@ export const buildAccordionField = (
     marginTop,
     marginBottom,
     condition,
+    singleExpand = true,
   } = data
   return {
     children: undefined,
@@ -1260,6 +1261,7 @@ export const buildAccordionField = (
     marginBottom,
     accordionItems,
     condition,
+    singleExpand,
     type: FieldTypes.ACCORDION,
     component: FieldComponents.ACCORDION,
   }

--- a/libs/application/types/src/lib/Fields.ts
+++ b/libs/application/types/src/lib/Fields.ts
@@ -904,6 +904,7 @@ export type AccordionItem = {
   itemTitle: FormText
   itemContent?: FormText
   children?: Field[]
+  startExpanded?: boolean
 }
 export interface AccordionField extends BaseField {
   readonly type: FieldTypes.ACCORDION
@@ -912,6 +913,7 @@ export interface AccordionField extends BaseField {
     | Array<AccordionItem>
     | ((application: Application) => Array<AccordionItem>)
   titleVariant?: TitleVariants
+  singleExpand?: boolean
 }
 export interface BankAccountField extends InputField {
   readonly type: FieldTypes.BANK_ACCOUNT

--- a/libs/application/ui-fields/src/lib/AccordionFormField/AccordionFormField.tsx
+++ b/libs/application/ui-fields/src/lib/AccordionFormField/AccordionFormField.tsx
@@ -37,7 +37,14 @@ export const AccordionFormField = ({
   const [items, setItems] = useState<Array<AccordionItemType>>()
   const { formatMessage, lang: locale } = useLocale()
   const user = useUserInfo()
-  const { accordionItems, marginBottom, marginTop, title, titleVariant } = field
+  const {
+    accordionItems,
+    marginBottom,
+    marginTop,
+    title,
+    titleVariant,
+    singleExpand,
+  } = field
   const formValues = useWatch({ defaultValue: application.answers })
   const prevVisibilityRef = useRef<Record<string, boolean>>({})
 
@@ -100,7 +107,7 @@ export const AccordionFormField = ({
           </Text>
         </Box>
       )}
-      <Accordion>
+      <Accordion singleExpand={singleExpand}>
         {items.map((item, index) => {
           const hasContent = !!item.itemContent
           const hasChildren = item.children && item.children.length > 0
@@ -109,6 +116,7 @@ export const AccordionFormField = ({
               key={`accordion-item-${index}`}
               id={`accordion-item-${index}`}
               label={formatText(item.itemTitle, application, formatMessage)}
+              startExpanded={item.startExpanded}
             >
               {hasContent && (
                 <Markdown>


### PR DESCRIPTION
## What

Add `singleExpand` and `startExpanded` properties to `AccordionFormField`

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [x] No AI tools were used in preparing this pull request
- [ ] AI tools were used in preparing this pull request
      Tools used:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable accordion expansion behavior.
  * Accordions can now restrict expansion to one item at a time.
  * Individual accordion items can be configured to start expanded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->