### PR TITLE
feat(j-s): Show breadcrumbs for defence users

### DIFF
--- a/apps/judicial-system/web/src/components/PageLayout/PageLayout.tsx
+++ b/apps/judicial-system/web/src/components/PageLayout/PageLayout.tsx
@@ -216,7 +216,7 @@ const PageLayout: FC<PropsWithChildren<PageProps>> = ({
   const { isCreating } = useContext(FormContext)
   const { user } = useContext(UserContext)
   const { formatMessage } = useIntl()
-  const hideBreadcrumbs = isDefenceUser(user) || isCreating
+  const hideBreadcrumbs = isCreating
 
   return (
     <>


### PR DESCRIPTION
# Show breadcrumbs for defence users

[Sýna verjendum breadcrumbs](https://app.asana.com/1/203394141643832/project/1199153462262248/task/1217012120794997)

Breadcrumbs in `PageLayout` were hidden for defence users. Since defenders now
navigate the same case-table based case lists as other users, the breadcrumb
trail is meaningful for them too, so the `isDefenceUser` condition is removed
from `hideBreadcrumbs` — breadcrumbs are now only hidden while a case is being
created.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Breadcrumbs are now displayed for defence users when they are not creating a new item.
  * Breadcrumbs remain hidden while creating a new item.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->