### PR TITLE
fix(j-s): Clear subpoena type when indictment is served by other means

### DIFF
--- a/apps/judicial-system/web/src/routes/Court/Indictments/Subpoena/Subpoena.tsx
+++ b/apps/judicial-system/web/src/routes/Court/Indictments/Subpoena/Subpoena.tsx
@@ -103,10 +103,19 @@ const Subpoena: FC = () => {
   )
 
   const toggleNewAlternativeService = (defendant: Defendant) => () => {
+    if (!defendant.isAlternativeService) {
+      setNewAlternativeServices((previous) => [...previous, defendant.id])
+      return
+    }
+
     setNewAlternativeServices((previous) =>
-      defendant.isAlternativeService
-        ? previous.filter((id) => id !== defendant.id)
-        : [...previous, defendant.id],
+      previous.filter((id) => id !== defendant.id),
+    )
+
+    // Turning alternative service off means a new subpoena is being issued,
+    // just like when the new subpoena button is used
+    setNewSubpoenas((previous) =>
+      previous.includes(defendant.id) ? previous : [...previous, defendant.id],
     )
   }
 
@@ -147,10 +156,10 @@ const Subpoena: FC = () => {
           alternativeServiceDescription: defendant.isAlternativeService
             ? defendant.alternativeServiceDescription
             : null,
-          // Only change the subpoena type if the defendant is not
+          // Clear the subpoena type if the defendant is
           // being served by alternative means
           subpoenaType: defendant.isAlternativeService
-            ? undefined
+            ? null
             : defendant.subpoenaType,
         }),
       )
@@ -203,12 +212,16 @@ const Subpoena: FC = () => {
       return
     }
 
-    // Create subpoenas for selected defendants (or all if first-time scheduling)
-    const defendantIdsToCreateSubpoenasFor = isArraignmentScheduled
-      ? newSubpoenas
-      : updates?.defendants
-          ?.filter((defendant) => !defendant.isAlternativeService)
-          .map((defendant) => defendant.id) ?? []
+    // Create subpoenas for selected defendants (or all if first-time scheduling),
+    // never for defendants being served by alternative means
+    const defendantIdsToCreateSubpoenasFor =
+      updates?.defendants
+        ?.filter(
+          (defendant) =>
+            !defendant.isAlternativeService &&
+            (!isArraignmentScheduled || newSubpoenas.includes(defendant.id)),
+        )
+        .map((defendant) => defendant.id) ?? []
 
     if (defendantIdsToCreateSubpoenasFor.length > 0) {
       const arraignmentDate = updates?.theCase.arraignmentDate?.date

--- a/apps/judicial-system/web/src/routes/Court/components/SubpoenaType/SubpoenaType.tsx
+++ b/apps/judicial-system/web/src/routes/Court/components/SubpoenaType/SubpoenaType.tsx
@@ -68,7 +68,14 @@ const SubpoenaType: FC<SubpoenaTypeProps> = ({
                   item.toggleNewAlternativeService &&
                     item.toggleNewAlternativeService()
 
-                  item.onUpdate({ caseId, defendantId, isAlternativeService })
+                  item.onUpdate({
+                    caseId,
+                    defendantId,
+                    isAlternativeService,
+                    // A subpoena type does not apply when the indictment
+                    // is served by other means
+                    ...(isAlternativeService ? { subpoenaType: null } : {}),
+                  })
                 }}
                 tooltip={
                   'Ef ákæra og fyrirkall eru birt utan gáttarinnar, t.d. í þinghaldi eða í Lögbirtingablaðinu, þá er hægt að haka í þennan reit til að komast áfram án þess að gefa út fyrirkall í gegnum Réttarvörslugátt.'


### PR DESCRIPTION
# Clear subpoena type when indictment is served by other means

[Ef hakað fyrst i útivist/handtöku en svo breitt í birt með öðrum hætti helst hakið](https://app.asana.com/1/203394141643832/project/1199153462262248/task/1214051587709425)

On the district court subpoena page, picking a subpoena type (útivistarfyrirkall / handtökufyrirkall) and then ticking "Ákæra var birt með öðrum hætti" left the radio button selected — it was only disabled, never cleared. The two choices are mutually exclusive, so the leftover selection was misleading, and the stale type stayed in the database as well.

## Changes

- **`SubpoenaType.tsx`** — ticking the alternative service checkbox now sends `subpoenaType: null` in the same update, so the radio unchecks immediately.
- **`Subpoena.tsx`** — the save path sends `subpoenaType: null` instead of `undefined` for defendants served by other means, so the cleared value is actually persisted and does not reappear on refetch. `UpdateDefendantInput.subpoenaType` is already nullable end to end, so no codegen, migration or backend change was needed.
- **`Subpoena.tsx`** — unticking the checkbox while the arraignment is already scheduled now registers the defendant in `newSubpoenas`, the same as the "Nýtt fyrirkall" button does. Without this the radios stayed disabled after unticking (the defendant was in neither list), which — with the type now cleared — left the step impossible to validate. Ticking the box deliberately leaves `newSubpoenas` untouched so the "Hætta við" revert button stays available.
- **`Subpoena.tsx`** — when deciding who gets a subpoena on reschedule, `newSubpoenas` is now filtered by `!isAlternativeService`, matching the first-time scheduling branch. Previously such defendants were only filtered out server side.

## Notes

- Already issued subpoenas are unaffected: the PDF formatter falls back to the per-subpoena `Subpoena.type` column, which is written at creation time.
- One consumer still reads the defendant column — `digital-mailbox-api/.../subpoena.response.ts` uses `defendantInfo?.subpoenaType` and already carries a `// TODO: Change to latestSubpoena.type`. For a defendant who had a subpoena served and later gets alternative service on a reschedule, the "útivistar-/handtökufyrirkall" phrase in the island.is mailbox text is omitted. It degrades gracefully; fixing that TODO is out of scope here.
- Cases already stored with both `isAlternativeService = true` and a `subpoenaType` will still show the radio checked on load until the checkbox is toggled. Hiding the radios entirely would have covered those too, but was deliberately not done.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved alternative-service selection and disabling behavior during subpoena management.
  * Ensured subpoena types are cleared when alternative service is enabled.
  * Improved defendant eligibility handling when creating or rescheduling subpoenas.
  * Ensured defendants requiring new subpoenas are correctly identified after alternative service changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->