### PR TITLE
fix(j-s): Admin user creation conflicts and locked name field

### DIFF
--- a/apps/judicial-system/backend/src/app/modules/user/test/create.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/user/test/create.spec.ts
@@ -1,4 +1,7 @@
+import { UniqueConstraintError } from 'sequelize'
 import { v4 as uuid } from 'uuid'
+
+import { ConflictException } from '@nestjs/common'
 
 import { UserRole } from '@island.is/judicial-system/types'
 
@@ -78,6 +81,40 @@ describe('UserController - Create', () => {
         canConfirmIndictment,
       })
       expect(then.result).toBe(user)
+    })
+  })
+
+  describe('user already exists', () => {
+    let then: Then
+
+    beforeEach(async () => {
+      const mockCreate = mockUserModel.create as jest.Mock
+      mockCreate.mockRejectedValueOnce(new UniqueConstraintError({}))
+
+      then = await givenWhenThen()
+    })
+
+    it('should throw a conflict exception', () => {
+      expect(then.error).toBeInstanceOf(ConflictException)
+      expect(then.error.message).toBe(
+        'A user with this national id, role and institution already exists',
+      )
+    })
+  })
+
+  describe('user creation fails', () => {
+    const error = new Error('database error')
+    let then: Then
+
+    beforeEach(async () => {
+      const mockCreate = mockUserModel.create as jest.Mock
+      mockCreate.mockRejectedValueOnce(error)
+
+      then = await givenWhenThen()
+    })
+
+    it('should rethrow the error', () => {
+      expect(then.error).toBe(error)
     })
   })
 })

--- a/apps/judicial-system/backend/src/app/modules/user/user.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/user/user.service.ts
@@ -1,6 +1,11 @@
-import { Op } from 'sequelize'
+import { Op, UniqueConstraintError } from 'sequelize'
 
