### PR TITLE
fix(j-s): Point court date emails at the case overview

### DIFF
--- a/apps/judicial-system/backend/src/app/modules/notification/services/caseNotification/caseNotification.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/services/caseNotification/caseNotification.service.ts
@@ -585,6 +585,17 @@ export class CaseNotificationService extends BaseNotificationService {
       theCase.sessionArrangements,
     )
 
+    const overviewUrl = `${
+      isRestrictionCase(theCase.type)
+        ? `${this.config.clientUrl}${PROSECUTION_RESTRICTION_CASE_OVERVIEW_ROUTE}`
+        : `${this.config.clientUrl}${PROSECUTION_INVESTIGATION_CASE_POLICE_CONFIRMATION_ROUTE}`
+    }/${theCase.id}`
+
+    const html = `${body} ${this.formatMessage(notifications.emailTail, {
+      linkStart: `<a href="${overviewUrl}">`,
+      linkEnd: '</a>',
+    })}`
+
     const calendarInvite =
       theCase.sessionArrangements === SessionArrangements.NONE_PRESENT ||
       !arraignmentDate
@@ -593,7 +604,7 @@ export class CaseNotificationService extends BaseNotificationService {
 
     return this.sendEmail({
       subject,
-      html: body,
+      html,
       recipientName: theCase.prosecutor?.name,
       recipientEmail: theCase.prosecutor?.email,
       attachments: calendarInvite ? [calendarInvite] : undefined,
@@ -671,7 +682,7 @@ export class CaseNotificationService extends BaseNotificationService {
       : undefined
 
     const subject = `Fyrirtaka í máli ${theCase.courtCaseNumber}`
-    const html = formatDefenderCourtDateEmailNotification(
+    const body = formatDefenderCourtDateEmailNotification(
       this.formatMessage,
       theCase.court?.name,
       theCase.courtCaseNumber,
@@ -685,17 +696,28 @@ export class CaseNotificationService extends BaseNotificationService {
       defenderSubRole,
     )
 
+    const overviewUrl =
+      defenderNationalId &&
+      formatDefenderRoute(this.config.clientUrl, theCase.type, theCase.id)
+
+    const html = overviewUrl
+      ? `${body} ${this.formatMessage(notifications.emailTail, {
+          linkStart: `<a href="${overviewUrl}">`,
+          linkEnd: '</a>',
+        })}`
+      : body
+
     return this.sendEmail({
       subject,
       html,
       recipientName: defenderName,
       recipientEmail: defenderEmail,
       attachments: calendarInvite ? [calendarInvite] : undefined,
-      skipTail: !defenderNationalId,
+      skipTail: !overviewUrl,
     }).then((recipient) => {
       if (recipient.success) {
         // No need to wait
-        this.uploadEmailToCourt(theCase, subject, html, user, defenderEmail)
+        this.uploadEmailToCourt(theCase, subject, body, user, defenderEmail)
       }
 
       return recipient

--- a/apps/judicial-system/backend/src/app/modules/notification/test/internalNotificationController/sendCourtDateNotifications.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/test/internalNotificationController/sendCourtDateNotifications.spec.ts
@@ -4,7 +4,10 @@ import { ConfigType } from '@nestjs/config'
 
 import { EmailService } from '@island.is/email-service'
 
-import { DEFENDER_REQUEST_CASE_ROUTE, PROSECUTION_RESTRICTION_CASE_OVERVIEW_ROUTE } from '@island.is/judicial-system/consts'
+import {
+  DEFENDER_REQUEST_CASE_ROUTE,
+  PROSECUTION_RESTRICTION_CASE_OVERVIEW_ROUTE,
+} from '@island.is/judicial-system/consts'
 import {
   CaseType,
   RequestCaseNotificationType,

--- a/apps/judicial-system/backend/src/app/modules/notification/test/internalNotificationController/sendCourtDateNotifications.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/test/internalNotificationController/sendCourtDateNotifications.spec.ts
@@ -4,6 +4,7 @@ import { ConfigType } from '@nestjs/config'
 
 import { EmailService } from '@island.is/email-service'
 
+import { DEFENDER_REQUEST_CASE_ROUTE, PROSECUTION_RESTRICTION_CASE_OVERVIEW_ROUTE } from '@island.is/judicial-system/consts'
 import {
   CaseType,
   RequestCaseNotificationType,
@@ -99,6 +100,7 @@ describe('InternalNotificationController - Send court date notifications', () =>
       courtCaseNumber,
       defenderName: defender.name,
       defenderEmail: defender.email,
+      defenderNationalId: defender.nationalId,
     } as Case
 
     beforeEach(async () => {
@@ -110,7 +112,7 @@ describe('InternalNotificationController - Send court date notifications', () =>
         expect.objectContaining({
           to: [{ name: prosecutor.name, address: prosecutor.email }],
           subject: `Fyrirtaka í máli: ${courtCaseNumber}`,
-          html: `Héraðsdómur Reykjavíkur hefur staðfest fyrirtökutíma fyrir kröfu um gæsluvarðhald.<br /><br />Fyrirtaka mun fara fram á ótilgreindum tíma.<br /><br />Dómsalur hefur ekki verið skráður.<br /><br />Dómari hefur ekki verið skráður.<br /><br />Verjandi sakbornings: ${defender.name}. Hægt er að nálgast yfirlitssíðu málsins í <a href="${mockConfig.clientUrl}">Réttarvörslugátt</a>.`,
+          html: `Héraðsdómur Reykjavíkur hefur staðfest fyrirtökutíma fyrir kröfu um gæsluvarðhald.<br /><br />Fyrirtaka mun fara fram á ótilgreindum tíma.<br /><br />Dómsalur hefur ekki verið skráður.<br /><br />Dómari hefur ekki verið skráður.<br /><br />Verjandi sakbornings: ${defender.name}. Hægt er að nálgast yfirlitssíðu málsins í <a href="${mockConfig.clientUrl}${PROSECUTION_RESTRICTION_CASE_OVERVIEW_ROUTE}/${caseId}">Réttarvörslugátt</a>.`,
         }),
       )
 
@@ -118,7 +120,7 @@ describe('InternalNotificationController - Send court date notifications', () =>
         expect.objectContaining({
           to: [{ name: defender.name, address: defender.email }],
           subject: `Fyrirtaka í máli ${courtCaseNumber}`,
-          html: `Héraðsdómur Reykjavíkur hefur boðað þig í fyrirtöku sem verjanda sakbornings.<br /><br />Fyrirtaka mun fara fram á ótilgreindum tíma.<br /><br />Málsnúmer: ${courtCaseNumber}.<br /><br />Dómsalur hefur ekki verið skráður.<br /><br />Dómari: .<br /><br />Sækjandi: ${prosecutor.name} ().`,
+          html: `Héraðsdómur Reykjavíkur hefur boðað þig í fyrirtöku sem verjanda sakbornings.<br /><br />Fyrirtaka mun fara fram á ótilgreindum tíma.<br /><br />Málsnúmer: ${courtCaseNumber}.<br /><br />Dómsalur hefur ekki verið skráður.<br /><br />Dómari: .<br /><br />Sækjandi: ${prosecutor.name} (). Hægt er að nálgast yfirlitssíðu málsins í <a href="${mockConfig.clientUrl}${DEFENDER_REQUEST_CASE_ROUTE}/${caseId}">Réttarvörslugátt</a>.`,
         }),
       )
 


### PR DESCRIPTION
[Taka út bbb á DEV hjá verjanda - póstur um úthlutun fyrirtökutíma](https://app.asana.com/1/203394141643832/project/1199153462262248/task/1217317634363012)

## What

Court date notification emails for prosecutors and defenders now link to the relevant case overview page instead of the client root URL.

- Prosecutor emails use the restriction-case overview route or the investigation-case police confirmation route
- Defender emails include the overview link when a national ID is available so the defender case route can be built
- Unit tests updated to assert the overview URLs

## Why

The email copy says recipients can open the case overview in Réttarvörslugátt, but the link previously pointed at the app root and landed people on the case list.

## Screenshots / Gifs

N/A

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Cursor


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Court-date emails to prosecutors now include a link to the relevant case overview.
  * Defender calendar-invite emails include a case link when the defender has access.
  * When no case link is available, the invitation email omits the link section.
  * Court records retain the original invitation message without a case link when required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->