### PR TITLE
fix(j-s): Restore advocate assigned notification and move court dates to event dispatch

### DIFF
--- a/apps/judicial-system/api/src/app/modules/case/dto/sendNotification.input.ts
+++ b/apps/judicial-system/api/src/app/modules/case/dto/sendNotification.input.ts
@@ -1,4 +1,4 @@
-import { Allow, IsOptional } from 'class-validator'
+import { Allow } from 'class-validator'
 
 import { Field, ID, InputType } from '@nestjs/graphql'
 
@@ -13,9 +13,4 @@ export class SendNotificationInput {
   @Allow()
   @Field(() => TrackedNotificationType)
   readonly type!: TrackedNotificationType
-
-  @Allow()
-  @IsOptional()
-  @Field(() => Boolean, { nullable: true })
-  readonly eventOnly?: boolean
 }

--- a/apps/judicial-system/backend/src/app/formatters/pdfHelpers/pdfHelpers.spec.ts
+++ b/apps/judicial-system/backend/src/app/formatters/pdfHelpers/pdfHelpers.spec.ts
@@ -286,6 +286,7 @@ describe('addRichText highlight placement', () => {
     }
 
     const docInternals = doc as unknown as {
+      // eslint-disable-next-line @typescript-eslint/naming-convention
       _fragment: (text: string, x: number, y: number, options: unknown) => void
     }
     const originalFragment = docInternals._fragment.bind(doc)

--- a/apps/judicial-system/backend/src/app/modules/appeal-case/limitedAccessAppealCase.controller.ts
+++ b/apps/judicial-system/backend/src/app/modules/appeal-case/limitedAccessAppealCase.controller.ts
@@ -30,7 +30,6 @@ import {
 
 import { defenderRule } from '../../guards'
 import { CurrentCase } from '../case/guards/case.decorator'
-import { CaseCompletedGuard } from '../case/guards/caseCompleted.guard'
 import { CaseTypeGuard } from '../case/guards/caseType.guard'
 import { CaseWriteGuard } from '../case/guards/caseWrite.guard'
 import { LimitedAccessCaseExistsGuard } from '../case/guards/limitedAccessCaseExists.guard'

--- a/apps/judicial-system/backend/src/app/modules/case/case.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/case/case.service.ts
@@ -84,7 +84,6 @@ import {
   AppealCaseRepositoryService,
   AppealDecision,
   AppealDecisionRepositoryService,
-  AppealEventLog,
   AppealEventLogRepositoryService,
   Case,
   caseInclude,
@@ -1659,7 +1658,7 @@ export class CaseService {
     }
   }
 
-  private handleStateChangeEventLogUpdatesForRequest(
+  private handleStateChangeEventLogUpdatesForRequests(
     theCase: Case,
     updatedCase: Case,
     user: TUser,
@@ -1715,7 +1714,7 @@ export class CaseService {
     }
 
     if (isRequestCase(theCase.type)) {
-      return this.handleStateChangeEventLogUpdatesForRequest(
+      return this.handleStateChangeEventLogUpdatesForRequests(
         theCase,
         updatedCase,
         user,
@@ -1865,7 +1864,9 @@ export class CaseService {
     }
   }
 
-  private async handleEventLogUpdatesForIndictments(
+  // Scheduling a court date drives court date notifications for both
+  // indictment and request cases - see NotificationDispatchService
+  private async handleCourtDateEventLogUpdates(
     theCase: Case,
     updatedCase: Case,
     user: TUser,
@@ -1990,14 +1991,12 @@ export class CaseService {
       )
     }
 
-    if (isIndictmentCase(theCase.type)) {
-      return this.handleEventLogUpdatesForIndictments(
-        theCase,
-        updatedCase,
-        user,
-        transaction,
-      )
-    }
+    return this.handleCourtDateEventLogUpdates(
+      theCase,
+      updatedCase,
+      user,
+      transaction,
+    )
   }
 
   async update(
@@ -2384,15 +2383,10 @@ export class CaseService {
     }
 
     if (requiresCourtTransition) {
-      this.eventService.postEvent(
-        CaseTransition.MOVE,
-        updatedCase ?? theCase,
-        false,
-        {
-          from: theCase.court?.name,
-          to: updatedCase?.court?.name,
-        },
-      )
+      this.eventService.postEvent(CaseTransition.MOVE, updatedCase, {
+        from: theCase.court?.name,
+        to: updatedCase?.court?.name,
+      })
     }
 
     if (returnUpdatedCase) {

--- a/apps/judicial-system/backend/src/app/modules/case/limitedAccessCase.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/case/limitedAccessCase.service.ts
@@ -14,7 +14,6 @@ import { LOGGER_PROVIDER } from '@island.is/logging'
 
 import type { User as TUser } from '@island.is/judicial-system/types'
 import {
-  AppealCaseNotificationType,
   appealEventTypes,
   CaseFileCategory,
   CaseFileState,
@@ -59,7 +58,6 @@ import {
   EventLog,
   IndictmentCount,
   Institution,
-  Notification,
   Offense,
   Subpoena,
   User,

--- a/apps/judicial-system/backend/src/app/modules/case/test/caseController/update.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/case/test/caseController/update.spec.ts
@@ -1007,15 +1007,73 @@ describe('CaseController - Update', () => {
   describe('arraignment date updated', () => {
     const arraignmentDate = { date: new Date(), location: uuid() }
     const caseToUpdate = { arraignmentDate }
+    const updatedCase = {
+      ...theCase,
+      type: CaseType.CUSTODY,
+      dateLogs: [{ dateType: DateType.ARRAIGNMENT_DATE, ...arraignmentDate }],
+    }
 
     beforeEach(async () => {
-      await givenWhenThen(caseId, user, theCase, caseToUpdate)
+      const mockFindOne = mockCaseRepositoryService.findOne as jest.Mock
+      mockFindOne.mockResolvedValueOnce(updatedCase)
+
+      await givenWhenThen(
+        caseId,
+        user,
+        { ...theCase, type: CaseType.CUSTODY } as Case,
+        caseToUpdate,
+      )
     })
 
     it('should update case', () => {
       expect(mockDateLogModel.create).toHaveBeenCalledWith(
         { dateType: DateType.ARRAIGNMENT_DATE, caseId, ...arraignmentDate },
         { transaction },
+      )
+    })
+
+    it('should log a court date scheduled event, which drives court date notifications', () => {
+      expect(mockEventLogService.createWithUser).toHaveBeenCalledWith(
+        EventType.COURT_DATE_SCHEDULED,
+        caseId,
+        user,
+        transaction,
+      )
+    })
+  })
+
+  describe('arraignment date unchanged', () => {
+    const arraignmentDate = { date: new Date(), location: uuid() }
+    const updatedCase = {
+      ...theCase,
+      type: CaseType.CUSTODY,
+      dateLogs: [{ dateType: DateType.ARRAIGNMENT_DATE, ...arraignmentDate }],
+    }
+
+    beforeEach(async () => {
+      const mockFindOne = mockCaseRepositoryService.findOne as jest.Mock
+      mockFindOne.mockResolvedValueOnce(updatedCase)
+
+      await givenWhenThen(
+        caseId,
+        user,
+        {
+          ...theCase,
+          type: CaseType.CUSTODY,
+          dateLogs: [
+            { dateType: DateType.ARRAIGNMENT_DATE, ...arraignmentDate },
+          ],
+        } as Case,
+        {},
+      )
+    })
+
+    it('should not log a court date scheduled event', () => {
+      expect(mockEventLogService.createWithUser).not.toHaveBeenCalledWith(
+        EventType.COURT_DATE_SCHEDULED,
+        caseId,
+        user,
+        transaction,
       )
     })
   })

--- a/apps/judicial-system/backend/src/app/modules/court/court.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/court/court.service.ts
@@ -318,7 +318,7 @@ export class CourtService {
   }
 
   async createEmail(
-    user: UserDescriptor,
+    user: UserDescriptor | undefined,
     caseId: string,
     courtId: string,
     courtCaseNumber: string,
@@ -347,8 +347,8 @@ export class CourtService {
           'Failed to create an email at court',
           {
             caseId,
-            actor: user.name,
-            institution: user.institution?.name,
+            actor: user?.name,
+            institution: user?.institution?.name,
             courtId,
             courtCaseNumber,
             subject: this.mask(subject),

--- a/apps/judicial-system/backend/src/app/modules/event/event.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/event/event.service.ts
@@ -128,7 +128,6 @@ export class EventService {
   async postEvent(
     event: Event,
     theCase: Case,
-    eventOnly = false,
     info?: { [key: string]: string | boolean | Date | undefined },
   ) {
     try {
@@ -136,9 +135,7 @@ export class EventService {
         return
       }
 
-      const title = `${eventHeading[event]}${
-        eventOnly ? ' - aðgerð ekki framkvæmd' : ''
-      }`
+      const title = eventHeading[event]
       const typeText = `${capitalize(formatCaseType(theCase.type))}${
         isIndictmentCase(theCase.type)
           ? `:(${readableIndictmentSubtypes(

--- a/apps/judicial-system/backend/src/app/modules/notification/dto/caseNotification.dto.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/dto/caseNotification.dto.ts
@@ -1,11 +1,4 @@
-import {
-  IsArray,
-  IsEnum,
-  IsNotEmpty,
-  IsObject,
-  IsOptional,
-  IsString,
-} from 'class-validator'
+import { IsEnum, IsNotEmpty, IsObject, IsOptional } from 'class-validator'
 
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger'
 
@@ -13,10 +6,12 @@ import type { User, UserDescriptor } from '@island.is/judicial-system/types'
 import { UmbrellaNotificationType } from '@island.is/judicial-system/types'
 
 export class CaseNotificationDto {
-  @IsNotEmpty()
+  // Notifications dispatched in response to logged events carry a
+  // userDescriptor rather than a registered user - see below
+  @IsOptional()
   @IsObject()
-  @ApiProperty({ type: Object })
-  readonly user!: User
+  @ApiPropertyOptional({ type: Object })
+  readonly user?: User
 
   @IsNotEmpty()
   @IsEnum(UmbrellaNotificationType)

--- a/apps/judicial-system/backend/src/app/modules/notification/dto/indictmentCaseNotification.dto.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/dto/indictmentCaseNotification.dto.ts
@@ -11,6 +11,9 @@ export class IndictmentCaseNotificationDto {
   @ApiProperty({ enum: IndictmentCaseNotificationType })
   readonly type!: IndictmentCaseNotificationType
 
+  // notifications triggered from the event service don't always have the user object defined,
+  // thus we include an optional sibling subtype of User to handle a minimal user info that
+  // is requires in few notification methods
   @IsOptional()
   @IsObject()
   @ApiPropertyOptional({ type: Object })

--- a/apps/judicial-system/backend/src/app/modules/notification/dto/notification.dto.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/dto/notification.dto.ts
@@ -1,12 +1,12 @@
-import { IsBoolean, IsEnum, IsNotEmpty, IsOptional } from 'class-validator'
+import { IsEnum, IsNotEmpty } from 'class-validator'
 
-import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger'
+import { ApiProperty } from '@nestjs/swagger'
 
 import { RequestCaseNotificationType } from '@island.is/judicial-system/types'
 
 export enum UserInitiatedNotificationType {
+  ADVOCATE_ASSIGNED = RequestCaseNotificationType.ADVOCATE_ASSIGNED,
   CASE_FILES_UPDATED = RequestCaseNotificationType.CASE_FILES_UPDATED,
-  COURT_DATE = RequestCaseNotificationType.COURT_DATE,
   HEADS_UP = RequestCaseNotificationType.HEADS_UP,
   READY_FOR_COURT = RequestCaseNotificationType.READY_FOR_COURT,
 }
@@ -16,9 +16,4 @@ export class NotificationDto {
   @IsEnum(UserInitiatedNotificationType)
   @ApiProperty({ enum: UserInitiatedNotificationType })
   readonly type!: UserInitiatedNotificationType
-
-  @IsOptional()
-  @IsBoolean()
-  @ApiPropertyOptional({ type: Boolean })
-  readonly eventOnly?: boolean
 }

--- a/apps/judicial-system/backend/src/app/modules/notification/guards/rolesRules.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/guards/rolesRules.ts
@@ -46,7 +46,7 @@ export const districtCourtJudgeNotificationRule: RolesRule = {
   role: UserRole.DISTRICT_COURT_JUDGE,
   type: RulesType.FIELD_VALUES,
   dtoField: 'type',
-  dtoFieldValues: [RequestCaseNotificationType.COURT_DATE],
+  dtoFieldValues: [RequestCaseNotificationType.ADVOCATE_ASSIGNED],
 }
 
 // Allows district court registrars to send notifications
@@ -54,7 +54,7 @@ export const districtCourtRegistrarNotificationRule: RolesRule = {
   role: UserRole.DISTRICT_COURT_REGISTRAR,
   type: RulesType.FIELD_VALUES,
   dtoField: 'type',
-  dtoFieldValues: [RequestCaseNotificationType.COURT_DATE],
+  dtoFieldValues: [RequestCaseNotificationType.ADVOCATE_ASSIGNED],
 }
 
 // Allows district court assistants to send notifications
@@ -62,5 +62,5 @@ export const districtCourtAssistantNotificationRule: RolesRule = {
   role: UserRole.DISTRICT_COURT_ASSISTANT,
   type: RulesType.FIELD_VALUES,
   dtoField: 'type',
-  dtoFieldValues: [RequestCaseNotificationType.COURT_DATE],
+  dtoFieldValues: [RequestCaseNotificationType.ADVOCATE_ASSIGNED],
 }

--- a/apps/judicial-system/backend/src/app/modules/notification/notification.controller.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/notification.controller.ts
@@ -70,7 +70,6 @@ export class NotificationController {
 
     return this.notificationService.addMessagesForNotificationToQueue(
       notificationDto.type,
-      notificationDto.eventOnly,
       theCase,
       user,
     )

--- a/apps/judicial-system/backend/src/app/modules/notification/services/baseNotification.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/services/baseNotification.service.ts
@@ -267,9 +267,9 @@ export abstract class BaseNotificationService {
 
   protected async uploadEmailToCourt(
     theCase: Case,
-    user: UserDescriptor,
     subject: string,
     body: string,
+    user?: UserDescriptor,
     recipients?: string,
   ): Promise<void> {
     try {
@@ -301,7 +301,7 @@ export abstract class BaseNotificationService {
     recipientEmail,
   }: {
     theCase: Case
-    user: UserDescriptor
+    user: UserDescriptor | undefined
     arraignmentDateLog: DateLog
     recipientName: string
     recipientEmail: string
@@ -329,7 +329,7 @@ export abstract class BaseNotificationService {
     }).then((recipient) => {
       if (recipient.success) {
         // No need to wait
-        this.uploadEmailToCourt(theCase, user, subject, body, recipientEmail)
+        this.uploadEmailToCourt(theCase, subject, body, user, recipientEmail)
       }
 
       return recipient
@@ -374,7 +374,7 @@ export abstract class BaseNotificationService {
     }).then((recipient) => {
       if (recipient.success) {
         // No need to wait
-        this.uploadEmailToCourt(theCase, user, subject, body, recipientEmail)
+        this.uploadEmailToCourt(theCase, subject, body, user, recipientEmail)
       }
 
       return recipient
@@ -396,7 +396,7 @@ export abstract class BaseNotificationService {
     recipientHasAccessToRVG,
   }: {
     theCase: Case
-    user: UserDescriptor
+    user: UserDescriptor | undefined
     recipientName: string
     recipientEmail: string
     recipientHasAccessToRVG: boolean

--- a/apps/judicial-system/backend/src/app/modules/notification/services/baseNotification.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/services/baseNotification.service.ts
@@ -345,7 +345,7 @@ export abstract class BaseNotificationService {
     recipientHasAccessToRVG,
   }: {
     theCase: Case
-    user: UserDescriptor
+    user: UserDescriptor | undefined
     courtDate: DateLog
     recipientName: string
     recipientEmail: string

--- a/apps/judicial-system/backend/src/app/modules/notification/services/caseNotification/caseNotification.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/services/caseNotification/caseNotification.service.ts
@@ -568,7 +568,7 @@ export class CaseNotificationService extends BaseNotificationService {
 
   private sendCourtDateEmailNotificationToProsecutor(
     theCase: Case,
-    user: UserDescriptor,
+    user?: UserDescriptor,
   ): Promise<Recipient> {
     const arraignmentDate = DateLog.arraignmentDate(theCase.dateLogs)
 
@@ -602,9 +602,9 @@ export class CaseNotificationService extends BaseNotificationService {
         // No need to wait
         this.uploadEmailToCourt(
           theCase,
-          user,
           subject,
           body,
+          user,
           theCase.prosecutor?.email,
         )
       }
@@ -695,7 +695,7 @@ export class CaseNotificationService extends BaseNotificationService {
     }).then((recipient) => {
       if (recipient.success) {
         // No need to wait
-        this.uploadEmailToCourt(theCase, user, subject, html, defenderEmail)
+        this.uploadEmailToCourt(theCase, subject, html, user, defenderEmail)
       }
 
       return recipient
@@ -804,11 +804,7 @@ export class CaseNotificationService extends BaseNotificationService {
     theCase: Case,
     user?: UserDescriptor,
   ): Promise<DeliverResponse> {
-    if (!user) {
-      // nothing happens
-      return { delivered: true }
-    }
-
+    // TODO: Move to case service
     this.eventService.postEvent('SCHEDULE_COURT_DATE', theCase)
 
     const promises: Promise<Recipient>[] = []
@@ -1814,6 +1810,42 @@ export class CaseNotificationService extends BaseNotificationService {
   //#endregion
 
   //#region ADVOCATE_ASSIGNED notifications */
+
+  // Sent when the district court registers an advocate but does not confirm an
+  // arraignment date. Without a confirmed arraignment date the advocate has no
+  // access to the case in RVG, so this notification is information only - it
+  // deliberately carries no link to the case.
+  private sendAdvocateAssignedEmailNotification({
+    theCase,
+    advocateName,
+    advocateEmail,
+    advocateSubRole,
+  }: {
+    theCase: Case
+    advocateName?: string
+    advocateEmail?: string
+    advocateSubRole: DefenderSubRole
+  }): Promise<Recipient> {
+    const html = formatDefenderCourtDateLinkEmailNotification({
+      formatMessage: this.formatMessage,
+      // No overview url - the advocate cannot access the case yet
+      overviewUrl: undefined,
+      court: theCase.court?.name,
+      courtCaseNumber: theCase.courtCaseNumber,
+      requestSharedWithDefender: false,
+      defenderSubRole: advocateSubRole,
+    })
+
+    return this.sendEmail({
+      subject: `Yfirlit máls ${theCase.courtCaseNumber}`,
+      html,
+      recipientName: advocateName,
+      recipientEmail: advocateEmail,
+      // The email is information only, so we do not append the link tail either
+      skipTail: true,
+    })
+  }
+
   private shouldSendAdvocateAssignedNotification(
     theCase: Case,
     advocateEmail?: string,
@@ -1821,34 +1853,18 @@ export class CaseNotificationService extends BaseNotificationService {
     if (!advocateEmail) {
       return false
     }
-    if (isInvestigationCase(theCase.type)) {
-      const isDefenderIncludedInSessionArrangements =
-        theCase.sessionArrangements &&
-        [
-          SessionArrangements.ALL_PRESENT,
-          SessionArrangements.ALL_PRESENT_SPOKESPERSON,
-        ].includes(theCase.sessionArrangements)
 
-      if (!isDefenderIncludedInSessionArrangements) {
-        return false
-      }
-    } else if (isRequestCase(theCase.type)) {
-      const hasDefenderBeenNotified = this.hasReceivedNotification(
-        [
-          TrackedNotificationType.READY_FOR_COURT,
-          TrackedNotificationType.COURT_DATE,
-          TrackedNotificationType.ADVOCATE_ASSIGNED,
-        ],
-        theCase.defenderEmail,
-        theCase.notifications,
-      )
+    const hasAdvocateBeenNotified = this.hasReceivedNotification(
+      [
+        TrackedNotificationType.READY_FOR_COURT,
+        TrackedNotificationType.COURT_DATE,
+        TrackedNotificationType.ADVOCATE_ASSIGNED,
+      ],
+      advocateEmail,
+      theCase.notifications,
+    )
 
-      if (hasDefenderBeenNotified) {
-        return false
-      }
-    }
-
-    return true
+    return !hasAdvocateBeenNotified
   }
 
   private async sendAdvocateAssignedNotifications(
@@ -1856,14 +1872,50 @@ export class CaseNotificationService extends BaseNotificationService {
   ): Promise<DeliverResponse> {
     const promises: Promise<Recipient>[] = []
 
-    if (DateLog.arraignmentDate(theCase.dateLogs)?.date) {
-      const shouldSend = this.shouldSendAdvocateAssignedNotification(
+    // DEFENDER / SPOKESPERSON
+    const isDefenderIncludedInSessionArrangements =
+      isRestrictionCase(theCase.type) ||
+      (theCase.sessionArrangements &&
+        [
+          SessionArrangements.ALL_PRESENT,
+          SessionArrangements.ALL_PRESENT_SPOKESPERSON,
+        ].includes(theCase.sessionArrangements))
+
+    if (
+      isDefenderIncludedInSessionArrangements &&
+      this.shouldSendAdvocateAssignedNotification(
         theCase,
         theCase.defenderEmail,
       )
+    ) {
+      promises.push(
+        this.sendAdvocateAssignedEmailNotification({
+          theCase,
+          advocateName: theCase.defenderName,
+          advocateEmail: theCase.defenderEmail,
+          advocateSubRole: DefenderSubRole.DEFENDANT_DEFENDER,
+        }),
+      )
+    }
 
-      if (shouldSend) {
-        promises.push(this.sendCourtDateEmailNotificationToDefender(theCase))
+    // VICTIM LAWYER
+    if (isInvestigationCase(theCase.type)) {
+      for (const victim of theCase.victims ?? []) {
+        if (
+          this.shouldSendAdvocateAssignedNotification(
+            theCase,
+            victim.lawyerEmail,
+          )
+        ) {
+          promises.push(
+            this.sendAdvocateAssignedEmailNotification({
+              theCase,
+              advocateName: victim.lawyerName,
+              advocateEmail: victim.lawyerEmail,
+              advocateSubRole: DefenderSubRole.VICTIM_LAWYER,
+            }),
+          )
+        }
       }
     }
 
@@ -2342,9 +2394,21 @@ export class CaseNotificationService extends BaseNotificationService {
   private sendNotification(
     type: UmbrellaNotificationType,
     theCase: Case,
-    user: User,
+    user?: User,
     userDescriptor?: UserDescriptor,
   ): Promise<DeliverResponse> {
+    // A few notifications are only ever triggered by a registered user and
+    // cannot be sent without one
+    const requireUser = (): User => {
+      if (!user) {
+        throw new InternalServerErrorException(
+          `Notification type ${type} requires a user`,
+        )
+      }
+
+      return user
+    }
+
     switch (type) {
       case RequestCaseNotificationType.HEADS_UP:
         return this.sendHeadsUpNotifications(theCase)
@@ -2367,7 +2431,7 @@ export class CaseNotificationService extends BaseNotificationService {
       case RequestCaseNotificationType.RULING:
         return this.sendRulingNotifications(theCase)
       case RequestCaseNotificationType.MODIFIED:
-        return this.sendModifiedNotifications(theCase, user)
+        return this.sendModifiedNotifications(theCase, requireUser())
       case RequestCaseNotificationType.REVOKED:
         return this.sendRevokedNotifications(theCase)
       case RequestCaseNotificationType.ADVOCATE_ASSIGNED:
@@ -2377,7 +2441,7 @@ export class CaseNotificationService extends BaseNotificationService {
       case IndictmentCaseNotificationType.INDICTMENT_DENIED:
         return this.sendIndictmentDeniedNotifications(theCase)
       case RequestCaseNotificationType.CASE_FILES_UPDATED:
-        return this.sendCaseFilesUpdatedNotifications(theCase, user)
+        return this.sendCaseFilesUpdatedNotifications(theCase, requireUser())
       case IndictmentCaseNotificationType.RULING_ORDER_ADDED:
         return this.sendRulingOrderAddedNotifications(theCase)
       case IndictmentCaseNotificationType.PUBLIC_PROSECUTOR_REVIEWER_ASSIGNED:
@@ -2394,7 +2458,7 @@ export class CaseNotificationService extends BaseNotificationService {
   async sendCaseNotification(
     type: UmbrellaNotificationType,
     theCase: Case,
-    user: User,
+    user?: User,
     userDescriptor?: UserDescriptor,
   ): Promise<DeliverResponse> {
     await this.refreshFormatMessage()

--- a/apps/judicial-system/backend/src/app/modules/notification/services/caseNotification/caseNotification.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/services/caseNotification/caseNotification.service.ts
@@ -841,13 +841,19 @@ export class CaseNotificationService extends BaseNotificationService {
         }),
       )
 
-      const hasDefenderBeenNotified = this.hasReceivedNotification(
-        TrackedNotificationType.READY_FOR_COURT,
+      // The link to the case carries no court date, so it is only sent once.
+      // Note that an advocate assigned notification does not count - it is
+      // information only and carries no link.
+      const hasDefenderBeenSentLinkToCase = this.hasReceivedNotification(
+        [
+          TrackedNotificationType.READY_FOR_COURT,
+          TrackedNotificationType.COURT_DATE,
+        ],
         theCase.defenderEmail,
         theCase.notifications,
       )
 
-      if (!hasDefenderBeenNotified) {
+      if (!hasDefenderBeenSentLinkToCase) {
         promises.push(this.sendCourtDateEmailNotificationToDefender(theCase))
       }
     }

--- a/apps/judicial-system/backend/src/app/modules/notification/services/caseNotification/caseNotification.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/services/caseNotification/caseNotification.service.ts
@@ -1870,7 +1870,11 @@ export class CaseNotificationService extends BaseNotificationService {
   private async sendAdvocateAssignedNotifications(
     theCase: Case,
   ): Promise<DeliverResponse> {
-    const promises: Promise<Recipient>[] = []
+    const advocates: {
+      name?: string
+      email?: string
+      subRole: DefenderSubRole
+    }[] = []
 
     // DEFENDER / SPOKESPERSON
     const isDefenderIncludedInSessionArrangements =
@@ -1881,45 +1885,45 @@ export class CaseNotificationService extends BaseNotificationService {
           SessionArrangements.ALL_PRESENT_SPOKESPERSON,
         ].includes(theCase.sessionArrangements))
 
-    if (
-      isDefenderIncludedInSessionArrangements &&
-      this.shouldSendAdvocateAssignedNotification(
-        theCase,
-        theCase.defenderEmail,
-      )
-    ) {
-      promises.push(
-        this.sendAdvocateAssignedEmailNotification({
-          theCase,
-          advocateName: theCase.defenderName,
-          advocateEmail: theCase.defenderEmail,
-          advocateSubRole: DefenderSubRole.DEFENDANT_DEFENDER,
-        }),
-      )
+    if (isDefenderIncludedInSessionArrangements) {
+      advocates.push({
+        name: theCase.defenderName,
+        email: theCase.defenderEmail,
+        subRole: DefenderSubRole.DEFENDANT_DEFENDER,
+      })
     }
 
     // VICTIM LAWYER
     if (isInvestigationCase(theCase.type)) {
-      for (const victim of theCase.victims ?? []) {
-        if (
-          this.shouldSendAdvocateAssignedNotification(
-            theCase,
-            victim.lawyerEmail,
-          )
-        ) {
-          promises.push(
-            this.sendAdvocateAssignedEmailNotification({
-              theCase,
-              advocateName: victim.lawyerName,
-              advocateEmail: victim.lawyerEmail,
-              advocateSubRole: DefenderSubRole.VICTIM_LAWYER,
-            }),
-          )
-        }
-      }
+      advocates.push(
+        ...(theCase.victims ?? []).map((victim) => ({
+          name: victim.lawyerName,
+          email: victim.lawyerEmail,
+          subRole: DefenderSubRole.VICTIM_LAWYER,
+        })),
+      )
     }
 
-    const recipients = await Promise.all(promises)
+    // The same advocate can be registered more than once - victims can share a
+    // lawyer, and a victim's lawyer can also be the defender - but should only
+    // be notified once
+    const uniqueAdvocates = _uniqBy(
+      advocates.filter((advocate) =>
+        this.shouldSendAdvocateAssignedNotification(theCase, advocate.email),
+      ),
+      (advocate) => advocate.email,
+    )
+
+    const recipients = await Promise.all(
+      uniqueAdvocates.map((advocate) =>
+        this.sendAdvocateAssignedEmailNotification({
+          theCase,
+          advocateName: advocate.name,
+          advocateEmail: advocate.email,
+          advocateSubRole: advocate.subRole,
+        }),
+      ),
+    )
 
     if (recipients.length === 0) {
       // Nothing to send

--- a/apps/judicial-system/backend/src/app/modules/notification/services/caseNotification/caseNotification.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/services/caseNotification/caseNotification.service.ts
@@ -658,7 +658,7 @@ export class CaseNotificationService extends BaseNotificationService {
     defenderSubRole,
   }: {
     theCase: Case
-    user: UserDescriptor
+    user: UserDescriptor | undefined
     defenderName?: string
     defenderEmail?: string
     defenderNationalId?: string

--- a/apps/judicial-system/backend/src/app/modules/notification/services/caseNotification/caseNotification.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/services/caseNotification/caseNotification.service.ts
@@ -815,44 +815,56 @@ export class CaseNotificationService extends BaseNotificationService {
     )
 
     // DEFENDER
-    if (theCase.defenderEmail) {
-      if (
-        isRestrictionCase(theCase.type) ||
-        (isInvestigationCase(theCase.type) &&
-          theCase.sessionArrangements &&
-          [
-            SessionArrangements.ALL_PRESENT,
-            SessionArrangements.ALL_PRESENT_SPOKESPERSON,
-          ].includes(theCase.sessionArrangements))
-      ) {
-        promises.push(
-          this.sendCourtDateCalendarInviteEmailNotificationToDefender({
-            theCase,
-            user,
-            defenderName: theCase.defenderName,
-            defenderEmail: theCase.defenderEmail,
-            defenderNationalId: theCase.defenderNationalId,
-            defenderSubRole: DefenderSubRole.DEFENDANT_DEFENDER,
-          }),
-        )
+    const isDefenderIncludedInSessionArrangements =
+      isRestrictionCase(theCase.type) ||
+      (isInvestigationCase(theCase.type) &&
+        theCase.sessionArrangements &&
+        [
+          SessionArrangements.ALL_PRESENT,
+          SessionArrangements.ALL_PRESENT_SPOKESPERSON,
+        ].includes(theCase.sessionArrangements))
 
-        const hasDefenderBeenNotified = this.hasReceivedNotification(
-          TrackedNotificationType.READY_FOR_COURT,
-          theCase.defenderEmail,
-          theCase.notifications,
-        )
+    const notifiedDefenderEmail =
+      theCase.defenderEmail && isDefenderIncludedInSessionArrangements
+        ? theCase.defenderEmail
+        : undefined
 
-        if (!hasDefenderBeenNotified) {
-          promises.push(this.sendCourtDateEmailNotificationToDefender(theCase))
-        }
+    if (notifiedDefenderEmail) {
+      promises.push(
+        this.sendCourtDateCalendarInviteEmailNotificationToDefender({
+          theCase,
+          user,
+          defenderName: theCase.defenderName,
+          defenderEmail: theCase.defenderEmail,
+          defenderNationalId: theCase.defenderNationalId,
+          defenderSubRole: DefenderSubRole.DEFENDANT_DEFENDER,
+        }),
+      )
+
+      const hasDefenderBeenNotified = this.hasReceivedNotification(
+        TrackedNotificationType.READY_FOR_COURT,
+        theCase.defenderEmail,
+        theCase.notifications,
+      )
+
+      if (!hasDefenderBeenNotified) {
+        promises.push(this.sendCourtDateEmailNotificationToDefender(theCase))
       }
     }
 
     // VICTIM LAWYER
     if (isInvestigationCase(theCase.type)) {
-      theCase.victims?.forEach((victim) => {
-        if (!victim.lawyerEmail) return
+      // Victims can share a lawyer, and a victim's lawyer can also be the
+      // defender, but each advocate should only be notified once
+      const uniqueVictimLawyers = _uniqBy(
+        theCase.victims?.filter(
+          (victim) =>
+            victim.lawyerEmail && victim.lawyerEmail !== notifiedDefenderEmail,
+        ) ?? [],
+        (victim) => victim.lawyerEmail,
+      )
 
+      uniqueVictimLawyers.forEach((victim) => {
         const hasReceivedCourtDateEventNotification =
           this.hasReceivedNotification(
             TrackedNotificationType.COURT_DATE,

--- a/apps/judicial-system/backend/src/app/modules/notification/services/civilClaimantNotification/civilClaimantNotification.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/services/civilClaimantNotification/civilClaimantNotification.service.ts
@@ -137,7 +137,7 @@ export class CivilClaimantNotificationService extends BaseNotificationService {
       TrackedNotificationType.SPOKESPERSON_COURT_DATE_FOLLOW_UP,
     )
 
-    if (!shouldSendCourtDateFollowUp || !user) {
+    if (!shouldSendCourtDateFollowUp) {
       // Nothing should be sent so we return a successful response
       return { delivered: true }
     }

--- a/apps/judicial-system/backend/src/app/modules/notification/services/indictmentCaseNotification/indictmentCaseNotification.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/services/indictmentCaseNotification/indictmentCaseNotification.service.ts
@@ -185,7 +185,7 @@ export class IndictmentCaseNotificationService extends BaseNotificationService {
 
   private sendArraignmentDateEmailNotifications(
     theCase: Case,
-    user: UserDescriptor,
+    user: UserDescriptor | undefined,
     arraignmentDate: DateLog,
   ) {
     this.eventService.postEvent('SCHEDULE_ARRAIGNMENT_DATE', theCase)
@@ -257,7 +257,7 @@ export class IndictmentCaseNotificationService extends BaseNotificationService {
 
   private async sendPostponedCourtDateEmailNotification(
     theCase: Case,
-    user: UserDescriptor,
+    user: UserDescriptor | undefined,
     courtDate: DateLog,
     calendarInvite: Attachment | undefined,
     overviewUrl?: string,
@@ -281,7 +281,7 @@ export class IndictmentCaseNotificationService extends BaseNotificationService {
     }).then((recipient) => {
       if (recipient.success) {
         // No need to wait
-        this.uploadEmailToCourt(theCase, user, subject, body, email)
+        this.uploadEmailToCourt(theCase, subject, body, user, email)
       }
 
       return recipient
@@ -291,7 +291,7 @@ export class IndictmentCaseNotificationService extends BaseNotificationService {
   private sendPostponedCourtDateEmailNotifications(
     theCase: Case,
     courtDate: DateLog,
-    user: UserDescriptor,
+    user: UserDescriptor | undefined,
   ): Promise<Recipient>[] {
     this.eventService.postEvent('SCHEDULE_COURT_DATE', theCase)
 
@@ -379,7 +379,7 @@ export class IndictmentCaseNotificationService extends BaseNotificationService {
 
   private sendCourtDateEmailNotification(
     theCase: Case,
-    user: UserDescriptor,
+    user: UserDescriptor | undefined,
   ): Promise<Recipient>[] {
     // check both regular court dates and arraignment date
     const courtDate = DateLog.courtDate(theCase.dateLogs)
@@ -407,13 +407,8 @@ export class IndictmentCaseNotificationService extends BaseNotificationService {
 
   private async sendCourtDateNotifications(
     theCase: Case,
-    user?: UserDescriptor,
+    user: UserDescriptor | undefined,
   ): Promise<DeliverResponse> {
-    if (!user) {
-      // nothing happens
-      return { delivered: true }
-    }
-
     const promises: Promise<Recipient>[] = this.sendCourtDateEmailNotification(
       theCase,
       user,

--- a/apps/judicial-system/backend/src/app/modules/notification/services/notification.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/services/notification.service.ts
@@ -4,13 +4,8 @@ import {
   addMessagesToQueue,
   MessageType,
 } from '@island.is/judicial-system/message'
-import {
-  CaseState,
-  RequestCaseNotificationType,
-  type User,
-} from '@island.is/judicial-system/types'
+import { CaseState, type User } from '@island.is/judicial-system/types'
 
-import { EventService } from '../../event'
 import { type Case } from '../../repository'
 import { UserInitiatedAppealNotificationType } from '../dto/appealNotification.dto'
 import { UserInitiatedNotificationType } from '../dto/notification.dto'
@@ -18,12 +13,8 @@ import { SendNotificationResponse } from '../models/sendNotification.response'
 
 @Injectable()
 export class NotificationService {
-  constructor(private readonly eventService: EventService) {}
-
   private addMessageForNotificationToQueue(
-    type:
-      | UserInitiatedNotificationType
-      | RequestCaseNotificationType.ADVOCATE_ASSIGNED,
+    type: UserInitiatedNotificationType,
     user: User,
     theCase: Case,
   ): void {
@@ -64,7 +55,6 @@ export class NotificationService {
 
   async addMessagesForNotificationToQueue(
     type: UserInitiatedNotificationType,
-    eventOnly = false,
     theCase: Case,
     user: User,
   ): Promise<SendNotificationResponse> {
@@ -80,22 +70,7 @@ export class NotificationService {
           })
         }
         break
-      case UserInitiatedNotificationType.COURT_DATE:
-        if (eventOnly) {
-          this.eventService.postEvent('SCHEDULE_COURT_DATE', theCase, true)
-
-          // We still want to send the defender a link to the case even if
-          // the judge chooses not to send a calendar invitation
-          // Note: This is only relevant for non-indictment cases
-          this.addMessageForNotificationToQueue(
-            RequestCaseNotificationType.ADVOCATE_ASSIGNED,
-            user,
-            theCase,
-          )
-        } else {
-          this.addMessageForNotificationToQueue(type, user, theCase)
-        }
-        break
+      case UserInitiatedNotificationType.ADVOCATE_ASSIGNED:
       case UserInitiatedNotificationType.HEADS_UP:
       case UserInitiatedNotificationType.CASE_FILES_UPDATED:
         this.addMessageForNotificationToQueue(type, user, theCase)

--- a/apps/judicial-system/backend/src/app/modules/notification/services/notificationDispatch.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/services/notificationDispatch.service.ts
@@ -20,6 +20,7 @@ import {
   isIndictmentCase,
   NotificationDispatchType,
   prosecutorsOfficeTypes,
+  RequestCaseNotificationType,
   ServiceRequirement,
   UserDescriptor,
 } from '@island.is/judicial-system/types'
@@ -160,10 +161,14 @@ export class NotificationDispatchService {
         },
       })
     } else {
-      // This path is never hit as EventNotificationType.COURT_DATE_SCHEDULED is only dispatched for indictment cases
-      this.logger.warn(
-        `Attempted to dispatch court date notification for case ${theCase.id} of type ${theCase.type}`,
-      )
+      addMessagesToQueue({
+        type: MessageType.NOTIFICATION,
+        caseId: theCase.id,
+        body: {
+          type: RequestCaseNotificationType.COURT_DATE,
+          userDescriptor,
+        },
+      })
     }
   }
 

--- a/apps/judicial-system/backend/src/app/modules/notification/test/internalNotificationController/eventNotificationDispatch/eventNotificationDispatch.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/test/internalNotificationController/eventNotificationDispatch/eventNotificationDispatch.spec.ts
@@ -6,6 +6,7 @@ import {
   CaseType,
   EventNotificationType,
   IndictmentCaseNotificationType,
+  RequestCaseNotificationType,
   User,
 } from '@island.is/judicial-system/types'
 
@@ -80,6 +81,34 @@ describe('InternalNotificationController - Dispatch event notifications', () => 
           caseId,
           body: {
             type: IndictmentCaseNotificationType.COURT_DATE,
+            userDescriptor: { name: user.name },
+          },
+        },
+      ],
+    },
+    {
+      theCase: setCaseType(CaseType.CUSTODY),
+      notificationType: EventNotificationType.COURT_DATE_SCHEDULED,
+      expectedMessages: [
+        {
+          type: MessageType.NOTIFICATION,
+          caseId,
+          body: {
+            type: RequestCaseNotificationType.COURT_DATE,
+            userDescriptor: { name: user.name },
+          },
+        },
+      ],
+    },
+    {
+      theCase: setCaseType(CaseType.PHONE_TAPPING),
+      notificationType: EventNotificationType.COURT_DATE_SCHEDULED,
+      expectedMessages: [
+        {
+          type: MessageType.NOTIFICATION,
+          caseId,
+          body: {
+            type: RequestCaseNotificationType.COURT_DATE,
             userDescriptor: { name: user.name },
           },
         },

--- a/apps/judicial-system/backend/src/app/modules/notification/test/internalNotificationController/sendAdvocateAssignedNotifications.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/test/internalNotificationController/sendAdvocateAssignedNotifications.spec.ts
@@ -3,11 +3,13 @@ import { v4 as uuid } from 'uuid'
 import { EmailService } from '@island.is/email-service'
 import { ConfigType } from '@island.is/nest/config'
 
-import { DEFENDER_REQUEST_CASE_ROUTE } from '@island.is/judicial-system/consts'
 import {
   CaseType,
-  DateType,
   RequestCaseNotificationType,
+  RequestSharedWhen,
+  RequestSharedWithDefender,
+  SessionArrangements,
+  TrackedNotificationType,
   User,
 } from '@island.is/judicial-system/types'
 
@@ -34,17 +36,46 @@ type GivenWhenThen = (
   notificationDto: CaseNotificationDto,
 ) => Promise<Then>
 
-describe('InternalNotificationController - Send defender assigned notifications', () => {
+describe('InternalNotificationController - Send advocate assigned notifications', () => {
   const userId = uuid()
 
-  const { defender } = createTestUsers(['defender'])
+  const { defender, victimLawyer } = createTestUsers([
+    'defender',
+    'victimLawyer',
+  ])
 
   const court = { name: 'Héraðsdómur Reykjavíkur' } as Case['court']
+  const courtCaseNumber = 'R-123/2022'
 
   let mockEmailService: EmailService
   let mockConfig: ConfigType<typeof notificationModuleConfig>
   let givenWhenThen: GivenWhenThen
   let notificationDTO: CaseNotificationDto
+
+  const expectedEmail = ({
+    name,
+    address,
+    responsibility,
+  }: {
+    name?: string
+    address?: string
+    responsibility: string
+  }) => ({
+    from: {
+      name: mockConfig.email.fromName,
+      address: mockConfig.email.fromEmail,
+    },
+    to: [{ name, address }],
+    replyTo: {
+      name: mockConfig.email.replyToName,
+      address: mockConfig.email.replyToEmail,
+    },
+    attachments: undefined,
+    subject: `Yfirlit máls ${courtCaseNumber}`,
+    text: expect.anything(),
+    // The advocate has no access to the case yet, so the email carries no link
+    html: `Héraðsdómur Reykjavíkur hefur skráð þig sem ${responsibility} í máli ${courtCaseNumber}.<br /><br />Þú getur nálgast yfirlit málsins hjá Héraðsdómi Reykjavíkur ef það hefur ekki þegar verið afhent.`,
+  })
 
   beforeEach(async () => {
     const { emailService, notificationConfig, internalNotificationController } =
@@ -79,107 +110,209 @@ describe('InternalNotificationController - Send defender assigned notifications'
     }
   })
 
-  describe('when sending assigned defender notifications in a restriction case', () => {
+  describe('when the defender has no access to a restriction case', () => {
     const caseId = uuid()
+    // Note: no arraignment date - it was not confirmed
     const theCase = {
       id: caseId,
       type: CaseType.ADMISSION_TO_FACILITY,
       court,
-      courtCaseNumber: 'R-123/2022',
+      courtCaseNumber,
       defenderEmail: defender.email,
       defenderName: defender.name,
       defenderNationalId: '1234567890',
-      dateLogs: [{ date: new Date(), dateType: DateType.ARRAIGNMENT_DATE }],
+      requestSharedWithDefender: RequestSharedWithDefender.COURT_DATE,
     } as Case
 
     beforeEach(async () => {
       await givenWhenThen(caseId, theCase, notificationDTO)
     })
 
-    it('should send email with link', () => {
+    it('should send an information only email without a link', () => {
       expect(mockEmailService.sendEmail).toHaveBeenCalledTimes(1)
-      expect(mockEmailService.sendEmail).toHaveBeenCalledWith({
-        from: {
-          name: mockConfig.email.fromName,
-          address: mockConfig.email.fromEmail,
-        },
-        to: [
-          {
-            name: theCase.defenderName,
-            address: theCase.defenderEmail,
-          },
-        ],
-        replyTo: {
-          name: mockConfig.email.replyToName,
-          address: mockConfig.email.replyToEmail,
-        },
-        attachments: undefined,
-        subject: `Yfirlit máls ${theCase.courtCaseNumber}`,
-        text: expect.anything(),
-        html: `Héraðsdómur Reykjavíkur hefur skráð þig sem verjanda/talsmann sakbornings í máli ${theCase.courtCaseNumber}.<br /><br />Þú getur nálgast yfirlit málsins á <a href="${mockConfig.clientUrl}${DEFENDER_REQUEST_CASE_ROUTE}/${caseId}">yfirlitssíðu málsins í Réttarvörslugátt</a>.`,
-      })
+      expect(mockEmailService.sendEmail).toHaveBeenCalledWith(
+        expectedEmail({
+          name: defender.name,
+          address: defender.email,
+          responsibility: 'verjanda/talsmann sakbornings',
+        }),
+      )
     })
   })
 
-  describe('when sending assigned defender without national id notifications in a restriction case', () => {
+  describe('when the request is never shared with the defender', () => {
     const caseId = uuid()
     const theCase = {
       id: caseId,
-      type: CaseType.ADMISSION_TO_FACILITY,
+      type: CaseType.CUSTODY,
       court,
-      courtCaseNumber: 'R-123/2022',
+      courtCaseNumber,
       defenderEmail: defender.email,
       defenderName: defender.name,
-      dateLogs: [{ date: new Date(), dateType: DateType.ARRAIGNMENT_DATE }],
+      requestSharedWithDefender: RequestSharedWithDefender.NOT_SHARED,
     } as Case
 
     beforeEach(async () => {
       await givenWhenThen(caseId, theCase, notificationDTO)
     })
 
-    it('should send an email without a link', () => {
+    it('should send an information only email without a link', () => {
       expect(mockEmailService.sendEmail).toHaveBeenCalledTimes(1)
-      expect(mockEmailService.sendEmail).toHaveBeenCalledWith({
-        from: {
-          name: mockConfig.email.fromName,
-          address: mockConfig.email.fromEmail,
-        },
-        to: [
-          {
-            name: theCase.defenderName,
-            address: theCase.defenderEmail,
-          },
-        ],
-        replyTo: {
-          name: mockConfig.email.replyToName,
-          address: mockConfig.email.replyToEmail,
-        },
-        attachments: undefined,
-        subject: `Yfirlit máls ${theCase.courtCaseNumber}`,
-        text: expect.anything(),
-        html: `Héraðsdómur Reykjavíkur hefur skráð þig sem verjanda/talsmann sakbornings í máli ${theCase.courtCaseNumber}.<br /><br />Þú getur nálgast yfirlit málsins hjá Héraðsdómi Reykjavíkur ef það hefur ekki þegar verið afhent.`,
-      })
+      expect(mockEmailService.sendEmail).toHaveBeenCalledWith(
+        expectedEmail({
+          name: defender.name,
+          address: defender.email,
+          responsibility: 'verjanda/talsmann sakbornings',
+        }),
+      )
     })
   })
 
-  describe('when sending notifications in an investigation case', () => {
+  describe('when the defender already has access to the case', () => {
+    const caseId = uuid()
+    const theCase = {
+      id: caseId,
+      type: CaseType.CUSTODY,
+      court,
+      courtCaseNumber,
+      defenderEmail: defender.email,
+      defenderName: defender.name,
+      requestSharedWithDefender: RequestSharedWithDefender.READY_FOR_COURT,
+    } as Case
+
+    let then: Then
+
+    beforeEach(async () => {
+      then = await givenWhenThen(caseId, theCase, notificationDTO)
+    })
+
+    it('should not send an email', () => {
+      expect(mockEmailService.sendEmail).not.toHaveBeenCalled()
+      expect(then.result).toEqual({ delivered: true })
+    })
+  })
+
+  describe('when the defender has already been notified', () => {
+    const caseId = uuid()
+    const theCase = {
+      id: caseId,
+      type: CaseType.CUSTODY,
+      court,
+      courtCaseNumber,
+      defenderEmail: defender.email,
+      defenderName: defender.name,
+      requestSharedWithDefender: RequestSharedWithDefender.NOT_SHARED,
+      notifications: [
+        {
+          type: TrackedNotificationType.ADVOCATE_ASSIGNED,
+          recipients: [{ address: defender.email, success: true }],
+        },
+      ],
+    } as Case
+
+    let then: Then
+
+    beforeEach(async () => {
+      then = await givenWhenThen(caseId, theCase, notificationDTO)
+    })
+
+    it('should not send an email', () => {
+      expect(mockEmailService.sendEmail).not.toHaveBeenCalled()
+      expect(then.result).toEqual({ delivered: true })
+    })
+  })
+
+  describe('when the defender is not included in the session arrangements', () => {
     const caseId = uuid()
     const theCase = {
       id: caseId,
       type: CaseType.PHONE_TAPPING,
       court,
-      courtCaseNumber: 'R-123/2022',
+      courtCaseNumber,
       defenderEmail: defender.email,
       defenderName: defender.name,
-      dateLogs: [{ date: new Date(), dateType: DateType.ARRAIGNMENT_DATE }],
+      sessionArrangements: SessionArrangements.PROSECUTOR_PRESENT,
+      requestSharedWithDefender: RequestSharedWithDefender.NOT_SHARED,
     } as Case
 
     beforeEach(async () => {
       await givenWhenThen(caseId, theCase, notificationDTO)
     })
 
-    it('should not send email', () => {
-      expect(mockEmailService.sendEmail).toHaveBeenCalledTimes(0)
+    it('should not send an email', () => {
+      expect(mockEmailService.sendEmail).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('when an investigation case has a defender and victim lawyers', () => {
+    const caseId = uuid()
+    const theCase = {
+      id: caseId,
+      type: CaseType.PHONE_TAPPING,
+      court,
+      courtCaseNumber,
+      defenderEmail: defender.email,
+      defenderName: defender.name,
+      sessionArrangements: SessionArrangements.ALL_PRESENT,
+      requestSharedWithDefender: RequestSharedWithDefender.NOT_SHARED,
+      victims: [
+        {
+          lawyerEmail: victimLawyer.email,
+          lawyerName: victimLawyer.name,
+          lawyerAccessToRequest: RequestSharedWhen.ARRAIGNMENT_DATE_ASSIGNED,
+        },
+      ],
+    } as Case
+
+    beforeEach(async () => {
+      await givenWhenThen(caseId, theCase, notificationDTO)
+    })
+
+    it('should send an information only email to both advocates', () => {
+      expect(mockEmailService.sendEmail).toHaveBeenCalledTimes(2)
+      expect(mockEmailService.sendEmail).toHaveBeenCalledWith(
+        expectedEmail({
+          name: defender.name,
+          address: defender.email,
+          responsibility: 'verjanda/talsmann sakbornings',
+        }),
+      )
+      expect(mockEmailService.sendEmail).toHaveBeenCalledWith(
+        expectedEmail({
+          name: victimLawyer.name,
+          address: victimLawyer.email,
+          responsibility: 'réttargæslumaður',
+        }),
+      )
+    })
+  })
+
+  describe('when a victim lawyer already has access to the case', () => {
+    const caseId = uuid()
+    const theCase = {
+      id: caseId,
+      type: CaseType.PHONE_TAPPING,
+      court,
+      courtCaseNumber,
+      sessionArrangements: SessionArrangements.ALL_PRESENT,
+      victims: [
+        {
+          lawyerEmail: victimLawyer.email,
+          lawyerName: victimLawyer.name,
+          lawyerAccessToRequest: RequestSharedWhen.READY_FOR_COURT,
+        },
+      ],
+    } as Case
+
+    let then: Then
+
+    beforeEach(async () => {
+      then = await givenWhenThen(caseId, theCase, notificationDTO)
+    })
+
+    it('should not send an email', () => {
+      expect(mockEmailService.sendEmail).not.toHaveBeenCalled()
+      expect(then.result).toEqual({ delivered: true })
     })
   })
 })

--- a/apps/judicial-system/backend/src/app/modules/notification/test/internalNotificationController/sendAdvocateAssignedNotifications.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/test/internalNotificationController/sendAdvocateAssignedNotifications.spec.ts
@@ -293,6 +293,60 @@ describe('InternalNotificationController - Send advocate assigned notifications'
     })
   })
 
+  describe('when the same advocate is registered more than once', () => {
+    const caseId = uuid()
+    const theCase = {
+      id: caseId,
+      type: CaseType.PHONE_TAPPING,
+      court,
+      courtCaseNumber,
+      // The defender is also the legal rights protector of one of the victims
+      defenderEmail: defender.email,
+      defenderName: defender.name,
+      sessionArrangements: SessionArrangements.ALL_PRESENT,
+      victims: [
+        {
+          lawyerEmail: victimLawyer.email,
+          lawyerName: victimLawyer.name,
+          lawyerAccessToRequest: RequestSharedWhen.ARRAIGNMENT_DATE_ASSIGNED,
+        },
+        // Victims can share a lawyer
+        {
+          lawyerEmail: victimLawyer.email,
+          lawyerName: victimLawyer.name,
+          lawyerAccessToRequest: RequestSharedWhen.ARRAIGNMENT_DATE_ASSIGNED,
+        },
+        {
+          lawyerEmail: defender.email,
+          lawyerName: defender.name,
+          lawyerAccessToRequest: RequestSharedWhen.ARRAIGNMENT_DATE_ASSIGNED,
+        },
+      ],
+    } as Case
+
+    beforeEach(async () => {
+      await givenWhenThen(caseId, theCase, notificationDTO)
+    })
+
+    it('should only send one email to each advocate', () => {
+      expect(mockEmailService.sendEmail).toHaveBeenCalledTimes(2)
+      expect(mockEmailService.sendEmail).toHaveBeenCalledWith(
+        expectedEmail({
+          name: defender.name,
+          address: defender.email,
+          responsibility: 'verjanda/talsmann sakbornings',
+        }),
+      )
+      expect(mockEmailService.sendEmail).toHaveBeenCalledWith(
+        expectedEmail({
+          name: victimLawyer.name,
+          address: victimLawyer.email,
+          responsibility: 'réttargæslumaður',
+        }),
+      )
+    })
+  })
+
   describe('when a victim lawyer has already been sent a link to the case', () => {
     const caseId = uuid()
     const theCase = {

--- a/apps/judicial-system/backend/src/app/modules/notification/test/internalNotificationController/sendAdvocateAssignedNotifications.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/test/internalNotificationController/sendAdvocateAssignedNotifications.spec.ts
@@ -168,7 +168,7 @@ describe('InternalNotificationController - Send advocate assigned notifications'
     })
   })
 
-  describe('when the defender already has access to the case', () => {
+  describe('when the defender has already been sent a link to the case', () => {
     const caseId = uuid()
     const theCase = {
       id: caseId,
@@ -178,6 +178,12 @@ describe('InternalNotificationController - Send advocate assigned notifications'
       defenderEmail: defender.email,
       defenderName: defender.name,
       requestSharedWithDefender: RequestSharedWithDefender.READY_FOR_COURT,
+      notifications: [
+        {
+          type: TrackedNotificationType.READY_FOR_COURT,
+          recipients: [{ address: defender.email, success: true }],
+        },
+      ],
     } as Case
 
     let then: Then
@@ -287,7 +293,7 @@ describe('InternalNotificationController - Send advocate assigned notifications'
     })
   })
 
-  describe('when a victim lawyer already has access to the case', () => {
+  describe('when a victim lawyer has already been sent a link to the case', () => {
     const caseId = uuid()
     const theCase = {
       id: caseId,
@@ -300,6 +306,12 @@ describe('InternalNotificationController - Send advocate assigned notifications'
           lawyerEmail: victimLawyer.email,
           lawyerName: victimLawyer.name,
           lawyerAccessToRequest: RequestSharedWhen.READY_FOR_COURT,
+        },
+      ],
+      notifications: [
+        {
+          type: TrackedNotificationType.READY_FOR_COURT,
+          recipients: [{ address: victimLawyer.email, success: true }],
         },
       ],
     } as Case

--- a/apps/judicial-system/backend/src/app/modules/notification/test/internalNotificationController/sendCourtDateNotifications.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/test/internalNotificationController/sendCourtDateNotifications.spec.ts
@@ -7,6 +7,8 @@ import { EmailService } from '@island.is/email-service'
 import {
   CaseType,
   RequestCaseNotificationType,
+  RequestSharedWhen,
+  SessionArrangements,
   TrackedNotificationType,
   User,
 } from '@island.is/judicial-system/types'
@@ -41,7 +43,11 @@ describe('InternalNotificationController - Send court date notifications', () =>
   const courtName = 'Héraðsdómur Reykjavíkur'
   const courtCaseNumber = uuid()
 
-  const { prosecutor, defender } = createTestUsers(['prosecutor', 'defender'])
+  const { prosecutor, defender, victimLawyer } = createTestUsers([
+    'prosecutor',
+    'defender',
+    'victimLawyer',
+  ])
 
   let mockConfig: ConfigType<typeof notificationModuleConfig>
 
@@ -174,6 +180,59 @@ describe('InternalNotificationController - Send court date notifications', () =>
       )
 
       expect(then.result).toEqual({ delivered: true })
+    })
+  })
+
+  describe('the same advocate is registered more than once', () => {
+    const notificationDto: CaseNotificationDto = {
+      user: { id: userId } as User,
+      userDescriptor: { name: userName },
+      type: RequestCaseNotificationType.COURT_DATE,
+    }
+
+    const theCase = {
+      id: caseId,
+      type: CaseType.PHONE_TAPPING,
+      prosecutor: { name: prosecutor.name, email: prosecutor.email },
+      court: { name: courtName },
+      courtCaseNumber,
+      // The defender is also the legal rights protector of one of the victims
+      defenderName: defender.name,
+      defenderEmail: defender.email,
+      sessionArrangements: SessionArrangements.ALL_PRESENT,
+      victims: [
+        {
+          lawyerName: victimLawyer.name,
+          lawyerEmail: victimLawyer.email,
+          lawyerAccessToRequest: RequestSharedWhen.ARRAIGNMENT_DATE_ASSIGNED,
+        },
+        // Victims can share a lawyer
+        {
+          lawyerName: victimLawyer.name,
+          lawyerEmail: victimLawyer.email,
+          lawyerAccessToRequest: RequestSharedWhen.ARRAIGNMENT_DATE_ASSIGNED,
+        },
+        {
+          lawyerName: defender.name,
+          lawyerEmail: defender.email,
+          lawyerAccessToRequest: RequestSharedWhen.ARRAIGNMENT_DATE_ASSIGNED,
+        },
+      ],
+    } as Case
+
+    const countEmailsTo = (address: string) =>
+      (mockEmailService.sendEmail as jest.Mock).mock.calls.filter(
+        ([email]) => email.to[0].address === address,
+      ).length
+
+    beforeEach(async () => {
+      await givenWhenThen(theCase, notificationDto)
+    })
+
+    it('should only send one calendar invitation to each advocate', () => {
+      // A calendar invitation and a link to the case, but only once each
+      expect(countEmailsTo(defender.email)).toBe(2)
+      expect(countEmailsTo(victimLawyer.email)).toBe(2)
     })
   })
 })

--- a/apps/judicial-system/backend/src/app/modules/notification/test/internalNotificationController/sendCourtDateNotifications.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/test/internalNotificationController/sendCourtDateNotifications.spec.ts
@@ -183,6 +183,57 @@ describe('InternalNotificationController - Send court date notifications', () =>
     })
   })
 
+  describe('the court date is sent again', () => {
+    const notificationDto: CaseNotificationDto = {
+      user: { id: userId } as User,
+      userDescriptor: { name: userName },
+      type: RequestCaseNotificationType.COURT_DATE,
+    }
+
+    const theCase = {
+      id: caseId,
+      type: CaseType.CUSTODY,
+      prosecutor: { name: prosecutor.name, email: prosecutor.email },
+      court: { name: courtName },
+      courtCaseNumber,
+      defenderName: defender.name,
+      defenderEmail: defender.email,
+      // The defender was notified the first time the court date was sent
+      notifications: [
+        {
+          caseId,
+          type: TrackedNotificationType.COURT_DATE,
+          recipients: [{ address: defender.email, success: true }],
+        },
+      ],
+    } as Case
+
+    beforeEach(async () => {
+      const mockCreate = mockNotificationModel.create as jest.Mock
+      mockCreate.mockResolvedValueOnce({} as Notification)
+
+      await givenWhenThen(theCase, notificationDto)
+    })
+
+    it('should not send the link to the case to the defender again', () => {
+      expect(mockEmailService.sendEmail).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          to: [{ name: defender.name, address: defender.email }],
+          subject: `Yfirlit máls ${courtCaseNumber}`,
+        }),
+      )
+    })
+
+    it('should still send a calendar invitation to the defender', () => {
+      expect(mockEmailService.sendEmail).toHaveBeenCalledWith(
+        expect.objectContaining({
+          to: [{ name: defender.name, address: defender.email }],
+          subject: `Fyrirtaka í máli ${courtCaseNumber}`,
+        }),
+      )
+    })
+  })
+
   describe('the same advocate is registered more than once', () => {
     const notificationDto: CaseNotificationDto = {
       user: { id: userId } as User,

--- a/apps/judicial-system/backend/src/app/modules/notification/test/internalNotificationController/sendRevokedNotificationsForRequestCase.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/test/internalNotificationController/sendRevokedNotificationsForRequestCase.spec.ts
@@ -7,7 +7,6 @@ import { EmailService } from '@island.is/email-service'
 import {
   CaseType,
   RequestCaseNotificationType,
-  TrackedNotificationType,
 } from '@island.is/judicial-system/types'
 
 import {

--- a/apps/judicial-system/backend/src/app/modules/notification/test/notificationController/sendAdvocateAssignedNotification.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/test/notificationController/sendAdvocateAssignedNotification.spec.ts
@@ -1,14 +1,12 @@
 import { v4 as uuid } from 'uuid'
 
 import { Message, MessageType } from '@island.is/judicial-system/message'
-import {
-  RequestCaseNotificationType,
-  User,
-} from '@island.is/judicial-system/types'
+import { User } from '@island.is/judicial-system/types'
 
 import { createTestingNotificationModule } from '../createTestingNotificationModule'
 
 import { Case } from '../../../repository'
+import { UserInitiatedNotificationType } from '../../dto/notification.dto'
 import { SendNotificationResponse } from '../../models/sendNotification.response'
 
 interface Then {
@@ -16,9 +14,9 @@ interface Then {
   error: Error
 }
 
-type GivenWhenThen = (caseId: string, eventOnly?: boolean) => Promise<Then>
+type GivenWhenThen = (caseId: string) => Promise<Then>
 
-describe('NotificationController - Send court date notification', () => {
+describe('NotificationController - Send advocate assigned notification', () => {
   const userId = uuid()
   const user = { id: userId } as User
 
@@ -31,13 +29,12 @@ describe('NotificationController - Send court date notification', () => {
 
     mockQueuedMessages = queuedMessages
 
-    givenWhenThen = async (caseId, eventOnly) => {
+    givenWhenThen = async (caseId) => {
       const then = {} as Then
 
       await notificationController
         .sendCaseNotification(caseId, user, { id: caseId } as Case, {
-          type: RequestCaseNotificationType.COURT_DATE,
-          eventOnly,
+          type: UserInitiatedNotificationType.ADVOCATE_ASSIGNED,
         })
         .then((result) => (then.result = result))
         .catch((error) => (then.error = error))
@@ -54,34 +51,13 @@ describe('NotificationController - Send court date notification', () => {
       then = await givenWhenThen(caseId)
     })
 
-    it('should send message to queue', () => {
+    it('should send advocate assigned message to queue', () => {
       expect(mockQueuedMessages).toEqual([
         {
           type: MessageType.NOTIFICATION,
           user,
           caseId,
-          body: { type: RequestCaseNotificationType.COURT_DATE },
-        },
-      ])
-      expect(then.result).toEqual({ notificationSent: true })
-    })
-  })
-
-  describe('message with event only queued', () => {
-    const caseId = uuid()
-    let then: Then
-
-    beforeEach(async () => {
-      then = await givenWhenThen(caseId, true)
-    })
-
-    it('should send defender assigned message to queue', () => {
-      expect(mockQueuedMessages).toEqual([
-        {
-          type: MessageType.NOTIFICATION,
-          user,
-          caseId,
-          body: { type: RequestCaseNotificationType.ADVOCATE_ASSIGNED },
+          body: { type: UserInitiatedNotificationType.ADVOCATE_ASSIGNED },
         },
       ])
       expect(then.result).toEqual({ notificationSent: true })

--- a/apps/judicial-system/backend/src/app/modules/notification/test/notificationController/sendCaseNotificationRolesRules.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/test/notificationController/sendCaseNotificationRolesRules.spec.ts
@@ -1,3 +1,6 @@
+import { RolesRule, RulesType } from '@island.is/judicial-system/auth'
+
+import { UserInitiatedNotificationType } from '../../dto/notification.dto'
 import {
   defenderNotificationRule,
   districtCourtAssistantNotificationRule,
@@ -6,6 +9,36 @@ import {
   prosecutorNotificationRule,
 } from '../../guards/rolesRules'
 import { NotificationController } from '../../notification.controller'
+
+const allowedNotificationTypes: {
+  rule: RolesRule
+  notificationTypes: UserInitiatedNotificationType[]
+}[] = [
+  {
+    rule: prosecutorNotificationRule,
+    notificationTypes: [
+      UserInitiatedNotificationType.HEADS_UP,
+      UserInitiatedNotificationType.READY_FOR_COURT,
+      UserInitiatedNotificationType.CASE_FILES_UPDATED,
+    ],
+  },
+  {
+    rule: defenderNotificationRule,
+    notificationTypes: [UserInitiatedNotificationType.CASE_FILES_UPDATED],
+  },
+  {
+    rule: districtCourtJudgeNotificationRule,
+    notificationTypes: [UserInitiatedNotificationType.ADVOCATE_ASSIGNED],
+  },
+  {
+    rule: districtCourtRegistrarNotificationRule,
+    notificationTypes: [UserInitiatedNotificationType.ADVOCATE_ASSIGNED],
+  },
+  {
+    rule: districtCourtAssistantNotificationRule,
+    notificationTypes: [UserInitiatedNotificationType.ADVOCATE_ASSIGNED],
+  },
+]
 
 describe('NotificationController - Send case notification rules', () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -25,5 +58,28 @@ describe('NotificationController - Send case notification rules', () => {
     expect(rules).toContain(districtCourtRegistrarNotificationRule)
     expect(rules).toContain(districtCourtAssistantNotificationRule)
     expect(rules).toContain(defenderNotificationRule)
+  })
+
+  // A role that is not allowed to send a notification type is rejected before
+  // the request reaches the controller
+  it.each(allowedNotificationTypes)(
+    'should allow $rule.role to send $notificationTypes',
+    ({ rule, notificationTypes }) => {
+      expect(rule.type).toBe(RulesType.FIELD_VALUES)
+      expect(rule.dtoField).toBe('type')
+      expect(rule.dtoFieldValues).toEqual(notificationTypes)
+    },
+  )
+
+  it('should allow every user initiated notification type to be sent by some role', () => {
+    const allAllowedTypes = new Set(
+      allowedNotificationTypes.flatMap(
+        ({ notificationTypes }) => notificationTypes,
+      ),
+    )
+
+    expect([...allAllowedTypes].sort()).toEqual(
+      Object.values(UserInitiatedNotificationType).sort(),
+    )
   })
 })

--- a/apps/judicial-system/backend/src/app/modules/statistics/statistics.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/statistics/statistics.service.ts
@@ -13,7 +13,6 @@ import { LOGGER_PROVIDER } from '@island.is/logging'
 
 import type { User } from '@island.is/judicial-system/types'
 import {
-  AppealCaseNotificationType,
   CaseState,
   CaseType,
   DataGroups,
@@ -37,7 +36,6 @@ import {
   EventLog,
   IndictmentCount,
   Institution,
-  Notification,
   Offense,
   Subpoena,
   SubpoenaRepositoryService,

--- a/apps/judicial-system/backend/src/app/modules/subpoena/subpoena.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/subpoena/subpoena.service.ts
@@ -197,7 +197,7 @@ export class SubpoenaService {
       user,
     )
 
-    this.eventService.postEvent('SUBPOENA_ISSUED', theCase, false, {
+    this.eventService.postEvent('SUBPOENA_ISSUED', theCase, {
       Varnaraðili: defendantsToProcess
         .map((defendant) => defendant.id)
         .join(', '),
@@ -375,7 +375,7 @@ export class SubpoenaService {
       update.serviceStatus &&
       update.serviceStatus !== subpoena.serviceStatus
     ) {
-      this.eventService.postEvent('SUBPOENA_SERVICE_STATUS', theCase, false, {
+      this.eventService.postEvent('SUBPOENA_SERVICE_STATUS', theCase, {
         Staða: getServiceStatusText(update.serviceStatus),
       })
     }
@@ -505,15 +505,10 @@ export class SubpoenaService {
         `Subpoena with police subpoena id ${createdSubpoena.policeSubpoenaId} delivered to the police centralized file service`,
       )
 
-      this.eventService.postEvent(
-        'SUBPOENA_DELIVERED_TO_POLICE',
-        theCase,
-        false,
-        {
-          Varnaraðili: defendant.id,
-          'RLS auðkenni': createdSubpoena.policeSubpoenaId,
-        },
-      )
+      this.eventService.postEvent('SUBPOENA_DELIVERED_TO_POLICE', theCase, {
+        Varnaraðili: defendant.id,
+        'RLS auðkenni': createdSubpoena.policeSubpoenaId,
+      })
 
       return { delivered: true }
     } catch (error) {

--- a/apps/judicial-system/backend/src/app/modules/verdict/internalVerdict.controller.ts
+++ b/apps/judicial-system/backend/src/app/modules/verdict/internalVerdict.controller.ts
@@ -243,7 +243,7 @@ export class InternalVerdictController {
         })
       }
 
-      this.eventService.postEvent('VERDICT_SERVICE_STATUS', theCase, false, {
+      this.eventService.postEvent('VERDICT_SERVICE_STATUS', theCase, {
         Staða: getVerdictServiceStatusText(updatedVerdict.serviceStatus),
         Birt:
           formatDate(updatedVerdict.serviceDate, 'dd.MM.y HH:mm') ??

--- a/apps/judicial-system/backend/src/app/modules/verdict/verdict.controller.ts
+++ b/apps/judicial-system/backend/src/app/modules/verdict/verdict.controller.ts
@@ -217,7 +217,7 @@ export class VerdictController {
       currentVerdict.serviceStatus &&
       currentVerdict.serviceStatus !== verdict.serviceStatus
     ) {
-      this.eventService.postEvent('VERDICT_SERVICE_STATUS', theCase, false, {
+      this.eventService.postEvent('VERDICT_SERVICE_STATUS', theCase, {
         Staða: getVerdictServiceStatusText(currentVerdict.serviceStatus),
       })
     }

--- a/apps/judicial-system/backend/src/app/modules/verdict/verdict.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/verdict/verdict.service.ts
@@ -500,15 +500,10 @@ export class VerdictService {
         transaction,
       )
 
-      this.eventService.postEvent(
-        'VERDICT_DELIVERED_TO_POLICE',
-        theCase,
-        false,
-        {
-          Varnaraðili: defendant.id,
-          'RLS auðkenni': createdDocument.externalPoliceDocumentId,
-        },
-      )
+      this.eventService.postEvent('VERDICT_DELIVERED_TO_POLICE', theCase, {
+        Varnaraðili: defendant.id,
+        'RLS auðkenni': createdDocument.externalPoliceDocumentId,
+      })
 
       return { delivered: true }
     } catch (error) {

--- a/apps/judicial-system/web/src/routes/Court/InvestigationCase/HearingArrangements/HearingArrangements.tsx
+++ b/apps/judicial-system/web/src/routes/Court/InvestigationCase/HearingArrangements/HearingArrangements.tsx
@@ -13,7 +13,7 @@ import {
   DISTRICT_COURT_INVESTIGATION_CASE_RULING_ROUTE,
 } from '@island.is/judicial-system/consts'
 import { isDistrictCourtUser } from '@island.is/judicial-system/types'
-import { errors, titles } from '@island.is/judicial-system-web/messages'
+import { titles } from '@island.is/judicial-system-web/messages'
 import {
   ArraignmentAlert,
   BlueBox,
@@ -63,13 +63,7 @@ const HearingArrangements = () => {
   const { user } = useContext(UserContext)
 
   const { formatMessage } = useIntl()
-  const {
-    setAndSendCaseToServer,
-    sendNotification,
-    isUpdatingCase,
-    isSendingNotification,
-    sendNotificationError,
-  } = useCase()
+  const { setAndSendCaseToServer, sendNotification, isUpdatingCase } = useCase()
   const {
     courtDate,
     courtDateHasChanged,
@@ -140,8 +134,7 @@ const HearingArrangements = () => {
   )
 
   const isModalConfirming = modalButtonLoading === ModalButtonLoading.PRIMARY
-  const isModalLoading =
-    isModalConfirming && (isUpdatingCase || isSendingNotification)
+  const isModalLoading = isModalConfirming && isUpdatingCase
 
   return (
     <PageLayout
@@ -393,6 +386,7 @@ const HearingArrangements = () => {
             onClick: async () => {
               setModalButtonLoading(ModalButtonLoading.PRIMARY)
 
+              // Saving the arraignment date triggers the court date notifications
               const courtDateSaved = await sendCourtDateToServer()
 
               if (!courtDateSaved) {
@@ -400,16 +394,7 @@ const HearingArrangements = () => {
                 return
               }
 
-              const notificationSent = await sendNotification(
-                workingCase.id,
-                TrackedNotificationType.COURT_DATE,
-              )
-
-              if (notificationSent) {
-                router.push(`${navigateTo}/${workingCase.id}`)
-              } else {
-                setModalButtonLoading(undefined)
-              }
+              router.push(`${navigateTo}/${workingCase.id}`)
             },
             isLoading: isModalLoading,
           }}
@@ -417,14 +402,16 @@ const HearingArrangements = () => {
             text: 'Nei, staðfesta seinna',
             isDisabled: isModalConfirming,
             onClick: () => {
+              // The arraignment date is not confirmed, so we only let registered
+              // advocates know that they are on the case
+              sendNotification(
+                workingCase.id,
+                TrackedNotificationType.ADVOCATE_ASSIGNED,
+              )
+
               router.push(`${navigateTo}/${workingCase.id}`)
             },
           }}
-          errorMessage={
-            modalButtonLoading && sendNotificationError
-              ? formatMessage(errors.sendNotification)
-              : undefined
-          }
         />
       )}
     </PageLayout>

--- a/apps/judicial-system/web/src/routes/Court/InvestigationCase/HearingArrangements/HearingArrangements.tsx
+++ b/apps/judicial-system/web/src/routes/Court/InvestigationCase/HearingArrangements/HearingArrangements.tsx
@@ -13,7 +13,7 @@ import {
   DISTRICT_COURT_INVESTIGATION_CASE_RULING_ROUTE,
 } from '@island.is/judicial-system/consts'
 import { isDistrictCourtUser } from '@island.is/judicial-system/types'
-import { titles } from '@island.is/judicial-system-web/messages'
+import { errors, titles } from '@island.is/judicial-system-web/messages'
 import {
   ArraignmentAlert,
   BlueBox,
@@ -50,6 +50,7 @@ import { icHearingArrangements as m } from './HearingArrangements.strings'
 
 enum ModalButtonLoading {
   PRIMARY = 'PRIMARY',
+  SECONDARY = 'SECONDARY',
 }
 
 const HearingArrangements = () => {
@@ -63,7 +64,13 @@ const HearingArrangements = () => {
   const { user } = useContext(UserContext)
 
   const { formatMessage } = useIntl()
-  const { setAndSendCaseToServer, sendNotification, isUpdatingCase } = useCase()
+  const {
+    setAndSendCaseToServer,
+    sendNotification,
+    isUpdatingCase,
+    isSendingNotification,
+    sendNotificationError,
+  } = useCase()
   const {
     courtDate,
     courtDateHasChanged,
@@ -134,7 +141,9 @@ const HearingArrangements = () => {
   )
 
   const isModalConfirming = modalButtonLoading === ModalButtonLoading.PRIMARY
+  const isModalDeferring = modalButtonLoading === ModalButtonLoading.SECONDARY
   const isModalLoading = isModalConfirming && isUpdatingCase
+  const isModalDeferringLoading = isModalDeferring && isSendingNotification
 
   return (
     <PageLayout
@@ -397,21 +406,36 @@ const HearingArrangements = () => {
               router.push(`${navigateTo}/${workingCase.id}`)
             },
             isLoading: isModalLoading,
+            isDisabled: isModalDeferring,
           }}
           secondaryButton={{
             text: 'Nei, staðfesta seinna',
             isDisabled: isModalConfirming,
-            onClick: () => {
+            onClick: async () => {
+              setModalButtonLoading(ModalButtonLoading.SECONDARY)
+
               // The arraignment date is not confirmed, so we only let registered
-              // advocates know that they are on the case
-              sendNotification(
+              // advocates know that they are on the case. This is their only
+              // notification, so we do not navigate away until it has been sent.
+              const notificationSent = await sendNotification(
                 workingCase.id,
                 TrackedNotificationType.ADVOCATE_ASSIGNED,
               )
 
+              if (!notificationSent) {
+                setModalButtonLoading(undefined)
+                return
+              }
+
               router.push(`${navigateTo}/${workingCase.id}`)
             },
+            isLoading: isModalDeferringLoading,
           }}
+          errorMessage={
+            isModalDeferring && sendNotificationError
+              ? formatMessage(errors.sendNotification)
+              : undefined
+          }
         />
       )}
     </PageLayout>

--- a/apps/judicial-system/web/src/routes/Court/RestrictionCase/HearingArrangements/HearingArrangements.tsx
+++ b/apps/judicial-system/web/src/routes/Court/RestrictionCase/HearingArrangements/HearingArrangements.tsx
@@ -7,7 +7,7 @@ import {
   DISTRICT_COURT_RESTRICTION_CASE_COURT_OVERVIEW_ROUTE,
   DISTRICT_COURT_RESTRICTION_CASE_RULING_ROUTE,
 } from '@island.is/judicial-system/consts'
-import { errors, titles } from '@island.is/judicial-system-web/messages'
+import { titles } from '@island.is/judicial-system-web/messages'
 import {
   ArraignmentAlert,
   CourtArrangements,
@@ -54,13 +54,7 @@ export const HearingArrangements = () => {
   const [modalButtonLoading, setModalButtonLoading] =
     useState<ModalButtonLoading>()
 
-  const {
-    setAndSendCaseToServer,
-    sendNotification,
-    isUpdatingCase,
-    isSendingNotification,
-    sendNotificationError,
-  } = useCase()
+  const { setAndSendCaseToServer, sendNotification, isUpdatingCase } = useCase()
   const { formatMessage } = useIntl()
   const {
     courtDate,
@@ -137,8 +131,7 @@ export const HearingArrangements = () => {
   )
 
   const isModalConfirming = modalButtonLoading === ModalButtonLoading.PRIMARY
-  const isModalLoading =
-    isModalConfirming && (isUpdatingCase || isSendingNotification)
+  const isModalLoading = isModalConfirming && isUpdatingCase
 
   return (
     <PageLayout
@@ -209,6 +202,7 @@ export const HearingArrangements = () => {
             onClick: async () => {
               setModalButtonLoading(ModalButtonLoading.PRIMARY)
 
+              // Saving the arraignment date triggers the court date notifications
               const courtDateSaved = await sendCourtDateToServer()
 
               if (!courtDateSaved) {
@@ -216,16 +210,7 @@ export const HearingArrangements = () => {
                 return
               }
 
-              const notificationSent = await sendNotification(
-                workingCase.id,
-                TrackedNotificationType.COURT_DATE,
-              )
-
-              if (notificationSent) {
-                router.push(`${navigateTo}/${workingCase.id}`)
-              } else {
-                setModalButtonLoading(undefined)
-              }
+              router.push(`${navigateTo}/${workingCase.id}`)
             },
             isLoading: isModalLoading,
           }}
@@ -233,14 +218,16 @@ export const HearingArrangements = () => {
             text: 'Nei, staðfesta seinna',
             isDisabled: isModalConfirming,
             onClick: () => {
+              // The arraignment date is not confirmed, so we only let a
+              // registered advocate know that they are on the case
+              sendNotification(
+                workingCase.id,
+                TrackedNotificationType.ADVOCATE_ASSIGNED,
+              )
+
               router.push(`${navigateTo}/${workingCase.id}`)
             },
           }}
-          errorMessage={
-            sendNotificationError
-              ? formatMessage(errors.sendNotification)
-              : undefined
-          }
         />
       )}
     </PageLayout>

--- a/apps/judicial-system/web/src/routes/Court/RestrictionCase/HearingArrangements/HearingArrangements.tsx
+++ b/apps/judicial-system/web/src/routes/Court/RestrictionCase/HearingArrangements/HearingArrangements.tsx
@@ -7,7 +7,7 @@ import {
   DISTRICT_COURT_RESTRICTION_CASE_COURT_OVERVIEW_ROUTE,
   DISTRICT_COURT_RESTRICTION_CASE_RULING_ROUTE,
 } from '@island.is/judicial-system/consts'
-import { titles } from '@island.is/judicial-system-web/messages'
+import { errors, titles } from '@island.is/judicial-system-web/messages'
 import {
   ArraignmentAlert,
   CourtArrangements,
@@ -39,6 +39,7 @@ import { rcHearingArrangements as m } from './HearingArrangements.strings'
 
 enum ModalButtonLoading {
   PRIMARY = 'PRIMARY',
+  SECONDARY = 'SECONDARY',
 }
 
 export const HearingArrangements = () => {
@@ -54,7 +55,13 @@ export const HearingArrangements = () => {
   const [modalButtonLoading, setModalButtonLoading] =
     useState<ModalButtonLoading>()
 
-  const { setAndSendCaseToServer, sendNotification, isUpdatingCase } = useCase()
+  const {
+    setAndSendCaseToServer,
+    sendNotification,
+    isUpdatingCase,
+    isSendingNotification,
+    sendNotificationError,
+  } = useCase()
   const { formatMessage } = useIntl()
   const {
     courtDate,
@@ -131,7 +138,9 @@ export const HearingArrangements = () => {
   )
 
   const isModalConfirming = modalButtonLoading === ModalButtonLoading.PRIMARY
+  const isModalDeferring = modalButtonLoading === ModalButtonLoading.SECONDARY
   const isModalLoading = isModalConfirming && isUpdatingCase
+  const isModalDeferringLoading = isModalDeferring && isSendingNotification
 
   return (
     <PageLayout
@@ -213,21 +222,37 @@ export const HearingArrangements = () => {
               router.push(`${navigateTo}/${workingCase.id}`)
             },
             isLoading: isModalLoading,
+            isDisabled: isModalDeferring,
           }}
           secondaryButton={{
             text: 'Nei, staðfesta seinna',
             isDisabled: isModalConfirming,
-            onClick: () => {
+            onClick: async () => {
+              setModalButtonLoading(ModalButtonLoading.SECONDARY)
+
               // The arraignment date is not confirmed, so we only let a
-              // registered advocate know that they are on the case
-              sendNotification(
+              // registered advocate know that they are on the case. This is
+              // their only notification, so we do not navigate away until it
+              // has been sent.
+              const notificationSent = await sendNotification(
                 workingCase.id,
                 TrackedNotificationType.ADVOCATE_ASSIGNED,
               )
 
+              if (!notificationSent) {
+                setModalButtonLoading(undefined)
+                return
+              }
+
               router.push(`${navigateTo}/${workingCase.id}`)
             },
+            isLoading: isModalDeferringLoading,
           }}
+          errorMessage={
+            isModalDeferring && sendNotificationError
+              ? formatMessage(errors.sendNotification)
+              : undefined
+          }
         />
       )}
     </PageLayout>

--- a/apps/judicial-system/web/src/utils/hooks/useCase/index.ts
+++ b/apps/judicial-system/web/src/utils/hooks/useCase/index.ts
@@ -273,7 +273,6 @@ const useCase = () => {
       async (
         id: string,
         notificationType: TrackedNotificationType,
-        eventOnly?: boolean,
       ): Promise<boolean> => {
         try {
           const { data } = await sendNotificationMutation({
@@ -281,7 +280,6 @@ const useCase = () => {
               input: {
                 caseId: id,
                 type: notificationType,
-                eventOnly,
               },
             },
           })

--- a/libs/judicial-system/types/src/lib/notification.ts
+++ b/libs/judicial-system/types/src/lib/notification.ts
@@ -41,15 +41,15 @@ export enum TrackedNotificationType {
 
 export enum RequestCaseNotificationType {
   ADVOCATE_ASSIGNED = TrackedNotificationType.ADVOCATE_ASSIGNED,
-  CASE_FILES_UPDATED = TrackedNotificationType.CASE_FILES_UPDATED,
+  CASE_FILES_UPDATED = TrackedNotificationType.CASE_FILES_UPDATED, // Líka notað fyrir ákærur
   COURT_DATE = TrackedNotificationType.COURT_DATE,
   DEFENDANTS_NOT_UPDATED_AT_COURT = TrackedNotificationType.DEFENDANTS_NOT_UPDATED_AT_COURT,
   HEADS_UP = TrackedNotificationType.HEADS_UP,
   MODIFIED = TrackedNotificationType.MODIFIED,
-  READY_FOR_COURT = TrackedNotificationType.READY_FOR_COURT,
-  RECEIVED_BY_COURT = TrackedNotificationType.RECEIVED_BY_COURT,
-  REVOKED = TrackedNotificationType.REVOKED,
-  RULING = TrackedNotificationType.RULING,
+  READY_FOR_COURT = TrackedNotificationType.READY_FOR_COURT, // Líka notað fyrir ákærur
+  RECEIVED_BY_COURT = TrackedNotificationType.RECEIVED_BY_COURT, // Líka notað fyrir ákærur
+  REVOKED = TrackedNotificationType.REVOKED, // Líka notað fyrir ákærur
+  RULING = TrackedNotificationType.RULING, // Líka notað fyrir ákærur
 }
 
 export enum IndictmentCaseNotificationType {


### PR DESCRIPTION
# Restore advocate assigned notification and move court dates to event dispatch

[Senda tilkynningu til verjanda þó fyrirtökutími sé ekki staðfestur](https://app.asana.com/1/203394141643832/project/1199153462262248/task/1217116881123354)

The `ADVOCATE_ASSIGNED` notification has not been sent since #23147. Its only
trigger was the `eventOnly` variant of the court date notification, fired from
the "Nei, staðfesta seinna" button on the district court hearing arrangements
screens. That call was removed when the confirm-arraignment-date modal was
rewritten, leaving the notification unreachable.

Rather than reinstate the `eventOnly` flag, this PR moves request case court
date notifications onto the event dispatch mechanism already used for
indictments, which frees the user initiated notification endpoint to carry
`ADVOCATE_ASSIGNED` explicitly.

## Court date notifications for request cases

Saving an arraignment date on a request case now logs `COURT_DATE_SCHEDULED`
exactly as an indictment does, and `NotificationDispatchService` fans that out
to `RequestCaseNotificationType.COURT_DATE`. The non-indictment branch of
`dispatchCourtDateNotifications` was previously dead code with a warning; it is
now implemented.

Because event dispatched notifications carry a `userDescriptor` rather than a
registered user, `user` is optional throughout the case notification path. The
two notification types that genuinely need a registered user (`MODIFIED`,
`CASE_FILES_UPDATED`) go through a `requireUser()` helper that throws rather
than silently sending nothing.

The confirm button on both hearing arrangements screens no longer sends the
notification itself - it just saves the date and navigates.

## Advocate assigned notification

`eventOnly` is removed end to end (dto, controller, service, GraphQL input, web
hook), and with it the now unreachable `eventOnly` parameter of
`EventService.postEvent` and its " - aðgerð ekki framkvæmd" event title variant.

`ADVOCATE_ASSIGNED` becomes a first class user initiated notification type. The
"Nei, staðfesta seinna" button posts it; the backend decides whether anyone gets
mail. It is sent when there is a registered advocate who has not already been
sent a link to the case - covering the defender or spokesperson, and now also
victim lawyers on investigation cases.

Since the arraignment date is deliberately not persisted when the court declines
to confirm it, the advocate has no access to the case in RVG. The email is
therefore information only and carries no link at all.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Advocate-assigned notifications are supported for defenders and victim lawyers.
  - Court-date updates generate notifications for relevant case types.
  - Notifications can use basic contact details when no registered user profile is available.

- **Improvements**
  - Duplicate notifications and calendar invitations are avoided.
  - Hearing-arrangement confirmations provide clearer loading and error feedback.
  - Notification handling is more consistent across case types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->