### PR TITLE
fix(j-s): backfill attendees field with "Mættir eru"

### DIFF
--- a/apps/judicial-system/backend/migrations/20260807120000-backfill-court-session-attendees-maettir-eru.js
+++ b/apps/judicial-system/backend/migrations/20260807120000-backfill-court-session-attendees-maettir-eru.js
@@ -3,7 +3,7 @@
 // After making "Mættir eru" part of the editable attendees text (and removing
 // the fixed PDF heading), existing court_session rows still store names only.
 // Prepend the same prefix the UI now uses on init so old PDFs keep the heading.
-//
+
 module.exports = {
   async up(queryInterface) {
     return queryInterface.sequelize.transaction((transaction) =>
@@ -12,8 +12,8 @@ module.exports = {
         UPDATE court_session
         SET attendees = 'Mættir eru' || CHR(10) || attendees
         WHERE attendees IS NOT NULL
-          AND BTRIM(attendees) <> ''
-          AND attendees NOT LIKE 'Mættir eru%'
+          AND BTRIM(attendees, E' \t\n\r') <> ''
+          AND BTRIM(attendees, E' \t\n\r') NOT LIKE 'Mættir eru%'
         `,
         { transaction },
       ),

--- a/apps/judicial-system/backend/migrations/20260807120000-backfill-court-session-attendees-maettir-eru.js
+++ b/apps/judicial-system/backend/migrations/20260807120000-backfill-court-session-attendees-maettir-eru.js
@@ -1,0 +1,26 @@
+'use strict'
+
+// After making "Mættir eru" part of the editable attendees text (and removing
+// the fixed PDF heading), existing court_session rows still store names only.
+// Prepend the same prefix the UI now uses on init so old PDFs keep the heading.
+//
+module.exports = {
+  async up(queryInterface) {
+    return queryInterface.sequelize.transaction((transaction) =>
+      queryInterface.sequelize.query(
+        `
+        UPDATE court_session
+        SET attendees = 'Mættir eru' || CHR(10) || attendees
+        WHERE attendees IS NOT NULL
+          AND BTRIM(attendees) <> ''
+          AND attendees NOT LIKE 'Mættir eru%'
+        `,
+        { transaction },
+      ),
+    )
+  },
+
+  async down() {
+    return Promise.resolve()
+  },
+}

--- a/apps/judicial-system/backend/migrations/20260807120000-backfill-court-session-attendees-maettir-eru.js
+++ b/apps/judicial-system/backend/migrations/20260807120000-backfill-court-session-attendees-maettir-eru.js
@@ -10,7 +10,7 @@ module.exports = {
       queryInterface.sequelize.query(
         `
         UPDATE court_session
-        SET attendees = 'Mættir eru' || CHR(10) || attendees
+        SET attendees = 'Mættir eru:' || CHR(10) || attendees
         WHERE attendees IS NOT NULL
           AND BTRIM(attendees, E' \t\n\r') <> ''
           AND BTRIM(attendees, E' \t\n\r') NOT LIKE 'Mættir eru%'

--- a/apps/judicial-system/web/src/routes/Court/Indictments/CourtRecord/CourtSessionAccordionItem.tsx
+++ b/apps/judicial-system/web/src/routes/Court/Indictments/CourtRecord/CourtSessionAccordionItem.tsx
@@ -339,7 +339,7 @@ const CourtSessionAccordionItem: FC<Props> = (props) => {
       })
     }
 
-    return `Mættir eru\n${attendees.join('')}`
+    return `Mættir eru:\n${attendees.join('')}`
   }, [workingCase.prosecutor, workingCase.defendants])
 
   const initialize = useCallback(() => {


### PR DESCRIPTION

## What

Backfill  "Mættir eru" to attendees field

## Why

We removed the hardcoded section heading from the pdf, but instead prefill it in the text field itself. This way users can remove it if they dont like it, or keep it in if they dont mind it.

This migration fixes old court records that only have the names in the attendees field. 

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Cursor


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Data Updates**
  * Updated existing court session attendee entries to begin with “Mættir eru:” where applicable.
  * Entries that are blank, missing, or already use this wording remain unchanged.
* **User Interface**
  * Updated the default court session attendee text to use the “Mættir eru:” format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->