### PR TITLE
feat(my-pages): Health appointments additional info

### DIFF
--- a/libs/portals/my-pages/health/src/lib/messages.ts
+++ b/libs/portals/my-pages/health/src/lib/messages.ts
@@ -2828,10 +2828,6 @@ export const messages = defineMessages({
     id: 'sp.health:appointment-modality-video',
     defaultMessage: 'Myndsímtal',
   },
-  appointmentAssignees: {
-    id: 'sp.health:appointment-assignees',
-    defaultMessage: 'Úthlutað til',
-  },
   appointmentAssigneeTypeRole: {
     id: 'sp.health:appointment-assignee-type-role',
     defaultMessage: 'Hlutverk',

--- a/libs/portals/my-pages/health/src/lib/messages.ts
+++ b/libs/portals/my-pages/health/src/lib/messages.ts
@@ -2832,6 +2832,30 @@ export const messages = defineMessages({
     id: 'sp.health:appointment-assignees',
     defaultMessage: 'Úthlutað til',
   },
+  appointmentAssigneeTypeRole: {
+    id: 'sp.health:appointment-assignee-type-role',
+    defaultMessage: 'Hlutverk',
+  },
+  appointmentAssigneeTypeRoom: {
+    id: 'sp.health:appointment-assignee-type-room',
+    defaultMessage: 'Herbergi',
+  },
+  appointmentAssigneeTypeEquipment: {
+    id: 'sp.health:appointment-assignee-type-equipment',
+    defaultMessage: 'Tæki',
+  },
+  appointmentAssigneeTypeService: {
+    id: 'sp.health:appointment-assignee-type-service',
+    defaultMessage: 'Þjónusta',
+  },
+  appointmentAssigneeTypeTeam: {
+    id: 'sp.health:appointment-assignee-type-team',
+    defaultMessage: 'Teymi',
+  },
+  appointmentAssigneeTypeOther: {
+    id: 'sp.health:appointment-assignee-type-other',
+    defaultMessage: 'Annað',
+  },
   appointmentVideoCallLink: {
     id: 'sp.health:appointment-video-call-link',
     defaultMessage: 'Hefja myndsímtal',

--- a/libs/portals/my-pages/health/src/screens/Appointments/AppointmentDetail.graphql
+++ b/libs/portals/my-pages/health/src/screens/Appointments/AppointmentDetail.graphql
@@ -1,44 +1,48 @@
+fragment AppointmentDetailFields on HealthDirectorateAppointmentDetail {
+  id
+  title
+  instruction
+  date
+  duration
+  modality
+  practitioners
+  assignees {
+    type
+    name
+  }
+  links {
+    type
+    url
+    activatesAt
+    expiresAt
+  }
+  location {
+    __typename
+    name
+    organization
+    address
+    department
+    wing
+    floor
+    room
+    city
+    postalCode
+    country
+    latitude
+    longitude
+    link
+    locationLinks {
+      type
+      url
+    }
+    phoneNumber
+    openingHoursText
+  }
+}
+
 query getAppointmentDetail($id: String!) {
   healthDirectorateAppointment(id: $id) {
     __typename
-    id
-    title
-    instruction
-    date
-    duration
-    modality
-    practitioners
-    assignees {
-      type
-      name
-    }
-    links {
-      type
-      url
-      activatesAt
-      expiresAt
-    }
-    location {
-      __typename
-      name
-      organization
-      address
-      department
-      wing
-      floor
-      room
-      city
-      postalCode
-      country
-      latitude
-      longitude
-      link
-      locationLinks {
-        type
-        url
-      }
-      phoneNumber
-      openingHoursText
-    }
+    ...AppointmentDetailFields
   }
 }

--- a/libs/portals/my-pages/health/src/screens/Appointments/AppointmentDetail.tsx
+++ b/libs/portals/my-pages/health/src/screens/Appointments/AppointmentDetail.tsx
@@ -1,26 +1,17 @@
 import { HealthDirectorateAppointmentModality } from '@island.is/api/schema'
-import { Box, Icon, Stack, Text } from '@island.is/island-ui/core'
+import { Box, Stack, Text } from '@island.is/island-ui/core'
 import { useLocale, useNamespaces } from '@island.is/localization'
-import {
-  CardLoader,
-  InfoLine,
-  InfoLineStack,
-  IntroWrapper,
-  LinkButton,
-  formatDate,
-  getTime,
-  getWeekday,
-} from '@island.is/portals/my-pages/core'
+import { CardLoader, IntroWrapper } from '@island.is/portals/my-pages/core'
 
 import { Problem } from '@island.is/react-spa/shared'
 import { useParams } from 'react-router-dom'
 import { messages } from '../../lib/messages'
 
-import { generateGoogleMapsLink } from '../../utils/googleMaps'
-import { mapWeekday } from '../../utils/mappers'
 import { useGetAppointmentDetailQuery } from './AppointmentDetail.generated'
-import { useHealthPlausibleSwap } from '../../utils/useHealthPlausibleSwap'
+import { AppointmentDetailCardInfo } from './AppointmentDetailCardInfo'
+import { AppointmentDetailInfoLines } from './AppointmentDetailInfoLines'
 import { AppointmentVideoCallAlert } from './AppointmentVideoCallAlert'
+import { useHealthPlausibleSwap } from '../../utils/useHealthPlausibleSwap'
 
 const AppointmentDetail = () => {
   useNamespaces('sp.health')
@@ -34,30 +25,6 @@ const AppointmentDetail = () => {
   })
 
   const appointment = data?.healthDirectorateAppointment
-
-  const locationLink =
-    appointment?.location?.locationLinks?.find((l) => l.type === 'WEBSITE')
-      ?.url ??
-    appointment?.location?.link ??
-    undefined
-
-  const mapsLink = generateGoogleMapsLink(
-    appointment?.location?.latitude,
-    appointment?.location?.longitude,
-  )
-
-  const fullAddress =
-    [
-      appointment?.location?.name,
-      appointment?.location?.address,
-      [appointment?.location?.postalCode, appointment?.location?.city]
-        .filter(Boolean)
-        .join(' '),
-    ]
-      .filter(Boolean)
-      .join(', ') || undefined
-
-  const weekday = mapWeekday(getWeekday(appointment?.date ?? ''), formatMessage)
 
   return (
     <IntroWrapper
@@ -89,127 +56,7 @@ const AppointmentDetail = () => {
                 <Text variant="h4" color="blue400">
                   {appointment.title}
                 </Text>
-                <Stack space={2}>
-                  {appointment.date && (
-                    <Box display="flex" alignItems="center" columnGap={1}>
-                      <Icon
-                        icon="calendar"
-                        size="small"
-                        color="blue400"
-                        type="outline"
-                      />
-                      <Text>
-                        {weekday ? `${weekday}, ` : ''}
-                        {formatDate(appointment.date)}
-                      </Text>
-                    </Box>
-                  )}
-                  {appointment.date && (
-                    <Box display="flex" alignItems="center" columnGap={1}>
-                      <Icon
-                        icon="time"
-                        size="small"
-                        color="blue400"
-                        type="outline"
-                      />
-                      <Text>{getTime(appointment.date)}</Text>
-                    </Box>
-                  )}
-                  {appointment.duration && (
-                    <Box display="flex" alignItems="center" columnGap={1}>
-                      <Icon
-                        icon="hourglass"
-                        size="small"
-                        color="blue400"
-                        type="outline"
-                      />
-                      <Text>
-                        {formatMessage(messages.argWithMinutes, {
-                          arg: appointment.duration,
-                        })}
-                      </Text>
-                    </Box>
-                  )}
-                  {appointment.modality ===
-                    HealthDirectorateAppointmentModality.VIDEO && (
-                    <Box display="flex" alignItems="center" columnGap={1}>
-                      <Icon
-                        icon="videoCam"
-                        size="small"
-                        color="blue400"
-                        type="outline"
-                      />
-                      <Text>
-                        {formatMessage(messages.appointmentModalityVideo)}
-                      </Text>
-                    </Box>
-                  )}
-                  {appointment.modality !==
-                    HealthDirectorateAppointmentModality.VIDEO &&
-                    fullAddress && (
-                      <Box display="flex" alignItems="flexStart" columnGap={1}>
-                        <Box flexShrink={0}>
-                          <Icon
-                            icon="location"
-                            size="small"
-                            color="blue400"
-                            type="outline"
-                          />
-                        </Box>
-                        <Box
-                          display="flex"
-                          flexWrap="wrap"
-                          alignItems="center"
-                          columnGap={2}
-                        >
-                          <Text>{fullAddress}</Text>
-                          {mapsLink && (
-                            <LinkButton
-                              to={mapsLink}
-                              text={formatMessage(messages.openMap)}
-                              variant="text"
-                              size="small"
-                              icon="open"
-                            />
-                          )}
-                        </Box>
-                      </Box>
-                    )}
-
-                  {appointment.modality !==
-                    HealthDirectorateAppointmentModality.VIDEO &&
-                    locationLink && (
-                      <Box display="flex" alignItems="flexStart" columnGap={1}>
-                        <Box flexShrink={0}>
-                          <Icon
-                            icon="informationCircle"
-                            size="small"
-                            color="blue400"
-                            type="outline"
-                          />
-                        </Box>
-                        <Box
-                          display="flex"
-                          flexWrap="wrap"
-                          alignItems="center"
-                          columnGap={2}
-                        >
-                          <Text>
-                            {formatMessage(messages.locationInstructions)}
-                          </Text>
-                          {locationLink && (
-                            <LinkButton
-                              to={locationLink}
-                              text={formatMessage(messages.seeMore)}
-                              variant="text"
-                              size="small"
-                              icon="open"
-                            />
-                          )}
-                        </Box>
-                      </Box>
-                    )}
-                </Stack>
+                <AppointmentDetailCardInfo appointment={appointment} />
               </Stack>
               <Box
                 display={['none', 'none', 'block']}
@@ -227,51 +74,10 @@ const AppointmentDetail = () => {
             )}
           </Box>
 
-          {((appointment.practitioners?.length ?? 0) > 0 ||
-            appointment.instruction ||
-            appointment.location?.phoneNumber ||
-            appointment.location?.openingHoursText) && (
-            <InfoLineStack
-              label={formatMessage(messages.appointmentMoreInfo)}
-              space={1}
-            >
-              {(appointment.practitioners?.length ?? 0) > 0 && (
-                <InfoLine
-                  loading={loading}
-                  label={formatMessage(messages.appointmentAtSimple)}
-                  content={appointment.practitioners.join(', ')}
-                />
-              )}
-              {appointment.instruction && (
-                <InfoLine
-                  loading={loading}
-                  label={formatMessage(messages.instructions)}
-                  content={appointment.instruction}
-                />
-              )}
-              {appointment.location?.phoneNumber && (
-                <InfoLine
-                  loading={loading}
-                  label={formatMessage(messages.phoneNumber)}
-                  content={appointment.location.phoneNumber}
-                />
-              )}
-              {appointment.location?.openingHoursText && (
-                <InfoLine
-                  loading={loading}
-                  label={formatMessage(messages.openingHours)}
-                  content={appointment.location.openingHoursText}
-                />
-              )}
-              {appointment.location?.organization && (
-                <InfoLine
-                  loading={loading}
-                  label={formatMessage(messages.organization)}
-                  content={appointment.location.organization}
-                />
-              )}
-            </InfoLineStack>
-          )}
+          <AppointmentDetailInfoLines
+            appointment={appointment}
+            loading={loading}
+          />
         </Stack>
       )}
     </IntroWrapper>

--- a/libs/portals/my-pages/health/src/screens/Appointments/AppointmentDetail.tsx
+++ b/libs/portals/my-pages/health/src/screens/Appointments/AppointmentDetail.tsx
@@ -74,10 +74,7 @@ const AppointmentDetail = () => {
             )}
           </Box>
 
-          <AppointmentDetailInfoLines
-            appointment={appointment}
-            loading={loading}
-          />
+          <AppointmentDetailInfoLines appointment={appointment} />
         </Stack>
       )}
     </IntroWrapper>

