### PR TITLE
fix(j-s): remove double accordion

### DIFF
--- a/apps/judicial-system/web/src/components/IndictmentCaseFilesList/IndictmentCaseFilesList.tsx
+++ b/apps/judicial-system/web/src/components/IndictmentCaseFilesList/IndictmentCaseFilesList.tsx
@@ -49,6 +49,7 @@ import {
 } from '@island.is/judicial-system-web/src/utils/hooks'
 
 import { isNonEmptyArray } from '../../utils/arrayHelpers'
+import { isAppealFileCategoryVisible } from '../../utils/utils'
 import { CaseFileTable } from '../Table'
 import RulingOrderAppealFilesAccordion from './RulingOrderAppealFilesAccordion'
 import RulingOrderConfirmation from './RulingOrderConfirmation'
@@ -855,22 +856,44 @@ const IndictmentCaseFilesList: FC<Props> = ({
               (workingCase.rulingOrderAppealCases?.length ?? 0) > 0 && (
                 <Box>
                   <Accordion dividerOnBottom={false} dividerOnTop={false}>
-                    {workingCase.rulingOrderAppealCases?.map((appealCase) => {
-                      const rulingFile = workingCase.caseFiles?.find(
-                        (f) => f.id === appealCase.rulingFileId,
-                      )
-                      if (!rulingFile) {
-                        return null
-                      }
-                      return (
-                        <RulingOrderAppealFilesAccordion
-                          key={appealCase.id}
-                          appealCase={appealCase}
-                          rulingFile={rulingFile}
-                          onOpenFile={onOpen}
-                        />
-                      )
-                    })}
+                    {(workingCase.rulingOrderAppealCases ?? [])
+                      .flatMap((appealCase) => {
+                        const rulingFile = workingCase.caseFiles?.find(
+                          (f) => f.id === appealCase.rulingFileId,
+                        )
+                        if (!rulingFile) {
+                          return []
+                        }
+
+                        const hasVisibleFiles = (
+                          workingCase.caseFiles ?? []
+                        ).some((file) =>
+                          isAppealFileCategoryVisible(
+                            workingCase,
+                            appealCase,
+                            file,
+                            user,
+                          ),
+                        )
+                        if (!hasVisibleFiles) {
+                          return []
+                        }
+
+                        return [{ appealCase, rulingFile }]
+                      })
+                      .map(
+                        ({ appealCase, rulingFile }, index, visibleCases) => (
+                          <RulingOrderAppealFilesAccordion
+                            key={appealCase.id}
+                            appealCase={appealCase}
+                            rulingFile={rulingFile}
+                            onOpenFile={onOpen}
+                            hideTrailingSeparator={
+                              index < visibleCases.length - 1
+                            }
+                          />
+                        ),
+                      )}
                   </Accordion>
                 </Box>
               )}

--- a/apps/judicial-system/web/src/components/IndictmentCaseFilesList/RulingOrderAppealFilesAccordion.css.ts
+++ b/apps/judicial-system/web/src/components/IndictmentCaseFilesList/RulingOrderAppealFilesAccordion.css.ts
@@ -1,4 +1,11 @@
-import { style } from '@vanilla-extract/css'
+import { globalStyle, style } from '@vanilla-extract/css'
+
+export const filesList = style({})
+
+// Avoid double line: last PdfButton border + Accordion Divider between items.
+globalStyle(`${filesList} > *:last-child`, {
+  boxShadow: 'none',
+})
 
 export const metadataRow = style({
   display: 'flex',

--- a/apps/judicial-system/web/src/components/IndictmentCaseFilesList/RulingOrderAppealFilesAccordion.css.ts
+++ b/apps/judicial-system/web/src/components/IndictmentCaseFilesList/RulingOrderAppealFilesAccordion.css.ts
@@ -1,9 +1,10 @@
 import { globalStyle, style } from '@vanilla-extract/css'
 
-export const filesList = style({})
+export const filesListHideTrailing = style({})
 
 // Avoid double line: last PdfButton border + Accordion Divider between items.
-globalStyle(`${filesList} > *:last-child`, {
+// Only applied when another accordion item follows.
+globalStyle(`${filesListHideTrailing} > *:last-child`, {
   boxShadow: 'none',
 })
 

--- a/apps/judicial-system/web/src/components/IndictmentCaseFilesList/RulingOrderAppealFilesAccordion.tsx
+++ b/apps/judicial-system/web/src/components/IndictmentCaseFilesList/RulingOrderAppealFilesAccordion.tsx
@@ -136,7 +136,7 @@ const RulingOrderAppealFilesAccordion: FC<Props> = ({
       labelVariant="h3"
       labelUse="h3"
     >
-      <Box>
+      <Box className={styles.filesList}>
         {files.map((file) => {
           const isDisabled = !file.isKeyAccessible
           const canDelete = canDeleteFile(file)

--- a/apps/judicial-system/web/src/components/IndictmentCaseFilesList/RulingOrderAppealFilesAccordion.tsx
+++ b/apps/judicial-system/web/src/components/IndictmentCaseFilesList/RulingOrderAppealFilesAccordion.tsx
@@ -89,12 +89,14 @@ interface Props {
   appealCase: AppealCase
   rulingFile: CaseFile
   onOpenFile: (fileId: string) => void
+  hideTrailingSeparator?: boolean
 }
 
 const RulingOrderAppealFilesAccordion: FC<Props> = ({
   appealCase,
   rulingFile,
   onOpenFile,
+  hideTrailingSeparator = false,
 }) => {
   const { workingCase } = useContext(FormContext)
   const { user } = useContext(UserContext)
@@ -136,7 +138,11 @@ const RulingOrderAppealFilesAccordion: FC<Props> = ({
       labelVariant="h3"
       labelUse="h3"
     >
-      <Box className={styles.filesList}>
+      <Box
+        className={
+          hideTrailingSeparator ? styles.filesListHideTrailing : undefined
+        }
+      >
         {files.map((file) => {
           const isDisabled = !file.isKeyAccessible
           const canDelete = canDeleteFile(file)


### PR DESCRIPTION
[Asana](https://app.asana.com/1/203394141643832/project/1212657017130395/task/1217366404053383?focus=true)

## What

There was a double separator when the accordion item was expanded. Fixed by removing the separator on the last element of the list (if there is another accordion item following)

## Why

So i doesn't look bad

## Screenshots / Gifs

Before:
<img width="1648" height="622" alt="image" src="https://github.com/user-attachments/assets/54d58406-3ef2-4fe8-8c31-bba22d9e0760" />


After:

<img width="897" height="206" alt="image" src="https://github.com/user-attachments/assets/fe8c3806-b48e-4c3b-8c62-ee36226bcf6d" />

<img width="945" height="389" alt="image" src="https://github.com/user-attachments/assets/f738e55b-bc52-42ec-bb39-cdcbcac0daac" />

<img width="950" height="393" alt="image" src="https://github.com/user-attachments/assets/c64f76d0-4dda-44b0-9670-37f3b272afad" />



## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Cursor
