### PR TITLE
fix(my-pages): scope sidemenu dvh height to the mobile drawer

### DIFF
--- a/apps/portals/my-pages/src/components/Sidemenu/Sidemenu.css.ts
+++ b/apps/portals/my-pages/src/components/Sidemenu/Sidemenu.css.ts
@@ -122,12 +122,18 @@ const dropdownBaseMD: StyleWithSelectors = {
 
 // Mobile browser chrome (address bar) resizes the visual viewport as the
 // user scrolls, which makes a static 100vh leave a gap at the bottom of
-// this fixed-position drawer. Small dvh upgrade when supported.
+// this fixed-position drawer. Small dvh upgrade when supported. Scoped to
+// below-md: the desktop dropdown is height:auto, and an unscoped @supports
+// block is emitted after the md media query so it would override it.
 const dvhUpgrade = {
   '@supports': {
     '(height: 100dvh)': {
-      height: `calc(100dvh - ${theme.headerHeight.small}px)`,
-      maxHeight: `calc(100dvh - ${theme.headerHeight.small}px)`,
+      '@media': {
+        [`screen and (max-width: ${theme.breakpoints.md - 1}px)`]: {
+          height: `calc(100dvh - ${theme.headerHeight.small}px)`,
+          maxHeight: `calc(100dvh - ${theme.headerHeight.small}px)`,
+        },
+      },
     },
   },
 }


### PR DESCRIPTION
# Scope sidemenu dvh height to the mobile drawer

## What

- Only apply the sidemenu `100dvh` height on mobile.

## Why

- The `@supports (height: 100dvh)` block added in #23296 wasn't scoped to mobile, so it also overrode the desktop dropdown's `height: auto` and the overlay extended to the bottom of the screen.

## Screenshots / Gifs

Before:

<img width="1774" height="1394" alt="Screenshot 2026-08-12 at 14 05 13" src="https://github.com/user-attachments/assets/0b38ee85-e915-495a-ac49-3942e444e8fa" />

After:

<img width="1684" height="999" alt="Screenshot 2026-08-13 at 13 55 16" src="https://github.com/user-attachments/assets/b63c3c3a-c6e7-4a7a-9fb2-bbffc5bcbde3" />

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code