### PR TITLE
fix(application-system): Making sure maritalTitle is not fetched for children

### DIFF
--- a/libs/application/template-api-modules/src/lib/modules/shared/api/national-registry-v3/national-registry-v3.service.ts
+++ b/libs/application/template-api-modules/src/lib/modules/shared/api/national-registry-v3/national-registry-v3.service.ts
@@ -85,7 +85,9 @@ export class NationalRegistryV3Service extends BaseTemplateApiService {
       if (children.length > 0) {
         let foundChildWithIcelandicCitizenship = false
         for (const child of children) {
-          const individual = await this.getIndividual(child, auth)
+          const individual = await this.getIndividual(child, auth, {
+            skipMaritalTitle: true,
+          })
           if (individual?.citizenship?.code === 'IS') {
             foundChildWithIcelandicCitizenship = true
             break


### PR DESCRIPTION
# ...

Attach a link to issue if relevant

## What

Specify what you're trying to achieve

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [X] No AI tools were used in preparing this pull request
- [ ] AI tools were used in preparing this pull request
      Tools used:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved custody child citizenship checks by preventing irrelevant marital-title information from being retrieved during verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->