### PR TITLE
fix(j-s): Add missing label to court attendees input

### DIFF
--- a/apps/judicial-system/web/src/routes/Court/Indictments/CourtRecord/CourtSessionAccordionItem.tsx
+++ b/apps/judicial-system/web/src/routes/Court/Indictments/CourtRecord/CourtSessionAccordionItem.tsx
@@ -1005,6 +1005,7 @@ const CourtSessionAccordionItem: FC<Props> = (props) => {
               <Input
                 data-testid="courtAttendees"
                 name="courtAttendees"
+                label="Mættir eru"
                 value={courtSession.attendees ?? getInitialAttendees()}
                 placeholder="Skrifa hér..."
                 onChange={(event) => {


### PR DESCRIPTION
## What
Add the missing "Mættir eru" label to the court attendees input in the court session accordion item on the indictment court record page.

## Why
The input was rendered without a label, so it only showed the placeholder text. Adding the label keeps the field consistent with other inputs on the page and improves accessibility.

## Screenshots / Gifs
Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code
- [ ] No AI tools were used in preparing this pull request

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the court attendees input label to “Mættir eru” for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->