### PR TITLE
fix(j-s): Notify court when a file is too large for Auður

### DIFF
--- a/apps/judicial-system/backend/src/app/modules/case/internalCase.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/case/internalCase.service.ts
@@ -61,7 +61,11 @@ import {
 } from '../../formatters'
 import { courtUpload, notifications } from '../../messages'
 import { AwsS3Service } from '../aws-s3'
-import { CourtDocumentFolder, CourtService } from '../court'
+import {
+  CourtDocumentFolder,
+  CourtService,
+  isFileTooLargeForCourt,
+} from '../court'
 import { buildIndictmentConclusionContent } from '../court/court.service'
 import { DefendantService } from '../defendant'
 import { EventService } from '../event'
@@ -264,7 +268,8 @@ export class InternalCaseService {
         { error },
       )
 
-      return false
+      // Do not retry an upload the court service will never accept
+      return isFileTooLargeForCourt(error)
     }
   }
 
@@ -313,7 +318,8 @@ export class InternalCaseService {
         { error },
       )
 
-      return false
+      // Do not retry an upload the court service will never accept
+      return isFileTooLargeForCourt(error)
     }
   }
 
@@ -350,7 +356,8 @@ export class InternalCaseService {
           { error },
         )
 
-        return false
+        // Do not retry an upload the court service will never accept
+        return isFileTooLargeForCourt(error)
       })
   }
 
@@ -399,7 +406,8 @@ export class InternalCaseService {
         { error },
       )
 
-      return false
+      // Do not retry an upload the court service will never accept
+      return isFileTooLargeForCourt(error)
     }
   }
 
@@ -927,7 +935,8 @@ export class InternalCaseService {
           { reason },
         )
 
-        return { delivered: false }
+        // Do not retry an upload the court service will never accept
+        return { delivered: isFileTooLargeForCourt(reason) }
       })
   }
 
@@ -1266,7 +1275,8 @@ export class InternalCaseService {
           { reason },
         )
 
-        return { delivered: false }
+        // Do not retry an upload the court service will never accept
+        return { delivered: isFileTooLargeForCourt(reason) }
       })
   }
 

--- a/apps/judicial-system/backend/src/app/modules/court/court.config.ts
+++ b/apps/judicial-system/backend/src/app/modules/court/court.config.ts
@@ -16,5 +16,8 @@ export const courtModuleConfig = defineConfig({
     fromName: env.required('EMAIL_FROM_NAME', 'Réttarvörslugátt'),
     replyToEmail: env.required('EMAIL_REPLY_TO', 'ben10@omnitrix.is'),
     replyToName: env.required('EMAIL_REPLY_TO_NAME', 'Réttarvörslugátt'),
+    courtsEmails: env.requiredJSON('COURTS_EMAILS', {
+      'd1e6e06f-dcfd-45e0-9a24-2fdabc2cc8bf': 'jl+d+court@kolibri.is',
+    }) as { [key: string]: string },
   }),
 })

--- a/apps/judicial-system/backend/src/app/modules/court/court.helpers.ts
+++ b/apps/judicial-system/backend/src/app/modules/court/court.helpers.ts
@@ -1,0 +1,10 @@
+import { PayloadTooLargeException } from '@nestjs/common'
+
+/**
+ * True when an upload failed because the court service rejected the file as
+ * too large. Such an upload will never succeed, so deliveries are completed
+ * without retrying - the court has been notified by email and is expected to
+ * upload the file by hand.
+ */
+export const isFileTooLargeForCourt = (reason: unknown): boolean =>
+  reason instanceof PayloadTooLargeException

--- a/apps/judicial-system/backend/src/app/modules/court/court.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/court/court.service.ts
@@ -3,7 +3,12 @@ import { Base64 } from 'js-base64'
 import { Op } from 'sequelize'
 import { ConfidentialClientApplication } from '@azure/msal-node'
 
-import { Inject, Injectable, ServiceUnavailableException } from '@nestjs/common'
+import {
+  Inject,
+  Injectable,
+  PayloadTooLargeException,
+  ServiceUnavailableException,
+} from '@nestjs/common'
 import { InjectModel } from '@nestjs/sequelize'
 
 import { EmailService } from '@island.is/email-service'
