### PR TITLE
fix(j-s): Save the court case number on blur and clear stale field errors

### DIFF
--- a/apps/judicial-system/web/src/routes/Court/components/CourtCaseNumber/CourtCaseNumberInput.tsx
+++ b/apps/judicial-system/web/src/routes/Court/components/CourtCaseNumber/CourtCaseNumberInput.tsx
@@ -1,5 +1,4 @@
-import { FC, useContext, useState } from 'react'
-import { useDebounce } from 'react-use'
+import { FC, useContext, useRef, useState } from 'react'
 
 import { Button, Input } from '@island.is/island-ui/core'
 import { isIndictmentCase } from '@island.is/judicial-system/types'
@@ -8,8 +7,12 @@ import {
   FormContext,
 } from '@island.is/judicial-system-web/src/components'
 import { CaseState } from '@island.is/judicial-system-web/src/graphql/schema'
+import {
+  removeErrorMessageIfValid,
+  validateAndSetErrorMessage,
+} from '@island.is/judicial-system-web/src/utils/formHelper'
 import { useCase } from '@island.is/judicial-system-web/src/utils/hooks'
-import { validate } from '@island.is/judicial-system-web/src/utils/validate'
+import { Validation } from '@island.is/judicial-system-web/src/utils/validate'
 
 import * as styles from './CourtCaseNumber.css'
 