-import { Inject, Injectable, NotFoundException } from '@nestjs/common'
+import {
+  ConflictException,
+  Inject,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common'
 import { InjectModel } from '@nestjs/sequelize'
 
 import type { Logger } from '@island.is/logging'
@@ -108,7 +113,17 @@ export class UserService {
   }
 
   async create(userToCreate: CreateUserDto): Promise<User> {
-    return this.userModel.create({ ...userToCreate })
+    try {
+      return await this.userModel.create({ ...userToCreate })
+    } catch (error) {
+      if (error instanceof UniqueConstraintError) {
+        throw new ConflictException(
+          'A user with this national id, role and institution already exists',
+        )
+      }
+
+      throw error
+    }
   }
 
   async update(userId: string, update: UpdateUserDto): Promise<User> {

--- a/apps/judicial-system/web/src/routes/Admin/NewUser/NewUser.tsx
+++ b/apps/judicial-system/web/src/routes/Admin/NewUser/NewUser.tsx
@@ -46,7 +46,9 @@ export const NewUser = () => {
         const code = error.graphQLErrors[0]?.extensions?.code
 
         if (code === 'https://httpstatuses.org/409') {
-          toast.error('Notandi með þessa kennitölu er nú þegar til')
+          toast.error(
+            'Notandi með þessa kennitölu, hlutverk og stofnun er nú þegar til',
+          )
         } else {
           toast.error(formatMessage(strings.createError))
         }

--- a/apps/judicial-system/web/src/routes/Admin/NewUser/NewUser.tsx
+++ b/apps/judicial-system/web/src/routes/Admin/NewUser/NewUser.tsx
@@ -42,8 +42,14 @@ export const NewUser = () => {
   const [createUserMutation, { loading: userCreating }] = useCreateUserMutation(
     {
       onCompleted: () => router.push(ADMIN_USERS_ROUTE),
-      onError: () => {
-        toast.error(formatMessage(strings.createError))
+      onError: (error) => {
+        const code = error.graphQLErrors[0]?.extensions?.code
+
+        if (code === 'https://httpstatuses.org/409') {
+          toast.error('Notandi með þessa kennitölu er nú þegar til')
+        } else {
+          toast.error(formatMessage(strings.createError))
+        }
       },
     },
   )

--- a/apps/judicial-system/web/src/routes/Admin/UserForm/UserForm.spec.tsx
+++ b/apps/judicial-system/web/src/routes/Admin/UserForm/UserForm.spec.tsx
@@ -1,0 +1,93 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import {
+  User,
+  UserRole,
+} from '@island.is/judicial-system-web/src/graphql/schema'
+import {
+  IntlProviderWrapper,
+  UserContextWrapper,
+} from '@island.is/judicial-system-web/src/utils/testHelpers'
+
+import UserForm from './UserForm'
+
+jest.mock('next/router', () => ({
+  push: jest.fn(),
+}))
+
+const newUser: User = {
+  id: '',
+  active: true,
+  canConfirmIndictment: false,
+}
+
+const renderForm = (user: User) =>
+  render(
+    <IntlProviderWrapper>
+      <UserContextWrapper userRole={UserRole.ADMIN}>
+        <UserForm
+          user={user}
+          institutions={[]}
+          onSave={jest.fn()}
+          loading={false}
+        />
+      </UserContextWrapper>
+    </IntlProviderWrapper>,
+  )
+
+describe('UserForm', () => {
+  let mockFetch: jest.Mock
+
+  beforeEach(() => {
+    mockFetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ items: [{ name: 'Gervimaður Afríka' }] }),
+    })
+    global.fetch = mockFetch
+  })
+
+  it('should fill in the name from the national registry for a new user', async () => {
+    renderForm(newUser)
+
+    await userEvent.type(screen.getByTestId('nationalId'), '0101302989')
+
+    await waitFor(() =>
+      expect(screen.getByRole('textbox', { name: /^Nafn/ })).toHaveValue(
+        'Gervimaður Afríka',
+      ),
+    )
+  })
+
+  it('should allow the name to be changed after a national registry lookup', async () => {
+    renderForm(newUser)
+
+    await userEvent.type(screen.getByTestId('nationalId'), '0101302989')
+
+    const nameInput = screen.getByRole('textbox', { name: /^Nafn/ })
+
+    await waitFor(() => expect(nameInput).toHaveValue('Gervimaður Afríka'))
+
+    await userEvent.clear(nameInput)
+    await userEvent.type(nameInput, 'Jón Jónsson')
+
+    expect(nameInput).toHaveValue('Jón Jónsson')
+  })
+
+  it('should not look up existing users in the national registry', async () => {
+    renderForm({
+      ...newUser,
+      id: 'some-id',
+      nationalId: '0101302989',
+      name: 'Upprunalegt Nafn',
+    })
+
+    const nameInput = screen.getByRole('textbox', { name: /^Nafn/ })
+
+    await userEvent.clear(nameInput)
+    await userEvent.type(nameInput, 'Jón Jónsson')
+
+    expect(nameInput).toHaveValue('Jón Jónsson')
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+})

--- a/apps/judicial-system/web/src/routes/Admin/UserForm/UserForm.tsx
+++ b/apps/judicial-system/web/src/routes/Admin/UserForm/UserForm.tsx
@@ -175,7 +175,13 @@ export const UserForm: FC<Props> = ({
     mobileNumber: existingUser.mobileNumber,
   })
 
-  const { personData, error } = useNationalRegistry(user.nationalId)
+  const isNewUser = user.id.length === 0
+
+  // The national id of an existing user cannot be changed, so only look up
+  // the name of new users in the national registry
+  const { personData, error } = useNationalRegistry(user.nationalId, {
+    skip: !isNewUser,
+  })
 
   const [nameErrorMessage, setNameErrorMessage] = useState<string>()
   const [nationalIdErrorMessage, setNationalIdErrorMessage] = useState<string>()
@@ -185,16 +191,11 @@ export const UserForm: FC<Props> = ({
     useState<string>()
   const [emailErrorMessage, setEmailErrorMessage] = useState<string>()
 
-  const isNewUser = user.id.length === 0
-
-  const setName = useCallback(
-    (name: string) => {
-      if (name !== user.name) {
-        setUser((prevUser) => ({ ...prevUser, name: name }))
-      }
-    },
-    [user],
-  )
+  const setName = useCallback((name: string) => {
+    setUser((prevUser) =>
+      prevUser.name === name ? prevUser : { ...prevUser, name },
+    )
+  }, [])
 
   useEffect(() => {
     if (error || (personData && personData.items?.length === 0)) {


### PR DESCRIPTION
## What

Two fixes in the user admin (`/notendur`):

- Creating a user that already exists (same national id, role and institution) now returns **409 Conflict** instead of an unhandled 500, and the admin UI shows a specific error toast ("Notandi með þessa kennitölu er nú þegar til") instead of the generic failure message.
- The name field in the user form is no longer locked to the national registry lookup result. An unstable `setName` callback caused the auto-fill effect to re-run on every keystroke, overwriting whatever the admin typed. The name is now filled in once per lookup and stays editable. Existing users (whose national id is read-only) skip the lookup entirely, so their stored name is no longer overwritten on page load. Also removed a stray `console.log` from the form.

## Why

Creating a duplicate user surfaced as an opaque server error with no hint about the cause, and the national registry auto-fill made it impossible to correct or adjust a user's name in the form.

## Screenshots / Gifs
Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code
- [ ] No AI tools were used in preparing this pull request

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved user creation error handling for duplicate national IDs with a clear, specific message.
  * National Registry name lookups now occur only when creating new users.
  * Existing user details are no longer overwritten by unnecessary registry lookups.
  * Manual name changes after a registry lookup are preserved correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->