### PR TITLE
refactor(driving-license): share the health-declaration question set

### DIFF
--- a/libs/application/templates/driving-license/src/forms/draft/subSectionHealthDeclaration.ts
+++ b/libs/application/templates/driving-license/src/forms/draft/subSectionHealthDeclaration.ts
@@ -17,6 +17,136 @@ import {
 } from '../../lib/utils/formUtils'
 import { BE, B_FULL_RENEWAL_65 } from '../../lib/constants'
 
+/**
+ * The ten health questions plus the glasses-mismatch alert. Shared verbatim by
+ * the B-full/B-temp block and the BE block — they were previously defined twice,
+ * so changing a question meant editing both copies or silently letting one
+ * product drift.
+ *
+ * The field ids are deliberately identical across both blocks: only one is ever
+ * visible at a time (their conditions are mutually exclusive on
+ * `applicationFor`), so the answers land at the same path regardless of product
+ * and in-flight drafts are unaffected.
+ *
+ * A function rather than a shared array so each caller gets its own field
+ * objects — two multifields must never hold references to the same instances.
+ *
+ * Note: the two 65+ blocks below deliberately do NOT use this. 65+ has no
+ * questionnaire at all (per product decision it always submits a fresh health
+ * certificate), so there is nothing to share.
+ */
+const healthDeclarationQuestions = () => [
+  buildCustomField(
+    {
+      id: 'healthDeclaration.usesContactGlasses',
+      title: '',
+      component: 'HealthDeclaration',
+    },
+    {
+      title: m.healthDeclarationMultiFieldSubTitle,
+      label: m.healthDeclaration1,
+    },
+  ),
+  buildCustomField(
+    {
+      id: 'healthDeclaration.hasReducedPeripheralVision',
+      title: '',
+      component: 'HealthDeclaration',
+    },
+    {
+      label: m.healthDeclaration2,
+    },
+  ),
+  buildCustomField(
+    {
+      id: 'healthDeclaration.hasEpilepsy',
+      title: '',
+      component: 'HealthDeclaration',
+    },
+    {
+      label: m.healthDeclaration3,
+    },
+  ),
+  buildCustomField(
+    {
+      id: 'healthDeclaration.hasHeartDisease',
+      title: '',
+      component: 'HealthDeclaration',
+    },
+    {
+      label: m.healthDeclaration4,
+    },
+  ),
+  buildCustomField(
+    {
+      id: 'healthDeclaration.hasMentalIllness',
+      title: '',
+      component: 'HealthDeclaration',
+    },
+    {
+      label: m.healthDeclaration5,
+    },
+  ),
+  buildCustomField(
+    {
+      id: 'healthDeclaration.usesMedicalDrugs',
+      title: '',
+      component: 'HealthDeclaration',
+    },
+    {
+      label: m.healthDeclaration6,
+    },
+  ),
+  buildCustomField(
+    {
+      id: 'healthDeclaration.isAlcoholic',
+      title: '',
+      component: 'HealthDeclaration',
+    },
+    {
+      label: m.healthDeclaration7,
+    },
+  ),
+  buildCustomField(
+    {
+      id: 'healthDeclaration.hasDiabetes',
+      title: '',
+      component: 'HealthDeclaration',
+    },
+    {
+      label: m.healthDeclaration8,
+    },
+  ),
+  buildCustomField(
+    {
+      id: 'healthDeclaration.isDisabled',
+      title: '',
+      component: 'HealthDeclaration',
+    },
+    {
+      label: m.healthDeclaration9,
+    },
+  ),
+  buildCustomField(
+    {
+      id: 'healthDeclaration.hasOtherDiseases',
+      title: '',
+      component: 'HealthDeclaration',
+    },
+    {
+      label: m.healthDeclaration10,
+    },
+  ),
+  buildAlertMessageField({
+    id: 'healthDeclaration.contactGlassesMismatch',
+    message: m.alertHealthDeclarationGlassesMismatch,
+    alertType: 'warning',
+    condition: (answers) =>
+      getValueViaPath(answers, 'healthDeclaration.contactGlassesMismatch') ===
+      true,
+  }),
+]
+
 export const subSectionHealthDeclaration = buildSubSection({
   id: 'healthDeclaration',
   title: m.healthDeclarationSectionTitle,
@@ -43,117 +173,7 @@ export const subSectionHealthDeclaration = buildSubSection({
           condition: (answers, externalData) =>
             hasHealthRemarks(externalData) && answers.applicationFor !== BE,
         }),
-        buildCustomField(
-          {
-            id: 'healthDeclaration.usesContactGlasses',
-            title: '',
-            component: 'HealthDeclaration',
-          },
-          {
-            title: m.healthDeclarationMultiFieldSubTitle,
-            label: m.healthDeclaration1,
-          },
-        ),
-        buildCustomField(
-          {
-            id: 'healthDeclaration.hasReducedPeripheralVision',
-            title: '',
-            component: 'HealthDeclaration',
-          },
-          {
-            label: m.healthDeclaration2,
-          },
-        ),
-        buildCustomField(
-          {
-            id: 'healthDeclaration.hasEpilepsy',
-            title: '',
-            component: 'HealthDeclaration',
-          },
-          {
-            label: m.healthDeclaration3,
-          },
-        ),
-        buildCustomField(
-          {
-            id: 'healthDeclaration.hasHeartDisease',
-            title: '',
-            component: 'HealthDeclaration',
-          },
-          {
-            label: m.healthDeclaration4,
-          },
-        ),
-        buildCustomField(
-          {
-            id: 'healthDeclaration.hasMentalIllness',
-            title: '',
-            component: 'HealthDeclaration',
-          },
-          {
-            label: m.healthDeclaration5,
-          },
-        ),
-        buildCustomField(
-          {
-            id: 'healthDeclaration.usesMedicalDrugs',
-            title: '',
-            component: 'HealthDeclaration',
-          },
-          {
-            label: m.healthDeclaration6,
-          },
-        ),
-        buildCustomField(
-          {
-            id: 'healthDeclaration.isAlcoholic',
-            title: '',
-            component: 'HealthDeclaration',
-          },
-          {
-            label: m.healthDeclaration7,
-          },
-        ),
-        buildCustomField(
-          {
-            id: 'healthDeclaration.hasDiabetes',
-            title: '',
-            component: 'HealthDeclaration',
-          },
-          {
-            label: m.healthDeclaration8,
-          },
-        ),
-        buildCustomField(
-          {
-            id: 'healthDeclaration.isDisabled',
-            title: '',
-            component: 'HealthDeclaration',
-          },
-          {
-            label: m.healthDeclaration9,
-          },
-        ),
-        buildCustomField(
-          {
-            id: 'healthDeclaration.hasOtherDiseases',
-            title: '',
-            component: 'HealthDeclaration',
-          },
-          {
-            label: m.healthDeclaration10,
-          },
-        ),
-        buildAlertMessageField({
-          id: 'healthDeclaration.contactGlassesMismatch',
-          message: m.alertHealthDeclarationGlassesMismatch,
-          alertType: 'warning',
-          condition: (answers) =>
-            getValueViaPath(
-              answers,
-              'healthDeclaration.contactGlassesMismatch',
-            ) === true,
-        }),
+        ...healthDeclarationQuestions(),
       ],
     }),
     // Same health declaration questions for BE, plus health certificate
