### PR TITLE
fix(web): prevent mobile header menu flash

### DIFF
--- a/apps/web/layouts/main.tsx
+++ b/apps/web/layouts/main.tsx
@@ -62,10 +62,7 @@ import { GET_ALERT_BANNER_QUERY } from '../screens/queries/AlertBanner'
 import { GET_GROUPED_MENU_QUERY } from '../screens/queries/Menu'
 import { GET_ORGANIZATION_LOGOS_QUERY } from '../screens/queries/Organization'
 import { Screen, ScreenContext } from '../types'
-import {
-  extractOrganizationSlugFromPathname,
-  pathIsProjectPage,
-} from '../utils/organization'
+import { getHeaderNavigationPropsFromUrl } from '../utils/organization'
 import Illustration from './Illustration'
 import * as styles from './main.css'
 
@@ -255,22 +252,12 @@ const Layout: Screen<LayoutProps> = ({
 
   const isServiceWeb = pathIsRoute(router.asPath, 'serviceweb', activeLocale)
 
-  const organizationSearchFilter =
-    organizationSearchFilterOverride ??
-    extractOrganizationSlugFromPathname(router.asPath, activeLocale)
-
-  // Institution sites (stofnanavefir) and project pages (/verkefni) get the
-  // simplified header: logo, search, My Pages and language toggle stay, but
-  // the burger menu and navigation links are hidden. `organizationSearchFilter`
-  // is truthy whenever we're within a specific organization's site, and the
-  // project routes all resolve to a `project*` link type. Individual screens
-  // can also force the simplified header from their `withMainLayout` config via
-  // `showHeaderNavigation: false` — an opt-out kill switch that hides the nav
-  // but can never force it onto an org/project page.
+  // Route-derived defaults come from getProps so the server markup and first
+  // hydrated render agree. Explicit search filters and `false` remain one-way
+  // overrides that can hide navigation on additional pages.
+  const organizationSearchFilter = organizationSearchFilterOverride ?? ''
   const showHeaderNavigation =
-    showHeaderNavigationOverride !== false &&
-    !organizationSearchFilter &&
-    !pathIsProjectPage(router.asPath)
+    showHeaderNavigationOverride !== false && !organizationSearchFilter
 
   return (
     <GlobalContextProvider namespace={namespace} isServiceWeb={isServiceWeb}>
@@ -554,6 +541,10 @@ Layout.getProps = async ({ apolloClient, locale, req }) => {
 
   const { origin } = absoluteUrl(req, 'localhost:4200')
   const respOrigin = `${origin}`
+  const headerNavigationProps = getHeaderNavigationPropsFromUrl(
+    req?.url,
+    lang as Locale,
+  )
   const [
     categories,
     alertBanner,
@@ -734,6 +725,7 @@ Layout.getProps = async ({ apolloClient, locale, req }) => {
     namespace,
     respOrigin,
     headerNavData,
+    ...headerNavigationProps,
   }
 }
 
@@ -810,17 +802,26 @@ export const withMainLayout = <T, C extends ScreenContext>(
     const languageToggleHrefOverride =
       layoutComponentProps?.languageToggleHrefOverride
 
+    const mergedLayoutProps = {
+      ...layoutProps,
+      ...layoutConfig,
+      ...themeConfig,
+      organizationAlertBannerContent,
+      articleAlertBannerContent,
+      customAlertBannerContent,
+      languageToggleQueryParams,
+      customTopLoginButtonItem,
+      languageToggleHrefOverride,
+    }
+
+    // Route restrictions are authoritative. Page config may hide navigation
+    // elsewhere, but it cannot re-enable it on organization or project pages.
     return {
       layoutProps: {
-        ...layoutProps,
-        ...layoutConfig,
-        ...themeConfig,
-        organizationAlertBannerContent,
-        articleAlertBannerContent,
-        customAlertBannerContent,
-        languageToggleQueryParams,
-        customTopLoginButtonItem,
-        languageToggleHrefOverride,
+        ...mergedLayoutProps,
+        showHeaderNavigation:
+          layoutProps.showHeaderNavigation !== false &&
+          mergedLayoutProps.showHeaderNavigation !== false,
       },
       componentProps,
     }

--- a/apps/web/utils/organization.spec.ts
+++ b/apps/web/utils/organization.spec.ts
@@ -1,7 +1,6 @@
-import { Locale } from '@island.is/shared/types'
-
 import {
   extractOrganizationSlugFromPathname,
+  getHeaderNavigationPropsFromUrl,
   pathIsProjectPage,
 } from './organization'
 
@@ -61,33 +60,28 @@ describe('extractOrganizationSlugFromPathname', () => {
   })
 })
 
-describe('header simplified-header rule', () => {
-  // Mirrors the layout's condition in main.tsx without importing it:
-  //   organizationSearchFilter = extractOrganizationSlugFromPathname(path, locale)
-  //   showHeaderNavigation = !organizationSearchFilter && !pathIsProjectPage(path)
-  const showHeaderNavigation = (path: string, locale: Locale): boolean => {
-    const organizationSearchFilter = extractOrganizationSlugFromPathname(
-      path,
-      locale,
-    )
-    return !organizationSearchFilter && !pathIsProjectPage(path)
-  }
+describe('getHeaderNavigationPropsFromUrl', () => {
+  it.each([
+    ['/s/blodbankinn', 'is', 'blodbankinn'],
+    ['/en/o/blodbankinn', 'en', 'blodbankinn'],
+    ['/_next/data/build-id/s/blodbankinn.json', 'is', 'blodbankinn'],
+    ['/v/thjodaratkvaedagreidsla-2026', 'is', ''],
+    ['/en/p/thjodaratkvaedagreidsla-2026', 'en', ''],
+    ['/_next/data/build-id/en/p/thjodaratkvaedagreidsla-2026.json', 'en', ''],
+  ] as const)(
+    'hides navigation for %s',
+    (url, locale, organizationSearchFilter) => {
+      expect(getHeaderNavigationPropsFromUrl(url, locale)).toEqual({
+        organizationSearchFilter,
+        showHeaderNavigation: false,
+      })
+    },
+  )
 
-  it('hides navigation on organization (stofnanavefir) pages', () => {
-    expect(showHeaderNavigation('/s/blodbankinn', 'is')).toBe(false)
-  })
-
-  it('hides navigation on project (verkefni) pages', () => {
-    expect(showHeaderNavigation('/v/thjodaratkvaedagreidsla-2026', 'is')).toBe(
-      false,
-    )
-  })
-
-  it('shows navigation on the front page', () => {
-    expect(showHeaderNavigation('/', 'is')).toBe(true)
-  })
-
-  it('shows navigation on a news article', () => {
-    expect(showHeaderNavigation('/frett/einhver-frett', 'is')).toBe(true)
+  it.each(['/', '/frett/einhver-frett'])('shows navigation for %s', (url) => {
+    expect(getHeaderNavigationPropsFromUrl(url, 'is')).toEqual({
+      organizationSearchFilter: '',
+      showHeaderNavigation: true,
+    })
   })
 })

--- a/apps/web/utils/organization.ts
+++ b/apps/web/utils/organization.ts
@@ -3,6 +3,7 @@ import { Locale } from '@island.is/shared/types'
 import { OrganizationPage, OrganizationTheme } from '../graphql/schema'
 import { linkResolver, pathIsRoute, typeResolver } from '../hooks'
 import { isLocale } from '../i18n/I18n'
+import { safelyExtractPathnameFromUrl } from './safelyExtractPathnameFromUrl'
 
 // TODO: Perhaps add this functionality to the linkResolver
 export const getOrganizationLink = (
@@ -60,4 +61,21 @@ export const extractOrganizationSlugFromPathname = (
 export const pathIsProjectPage = (pathname: string) => {
   const path = pathname.split(/[?#]/)[0]
   return Boolean(typeResolver(path)?.type?.startsWith('project'))
+}
+
+export const getHeaderNavigationPropsFromUrl = (
+  url: string | undefined,
+  locale: Locale,
+) => {
+  const pathname = safelyExtractPathnameFromUrl(url)
+  const organizationSearchFilter = extractOrganizationSlugFromPathname(
+    pathname,
+    locale,
+  )
+
+  return {
+    organizationSearchFilter,
+    showHeaderNavigation:
+      !organizationSearchFilter && !pathIsProjectPage(pathname),
+  }
 }


### PR DESCRIPTION
# Prevent mobile header navigation flash

No linked issue.

## What

- Derive organization and project header navigation visibility from the request URL in `Layout.getProps`.
- Pass the route-derived values as stable layout props so server markup and the first hydrated render agree.
- Preserve explicit organization search filters and the one-way `showHeaderNavigation: false` override.
- Cover Icelandic and English organization/project routes, including client-side `/_next/data` requests.

## Why

The redesigned header derived navigation visibility from `router.asPath` during render. On organization and project pages, the initial router value could temporarily enable navigation, causing the mobile hamburger menu to appear for one frame before hydration corrected it.

## Screenshots / Gifs

Not included. The fixed mobile loading behavior was verified locally: the hamburger remains hidden from the first rendered frame.

Verification:

- `yarn test web --runInBand` — 8 suites and 130 tests passed.
- Prettier check passed for all changed files.
- `yarn lint web --skipNxCache` is currently blocked before file linting by the repository's ESLint 8 / ESM `eslint-plugin-storybook` incompatibility.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: OpenAI Codex (Oh My Pi harness)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved header navigation behavior across organization and project pages.
  * Applied consistent route restrictions when displaying header navigation.
  * Added safer handling for organization, project, front-page, news, and framework-generated URLs.
* **Tests**
  * Expanded coverage for URL-based header navigation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->