### PR TITLE
fix(my-pages): Remove xl screen handling

### DIFF
--- a/apps/portals/my-pages/src/components/Layout/SidebarLayout.tsx
+++ b/apps/portals/my-pages/src/components/Layout/SidebarLayout.tsx
@@ -8,8 +8,6 @@ import {
 
 import * as styles from './SidebarLayout.css'
 import cn from 'classnames'
-import { useWindowSize } from 'react-use'
-import { XL_SCREEN_WIDTH } from '../../lib/constants'
 
 interface SidebarLayoutProps {
   children: ReactNode
@@ -22,9 +20,6 @@ export const SidebarLayout: FC<SidebarLayoutProps> = ({
   isSticky = true,
   children,
 }) => {
-  const { width } = useWindowSize()
-  const isXLScreen = width > XL_SCREEN_WIDTH
-
   return (
     <Box paddingTop={[0, 0, 9]}>
       <GridContainer position="none">
@@ -43,10 +38,7 @@ export const SidebarLayout: FC<SidebarLayoutProps> = ({
           </Box>
           <GridContainer className={styles.sidebarWrap}>
             <GridRow>
-              <GridColumn
-                offset={isXLScreen ? '1/12' : '0'}
-                span={isXLScreen ? '11/12' : '12/12'}
-              >
+              <GridColumn span={'12/12'}>
                 <Box paddingLeft={[0, 0, 3, 6]}>{children}</Box>
               </GridColumn>
             </GridRow>

--- a/apps/portals/my-pages/src/lib/constants.ts
+++ b/apps/portals/my-pages/src/lib/constants.ts
@@ -1,1 +1,0 @@
-export const XL_SCREEN_WIDTH = 1512


### PR DESCRIPTION
## What

Removed the xl screen size offset

## Why

Design doesn't account for this shift and it makes some screens behave weirdly when the offset gets added. 

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [x] No AI tools were used in preparing this pull request
- [ ] AI tools were used in preparing this pull request
      Tools used:
