### PR TITLE
feat(applicaton-system): Add national id type endpoint

### DIFF
--- a/libs/application/template-api-modules/src/lib/modules/shared/api/national-registry-v3/national-registry-v3.service.ts
+++ b/libs/application/template-api-modules/src/lib/modules/shared/api/national-registry-v3/national-registry-v3.service.ts
@@ -24,6 +24,7 @@ import {
   CitizenshipDto,
   CohabitationDto,
   IndividualDto,
+  NationalIdTypeDto,
 } from '@island.is/clients/national-registry-v3-applications'
 import { TemplateApiError } from '@island.is/nest/problem'
 import { coreErrorMessages } from '@island.is/application/core'
@@ -867,5 +868,12 @@ export class NationalRegistryV3Service extends BaseTemplateApiService {
     }
 
     return custodians
+  }
+
+  async getNationalIdType(
+    nationalId: string,
+    auth: User,
+  ): Promise<NationalIdTypeDto | null> {
+    return this.nationalRegistryV3Api.getNationalIdType(nationalId, auth)
   }
 }

--- a/libs/clients/national-registry/v3-applications/src/clientConfig.json
+++ b/libs/clients/national-registry/v3-applications/src/clientConfig.json
@@ -132,6 +132,35 @@
         }
       }
     },
+    "/Einstaklingar/{kennitala}/kennitalaTegund": {
+      "get": {
+        "tags": ["Einstaklingar"],
+        "summary": "Get fyrir tegund einstaklinga",
+        "description": "Skilar upplýsingum um tegund kennitölu einstaklings. Annað hvort er um hefðbundina einstaklingskennitölu að ræða eða kerfiskennitölu.",
+        "parameters": [
+          {
+            "name": "kennitala",
+            "in": "path",
+            "description": "Kennitala einstaklings sem verið er að leita eftir. Má vera kerfiskennitala",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Eintak af EinstaklingurTegundDTO með upplýsingum um einstakling.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EinstaklingurTegundDTO"
+                }
+              }
+            }
+          }
+        },
+        "security": [{ "Bearer": [] }]
+      }
+    },
     "/Einstaklingar/{kennitala}/faedingarstadur": {
       "get": {
         "tags": ["Einstaklingar"],
@@ -1132,6 +1161,16 @@
           }
         },
         "additionalProperties": true
+      },
+      "EinstaklingurTegundDTO": {
+        "required": ["kennitala"],
+        "type": "object",
+        "properties": {
+          "kennitala": { "type": "string" },
+          "nafn": { "type": "string", "nullable": true },
+          "skraKodi": { "type": "string", "nullable": true },
+          "skraLysing": { "type": "string", "nullable": true }
+        }
       },
       "EinstaklingurUtlBaseDTO": {
         "type": "object",

--- a/libs/clients/national-registry/v3-applications/src/index.ts
+++ b/libs/clients/national-registry/v3-applications/src/index.ts
@@ -4,5 +4,6 @@ export { NationalRegistryV3ApplicationsClientService } from './lib/nationalRegis
 export { CitizenshipDto } from './lib/types/citizenship.dto'
 export { CohabitationDto } from './lib/types/cohabitation.dto'
 export { IndividualDto } from './lib/types/individual.dto'
+export { NationalIdTypeDto } from './lib/types/national-id-type.dto'
 export { ResidenceEntryDto } from './lib/types/residence-history-entry.dto'
 export * from '../gen/fetch'

--- a/libs/clients/national-registry/v3-applications/src/lib/nationalRegistryV3Applications.service.ts
+++ b/libs/clients/national-registry/v3-applications/src/lib/nationalRegistryV3Applications.service.ts
@@ -18,6 +18,10 @@ import { formatFamilyDto, FamilyDto } from './types/family.dto'
 import { formatBirthplaceDto, BirthplaceDto } from './types/birthplace.dto'
 import { formatCitizenshipDto, CitizenshipDto } from './types/citizenship.dto'
 import {
+  formatNationalIdTypeDto,
+  NationalIdTypeDto,
+} from './types/national-id-type.dto'
+import {
   formatIndividualDto,
   formatIndividualLiteDto,
   IndividualDto,
@@ -277,5 +281,18 @@ export class NationalRegistryV3ApplicationsClientService {
     })
 
     return formatCitizenshipDto(res)
+  }
+
+  async getNationalIdType(
+    nationalId: string,
+    auth: User,
+  ): Promise<NationalIdTypeDto | null> {
+    const res = await this.einstaklingarApiWithAuth(
+      auth,
+    ).einstaklingarKennitalaKennitalaTegundGet({
+      kennitala: nationalId,
+    })
+
+    return formatNationalIdTypeDto(res)
   }
 }

--- a/libs/clients/national-registry/v3-applications/src/lib/types/national-id-type.dto.ts
+++ b/libs/clients/national-registry/v3-applications/src/lib/types/national-id-type.dto.ts
@@ -1,0 +1,23 @@
+import { EinstaklingurTegundDTO } from '../../../gen/fetch'
+
+export interface NationalIdTypeDto {
+  nationalId: string
+  name: string | null
+  registryCode: string | null
+  registryDescription: string | null
+}
+
+export const formatNationalIdTypeDto = (
+  nationalIdType: EinstaklingurTegundDTO | null | undefined,
+): NationalIdTypeDto | null => {
+  if (nationalIdType == null) {
+    return null
+  }
+
+  return {
+    nationalId: nationalIdType.kennitala,
+    name: nationalIdType.nafn || null,
+    registryCode: nationalIdType.skraKodi || null,
+    registryDescription: nationalIdType.skraLysing || null,
+  }
+}


### PR DESCRIPTION
## What

Added a new endpoint `/Einstaklingar/{kennitala}/kennitalaTegund`

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for retrieving an individual’s national identification-number type from the National Registry.
  - Exposed the identification type, name, and registration details through the application API.
  - Added consistent handling for missing or unavailable identification-type information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->