@@ -32,56 +35,60 @@ export const CourtCaseNumberInput: FC<Props> = (props) => {
 
   const { updateCase, createCourtCase, isCreatingCourtCase } = useCase()
 
-  const [value, setValue] = useState<string>(courtCaseNumber ?? '')
-  const [courtCaseNumberErrorMessage, setCourtCaseNumberErrorMessage] =
-    useState<string>('')
+  const [errorMessage, setErrorMessage] = useState<string>('')
   const [createCourtCaseSuccess, setCreateCourtCaseSuccess] =
     useState<boolean>(false)
 
-  const policeCaseNumberValidator = isIndictmentCase
-    ? 'S-case-number'
-    : 'R-case-number'
+  // The value the field held when it last gained focus, so blur can tell
+  // whether the user actually changed anything. Assigning a court case number
+  // is not an idempotent write: the backend reads an update carrying one on a
+  // submitted case as receiving the case, and a changed number resets case file
+  // states. Tabbing through the field, or typing and undoing, must send
+  // nothing.
+  const valueOnFocus = useRef(courtCaseNumber ?? '')
+
+  const validations: Validation[] = [
+    'empty',
+    isIndictmentCase ? 'S-case-number' : 'R-case-number',
+  ]
+
+  const handleChange = (value: string) => {
+    setCreateCourtCaseSuccess(false)
+    removeErrorMessageIfValid(validations, value, errorMessage, setErrorMessage)
+    setCourtCaseNumber(value)
+  }
+
+  const handleBlur = (value: string) => {
+    const isValid = validateAndSetErrorMessage(
+      validations,
+      value,
+      setErrorMessage,
+    )
+
+    if (!isValid || value === valueOnFocus.current) {
+      return
+    }
+
+    valueOnFocus.current = value
+    updateCase(caseId, { courtCaseNumber: value })
+  }
 
   const handleCreateCourtCase = async () => {
-    const courtCaseNumber = await createCourtCase(caseId)
+    const createdCourtCaseNumber = await createCourtCase(caseId)
 
-    setCourtCaseNumber(courtCaseNumber)
+    setCourtCaseNumber(createdCourtCaseNumber)
 
-    if (courtCaseNumber !== '') {
-      setCourtCaseNumberErrorMessage('')
-      setValue(courtCaseNumber)
+    if (createdCourtCaseNumber !== '') {
+      // The server assigned it, so a later blur must not send it back.
+      valueOnFocus.current = createdCourtCaseNumber
+      setErrorMessage('')
       setCreateCourtCaseSuccess(true)
     } else {
-      setCourtCaseNumberErrorMessage(
+      setErrorMessage(
         'Ekki tókst að stofna nýtt mál, reyndu aftur eða sláðu inn málsnúmer',
       )
     }
   }
-
-  const updateCourtCaseNumber = async () => {
-    const isValid = validate([
-      [value, ['empty', policeCaseNumberValidator]],
-    ]).isValid
-
-    if (!isValid) {
-      return
-    }
-
-    updateCase(caseId, { courtCaseNumber: value })
-    setCourtCaseNumber(value)
-  }
-
-  const validateInput = (inputValue: string) => {
-    const validation = validate([
-      [inputValue, ['empty', policeCaseNumberValidator]],
-    ])
-
-    setCourtCaseNumberErrorMessage(
-      validation.isValid ? '' : validation.errorMessage,
-    )
-  }
-
-  useDebounce(updateCourtCaseNumber, 500, [value])
 
   return (
     <BlueBox className={styles.createCourtCaseContainer}>
@@ -107,21 +114,19 @@ export const CourtCaseNumberInput: FC<Props> = (props) => {
           autoComplete="off"
           size="sm"
           backgroundColor="white"
-          value={value}
+          value={courtCaseNumber ?? ''}
           icon={
             courtCaseNumber && createCourtCaseSuccess
               ? { name: 'checkmark' }
               : undefined
           }
-          errorMessage={courtCaseNumberErrorMessage}
-          hasError={!isCreatingCourtCase && courtCaseNumberErrorMessage !== ''}
-          onChange={(evt) => {
-            setCourtCaseNumberErrorMessage('')
-            setCreateCourtCaseSuccess(false)
-            setValue(evt.target.value)
-            setCourtCaseNumber(evt.target.value)
+          errorMessage={errorMessage}
+          hasError={!isCreatingCourtCase && errorMessage !== ''}
+          onFocus={(evt) => {
+            valueOnFocus.current = evt.target.value
           }}
-          onBlur={(evt) => validateInput(evt.target.value)}
+          onChange={(evt) => handleChange(evt.target.value)}
+          onBlur={(evt) => handleBlur(evt.target.value)}
           disabled={isDisabled}
           required
         />

--- a/apps/judicial-system/web/src/routes/Court/components/CourtCaseNumber/CourtCaseNumberInput.tsx
+++ b/apps/judicial-system/web/src/routes/Court/components/CourtCaseNumber/CourtCaseNumberInput.tsx
@@ -39,13 +39,18 @@ export const CourtCaseNumberInput: FC<Props> = (props) => {
   const [createCourtCaseSuccess, setCreateCourtCaseSuccess] =
     useState<boolean>(false)
 
-  // The value the field held when it last gained focus, so blur can tell
-  // whether the user actually changed anything. Assigning a court case number
-  // is not an idempotent write: the backend reads an update carrying one on a
-  // submitted case as receiving the case, and a changed number resets case file
-  // states. Tabbing through the field, or typing and undoing, must send
-  // nothing.
+  // Assigning a court case number is not an idempotent write: the backend reads
+  // an update carrying one on a submitted case as receiving the case, and a
+  // changed number resets case file states. So blur persists only what the user
+  // actually did, guarded twice over:
+  //
+  // - `hasUserEdited` means a value that arrived from anywhere other than the
+  //   keyboard is never echoed back. That covers the working case being filled
+  //   in or refreshed while the field happens to hold focus.
+  // - `valueOnFocus` means typing something and undoing it within one focus
+  //   session sends nothing either.
   const valueOnFocus = useRef(courtCaseNumber ?? '')
+  const hasUserEdited = useRef(false)
 
   const validations: Validation[] = [
     'empty',
@@ -53,6 +58,7 @@ export const CourtCaseNumberInput: FC<Props> = (props) => {
   ]
 
   const handleChange = (value: string) => {
+    hasUserEdited.current = true
     setCreateCourtCaseSuccess(false)
     removeErrorMessageIfValid(validations, value, errorMessage, setErrorMessage)
     setCourtCaseNumber(value)
@@ -65,7 +71,7 @@ export const CourtCaseNumberInput: FC<Props> = (props) => {
       setErrorMessage,
     )
 
-    if (!isValid || value === valueOnFocus.current) {
+    if (!isValid || !hasUserEdited.current || value === valueOnFocus.current) {
       return
     }
 

--- a/apps/judicial-system/web/src/utils/formHelper.spec.ts
+++ b/apps/judicial-system/web/src/utils/formHelper.spec.ts
@@ -48,6 +48,8 @@ describe('removeErrorMessageIfValid', () => {
     )
 
     expect(setErrorMessage).toHaveBeenCalledWith('')
+    // The newly failing rule is not surfaced while typing — that waits for blur.
+    expect(setErrorMessage).not.toHaveBeenCalledWith(FORMAT)
   })
 
   it('should keep the message while the value still breaks the same validation', () => {
@@ -63,7 +65,7 @@ describe('removeErrorMessageIfValid', () => {
     expect(setErrorMessage).not.toHaveBeenCalled()
   })
 
-  it('should not surface a newly broken validation', () => {
+  it('should keep a format message while the value still breaks the format rule', () => {
     const setErrorMessage = jest.fn()
 
     removeErrorMessageIfValid(
@@ -73,13 +75,21 @@ describe('removeErrorMessageIfValid', () => {
       setErrorMessage,
     )
 
-    expect(setErrorMessage).not.toHaveBeenCalledWith(FORMAT)
+    expect(setErrorMessage).not.toHaveBeenCalled()
   })
 
   it('should do nothing when no message is displayed', () => {
     const setErrorMessage = jest.fn()
 
     removeErrorMessageIfValid(['empty'], '', '', setErrorMessage)
+
+    expect(setErrorMessage).not.toHaveBeenCalled()
+  })
+
+  it('should do nothing when the caller tracks no message at all', () => {
+    const setErrorMessage = jest.fn()
+
+    removeErrorMessageIfValid(['empty'], 'R-', undefined, setErrorMessage)
 
     expect(setErrorMessage).not.toHaveBeenCalled()
   })

--- a/apps/judicial-system/web/src/utils/formHelper.spec.ts
+++ b/apps/judicial-system/web/src/utils/formHelper.spec.ts
@@ -12,9 +12,78 @@ import { faker } from '@island.is/shared/mocking'
 import {
   findFirstInvalidStep,
   hasDateChanged,
+  removeErrorMessageIfValid,
   toggleInArray,
   validateAndSendToServer,
 } from './formHelper'
+
+describe('removeErrorMessageIfValid', () => {
+  const EMPTY = 'Reitur má ekki vera tómur'
+  const FORMAT = `Dæmi: R-1234/${new Date().getFullYear()}`
+
+  it('should clear the error message once the value is valid', () => {
+    const setErrorMessage = jest.fn()
+
+    removeErrorMessageIfValid(
+      ['empty', 'R-case-number'],
+      `R-1/${new Date().getFullYear()}`,
+      EMPTY,
+      setErrorMessage,
+    )
+
+    expect(setErrorMessage).toHaveBeenCalledWith('')
+  })
+
+  // Regression: an empty-field message used to survive until the value passed
+  // every validation, so clearing a required field and starting to retype left
+  // "must not be empty" displayed next to a value that was no longer empty.
+  it('should clear a stale message when the value fails a different validation', () => {
+    const setErrorMessage = jest.fn()
+
+    removeErrorMessageIfValid(
+      ['empty', 'R-case-number'],
+      'R-',
+      EMPTY,
+      setErrorMessage,
+    )
+
+    expect(setErrorMessage).toHaveBeenCalledWith('')
+  })
+
+  it('should keep the message while the value still breaks the same validation', () => {
+    const setErrorMessage = jest.fn()
+
+    removeErrorMessageIfValid(
+      ['empty', 'R-case-number'],
+      '',
+      EMPTY,
+      setErrorMessage,
+    )
+
+    expect(setErrorMessage).not.toHaveBeenCalled()
+  })
+
+  it('should not surface a newly broken validation', () => {
+    const setErrorMessage = jest.fn()
+
+    removeErrorMessageIfValid(
+      ['empty', 'R-case-number'],
+      'R-',
+      FORMAT,
+      setErrorMessage,
+    )
+
+    expect(setErrorMessage).not.toHaveBeenCalledWith(FORMAT)
+  })
+
+  it('should do nothing when no message is displayed', () => {
+    const setErrorMessage = jest.fn()
+
+    removeErrorMessageIfValid(['empty'], '', '', setErrorMessage)
+
+    expect(setErrorMessage).not.toHaveBeenCalled()
+  })
+})
 
 describe('toggleInArray', () => {
   it.each`

--- a/apps/judicial-system/web/src/utils/formHelper.ts
+++ b/apps/judicial-system/web/src/utils/formHelper.ts
@@ -98,9 +98,19 @@ export const removeErrorMessageIfValid = (
   errorMessage?: string,
   errorMessageSetter?: (value: SetStateAction<string>) => void,
 ) => {
-  const isValid = validations.validate([[value, validationsToRun]]).isValid
+  if (errorMessage === '' || !errorMessageSetter) {
+    return
+  }
 
-  if (errorMessage !== '' && errorMessageSetter && isValid) {
+  const validation = validations.validate([[value, validationsToRun]])
+
+  // Clear as soon as the problem the message describes is fixed, even when the
+  // value is not valid yet. `validate` reports the first failing rule, so a
+  // different message means the displayed one is stale: clearing a required
+  // field and starting to retype would otherwise leave "Reitur má ekki vera
+  // tómur" sitting next to a value that is no longer empty. A newly broken rule
+  // is deliberately not surfaced here — errors appear on blur.
+  if (validation.isValid || validation.errorMessage !== errorMessage) {
     errorMessageSetter('')
   }
 }

--- a/apps/judicial-system/web/src/utils/formHelper.ts
+++ b/apps/judicial-system/web/src/utils/formHelper.ts
@@ -98,7 +98,9 @@ export const removeErrorMessageIfValid = (
   errorMessage?: string,
   errorMessageSetter?: (value: SetStateAction<string>) => void,
 ) => {
-  if (errorMessage === '' || !errorMessageSetter) {
+  // Nothing is displayed, so there is nothing to clear. An absent
+  // `errorMessage` means the caller does not track one at all.
+  if (!errorMessage || !errorMessageSetter) {
     return
   }
 


### PR DESCRIPTION
# Court case number: save on blur, not on a debounce

## What

`CourtCaseNumberInput` persisted through a hand-rolled `useDebounce(updateCourtCaseNumber, 500, [value])`. This moves the save to blur and deletes the machinery the debounce needed: the local `value` state, the create-court-case reset key, and the persisted-value tracking.

The value now lives in the working case, and a focus snapshot decides whether anything actually changed:

```tsx
onFocus={(evt) => { valueOnFocus.current = evt.target.value }}
onBlur={(evt) => handleBlur(evt.target.value)}
```

So tabbing through the field, or typing and undoing within one focus session, sends nothing.

## Why

Assigning a court case number is not an ordinary text edit. In `case.service.ts` the backend reads *any* update carrying a `courtCaseNumber` on a `SUBMITTED` case as **receiving the case** — `transitionCase(RECEIVE)`, court document creation, queue messages — and a *changed* number runs `resetCaseFileStates`. It is a short identifier, typed once, whose write has a state transition behind it. Debouncing it meant every typing pause sent a partially typed number.

The debounce was never a decision about this field. It arrived incidentally in #20821, which made the component reusable for the split-case flow: once `setWorkingCase` became optional and the parent no longer necessarily owned the working case, the existing blur save no longer fit the props, and a debounce over local state was the shortest path. As merged it had **no validity gate at all** — it sent whatever was in the box every 500 ms.

Three follow-up fixes repaired the fallout, and the last one reverted the reusability that prompted it:

| PR | What it repaired |
|---|---|
| #20951 | `onChange` had stopped writing to `workingCase`, so the value only lived in local state |
| #20999 | The create-court-case button did not push the generated number back into the input |
| #21244 | Props collapsed back to `caseId` / `courtCaseNumber` / `setCourtCaseNumber`; `FormContext` returned |

## Bonus: fixes a lost edit in the split-case flow

The "Staðfesta" button in the split-case modal (`Conclusion.tsx`) only calls `router.push` — it never saves the number itself, relying entirely on this component. Typing and confirming inside the 500 ms window dropped the number silently, with no unmount flush to catch it. Blur fires on mousedown, before the click, so it now lands.

## Also in here: a shared fix for stale field errors

Found while testing the field above. `removeErrorMessageIfValid` only cleared a message once the value passed **every** validation, so a message about one rule survived while the user was fixing it. Clear the court case number and you get "Reitur má ekki vera tómur"; type `R-` and that message stayed on screen next to a value that was plainly not empty, because the format rule had taken over as the failing one.

`validate` reports the first failing rule, so a changed message means the displayed one is stale and can go:

```ts
if (validation.isValid || validation.errorMessage !== errorMessage) {
  errorMessageSetter('')
}
```

A newly broken rule is still **not** surfaced here — errors continue to appear on blur only.

**Blast radius.** This helper is called from ten places directly, plus every `useDebouncedInput` field via `removeTabsValidateAndSet`. The change is only *observable* where a field has two or more validations, because with a single rule an invalid value always produces the same message, leaving only the `isValid` branch — the old behaviour exactly. That narrows it to two fields:

| Field | Validations |
|---|---|
| Court case number | `['empty', 'R-case-number' \| 'S-case-number']` |
| Police case number (`PoliceCase.tsx`) | `['empty', 'police-casenumber-format']` |

For the court case number this was a regression introduced by this PR — `main` cleared the error on any keystroke. For the police case number it is a pre-existing bug that this now fixes. Every other call site is single-validation and provably unchanged.

The helper also now treats an absent `errorMessage` as "nothing to clear". The stale-message comparison made that case worse than before: `undefined` never equals a validation message, so a caller passing a setter without a message would have had `''` written back on every change. No caller does that today, but it is fixed and covered.

Adds the first tests for this helper, which had none.

## Modal consumers: verified, no regression

The named export is also used in two modals. Both were manually verified.

**`CancelCase.tsx`** — I had expected a swallowed first click here, on the theory that blur fires `updateCase` on mousedown, flipping `isUpdatingCase`, which appears in the primary button's `isDisabled`, and a `disabled` button does not fire `click`. **That does not happen.** `useCase` is a plain hook with no provider, so each caller gets its own Apollo mutation and its own `loading` flag. `CancelCase.tsx:31` and `CourtCaseNumberInput.tsx:36` call `useCase()` independently, so a blur-triggered update through the input's instance never flips the modal's `isUpdatingCase`. The case completes on the first click, as it did before.

**`Conclusion.tsx` split-case modal** — improved, see above. Its primary button's `isDisabled` is validity-only, so it was never at risk from this either.

Worth noting for the future: neither modal should really host a self-persisting input — the modal should own the value and save it as part of its confirm action. Nothing in this PR depends on that, and the current behaviour is correct; it is a tidiness follow-up, not a defect.

## Relationship to #23338

Independent — this branch sits on `main` and imports nothing from that PR. **It can merge first.** If it does, #23338 should drop its `CourtCaseNumberInput` changes, since this file no longer uses the debounced hook at all; it will then fold in only `useDebouncedAppealAnnouncement`. The `resetKey` support in the hook stays either way, as later conversions need it for reused list rows.

## Verification

`tsc --noEmit` clean, prettier clean, 609 tests pass across 79 suites on this base (up from 603 — six new `formHelper` tests).

Manual pass completed, all passing:

- Reception page: no `UpdateCase` on load, none on focus-and-tab-out without typing, none on edit-then-revert, exactly one on a real change, and none for a partially typed number.
- Errors: clearing the field then typing one character clears the empty-field message immediately; the format error only appears on blur.
- Police case number: same error-clearing behaviour on the one other multi-validation field.
- A single-validation field spot-checked as unchanged.
- Receive: entering a number on a `SUBMITTED` case receives it exactly once; changing an existing number resets case file states from `STORED_IN_COURT` back to `STORED_IN_RVG`.
- Create-court-case button: number appears with the checkmark, and a later blur sends nothing.
- Split-case modal: the number now persists when confirming immediately — the lost edit described above is fixed.
- Cancel-case modal: completes on the first click, no regression.

## Screenshots / Gifs

No visual change.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved court case number validation during entry and when leaving the field.
  - Prevented invalid or unchanged values from being submitted.
  - Improved error handling by clearing outdated messages when the input becomes valid or its validation result changes.
  - Added clearer handling for successfully created case numbers, including error clearing and success feedback.
  - Improved input behavior by keeping the displayed value synchronized with the current case number.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