@@ -109,13 +114,56 @@ export class CourtService {
       : value
 
     const firstLetterInValue = valueWithoutFileExtension[0]
-    const mask = '*'.repeat(valueWithoutFileExtension.length - 2) // -2 to keep the first and last letter of the file name
+    const mask = '*'.repeat(
+      Math.max(0, valueWithoutFileExtension.length - 2), // -2 to keep the first and last letter of the file name
+    )
     const lastLetterInValueWithoutFileExtension =
       valueWithoutFileExtension[valueWithoutFileExtension.length - 1]
 
     return `${firstLetterInValue}${mask}${lastLetterInValueWithoutFileExtension}${
       valueIsFileName ? `.${fileNameEnding}` : ''
     }`
+  }
+
+  // The court service rejects files that exceed its size limit and no amount of
+  // retrying will change that, so the court is asked to upload the file by hand.
+  private async notifyCourtOfFileTooLarge(
+    courtId: string,
+    courtCaseNumber: string,
+    fileName: string,
+  ): Promise<void> {
+    const courtEmail = this.config.courtsEmails[courtId]
+
+    if (!courtEmail) {
+      this.logger.error(
+        `No email address is registered for court ${courtId}, so it cannot be notified that a file was too large for the court service`,
+      )
+
+      return
+    }
+
+    const body = `Ekki tókst að hlaða upp skjali ${this.mask(
+      fileName,
+    )} í Auði vegna stærðartakmarkana. Vinsamlegast hlaðið skjali upp handvirkt.`
+
+    try {
+      await this.emailService.sendEmail({
+        from: { name: this.config.fromName, address: this.config.fromEmail },
+        replyTo: {
+          name: this.config.replyToName,
+          address: this.config.replyToEmail,
+        },
+        to: [{ name: '', address: courtEmail }],
+        subject: `Ekki tókst að hlaða upp skjali í Auði í máli ${courtCaseNumber}`,
+        text: body,
+        html: body,
+      })
+    } catch (reason) {
+      this.logger.error(
+        `Failed to notify court ${courtId} that a file was too large for the court service`,
+        { reason },
+      )
+    }
   }
 
   private validateCourtRobotEmailParams(
@@ -186,10 +234,18 @@ export class CourtService {
           caseFolder,
         }),
       )
