### PR TITLE
fix(j-s): Send driving license suspension notification when service of verdict is not required

### DIFF
--- a/apps/judicial-system/backend/src/app/modules/notification/services/notificationDispatch.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/services/notificationDispatch.service.ts
@@ -120,11 +120,15 @@ export class NotificationDispatchService {
       (defendant) => defendant.isDrivingLicenseSuspended,
     )
 
-    const hasServiceRequirementNotApplicable = theCase.defendants?.some(
+    // The suspension takes effect without service of the verdict when the
+    // defendant was present at the ruling (NOT_APPLICABLE) or service is
+    // not required (NOT_REQUIRED)
+    const hasVerdictThatDoesNotRequireService = theCase.defendants?.some(
       (defendant) =>
         defendant.verdicts?.some(
           (verdict) =>
-            verdict.serviceRequirement === ServiceRequirement.NOT_APPLICABLE,
+            verdict.serviceRequirement === ServiceRequirement.NOT_APPLICABLE ||
+            verdict.serviceRequirement === ServiceRequirement.NOT_REQUIRED,
         ),
     )
 
@@ -133,7 +137,7 @@ export class NotificationDispatchService {
 
     if (
       hasDrivingLicenseSuspension &&
-      (isFine || hasServiceRequirementNotApplicable)
+      (isFine || hasVerdictThatDoesNotRequireService)
     ) {
       addMessagesToQueue({
         type: MessageType.INDICTMENT_CASE_NOTIFICATION,

--- a/apps/judicial-system/backend/src/app/modules/notification/test/internalNotificationController/eventNotificationDispatch/eventNotificationDispatch.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/test/internalNotificationController/eventNotificationDispatch/eventNotificationDispatch.spec.ts
@@ -3,16 +3,18 @@ import { v4 as uuid } from 'uuid'
 import { Message, MessageType } from '@island.is/judicial-system/message'
 import {
   CaseFileCategory,
+  CaseIndictmentRulingDecision,
   CaseType,
   EventNotificationType,
   IndictmentCaseNotificationType,
   RequestCaseNotificationType,
+  ServiceRequirement,
   User,
 } from '@island.is/judicial-system/types'
 
 import { createTestingNotificationModule } from '../../createTestingNotificationModule'
 
-import { Case, CaseFile } from '../../../../repository'
+import { Case, CaseFile, Defendant } from '../../../../repository'
 import { InternalNotificationController } from '../../../internalNotification.controller'
 
 describe('InternalNotificationController - Dispatch event notifications', () => {
@@ -30,6 +32,20 @@ describe('InternalNotificationController - Dispatch event notifications', () => 
       ...baseCase,
       type,
     } as Case)
+  const setSuspendedDefendant = (
+    indictmentRulingDecision: CaseIndictmentRulingDecision,
+    serviceRequirement?: ServiceRequirement,
+  ) =>
+    ({
+      ...baseCase,
+      indictmentRulingDecision,
+      defendants: [
+        {
+          isDrivingLicenseSuspended: true,
+          verdicts: serviceRequirement ? [{ serviceRequirement }] : [],
+        },
+      ] as Defendant[],
+    } as Case)
   const user = { id: uuid(), name: 'Test' } as User
 
   let mockQueuedMessages: Message[]
@@ -46,6 +62,98 @@ describe('InternalNotificationController - Dispatch event notifications', () => 
   const notificationScenarios = [
     {
       theCase: baseCase,
+      notificationType:
+        EventNotificationType.INDICTMENT_SENT_TO_PUBLIC_PROSECUTOR,
+      expectedMessages: [
+        {
+          type: MessageType.INDICTMENT_CASE_NOTIFICATION,
+          caseId,
+          body: {
+            type: IndictmentCaseNotificationType.CRIMINAL_RECORD_FILES_UPLOADED,
+          },
+        },
+      ],
+    },
+    {
+      theCase: setSuspendedDefendant(
+        CaseIndictmentRulingDecision.RULING,
+        ServiceRequirement.NOT_REQUIRED,
+      ),
+      scenarioDescription:
+        'driving license suspension with service not required',
+      notificationType:
+        EventNotificationType.INDICTMENT_SENT_TO_PUBLIC_PROSECUTOR,
+      expectedMessages: [
+        {
+          type: MessageType.INDICTMENT_CASE_NOTIFICATION,
+          caseId,
+          body: {
+            type: IndictmentCaseNotificationType.DRIVING_LICENSE_SUSPENSION,
+          },
+        },
+        {
+          type: MessageType.INDICTMENT_CASE_NOTIFICATION,
+          caseId,
+          body: {
+            type: IndictmentCaseNotificationType.CRIMINAL_RECORD_FILES_UPLOADED,
+          },
+        },
+      ],
+    },
+    {
+      theCase: setSuspendedDefendant(
+        CaseIndictmentRulingDecision.RULING,
+        ServiceRequirement.NOT_APPLICABLE,
+      ),
+      scenarioDescription:
+        'driving license suspension with service not applicable',
+      notificationType:
+        EventNotificationType.INDICTMENT_SENT_TO_PUBLIC_PROSECUTOR,
+      expectedMessages: [
+        {
+          type: MessageType.INDICTMENT_CASE_NOTIFICATION,
+          caseId,
+          body: {
+            type: IndictmentCaseNotificationType.DRIVING_LICENSE_SUSPENSION,
+          },
+        },
+        {
+          type: MessageType.INDICTMENT_CASE_NOTIFICATION,
+          caseId,
+          body: {
+            type: IndictmentCaseNotificationType.CRIMINAL_RECORD_FILES_UPLOADED,
+          },
+        },
+      ],
+    },
+    {
+      theCase: setSuspendedDefendant(CaseIndictmentRulingDecision.FINE),
+      scenarioDescription: 'driving license suspension with fine',
+      notificationType:
+        EventNotificationType.INDICTMENT_SENT_TO_PUBLIC_PROSECUTOR,
+      expectedMessages: [
+        {
+          type: MessageType.INDICTMENT_CASE_NOTIFICATION,
+          caseId,
+          body: {
+            type: IndictmentCaseNotificationType.DRIVING_LICENSE_SUSPENSION,
+          },
+        },
+        {
+          type: MessageType.INDICTMENT_CASE_NOTIFICATION,
+          caseId,
+          body: {
+            type: IndictmentCaseNotificationType.CRIMINAL_RECORD_FILES_UPLOADED,
+          },
+        },
+      ],
+    },
+    {
+      theCase: setSuspendedDefendant(
+        CaseIndictmentRulingDecision.RULING,
+        ServiceRequirement.REQUIRED,
+      ),
+      scenarioDescription: 'driving license suspension with service required',
       notificationType:
         EventNotificationType.INDICTMENT_SENT_TO_PUBLIC_PROSECUTOR,
       expectedMessages: [
@@ -117,16 +225,16 @@ describe('InternalNotificationController - Dispatch event notifications', () => 
   ]
 
   it.each(
-    notificationScenarios.map(
-      ({ theCase, notificationType, expectedMessages }) => ({
-        theCase,
-        notificationType,
-        expectedMessages,
-        description: `should send messages to queue for notification type ${notificationType} ${
-          theCase.type ? `- ${theCase.type}` : ''
-        }`,
-      }),
-    ),
+    notificationScenarios.map((scenario) => ({
+      ...scenario,
+      description: `should send messages to queue for notification type ${
+        scenario.notificationType
+      }${scenario.theCase.type ? ` - ${scenario.theCase.type}` : ''}${
+        'scenarioDescription' in scenario
+          ? ` - ${scenario.scenarioDescription}`
+          : ''
+      }`,
+    })),
   )('$description', async ({ theCase, notificationType, expectedMessages }) => {
     const result =
       await internalNotificationController.dispatchEventNotification(


### PR DESCRIPTION
## What

Send the driving license suspension notification ("Svipting í máli X") to the prosecutor's office when a case with a license-suspended defendant is sent to the public prosecutor and the verdict's service requirement is "Birting dóms ekki þörf" (`NOT_REQUIRED`).

## Why

When the court selected "birting dóms ekki þörf" for a defendant with a driving license suspension, no notification email was ever sent:

- The dispatch condition on the sent-to-public-prosecutor event only covered `NOT_APPLICABLE` (defendant present at ruling) and fine rulings.
- The service-based triggers (police service status update, manually recorded service date) never fire in this scenario, since the verdict is never served.

This is a likely scenario when the fine amount is low but the ruling includes a driving license suspension. Since the suspension takes effect without service of the verdict — just like `NOT_APPLICABLE` — the notification should be sent immediately when the case is sent to the public prosecutor.

Note: cases where `NOT_REQUIRED` was selected and the case was already sent to the public prosecutor before this fix will not receive the email retroactively — the notification only fires on the send-to-public-prosecutor event.

## Screenshots / Gifs

N/A — backend notification dispatch only.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Driving-license suspension notifications are now triggered when verdict service requirements are marked either “Not applicable” or “Not required.”
  * Improved notification handling across different ruling decisions and case scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->