### PR TITLE
fix(web): Generic list item pages 404 under organization parent subpages

### DIFF
--- a/apps/web/components/GenericList/LatestGenericListItems/LatestGenericListItems.tsx
+++ b/apps/web/components/GenericList/LatestGenericListItems/LatestGenericListItems.tsx
@@ -25,13 +25,14 @@ export const LatestGenericListItems = ({
     // The url is [organizationPageSlug, subpageSlug] or, in case the subpage
     // belongs to a parent subpage, [organizationPageSlug, parentSubpageSlug, subpageSlug]
     const url = slice.seeMorePage.url ?? []
-    if (url.length >= 2 && url.every(Boolean)) {
-      seeMoreLinkHref = linkResolver(
-        url.length > 2
-          ? 'organizationparentsubpagechild'
-          : 'organizationsubpage',
-        url,
-      ).href
+    const linkType =
+      url.length === 3
+        ? 'organizationparentsubpagechild'
+        : url.length === 2
+        ? 'organizationsubpage'
+        : null
+    if (linkType && url.every(Boolean)) {
+      seeMoreLinkHref = linkResolver(linkType, url).href
     }
   }
 

--- a/apps/web/components/GenericList/LatestGenericListItems/LatestGenericListItems.tsx
+++ b/apps/web/components/GenericList/LatestGenericListItems/LatestGenericListItems.tsx
@@ -21,15 +21,18 @@ export const LatestGenericListItems = ({
 
   // Only allow organization subpage links as is
   let seeMoreLinkHref = ''
-  if (
-    slice.seeMorePage?.__typename === 'OrganizationSubpage' &&
-    slice.seeMorePage.organizationPage?.slug &&
-    slice.seeMorePage.slug
-  ) {
-    seeMoreLinkHref = linkResolver('organizationsubpage', [
-      slice.seeMorePage.organizationPage.slug,
-      slice.seeMorePage.slug,
-    ]).href
+  if (slice.seeMorePage?.__typename === 'OrganizationSubpage') {
+    // The url is [organizationPageSlug, subpageSlug] or, in case the subpage
+    // belongs to a parent subpage, [organizationPageSlug, parentSubpageSlug, subpageSlug]
+    const url = slice.seeMorePage.url ?? []
+    if (url.length >= 2 && url.every(Boolean)) {
+      seeMoreLinkHref = linkResolver(
+        url.length > 2
+          ? 'organizationparentsubpagechild'
+          : 'organizationsubpage',
+        url,
+      ).href
+    }
   }
 
   const itemsAreClickable =

--- a/apps/web/pages/api/rss/index.ts
+++ b/apps/web/pages/api/rss/index.ts
@@ -74,6 +74,9 @@ export default async function handler(
   const organizationSubpageSlug = req.query?.organizationsubpageslug as
     | string
     | undefined
+  // Only needed when the subpage belongs to an organization parent subpage
+  const organizationParentSubpageSlug = req.query
+    ?.organizationparentsubpageslug as string | undefined
 
   const contentType = parseAsStringEnum(CONTENT_TYPES)
     .withDefault('news')
@@ -140,21 +143,41 @@ export default async function handler(
       },
     })
 
+    const getListItemUrl = (itemSlug: string | null | undefined) => {
+      if (!organization || !organizationSubpageSlug || !itemSlug) {
+        return ''
+      }
+
+      // A subpage that belongs to a parent subpage is served on
+      // /[organization]/[parentSubpage]/[subpage] so the item url gets an extra path segment
+      if (organizationParentSubpageSlug) {
+        const subpageUrl = linkResolver(
+          'organizationparentsubpagechild',
+          [
+            organization,
+            organizationParentSubpageSlug,
+            organizationSubpageSlug,
+          ],
+          locale,
+        ).href
+        return `${baseUrl}${subpageUrl}/${itemSlug}`
+      }
+
+      return `${baseUrl}${
+        linkResolver(
+          'organizationsubpagelistitem',
+          [organization, organizationSubpageSlug, itemSlug],
+          locale,
+        ).href
+      }`
+    }
+
     itemString = (listItems.data.getGenericListItems?.items ?? [])
       .map((item) =>
         generateItemString({
           title: item.title,
           description: '',
-          fullUrl:
-            organization && organizationSubpageSlug && item.slug
-              ? `${baseUrl}${
-                  linkResolver(
-                    'organizationsubpagelistitem',
-                    [organization, organizationSubpageSlug, item.slug],
-                    locale,
-                  ).href
-                }`
-              : '',
+          fullUrl: getListItemUrl(item.slug),
           date: item.date ? new Date(item.date).toUTCString() : '',
         }),
       )

--- a/apps/web/screens/GenericList/OrganizationSubPageGenericListItem.tsx
+++ b/apps/web/screens/GenericList/OrganizationSubPageGenericListItem.tsx
@@ -6,7 +6,9 @@ import { useLinkResolver } from '@island.is/web/hooks'
 import { useI18n } from '@island.is/web/i18n'
 import { type LayoutProps } from '@island.is/web/layouts/main'
 import { Screen, ScreenContext } from '@island.is/web/types'
+import { CustomNextError } from '@island.is/web/units/errors'
 
+import OrganizationParentSubpage from '../Organization/ParentSubpage'
 import SubPage, { type SubPageProps } from '../Organization/SubPage'
 import GenericListItemPage, {
   type GenericListItemPageProps,
@@ -85,25 +87,52 @@ const OrganizationSubPageGenericListItem: Screen<
   )
 }
 
-OrganizationSubPageGenericListItem.getProps = async (context) => {
-  const organizationPageSlug = context.query.slugs?.[0] ?? ''
-  const organizationSubpageSlug =
-    context.query.slugs?.length === 4
-      ? context.query.slugs[2]
-      : context.query.slugs?.[1] ?? ''
+// The page that the generic list is displayed on is either an organization
+// subpage or a subpage that belongs to an organization parent subpage. Subpages
+// that belong to a parent subpage can't be fetched by slug on their own, so in
+// that case the parent subpage screen needs to resolve them.
+const getParentProps = (
+  context: OrganizationSubPageGenericListItemScreenContext,
+  querySlugs: string[],
+) => {
+  const withSlugs = (slugs: string[]) => ({
+    ...context,
+    query: {
+      ...context.query,
+      slugs,
+    },
+  })
 
-  const [subPageProps, genericListItemProps] = await Promise.all([
-    SubPage.getProps({
-      ...context,
-      query: {
-        ...context.query,
-        slugs: [organizationPageSlug, organizationSubpageSlug],
-      },
-    }),
+  // /s/[organization]/[parentSubpage]/[subpage]/[item]
+  if (querySlugs.length === 4) {
+    return OrganizationParentSubpage.getProps(withSlugs(querySlugs.slice(0, 3)))
+  }
+
+  // /s/[organization]/[subpage]/[item]
+  return SubPage.getProps(withSlugs(querySlugs.slice(0, 2))).catch((error) => {
+    if (!(error instanceof CustomNextError)) {
+      throw error
+    }
+    // /s/[organization]/[parentSubpage]/[item] - a parent subpage displays the
+    // content of its first child when no subpage slug is present in the url
+    return OrganizationParentSubpage.getProps(
+      withSlugs(querySlugs.slice(0, 2)),
+    ).catch(() => {
+      throw error
+    })
+  })
+}
+
+OrganizationSubPageGenericListItem.getProps = async (context) => {
+  const querySlugs = (context.query.slugs ?? []) as string[]
+
+  const [parentProps, genericListItemProps] = await Promise.all([
+    getParentProps(context, querySlugs),
     GenericListItemPage.getProps(context),
   ])
+
   return {
-    parentProps: subPageProps,
+    parentProps,
     genericListItemProps,
   } as OrganizationSubPageGenericListItemProps
 }

--- a/apps/web/screens/GenericList/OrganizationSubPageGenericListItem.tsx
+++ b/apps/web/screens/GenericList/OrganizationSubPageGenericListItem.tsx
@@ -117,7 +117,11 @@ const getParentProps = (
     // content of its first child when no subpage slug is present in the url
     return OrganizationParentSubpage.getProps(
       withSlugs(querySlugs.slice(0, 2)),
-    ).catch(() => {
+    ).catch((parentSubpageError) => {
+      if (!(parentSubpageError instanceof CustomNextError)) {
+        throw parentSubpageError
+      }
+      // Neither lookup found a page, the original error describes the url best
       throw error
     })
   })

--- a/apps/web/screens/queries/fragments.ts
+++ b/apps/web/screens/queries/fragments.ts
@@ -1042,6 +1042,7 @@ export const slices = gql`
         id
         title
         slug
+        url
         organizationPage {
           slug
         }

--- a/libs/cms/src/lib/models/featuredGenericListItems.model.ts
+++ b/libs/cms/src/lib/models/featuredGenericListItems.model.ts
@@ -65,9 +65,16 @@ export const mapFeaturedGenericListItems = ({
     fields.organizationPage?.fields?.slug &&
     fields.organizationSubpage?.fields?.slug
   ) {
+    // Subpages that belong to a parent subpage are served on
+    // /[organizationPage]/[parentSubpage]/[subpage]
+    const parentSubpageSlug =
+      fields.organizationSubpage.fields.organizationParentSubpage?.fields?.slug
+
     baseUrl = `/${getOrganizationPageUrlPrefix(sys.locale)}/${
       fields.organizationPage.fields.slug
-    }/${fields.organizationSubpage.fields.slug}`
+    }${parentSubpageSlug ? `/${parentSubpageSlug}` : ''}/${
+      fields.organizationSubpage.fields.slug
+    }`
     if (fields.genericList?.sys.id) {
       const tagGroupObject = Object.fromEntries(tagGroupsMap)
       if (Object.keys(tagGroupObject).length > 0)


### PR DESCRIPTION
# Generic list item pages 404 under organization parent subpages

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code - Opus 5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved “See more” links for organization lists, including nested subpages.
  - Updated organization subpage URLs to correctly include optional parent subpage paths.
  - Improved page resolution for two- and four-segment organization routes.
  - Preserved meaningful errors when a page cannot be resolved, improving reliability and troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->