-      .catch((reason) => {
+      .catch(async (reason) => {
         if (reason instanceof ServiceUnavailableException) {
           // Act as if the document was created successfully
           return ''
+        }
+
+        if (reason instanceof PayloadTooLargeException) {
+          await this.notifyCourtOfFileTooLarge(
+            courtId,
+            courtCaseNumber,
+            sanitizedFileName,
+          )
         }
 
         this.eventService.postErrorEvent(
@@ -235,10 +291,18 @@ export class CourtService {
           streamID: streamId,
         }),
       )
-      .catch((reason) => {
+      .catch(async (reason) => {
         if (reason instanceof ServiceUnavailableException) {
           // Act as if the document was created successfully
           return ''
+        }
+
+        if (reason instanceof PayloadTooLargeException) {
+          await this.notifyCourtOfFileTooLarge(
+            courtId,
+            courtCaseNumber,
+            fileName,
+          )
         }
 
         this.eventService.postErrorEvent(

--- a/apps/judicial-system/backend/src/app/modules/court/court.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/court/court.service.ts
@@ -113,10 +113,14 @@ export class CourtService {
       ? value.replace(`.${fileNameEnding}`, '')
       : value
 
+    // The first and last letter are always kept, so there is nothing left to
+    // mask in shorter values
+    if (valueWithoutFileExtension.length < 2) {
+      return value
+    }
+
     const firstLetterInValue = valueWithoutFileExtension[0]
-    const mask = '*'.repeat(
-      Math.max(0, valueWithoutFileExtension.length - 2), // -2 to keep the first and last letter of the file name
-    )
+    const mask = '*'.repeat(valueWithoutFileExtension.length - 2) // -2 to keep the first and last letter of the file name
     const lastLetterInValueWithoutFileExtension =
       valueWithoutFileExtension[valueWithoutFileExtension.length - 1]
 
@@ -220,52 +224,51 @@ export class CourtService {
   ): Promise<string> {
     const sanitizedFileName = sanitize(fileName)
 
-    return this.courtClientService
-      .uploadStream(courtId, {
+    try {
+      const streamId = await this.courtClientService.uploadStream(courtId, {
         value: content,
         options: { filename: sanitizedFileName, contentType: fileType },
       })
-      .then((streamId) =>
-        this.courtClientService.createDocument(courtId, {
-          caseNumber: courtCaseNumber,
-          subject,
-          fileName: sanitizedFileName,
-          streamID: streamId,
-          caseFolder,
-        }),
-      )
-      .catch(async (reason) => {
-        if (reason instanceof ServiceUnavailableException) {
-          // Act as if the document was created successfully
-          return ''
-        }
 
-        if (reason instanceof PayloadTooLargeException) {
-          await this.notifyCourtOfFileTooLarge(
-            courtId,
-            courtCaseNumber,
-            sanitizedFileName,
-          )
-        }
-
-        this.eventService.postErrorEvent(
-          'Failed to create a document at court',
-          {
-            caseId,
-            actor: user.name,
-            institution: user.institution?.name,
-            courtId,
-            courtCaseNumber,
-            subject: this.mask(subject),
-            fileName: this.mask(sanitize(fileName)),
-            fileType,
-            caseFolder,
-          },
-          reason,
-        )
-
-        throw reason
+      return await this.courtClientService.createDocument(courtId, {
+        caseNumber: courtCaseNumber,
+        subject,
+        fileName: sanitizedFileName,
+        streamID: streamId,
+        caseFolder,
       })
+    } catch (reason) {
+      if (reason instanceof ServiceUnavailableException) {
+        // Act as if the document was created successfully
+        return ''
+      }
+
+      if (reason instanceof PayloadTooLargeException) {
+        await this.notifyCourtOfFileTooLarge(
+          courtId,
+          courtCaseNumber,
+          sanitizedFileName,
+        )
+      }
+
+      this.eventService.postErrorEvent(
+        'Failed to create a document at court',
+        {
+          caseId,
+          actor: user.name,
+          institution: user.institution?.name,
+          courtId,
+          courtCaseNumber,
+          subject: this.mask(subject),
+          fileName: this.mask(sanitizedFileName),
+          fileType,
+          caseFolder,
+        },
+        reason,
+      )
+
+      throw reason
+    }
   }
 
   async createCourtRecord(
@@ -278,50 +281,45 @@ export class CourtService {
     fileType: string,
     content: Buffer,
   ): Promise<string> {
-    return this.courtClientService
-      .uploadStream(courtId, {
+    try {
+      const streamId = await this.courtClientService.uploadStream(courtId, {
         value: content,
         options: { filename: fileName, contentType: fileType },
       })
-      .then((streamId) =>
-        this.courtClientService.createThingbok(courtId, {
-          caseNumber: courtCaseNumber,
-          subject,
-          fileName,
-          streamID: streamId,
-        }),
-      )
-      .catch(async (reason) => {
-        if (reason instanceof ServiceUnavailableException) {
-          // Act as if the document was created successfully
-          return ''
-        }
 
-        if (reason instanceof PayloadTooLargeException) {
-          await this.notifyCourtOfFileTooLarge(
-            courtId,
-            courtCaseNumber,
-            fileName,
-          )
-        }
-
-        this.eventService.postErrorEvent(
-          'Failed to create a court record at court',
-          {
-            caseId,
-            actor: user.name,
-            institution: user.institution?.name,
-            courtId,
-            courtCaseNumber,
-            subject: this.mask(subject),
-            fileName: this.mask(fileName),
-            fileType,
-          },
-          reason,
-        )
-
-        throw reason
+      return await this.courtClientService.createThingbok(courtId, {
+        caseNumber: courtCaseNumber,
+        subject,
+        fileName,
+        streamID: streamId,
       })
+    } catch (reason) {
+      if (reason instanceof ServiceUnavailableException) {
+        // Act as if the document was created successfully
+        return ''
+      }
+
+      if (reason instanceof PayloadTooLargeException) {
+        await this.notifyCourtOfFileTooLarge(courtId, courtCaseNumber, fileName)
+      }
+
+      this.eventService.postErrorEvent(
+        'Failed to create a court record at court',
+        {
+          caseId,
+          actor: user.name,
+          institution: user.institution?.name,
+          courtId,
+          courtCaseNumber,
+          subject: this.mask(subject),
+          fileName: this.mask(fileName),
+          fileType,
+        },
+        reason,
+      )
+
+      throw reason
+    }
   }
 
   async createCourtCase(

--- a/apps/judicial-system/backend/src/app/modules/court/court.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/court/court.service.ts
@@ -249,23 +249,23 @@ export class CourtService {
           courtCaseNumber,
           sanitizedFileName,
         )
+      } else {
+        this.eventService.postErrorEvent(
+          'Failed to create a document at court',
+          {
+            caseId,
+            actor: user.name,
+            institution: user.institution?.name,
+            courtId,
+            courtCaseNumber,
+            subject: this.mask(subject),
+            fileName: this.mask(sanitizedFileName),
+            fileType,
+            caseFolder,
+          },
+          reason,
+        )
       }
-
-      this.eventService.postErrorEvent(
-        'Failed to create a document at court',
-        {
-          caseId,
-          actor: user.name,
-          institution: user.institution?.name,
-          courtId,
-          courtCaseNumber,
-          subject: this.mask(subject),
-          fileName: this.mask(sanitizedFileName),
-          fileType,
-          caseFolder,
-        },
-        reason,
-      )
 
       throw reason
     }
@@ -301,22 +301,22 @@ export class CourtService {
 
       if (reason instanceof PayloadTooLargeException) {
         await this.notifyCourtOfFileTooLarge(courtId, courtCaseNumber, fileName)
+      } else {
+        this.eventService.postErrorEvent(
+          'Failed to create a court record at court',
+          {
+            caseId,
+            actor: user.name,
+            institution: user.institution?.name,
+            courtId,
+            courtCaseNumber,
+            subject: this.mask(subject),
+            fileName: this.mask(fileName),
+            fileType,
+          },
+          reason,
+        )
       }
-
-      this.eventService.postErrorEvent(
-        'Failed to create a court record at court',
-        {
-          caseId,
-          actor: user.name,
-          institution: user.institution?.name,
-          courtId,
-          courtCaseNumber,
-          subject: this.mask(subject),
-          fileName: this.mask(fileName),
-          fileType,
-        },
-        reason,
-      )
 
       throw reason
     }

--- a/apps/judicial-system/backend/src/app/modules/court/court.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/court/court.service.ts
@@ -148,7 +148,7 @@ export class CourtService {
 
     const body = `Ekki tókst að hlaða upp skjali ${this.mask(
       fileName,
-    )} í Auði vegna stærðartakmarkana. Vinsamlegast hlaðið skjali upp handvirkt.`
+    )} í Auði vegna stærðartakmarkana. Vinsamlegast hlaðið skjali upp handvirkt í Auði.`
 
     try {
       await this.emailService.sendEmail({

--- a/apps/judicial-system/backend/src/app/modules/court/index.ts
+++ b/apps/judicial-system/backend/src/app/modules/court/index.ts
@@ -1,1 +1,2 @@
+export { isFileTooLargeForCourt } from './court.helpers'
 export { CourtDocumentFolder, CourtService } from './court.service'

--- a/apps/judicial-system/backend/src/app/modules/court/test/createDocument.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/court/test/createDocument.spec.ts
@@ -213,7 +213,7 @@ describe('CourtService - Create document', () => {
         expect.objectContaining({
           to: [{ name: '', address: courtEmail }],
           subject: `Ekki tókst að hlaða upp skjali í Auði í máli ${courtCaseNumber}`,
-          text: 'Ekki tókst að hlaða upp skjali t******e.pdf í Auði vegna stærðartakmarkana. Vinsamlegast hlaðið skjali upp handvirkt.',
+          text: 'Ekki tókst að hlaða upp skjali t******e.pdf í Auði vegna stærðartakmarkana. Vinsamlegast hlaðið skjali upp handvirkt í Auði.',
         }),
       )
     })

--- a/apps/judicial-system/backend/src/app/modules/court/test/createDocument.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/court/test/createDocument.spec.ts
@@ -1,5 +1,9 @@
 import { v4 as uuid } from 'uuid'
 
+import { PayloadTooLargeException } from '@nestjs/common'
+
+import { EmailService } from '@island.is/email-service'
+
 import { CourtClientService } from '@island.is/judicial-system/court-client'
 import { User } from '@island.is/judicial-system/types'
 
@@ -36,13 +40,18 @@ describe('CourtService - Create document', () => {
   const content = Buffer.from('content')
   const streamId = uuid()
   const documentId = uuid()
+  const courtEmail = 'court@omnitrix.is'
   let mockCourtClientService: CourtClientService
+  let mockEmailService: EmailService
   let givenWhenThen: GivenWhenThen
 
   beforeEach(async () => {
-    const { courtClientService, courtService } =
+    process.env.COURTS_EMAILS = `{"${courtId}": "${courtEmail}"}`
+
+    const { courtClientService, emailService, courtService } =
       await createTestingCourtModule()
 
+    mockEmailService = emailService
     mockCourtClientService = courtClientService
     const mockUploadStream = mockCourtClientService.uploadStream as jest.Mock
     mockUploadStream.mockResolvedValue(streamId)
@@ -176,6 +185,69 @@ describe('CourtService - Create document', () => {
     it('should throw an error', () => {
       expect(then.error).toBeInstanceOf(Error)
       expect(then.error.message).toBe('Create document failed')
+    })
+  })
+
+  describe('file is too large for the court service', () => {
+    const largeFileName = 'testFile.pdf'
+    let then: Then
+
+    beforeEach(async () => {
+      const mockUploadStream = mockCourtClientService.uploadStream as jest.Mock
+      mockUploadStream.mockRejectedValueOnce(new PayloadTooLargeException())
+
+      then = await givenWhenThen(
+        caseId,
+        courtId,
+        courtCaseNumber,
+        caseFolder,
+        subject,
+        largeFileName,
+        fileType,
+        content,
+      )
+    })
+
+    it('should notify the court with a masked file name', () => {
+      expect(mockEmailService.sendEmail).toHaveBeenCalledWith(
+        expect.objectContaining({
+          to: [{ name: '', address: courtEmail }],
+          subject: `Ekki tókst að hlaða upp skjali í Auði í máli ${courtCaseNumber}`,
+          text: 'Ekki tókst að hlaða upp skjali t******e.pdf í Auði vegna stærðartakmarkana. Vinsamlegast hlaðið skjali upp handvirkt.',
+        }),
+      )
+    })
+
+    it('should throw a payload too large exception', () => {
+      expect(then.error).toBeInstanceOf(PayloadTooLargeException)
+    })
+  })
+
+  describe('file is too large for a court without a registered email address', () => {
+    let then: Then
+
+    beforeEach(async () => {
+      const mockUploadStream = mockCourtClientService.uploadStream as jest.Mock
+      mockUploadStream.mockRejectedValueOnce(new PayloadTooLargeException())
+
+      then = await givenWhenThen(
+        caseId,
+        uuid(),
+        courtCaseNumber,
+        caseFolder,
+        subject,
+        fileName,
+        fileType,
+        content,
+      )
+    })
+
+    it('should not send an email', () => {
+      expect(mockEmailService.sendEmail).not.toHaveBeenCalled()
+    })
+
+    it('should throw a payload too large exception', () => {
+      expect(then.error).toBeInstanceOf(PayloadTooLargeException)
     })
   })
 })

--- a/apps/judicial-system/backend/src/app/modules/court/test/createTestingCourtModule.ts
+++ b/apps/judicial-system/backend/src/app/modules/court/test/createTestingCourtModule.ts
@@ -3,6 +3,7 @@ import { mock } from 'jest-mock-extended'
 import { getModelToken } from '@nestjs/sequelize'
 import { Test } from '@nestjs/testing'
 
+import { EmailService } from '@island.is/email-service'
 import { LOGGER_PROVIDER } from '@island.is/logging'
 import { ConfigModule } from '@island.is/nest/config'
 
@@ -48,9 +49,11 @@ export const createTestingCourtModule = async () => {
   const courtClientService =
     courtModule.get<CourtClientService>(CourtClientService)
 
+  const emailService = courtModule.get<EmailService>(EmailService)
+
   const courtService = courtModule.get<CourtService>(CourtService)
 
   courtModule.close()
 
-  return { courtClientService, courtService }
+  return { courtClientService, emailService, courtService }
 }

--- a/apps/judicial-system/backend/src/app/modules/court/test/createTestingCourtModule.ts
+++ b/apps/judicial-system/backend/src/app/modules/court/test/createTestingCourtModule.ts
@@ -26,6 +26,7 @@ export const createTestingCourtModule = async () => {
         useValue: {
           debug: jest.fn(),
           info: jest.fn(),
+          warn: jest.fn(),
           error: jest.fn(),
         },
       },

--- a/apps/judicial-system/backend/src/app/modules/file/internalFile.controller.ts
+++ b/apps/judicial-system/backend/src/app/modules/file/internalFile.controller.ts
@@ -19,6 +19,7 @@ import {
 
 import { AppealCaseExistsGuard, CurrentAppealCase } from '../appeal-case'
 import { CaseExistsGuard, CurrentCase } from '../case'
+import { isFileTooLargeForCourt } from '../court'
 import { AppealCase, Case, CaseFile } from '../repository'
 import { DeliverDto } from './dto/deliver.dto'
 import { CurrentCaseFile } from './guards/caseFile.decorator'
@@ -71,13 +72,21 @@ export class InternalFileController {
   ): Promise<DeliverResponse> {
     this.logger.debug(`Delivering file ${fileId} of case ${caseId} to court`)
 
-    const { success } = await this.fileService.uploadCaseFileToCourt(
-      theCase,
-      caseFile,
-      deliverDto.user,
-    )
+    try {
+      const { success } = await this.fileService.uploadCaseFileToCourt(
+        theCase,
+        caseFile,
+        deliverDto.user,
+      )
 
-    return { delivered: success }
+      return { delivered: success }
+    } catch (reason) {
+      if (isFileTooLargeForCourt(reason)) {
+        return { delivered: true }
+      }
+
+      throw reason
+    }
   }
 
   @UseGuards(AppealCaseExistsGuard)

--- a/apps/judicial-system/backend/src/app/modules/file/test/createTestingFileModule.ts
+++ b/apps/judicial-system/backend/src/app/modules/file/test/createTestingFileModule.ts
@@ -68,6 +68,7 @@ export const createTestingFileModule = async () => {
         useValue: {
           debug: jest.fn(),
           info: jest.fn(),
+          warn: jest.fn(),
           error: jest.fn(),
         },
       },

--- a/apps/judicial-system/backend/src/app/modules/file/test/internalFileController/deliverCaseFileToCourt.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/file/test/internalFileController/deliverCaseFileToCourt.spec.ts
@@ -1,7 +1,7 @@
 import each from 'jest-each'
 import { v4 as uuid } from 'uuid'
 
-import { NotFoundException } from '@nestjs/common'
+import { NotFoundException, PayloadTooLargeException } from '@nestjs/common'
 
 import {
   CaseFileCategory,
@@ -360,6 +360,35 @@ describe('InternalFileController - Deliver case file to court', () => {
     it('should throw error', () => {
       expect(then.error).toBeInstanceOf(Error)
       expect(then.error.message).toBe('Some error')
+    })
+  })
+
+  describe('file is too large for the court service', () => {
+    const caseId = uuid()
+    const theCase = { id: caseId } as Case
+    const fileId = uuid()
+    const key = `${caseId}/${uuid()}/test.txt`
+    const caseFile = { id: fileId, key, isKeyAccessible: true } as CaseFile
+    const content = Buffer.from('Test content')
+    let then: Then
+
+    beforeEach(async () => {
+      const mockObjectExists = mockAwsS3Service.objectExists as jest.Mock
+      mockObjectExists.mockResolvedValueOnce(true)
+      const mockGetObject = mockAwsS3Service.getObject as jest.Mock
+      mockGetObject.mockResolvedValueOnce(content)
+      const mockCreateDocument = mockCourtService.createDocument as jest.Mock
+      mockCreateDocument.mockRejectedValueOnce(new PayloadTooLargeException())
+
+      then = await givenWhenThen(caseId, fileId, theCase, caseFile)
+    })
+
+    it('should not mark the file as stored in court', () => {
+      expect(mockFileModel.update).not.toHaveBeenCalled()
+    })
+
+    it('should complete the delivery so that it is not retried', () => {
+      expect(then.result).toEqual({ delivered: true })
     })
   })
 

--- a/apps/judicial-system/backend/src/app/modules/subpoena/subpoena.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/subpoena/subpoena.service.ts
@@ -34,7 +34,11 @@ import {
 
 import { getCaseFileHash } from '../../formatters'
 import { PdfService } from '../case/pdf.service'
-import { CourtDocumentFolder, CourtService } from '../court'
+import {
+  CourtDocumentFolder,
+  CourtService,
+  isFileTooLargeForCourt,
+} from '../court'
 import { DefendantService } from '../defendant/defendant.service'
 import { EventService } from '../event'
 import { FileService } from '../file/file.service'
@@ -567,7 +571,8 @@ export class SubpoenaService {
           { reason },
         )
 
-        return { delivered: false }
+        // Do not retry an upload the court service will never accept
+        return { delivered: isFileTooLargeForCourt(reason) }
       })
   }
 
@@ -602,7 +607,8 @@ export class SubpoenaService {
           { reason },
         )
 
-        return { delivered: false }
+        // Do not retry an upload the court service will never accept
+        return { delivered: isFileTooLargeForCourt(reason) }
       })
   }
 

--- a/libs/judicial-system/court-client/src/lib/courtClient.service.ts
+++ b/libs/judicial-system/court-client/src/lib/courtClient.service.ts
@@ -93,7 +93,7 @@ const isPayloadTooLargeError = (reason: CourtClientError): boolean => {
     return false
   }
 
-  // X-road logs these errors when subbmitting large files to the court service on dev.
+  // X-road may surface oversized uploads as this proxy error instead of HTTP 413.
   return (
     reason.message.includes('Server.ServerProxy.LoggingFailed') &&
     reason.message.includes('Message size exceeds maximum loggable size')
@@ -397,12 +397,7 @@ export class CourtClientServiceImplementation implements CourtClientService {
     // limit. This is not a transient error, so it is kept out of the error
     // count that triggers a forced relogin.
     if (payloadTooLarge) {
-      this.logger.warn(
-        '[413-DEBUG] handleCaseError: mapping to PayloadTooLargeException',
-      )
-
       return new PayloadTooLargeException({
-        ...reason,
         message: 'The file is too large for the court service',
         detail: reason.message,
       })

--- a/libs/judicial-system/court-client/src/lib/courtClient.service.ts
+++ b/libs/judicial-system/court-client/src/lib/courtClient.service.ts
@@ -79,6 +79,8 @@ interface CourtsCredentials {
 interface CourtClientError {
   status?: number
   message: unknown
+  // Raw upstream response body when available (before any local wrapping).
+  detail?: unknown
 }
 
 // True when the court service or x-road rejected the upload because the file
@@ -89,14 +91,21 @@ const isPayloadTooLargeError = (reason: CourtClientError): boolean => {
     return true
   }
 
-  if (typeof reason.message !== 'string') {
+  const rawResponse =
+    typeof reason.detail === 'string'
+      ? reason.detail
+      : typeof reason.message === 'string'
+      ? reason.message
+      : undefined
+
+  if (!rawResponse) {
     return false
   }
 
   // X-road may surface oversized uploads as this proxy error instead of HTTP 413.
   return (
-    reason.message.includes('Server.ServerProxy.LoggingFailed') &&
-    reason.message.includes('Message size exceeds maximum loggable size')
+    rawResponse.includes('Server.ServerProxy.LoggingFailed') &&
+    rawResponse.includes('Message size exceeds maximum loggable size')
   )
 }
 
@@ -399,7 +408,7 @@ export class CourtClientServiceImplementation implements CourtClientService {
     if (payloadTooLarge) {
       return new PayloadTooLargeException({
         message: 'The file is too large for the court service',
-        detail: reason.message,
+        detail: reason.detail ?? reason.message,
       })
     }
 

--- a/libs/judicial-system/court-client/src/lib/courtClient.service.ts
+++ b/libs/judicial-system/court-client/src/lib/courtClient.service.ts
@@ -8,10 +8,12 @@ import {
 import {
   BadGatewayException,
   BadRequestException,
+  HttpStatus,
   Inject,
   Injectable,
   NotFoundException,
   NotImplementedException,
+  PayloadTooLargeException,
   ServiceUnavailableException,
   UnprocessableEntityException,
   UnsupportedMediaTypeException,
@@ -72,6 +74,11 @@ const stripResult = (str: string): string => {
 
 interface CourtsCredentials {
   [key: string]: CredentialsData
+}
+
+interface CourtClientError {
+  status?: number
+  message: unknown
 }
 
 interface ConnectionState {
@@ -343,10 +350,7 @@ export class CourtClientServiceImplementation implements CourtClientService {
     }
   }
 
-  private handleUnknownError(
-    courtId: string,
-    reason: { status: string; message: unknown },
-  ) {
+  private handleUnknownError(courtId: string, reason: CourtClientError) {
     // Get the connection state
     const connectionState = this.getConnectionState(courtId)
 
@@ -360,10 +364,7 @@ export class CourtClientServiceImplementation implements CourtClientService {
     })
   }
 
-  private handleCaseError(
-    courtId: string,
-    reason: { status: string; message: unknown },
-  ): Error {
+  private handleCaseError(courtId: string, reason: CourtClientError): Error {
     // Check for known errors
     if (
       typeof reason.message === 'string' &&
@@ -372,12 +373,23 @@ export class CourtClientServiceImplementation implements CourtClientService {
       return new NotFoundException(reason)
     }
 
+    // The court service, or x-road, rejects payloads that exceed their size
+    // limit. This is not a transient error, so it is kept out of the error
+    // count that triggers a forced relogin.
+    if (reason.status === HttpStatus.PAYLOAD_TOO_LARGE) {
+      return new PayloadTooLargeException({
+        ...reason,
+        message: 'The file is too large for the court service',
+        detail: reason.message,
+      })
+    }
+
     return this.handleUnknownError(courtId, reason)
   }
 
   private handleParticipantError(
     courtId: string,
-    reason: { status: string; message: unknown },
+    reason: CourtClientError,
   ): Error {
     // Check for known errors
     if (
@@ -422,7 +434,7 @@ export class CourtClientServiceImplementation implements CourtClientService {
       this.createDocumentApi.createDocument({
         createDocumentData: { ...args, authenticationToken },
       }),
-    ).catch((reason: { status: string; message: unknown }) => {
+    ).catch((reason: CourtClientError) => {
       this.logger.warn('Court client error - createDocument', {
         courtId,
         reason,
@@ -538,7 +550,7 @@ export class CourtClientServiceImplementation implements CourtClientService {
       this.updateCaseWithDefendantApi.updateCaseWithDefendant({
         updateCaseWithDefendantData: { ...args, authenticationToken },
       }),
-    ).catch((reason: { status: string; message: unknown }) => {
+    ).catch((reason: CourtClientError) => {
       this.logger.warn('Court client error - updateCaseWithDefendant', {
         courtId,
         reason,

--- a/libs/judicial-system/court-client/src/lib/courtClient.service.ts
+++ b/libs/judicial-system/court-client/src/lib/courtClient.service.ts
@@ -81,6 +81,25 @@ interface CourtClientError {
   message: unknown
 }
 
+// True when the court service or x-road rejected the upload because the file
+// is too large. X-road may surface this as HTTP 500 with a proxy logging
+// error instead of HTTP 413.
+const isPayloadTooLargeError = (reason: CourtClientError): boolean => {
+  if (reason.status === HttpStatus.PAYLOAD_TOO_LARGE) {
+    return true
+  }
+
+  if (typeof reason.message !== 'string') {
+    return false
+  }
+
+  // X-road logs these errors when subbmitting large files to the court service on dev.
+  return (
+    reason.message.includes('Server.ServerProxy.LoggingFailed') &&
+    reason.message.includes('Message size exceeds maximum loggable size')
+  )
+}
+
 interface ConnectionState {
   credentials: CredentialsData
   authenticationToken: string
@@ -365,6 +384,7 @@ export class CourtClientServiceImplementation implements CourtClientService {
   }
 
   private handleCaseError(courtId: string, reason: CourtClientError): Error {
+    const payloadTooLarge = isPayloadTooLargeError(reason)
     // Check for known errors
     if (
       typeof reason.message === 'string' &&
@@ -376,7 +396,11 @@ export class CourtClientServiceImplementation implements CourtClientService {
     // The court service, or x-road, rejects payloads that exceed their size
     // limit. This is not a transient error, so it is kept out of the error
     // count that triggers a forced relogin.
-    if (reason.status === HttpStatus.PAYLOAD_TOO_LARGE) {
+    if (payloadTooLarge) {
+      this.logger.warn(
+        '[413-DEBUG] handleCaseError: mapping to PayloadTooLargeException',
+      )
+
       return new PayloadTooLargeException({
         ...reason,
         message: 'The file is too large for the court service',

--- a/libs/judicial-system/court-client/src/lib/uploadStreamApi/uploadStreamApi.ts
+++ b/libs/judicial-system/court-client/src/lib/uploadStreamApi/uploadStreamApi.ts
@@ -56,10 +56,12 @@ export class UploadStreamApi {
             ? data
             : JSON.stringify(data)
 
-        // The status is reported separately so that callers can react to
-        // specific responses, such as the file being too large.
+        // The status and raw response body are reported separately so that
+        // callers can react to specific responses, such as the file being too
+        // large, without parsing the wrapped log message.
         throw {
           status,
+          detail: message,
           message: `Upload failed with status ${status}: ${message}`,
         }
       }

--- a/libs/judicial-system/court-client/src/lib/uploadStreamApi/uploadStreamApi.ts
+++ b/libs/judicial-system/court-client/src/lib/uploadStreamApi/uploadStreamApi.ts
@@ -49,7 +49,13 @@ export class UploadStreamApi {
       if (axios.isAxiosError(error)) {
         const status = error.response?.status
         const message = error.response?.data || error.message
-        throw new Error(`Upload failed with status ${status}: ${message}`)
+
+        // The status is reported separately so that callers can react to
+        // specific responses, such as the file being too large.
+        throw {
+          status,
+          message: `Upload failed with status ${status}: ${message}`,
+        }
       }
 
       throw new Error(

--- a/libs/judicial-system/court-client/src/lib/uploadStreamApi/uploadStreamApi.ts
+++ b/libs/judicial-system/court-client/src/lib/uploadStreamApi/uploadStreamApi.ts
@@ -48,7 +48,13 @@ export class UploadStreamApi {
     } catch (error) {
       if (axios.isAxiosError(error)) {
         const status = error.response?.status
-        const message = error.response?.data || error.message
+        const data = error.response?.data
+        const message =
+          data === undefined || data === null
+            ? error.message
+            : typeof data === 'string'
+            ? data
+            : JSON.stringify(data)
 
         // The status is reported separately so that callers can react to
         // specific responses, such as the file being too large.


### PR DESCRIPTION
Asana: Tilkynning á almennt netfang dómstóla þegar klikkar að senda stórt skjal upp í Auði

## What

When the court service (Auður) rejects a document upload with `413 Payload Too Large`, the court's general email address is now notified once and the delivery is not retried.

- `UploadStreamApi` throws the HTTP status alongside the message instead of flattening it into a string, so callers can react to specific responses. Previously a 413 was indistinguishable from any other upload failure.
- `CourtClientService.handleCaseError` maps status 413 to a `PayloadTooLargeException`. It is handled before `handleUnknownError` so it does not count towards the consecutive error count that forces a relogin.
- `CourtService.createDocument` / `createCourtRecord` send an email to the court's general address on a 413, reusing the existing `mask()` helper so only the first and last character of the file name and its extension are exposed:
  - Subject: `Ekki tókst að hlaða upp skjali í Auði í máli R-332/2026`
  - Body: `Ekki tókst að hlaða upp skjali t******e.pdf í Auði vegna stærðartakmarkana. Vinsamlegast hlaðið skjali upp handvirkt.`
- The address is resolved from `COURTS_EMAILS`, which is now also loaded by the court module config. If no address is registered for the court, the failure is logged and no email is sent.
- Every court delivery endpoint completes the delivery on a too-large file (`isFileTooLargeForCourt`), so the SQS message is dropped instead of being retried ten times with backoff. This also guarantees the email is only sent once.
- The case file itself is left in `STORED_IN_RVG`, so it still shows as not delivered in RVG rather than falsely appearing as uploaded.
- `mask()` no longer throws a `RangeError` on file names shorter than two characters.

## Why

It has become common for prosecutors to upload all investigation data as a single large package, and those uploads silently fail on the x-road size limit. The court had no way to find out other than comparing the documents in Auður with the ones in RVG, and the retry loop kept hammering an upload that can never succeed. This is the first-aid fix the ticket asks for: tell the court once, and let them upload the file manually.

## Screenshots / Gifs

N/A — backend only.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Cursor


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added handling for files exceeding the court’s upload size limit.
  - Configured email notifications for relevant courts when oversized uploads are rejected.

- **Bug Fixes**
  - Oversized files no longer trigger unnecessary delivery retries.
  - Delivery results correctly indicate these files were handled while preserving error details.
  - Other upload failures continue to be reported normally.
  - Improved handling of upload error messages and short masked filenames.

- **Tests**
  - Added coverage for oversized uploads, notifications, missing recipients, and delivery outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->