@@ -177,117 +197,7 @@ export const subSectionHealthDeclaration = buildSubSection({
         buildHiddenInput({
           id: 'hasHealthRemarks',
         }),
-        buildCustomField(
-          {
-            id: 'healthDeclaration.usesContactGlasses',
-            title: '',
-            component: 'HealthDeclaration',
-          },
-          {
-            title: m.healthDeclarationMultiFieldSubTitle,
-            label: m.healthDeclaration1,
-          },
-        ),
-        buildCustomField(
-          {
-            id: 'healthDeclaration.hasReducedPeripheralVision',
-            title: '',
-            component: 'HealthDeclaration',
-          },
-          {
-            label: m.healthDeclaration2,
-          },
-        ),
-        buildCustomField(
-          {
-            id: 'healthDeclaration.hasEpilepsy',
-            title: '',
-            component: 'HealthDeclaration',
-          },
-          {
-            label: m.healthDeclaration3,
-          },
-        ),
-        buildCustomField(
-          {
-            id: 'healthDeclaration.hasHeartDisease',
-            title: '',
-            component: 'HealthDeclaration',
-          },
-          {
-            label: m.healthDeclaration4,
-          },
-        ),
-        buildCustomField(
-          {
-            id: 'healthDeclaration.hasMentalIllness',
-            title: '',
-            component: 'HealthDeclaration',
-          },
-          {
-            label: m.healthDeclaration5,
-          },
-        ),
-        buildCustomField(
-          {
-            id: 'healthDeclaration.usesMedicalDrugs',
-            title: '',
-            component: 'HealthDeclaration',
-          },
-          {
-            label: m.healthDeclaration6,
-          },
-        ),
-        buildCustomField(
-          {
-            id: 'healthDeclaration.isAlcoholic',
-            title: '',
-            component: 'HealthDeclaration',
-          },
-          {
-            label: m.healthDeclaration7,
-          },
-        ),
-        buildCustomField(
-          {
-            id: 'healthDeclaration.hasDiabetes',
-            title: '',
-            component: 'HealthDeclaration',
-          },
-          {
-            label: m.healthDeclaration8,
-          },
-        ),
-        buildCustomField(
-          {
-            id: 'healthDeclaration.isDisabled',
-            title: '',
-            component: 'HealthDeclaration',
-          },
-          {
-            label: m.healthDeclaration9,
-          },
-        ),
-        buildCustomField(
-          {
-            id: 'healthDeclaration.hasOtherDiseases',
-            title: '',
-            component: 'HealthDeclaration',
-          },
-          {
-            label: m.healthDeclaration10,
-          },
-        ),
-        buildAlertMessageField({
-          id: 'healthDeclaration.contactGlassesMismatch',
-          message: m.alertHealthDeclarationGlassesMismatch,
-          alertType: 'warning',
-          condition: (answers) =>
-            getValueViaPath(
-              answers,
-              'healthDeclaration.contactGlassesMismatch',
-            ) === true,
-        }),
+        ...healthDeclarationQuestions(),
         buildDescriptionField({
           id: 'healthCertificateDescriptionBE',
           description: m.healthCertificateDescription,


### PR DESCRIPTION
## What

The ten health-declaration questions and the glasses-mismatch alert were defined **twice** — 111 lines duplicated verbatim between the B-full/B-temp block (`overview`) and the BE block (`overviewBE`). Extracted into a single `healthDeclarationQuestions()` used by both.

Net −90 lines, and more importantly one copy instead of two.

## Why

Changing a health question currently means editing both copies correctly, or one product silently drifts from the other. That is not hypothetical — there are three redesigns in flight across these products, and the health questions are exactly the kind of content that gets revised.

This is the same class of duplication as the photo selectors collapsed in #23136 and the biometric resolution collapsed in #23350; this was the largest remaining instance.

## What is deliberately NOT changed

**The two 65+ blocks are left alone.** 65+ has no questionnaire at all — per product decision it always submits a fresh health certificate — so there is nothing to share, and folding them into the same builder would be forced rather than useful.

**Field ids are unchanged**, and remain identical across both blocks. That is intentional, not an oversight: the two blocks' conditions are mutually exclusive on `applicationFor`, so only one is ever visible, and the answers land at the same path regardless of product. In-flight drafts are unaffected.

The extraction is a **function** rather than a shared array so each caller gets its own field objects — two multifields must never hold references to the same instances.

## Verification

A throwaway harness (removed before commit) deep-compared the built subsection against the pre-refactor definition, **invoking every closure** rather than comparing function objects structurally — across 13 answer shapes × 4 externalData shapes: every product, redesign-flag on/off/absent, glasses mismatch, cert-triggering answers, health remarks present/absent, and `glassesCheck` forcing the certificate.

Identical. Negative control: swapping a single question label fails the comparison, so the harness demonstrably bites.

Full driving-license suite (70 tests) green, lint clean.

## Screenshots / Gifs

No visual change — the rendered form is identical for every product and flag state.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code (Opus 5)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Standardized health declaration questions across applicable driving licence application forms.
  * Existing health checks, glasses-related alerts, and health certificate requirements continue to work as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->