--- a/libs/portals/my-pages/health/src/screens/Appointments/AppointmentDetail.tsx
+++ b/libs/portals/my-pages/health/src/screens/Appointments/AppointmentDetail.tsx
@@ -53,7 +53,7 @@ const AppointmentDetail = () => {
               alignItems="center"
             >
               <Stack space={3}>
-                <Text variant="h4" color="blue400">
+                <Text variant="h4" as="h4" color="blue400">
                   {appointment.title}
                 </Text>
                 <AppointmentDetailCardInfo appointment={appointment} />

--- a/libs/portals/my-pages/health/src/screens/Appointments/AppointmentDetailCardInfo.tsx
+++ b/libs/portals/my-pages/health/src/screens/Appointments/AppointmentDetailCardInfo.tsx
@@ -14,7 +14,7 @@ import { generateGoogleMapsLink } from '../../utils/googleMaps'
 import { mapWeekday } from '../../utils/mappers'
 import { AppointmentDetailFieldsFragment } from './AppointmentDetail.generated'
 
-interface Line {
+interface InfoLine {
   icon: IconMapIcon
   text: ReactNode
   link?: { to: string; label: string }
@@ -56,10 +56,10 @@ export const AppointmentDetailCardInfo = ({
     appointment.location?.link ??
     undefined
 
-  const lines: Line[] = []
+  const infoLines: InfoLine[] = []
 
   if (appointment.date) {
-    lines.push({
+    infoLines.push({
       icon: 'calendar',
       text: (
         <>
@@ -68,11 +68,11 @@ export const AppointmentDetailCardInfo = ({
         </>
       ),
     })
-    lines.push({ icon: 'time', text: getTime(appointment.date) })
+    infoLines.push({ icon: 'time', text: getTime(appointment.date) })
   }
 
   if (appointment.duration) {
-    lines.push({
+    infoLines.push({
       icon: 'hourglass',
       text: formatMessage(messages.argWithMinutes, {
         arg: appointment.duration,
@@ -81,12 +81,12 @@ export const AppointmentDetailCardInfo = ({
   }
 
   if (isVideo) {
-    lines.push({
+    infoLines.push({
       icon: 'videoCam',
       text: formatMessage(messages.appointmentModalityVideo),
     })
   } else if (fullAddress) {
-    lines.push({
+    infoLines.push({
       icon: 'location',
       text: fullAddress,
       link: mapsLink
@@ -96,7 +96,7 @@ export const AppointmentDetailCardInfo = ({
   }
 
   if (!isVideo && locationLink) {
-    lines.push({
+    infoLines.push({
       icon: 'informationCircle',
       text: formatMessage(messages.locationInstructions),
       link: { to: locationLink, label: formatMessage(messages.seeMore) },
@@ -105,7 +105,7 @@ export const AppointmentDetailCardInfo = ({
 
   return (
     <Stack space={2}>
-      {lines.map((line, index) =>
+      {infoLines.map((line, index) =>
         line.link ? (
           <Box key={index} display="flex" alignItems="flexStart" columnGap={1}>
             <Box flexShrink={0}>

--- a/libs/portals/my-pages/health/src/screens/Appointments/AppointmentDetailCardInfo.tsx
+++ b/libs/portals/my-pages/health/src/screens/Appointments/AppointmentDetailCardInfo.tsx
@@ -1,0 +1,145 @@
+import { ReactNode } from 'react'
+
+import { HealthDirectorateAppointmentModality } from '@island.is/api/schema'
+import { Box, Icon, IconMapIcon, Stack, Text } from '@island.is/island-ui/core'
+import { useLocale } from '@island.is/localization'
+import {
+  LinkButton,
+  formatDate,
+  getTime,
+  getWeekday,
+} from '@island.is/portals/my-pages/core'
+
+import { messages } from '../../lib/messages'
+import { generateGoogleMapsLink } from '../../utils/googleMaps'
+import { mapWeekday } from '../../utils/mappers'
+import { AppointmentDetailFieldsFragment } from './AppointmentDetail.generated'
+
+interface Line {
+  icon: IconMapIcon
+  text: ReactNode
+  link?: { to: string; label: string }
+}
+
+interface AppointmentDetailCardInfoProps {
+  appointment: AppointmentDetailFieldsFragment
+}
+
+export const AppointmentDetailCardInfo = ({
+  appointment,
+}: AppointmentDetailCardInfoProps) => {
+  const { formatMessage } = useLocale()
+
+  const isVideo =
+    appointment.modality === HealthDirectorateAppointmentModality.VIDEO
+
+  const weekday = mapWeekday(getWeekday(appointment.date ?? ''), formatMessage)
+
+  const mapsLink = generateGoogleMapsLink(
+    appointment.location?.latitude,
+    appointment.location?.longitude,
+  )
+
+  const fullAddress =
+    [
+      appointment.location?.name,
+      appointment.location?.address,
+      [appointment.location?.postalCode, appointment.location?.city]
+        .filter(Boolean)
+        .join(' '),
+    ]
+      .filter(Boolean)
+      .join(', ') || undefined
+
+  const locationLink =
+    appointment.location?.locationLinks?.find((l) => l.type === 'WEBSITE')
+      ?.url ??
+    appointment.location?.link ??
+    undefined
+
+  const lines: Line[] = []
+
+  if (appointment.date) {
+    lines.push({
+      icon: 'calendar',
+      text: (
+        <>
+          {weekday ? `${weekday}, ` : ''}
+          {formatDate(appointment.date)}
+        </>
+      ),
+    })
+    lines.push({ icon: 'time', text: getTime(appointment.date) })
+  }
+
+  if (appointment.duration) {
+    lines.push({
+      icon: 'hourglass',
+      text: formatMessage(messages.argWithMinutes, {
+        arg: appointment.duration,
+      }),
+    })
+  }
+
+  if (isVideo) {
+    lines.push({
+      icon: 'videoCam',
+      text: formatMessage(messages.appointmentModalityVideo),
+    })
+  } else if (fullAddress) {
+    lines.push({
+      icon: 'location',
+      text: fullAddress,
+      link: mapsLink
+        ? { to: mapsLink, label: formatMessage(messages.openMap) }
+        : undefined,
+    })
+  }
+
+  if (!isVideo && locationLink) {
+    lines.push({
+      icon: 'informationCircle',
+      text: formatMessage(messages.locationInstructions),
+      link: { to: locationLink, label: formatMessage(messages.seeMore) },
+    })
+  }
+
+  return (
+    <Stack space={2}>
+      {lines.map((line, index) =>
+        line.link ? (
+          <Box key={index} display="flex" alignItems="flexStart" columnGap={1}>
+            <Box flexShrink={0}>
+              <Icon
+                icon={line.icon}
+                size="small"
+                color="blue400"
+                type="outline"
+              />
+            </Box>
+            <Box
+              display="flex"
+              flexWrap="wrap"
+              alignItems="center"
+              columnGap={2}
+            >
+              <Text>{line.text}</Text>
+              <LinkButton
+                to={line.link.to}
+                text={line.link.label}
+                variant="text"
+                size="small"
+                icon="open"
+              />
+            </Box>
+          </Box>
+        ) : (
+          <Box key={index} display="flex" alignItems="center" columnGap={1}>
+            <Icon icon={line.icon} size="small" color="blue400" type="outline" />
+            <Text>{line.text}</Text>
+          </Box>
+        ),
+      )}
+    </Stack>
+  )
+}

--- a/libs/portals/my-pages/health/src/screens/Appointments/AppointmentDetailCardInfo.tsx
+++ b/libs/portals/my-pages/health/src/screens/Appointments/AppointmentDetailCardInfo.tsx
@@ -7,7 +7,6 @@ import {
   LinkButton,
   formatDate,
   getTime,
-  getWeekday,
 } from '@island.is/portals/my-pages/core'
 
 import { messages } from '../../lib/messages'
@@ -33,7 +32,7 @@ export const AppointmentDetailCardInfo = ({
   const isVideo =
     appointment.modality === HealthDirectorateAppointmentModality.VIDEO
 
-  const weekday = mapWeekday(getWeekday(appointment.date ?? ''), formatMessage)
+  const weekday = mapWeekday(appointment.date ?? '', formatMessage)
 
   const mapsLink = generateGoogleMapsLink(
     appointment.location?.latitude,

--- a/libs/portals/my-pages/health/src/screens/Appointments/AppointmentDetailCardInfo.tsx
+++ b/libs/portals/my-pages/health/src/screens/Appointments/AppointmentDetailCardInfo.tsx
@@ -135,7 +135,12 @@ export const AppointmentDetailCardInfo = ({
           </Box>
         ) : (
           <Box key={index} display="flex" alignItems="center" columnGap={1}>
-            <Icon icon={line.icon} size="small" color="blue400" type="outline" />
+            <Icon
+              icon={line.icon}
+              size="small"
+              color="blue400"
+              type="outline"
+            />
             <Text>{line.text}</Text>
           </Box>
         ),

--- a/libs/portals/my-pages/health/src/screens/Appointments/AppointmentDetailInfoLines.tsx
+++ b/libs/portals/my-pages/health/src/screens/Appointments/AppointmentDetailInfoLines.tsx
@@ -22,12 +22,10 @@ interface InfoLineItem {
 
 interface AppointmentDetailInfoLinesProps {
   appointment: AppointmentDetailFieldsFragment
-  loading?: boolean
 }
 
 export const AppointmentDetailInfoLines = ({
   appointment,
-  loading,
 }: AppointmentDetailInfoLinesProps) => {
   const { formatMessage } = useLocale()
 
@@ -138,7 +136,7 @@ export const AppointmentDetailInfoLines = ({
       space={1}
     >
       {lines.map((line, index) => (
-        <InfoLine key={index} loading={loading} {...line} />
+        <InfoLine key={index} {...line} />
       ))}
     </InfoLineStack>
   )

--- a/libs/portals/my-pages/health/src/screens/Appointments/AppointmentDetailInfoLines.tsx
+++ b/libs/portals/my-pages/health/src/screens/Appointments/AppointmentDetailInfoLines.tsx
@@ -9,7 +9,7 @@ import { messages } from '../../lib/messages'
 import { mapAssigneeType } from '../../utils/mappers'
 import { AppointmentDetailFieldsFragment } from './AppointmentDetail.generated'
 
-interface InfoLineItem {
+interface InfoLine {
   label: string
   content?: string
   button?: {
@@ -42,16 +42,16 @@ export const AppointmentDetailInfoLines = ({
     HealthDirectorateAppointmentLinkType.ORGANIZATION_INFO,
   )
 
-  const lines: InfoLineItem[] = []
+  const infoLines: InfoLine[] = []
 
   if ((appointment.practitioners?.length ?? 0) > 0) {
-    lines.push({
+    infoLines.push({
       label: formatMessage(messages.appointmentAtSimple),
       content: appointment.practitioners.join(', '),
     })
   }
 
-  lines.push(
+  infoLines.push(
     ...(appointment.assignees ?? []).map((assignee) => ({
       label: mapAssigneeType(assignee.type, formatMessage),
       content: assignee.name,
@@ -59,7 +59,7 @@ export const AppointmentDetailInfoLines = ({
   )
 
   if (appointment.instruction) {
-    lines.push({
+    infoLines.push({
       label: formatMessage(messages.instructions),
       content: appointment.instruction,
       button: patientInstructionsLink
@@ -74,7 +74,7 @@ export const AppointmentDetailInfoLines = ({
   }
 
   if (preparationLink) {
-    lines.push({
+    infoLines.push({
       label: formatMessage(messages.appointmentPreparation),
       button: {
         type: 'link',
@@ -85,7 +85,7 @@ export const AppointmentDetailInfoLines = ({
     })
   }
 
-  const locationLines: InfoLineItem[] = [
+  const locationLines: InfoLine[] = [
     {
       label: formatMessage(messages.appointmentLocationDepartment),
       content: appointment.location?.department ?? undefined,
@@ -124,9 +124,9 @@ export const AppointmentDetailInfoLines = ({
     },
   ]
 
-  lines.push(...locationLines.filter((line) => line.content))
+  infoLines.push(...locationLines.filter((line) => line.content))
 
-  if (lines.length === 0) {
+  if (infoLines.length === 0) {
     return null
   }
 
@@ -135,7 +135,7 @@ export const AppointmentDetailInfoLines = ({
       label={formatMessage(messages.appointmentMoreInfo)}
       space={1}
     >
-      {lines.map((line, index) => (
+      {infoLines.map((line, index) => (
         <InfoLine key={index} {...line} />
       ))}
     </InfoLineStack>

--- a/libs/portals/my-pages/health/src/screens/Appointments/AppointmentDetailInfoLines.tsx
+++ b/libs/portals/my-pages/health/src/screens/Appointments/AppointmentDetailInfoLines.tsx
@@ -124,9 +124,7 @@ export const AppointmentDetailInfoLines = ({
     },
   ]
 
-  infoLines.push(
-    ...locationLines.filter((line) => line.content || line.button),
-  )
+  infoLines.push(...locationLines.filter((line) => line.content || line.button))
 
   if (infoLines.length === 0) {
     return null

--- a/libs/portals/my-pages/health/src/screens/Appointments/AppointmentDetailInfoLines.tsx
+++ b/libs/portals/my-pages/health/src/screens/Appointments/AppointmentDetailInfoLines.tsx
@@ -124,7 +124,9 @@ export const AppointmentDetailInfoLines = ({
     },
   ]
 
-  infoLines.push(...locationLines.filter((line) => line.content))
+  infoLines.push(
+    ...locationLines.filter((line) => line.content || line.button),
+  )
 
   if (infoLines.length === 0) {
     return null

--- a/libs/portals/my-pages/health/src/screens/Appointments/AppointmentDetailInfoLines.tsx
+++ b/libs/portals/my-pages/health/src/screens/Appointments/AppointmentDetailInfoLines.tsx
@@ -1,0 +1,145 @@
+import { MessageDescriptor } from 'react-intl'
+
+import { HealthDirectorateAppointmentLinkType } from '@island.is/api/schema'
+import { IconMapIcon } from '@island.is/island-ui/core'
+import { useLocale } from '@island.is/localization'
+import { InfoLine, InfoLineStack } from '@island.is/portals/my-pages/core'
+
+import { messages } from '../../lib/messages'
+import { mapAssigneeType } from '../../utils/mappers'
+import { AppointmentDetailFieldsFragment } from './AppointmentDetail.generated'
+
+interface InfoLineItem {
+  label: string
+  content?: string
+  button?: {
+    type: 'link'
+    to: string
+    label: MessageDescriptor
+    icon: IconMapIcon
+  }
+}
+
+interface AppointmentDetailInfoLinesProps {
+  appointment: AppointmentDetailFieldsFragment
+  loading?: boolean
+}
+
+export const AppointmentDetailInfoLines = ({
+  appointment,
+  loading,
+}: AppointmentDetailInfoLinesProps) => {
+  const { formatMessage } = useLocale()
+
+  const findLink = (type: HealthDirectorateAppointmentLinkType) =>
+    appointment.links?.find((l) => l.type === type)?.url
+
+  const preparationLink = findLink(
+    HealthDirectorateAppointmentLinkType.PREPARATION,
+  )
+  const patientInstructionsLink = findLink(
+    HealthDirectorateAppointmentLinkType.PATIENT_INSTRUCTIONS,
+  )
+  const organizationInfoLink = findLink(
+    HealthDirectorateAppointmentLinkType.ORGANIZATION_INFO,
+  )
+
+  const lines: InfoLineItem[] = []
+
+  if ((appointment.practitioners?.length ?? 0) > 0) {
+    lines.push({
+      label: formatMessage(messages.appointmentAtSimple),
+      content: appointment.practitioners.join(', '),
+    })
+  }
+
+  lines.push(
+    ...(appointment.assignees ?? []).map((assignee) => ({
+      label: mapAssigneeType(assignee.type, formatMessage),
+      content: assignee.name,
+    })),
+  )
+
+  if (appointment.instruction) {
+    lines.push({
+      label: formatMessage(messages.instructions),
+      content: appointment.instruction,
+      button: patientInstructionsLink
+        ? {
+            type: 'link',
+            to: patientInstructionsLink,
+            label: messages.seeMore,
+            icon: 'open',
+          }
+        : undefined,
+    })
+  }
+
+  if (preparationLink) {
+    lines.push({
+      label: formatMessage(messages.appointmentPreparation),
+      button: {
+        type: 'link',
+        to: preparationLink,
+        label: messages.seeMore,
+        icon: 'open',
+      },
+    })
+  }
+
+  const locationLines: InfoLineItem[] = [
+    {
+      label: formatMessage(messages.appointmentLocationDepartment),
+      content: appointment.location?.department ?? undefined,
+    },
+    {
+      label: formatMessage(messages.appointmentLocationWing),
+      content: appointment.location?.wing ?? undefined,
+    },
+    {
+      label: formatMessage(messages.appointmentLocationFloor),
+      content: appointment.location?.floor ?? undefined,
+    },
+    {
+      label: formatMessage(messages.appointmentLocationRoom),
+      content: appointment.location?.room ?? undefined,
+    },
+    {
+      label: formatMessage(messages.phoneNumber),
+      content: appointment.location?.phoneNumber ?? undefined,
+    },
+    {
+      label: formatMessage(messages.openingHours),
+      content: appointment.location?.openingHoursText ?? undefined,
+    },
+    {
+      label: formatMessage(messages.organization),
+      content: appointment.location?.organization ?? undefined,
+      button: organizationInfoLink
+        ? {
+            type: 'link',
+            to: organizationInfoLink,
+            label: messages.seeMore,
+            icon: 'open',
+          }
+        : undefined,
+    },
+  ]
+
+  lines.push(...locationLines.filter((line) => line.content))
+
+  if (lines.length === 0) {
+    return null
+  }
+
+  return (
+    <InfoLineStack
+      label={formatMessage(messages.appointmentMoreInfo)}
+      space={1}
+    >
+      {lines.map((line, index) => (
+        <InfoLine key={index} loading={loading} {...line} />
+      ))}
+    </InfoLineStack>
+  )
+}

--- a/libs/portals/my-pages/health/src/screens/Appointments/AppointmentVideoCallAlert.tsx
+++ b/libs/portals/my-pages/health/src/screens/Appointments/AppointmentVideoCallAlert.tsx
@@ -81,7 +81,7 @@ export const AppointmentVideoCallAlert = ({ links }: Props) => {
   const isVideoCallActive = videoCallPhase === 'active'
 
   return (
-    <Box marginTop={3}>
+    <Box marginTop={3} role="status" aria-live="polite">
       <AlertMessage
         type="info"
         message={

--- a/libs/portals/my-pages/health/src/screens/HealthOverview/HealthOverview.tsx
+++ b/libs/portals/my-pages/health/src/screens/HealthOverview/HealthOverview.tsx
@@ -10,6 +10,7 @@ import { theme } from '@island.is/island-ui/theme'
 import { useLocale, useNamespaces } from '@island.is/localization'
 import { LinkResolver } from '@island.is/portals/my-pages/core'
 import { NotificationsBox } from '@island.is/portals/my-pages/information'
+import { DelegationPaths } from '@island.is/portals/shared-modules/delegations'
 import subYears from 'date-fns/subYears'
 import { useWindowSize } from 'react-use'
 import { HealthPaths } from '../../lib/paths'
@@ -133,7 +134,7 @@ export const HealthOverview = () => {
       label: formatMessage(messages.quickLinkMedicinePrescription),
     },
     {
-      href: HealthPaths.HealthMedicineDelegation,
+      href: DelegationPaths.Delegations,
       label: formatMessage(messages.quickLinkMedicineDelegation),
     },
     {

--- a/libs/portals/my-pages/health/src/screens/HealthOverview/components/Appointments.tsx
+++ b/libs/portals/my-pages/health/src/screens/HealthOverview/components/Appointments.tsx
@@ -4,7 +4,6 @@ import { useLocale } from '@island.is/localization'
 import {
   formatDate,
   getTime,
-  getWeekday,
   InfoCardGrid,
   LinkButton,
 } from '@island.is/portals/my-pages/core'
@@ -54,10 +53,7 @@ const Appointments: React.FC<Props> = ({ data, showLinkButton }) => {
         appointment: {
           date: formatDate(appointment.date ?? ''),
           time: getTime(appointment.date ?? ''),
-          weekday: mapWeekday(
-            getWeekday(appointment.date ?? ''),
-            formatMessage,
-          ),
+          weekday: mapWeekday(appointment.date ?? '', formatMessage),
           location: {
             label: appointment.location?.name ?? '',
             href:

--- a/libs/portals/my-pages/health/src/utils/mappers.ts
+++ b/libs/portals/my-pages/health/src/utils/mappers.ts
@@ -3,6 +3,7 @@ import {
   HealthDirectoratePrescriptionRenewalBlockedReason,
 } from '@island.is/api/schema'
 import { FormatMessage } from '@island.is/localization'
+import { getWeekday } from '@island.is/portals/my-pages/core'
 import { messages } from '../lib/messages'
 
 export const mapBlockedStatus = (
@@ -119,7 +120,8 @@ export const mapBlockedStatus = (
   }
 }
 
-export const mapWeekday = (weekday: string, formatMessage: FormatMessage) => {
+export const mapWeekday = (date: string, formatMessage: FormatMessage) => {
+  const weekday = getWeekday(date)
   switch (weekday.toLowerCase()) {
     case 'monday':
       return formatMessage(messages.weekdayMondayAcc)

--- a/libs/portals/my-pages/health/src/utils/mappers.ts
+++ b/libs/portals/my-pages/health/src/utils/mappers.ts
@@ -1,4 +1,7 @@
-import { HealthDirectoratePrescriptionRenewalBlockedReason } from '@island.is/api/schema'
+import {
+  HealthDirectorateAppointmentAssigneeType,
+  HealthDirectoratePrescriptionRenewalBlockedReason,
+} from '@island.is/api/schema'
 import { FormatMessage } from '@island.is/localization'
 import { messages } from '../lib/messages'
 
@@ -134,5 +137,25 @@ export const mapWeekday = (weekday: string, formatMessage: FormatMessage) => {
       return formatMessage(messages.weekdaySundayAcc)
     default:
       return weekday
+  }
+}
+
+export const mapAssigneeType = (
+  type: HealthDirectorateAppointmentAssigneeType,
+  formatMessage: FormatMessage,
+) => {
+  switch (type) {
+    case HealthDirectorateAppointmentAssigneeType.ROLE:
+      return formatMessage(messages.appointmentAssigneeTypeRole)
+    case HealthDirectorateAppointmentAssigneeType.ROOM:
+      return formatMessage(messages.appointmentAssigneeTypeRoom)
+    case HealthDirectorateAppointmentAssigneeType.EQUIPMENT:
+      return formatMessage(messages.appointmentAssigneeTypeEquipment)
+    case HealthDirectorateAppointmentAssigneeType.SERVICE:
+      return formatMessage(messages.appointmentAssigneeTypeService)
+    case HealthDirectorateAppointmentAssigneeType.TEAM:
+      return formatMessage(messages.appointmentAssigneeTypeTeam)
+    default:
+      return formatMessage(messages.appointmentAssigneeTypeOther)
   }
 }


### PR DESCRIPTION
## What

Handle more types of info that can accompany appointments

## Why

So we display all info we get about the appointment that the user should see 

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Appointment details now show clearer information for dates, times, duration, modality, locations, instructions, practitioners, assignees, and organizations.
  * Assignee types now have dedicated labels for roles, rooms, equipment, services, teams, and other assignments.
  * Health delegation links now direct to the shared delegations area.
* **Accessibility**
  * Video call status updates are now announced politely to assistive technologies.
* **Improvements**
  * Appointment weekday labels are derived consistently from the appointment date.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->