### PR TITLE
fix(payments): masked payment inputs corrupt digits under fast typing

### DIFF
--- a/apps/payments/components/BankTransferPayment/BankTransferPayment.tsx
+++ b/apps/payments/components/BankTransferPayment/BankTransferPayment.tsx
@@ -1,5 +1,5 @@
 import { useFormContext, Controller } from 'react-hook-form'
-import { format, InputMask } from '@react-input/mask'
+import { InputMask } from '@react-input/mask'
 
 import { AlertMessage, Box, Input } from '@island.is/island-ui/core'
 import { useLocale } from '@island.is/localization'
@@ -14,13 +14,6 @@ interface BankTransferPaymentInput {
 
 const BANK_ACCOUNT_MASK = '____-__-______'
 const MASK_REPLACEMENT = { _: /\d/ }
-
-// The form stores unmasked digits; the input displays the masked value.
-const toMaskedValue = (value: string | undefined) =>
-  format((value ?? '').replace(/\D/g, ''), {
-    mask: BANK_ACCOUNT_MASK,
-    replacement: MASK_REPLACEMENT,
-  })
 
 /**
  * The body shown between the {@link PaymentSelector} and the submit button when the user has
@@ -51,11 +44,6 @@ export const BankTransferPayment = () => {
               replacement={MASK_REPLACEMENT}
               component={Input}
               {...field}
-              value={toMaskedValue(field.value)}
-              onChange={(e) =>
-                // Strip dashes
-                field.onChange(e.target.value.replace(/\D/g, ''))
-              }
               inputMode="numeric"
               backgroundColor="blue"
               label={formatMessage(bankTransfer.accountNumber)}

--- a/apps/payments/components/BankTransferPayment/BankTransferPayment.utils.spec.ts
+++ b/apps/payments/components/BankTransferPayment/BankTransferPayment.utils.spec.ts
@@ -32,4 +32,10 @@ describe('validateBankAccountNumber', () => {
       'payments:bankTransfer.accountNumberInvalid',
     )
   })
+
+  it('rejects 12 digits with an extra letter', () => {
+    expect(validateBankAccountNumber('1234-56-789012a', formatMessage)).toBe(
+      'payments:bankTransfer.accountNumberInvalid',
+    )
+  })
 })

--- a/apps/payments/components/BankTransferPayment/BankTransferPayment.utils.spec.ts
+++ b/apps/payments/components/BankTransferPayment/BankTransferPayment.utils.spec.ts
@@ -9,6 +9,12 @@ describe('validateBankAccountNumber', () => {
     expect(validateBankAccountNumber('123456789012', formatMessage)).toBe(true)
   })
 
+  it('accepts the masked input value', () => {
+    expect(validateBankAccountNumber('1234-56-789012', formatMessage)).toBe(
+      true,
+    )
+  })
+
   it('rejects fewer than 12 digits', () => {
     expect(validateBankAccountNumber('12345', formatMessage)).toBe(
       'payments:bankTransfer.accountNumberInvalid',
@@ -21,8 +27,8 @@ describe('validateBankAccountNumber', () => {
     )
   })
 
-  it('rejects non-digit characters', () => {
-    expect(validateBankAccountNumber('1234-56-7890', formatMessage)).toBe(
+  it('rejects letters among the digits', () => {
+    expect(validateBankAccountNumber('1234-56-78901a', formatMessage)).toBe(
       'payments:bankTransfer.accountNumberInvalid',
     )
   })

--- a/apps/payments/components/BankTransferPayment/BankTransferPayment.utils.ts
+++ b/apps/payments/components/BankTransferPayment/BankTransferPayment.utils.ts
@@ -7,7 +7,8 @@ export const validateBankAccountNumber = (
   value: string,
   formatMessage: FormatMessage,
 ) => {
-  if (!/^\d{12}$/.test(value)) {
+  // The form stores the masked value (0000-00-000000); validate the digits.
+  if (!/^\d{12}$/.test(value.replace(/\D/g, ''))) {
     return formatMessage(bankTransfer.accountNumberInvalid)
   }
   return true

--- a/apps/payments/components/BankTransferPayment/BankTransferPayment.utils.ts
+++ b/apps/payments/components/BankTransferPayment/BankTransferPayment.utils.ts
@@ -7,8 +7,9 @@ export const validateBankAccountNumber = (
   value: string,
   formatMessage: FormatMessage,
 ) => {
-  // The form stores the masked value (0000-00-000000); validate the digits.
-  if (!/^\d{12}$/.test(value.replace(/\D/g, ''))) {
+  // The form stores the masked value (0000-00-000000); accept only digits
+  // and the mask separators, then require exactly 12 digits.
+  if (!/^[\d-]+$/.test(value) || !/^\d{12}$/.test(value.replace(/-/g, ''))) {
     return formatMessage(bankTransfer.accountNumberInvalid)
   }
   return true

--- a/apps/payments/components/CardPayment/CardPayment.tsx
+++ b/apps/payments/components/CardPayment/CardPayment.tsx
@@ -117,7 +117,10 @@ export const CardPayment = ({
           rules={{
             required: formatMessage(cardValidationError.cardNumber),
             validate: (value) => {
-              if (value.replace(/\D/g, '').length < 15) {
+              if (!/^[\d ]+$/.test(value)) {
+                return formatMessage(cardValidationError.invalidCardNumber)
+              }
+              if (value.replace(/ /g, '').length < 15) {
                 return formatMessage(cardValidationError.cardNumberTooShort)
               }
               return true

--- a/apps/payments/components/CardPayment/CardPayment.tsx
+++ b/apps/payments/components/CardPayment/CardPayment.tsx
@@ -1,5 +1,5 @@
 import { useFormContext, Controller } from 'react-hook-form'
-import { format, InputMask } from '@react-input/mask'
+import { InputMask } from '@react-input/mask'
 
 import { Box, Input, Text, Divider } from '@island.is/island-ui/core'
 import { useLocale } from '@island.is/localization'
@@ -18,13 +18,6 @@ interface CardPaymentInput {
 }
 
 const MASK_REPLACEMENT = { _: /\d/ }
-
-// The form stores unmasked digits; the inputs display the masked value.
-const toMaskedValue = (value: string | undefined, mask: string) =>
-  format((value ?? '').replace(/\D/g, ''), {
-    mask,
-    replacement: MASK_REPLACEMENT,
-  })
 
 const CARD_MASK_BY_TYPE = {
   default: '____ ____ ____ ____',
@@ -124,7 +117,7 @@ export const CardPayment = ({
           rules={{
             required: formatMessage(cardValidationError.cardNumber),
             validate: (value) => {
-              if (value.length < 15) {
+              if (value.replace(/\D/g, '').length < 15) {
                 return formatMessage(cardValidationError.cardNumberTooShort)
               }
               return true
@@ -136,11 +129,9 @@ export const CardPayment = ({
               replacement={MASK_REPLACEMENT}
               component={Input}
               {...field}
-              value={toMaskedValue(field.value, cardMask)}
               onChange={(e) => {
-                const cardNumber = e.target.value.replace(/\s/g, '')
-                handleCardChange(cardNumber)
-                field.onChange(cardNumber)
+                handleCardChange(e.target.value.replace(/\D/g, ''))
+                field.onChange(e.target.value)
               }}
               backgroundColor="blue"
               label={formatMessage(card.cardNumber)}
@@ -170,10 +161,6 @@ export const CardPayment = ({
                   replacement={MASK_REPLACEMENT}
                   component={Input}
                   {...field}
-                  value={toMaskedValue(field.value, '__/__')}
-                  onChange={(e) =>
-                    field.onChange(e.target.value.replace(/\s/g, ''))
-                  }
                   backgroundColor="blue"
                   label={formatMessage(card.cardExpiry)}
                   placeholder={formatMessage(card.cardExpiryPlaceholder)}
@@ -197,7 +184,6 @@ export const CardPayment = ({
                   replacement={MASK_REPLACEMENT}
                   component={Input}
                   {...field}
-                  value={toMaskedValue(field.value, '___')}
                   backgroundColor="blue"
                   label={formatMessage(card.cardCVC)}
                   placeholder={formatMessage(card.cardCVCPlaceholder)}

--- a/apps/payments/hooks/usePaymentOrchestration.ts
+++ b/apps/payments/hooks/usePaymentOrchestration.ts
@@ -141,7 +141,8 @@ export const usePaymentOrchestration = ({
           const [month, year] = cardExpiry.split('/')
           await cardPayment.processCardPayment({
             cardholderName,
-            number: card,
+            // The form stores the masked value; the processor needs digits.
+            number: card.replace(/\D/g, ''),
             expiryMonth: Number(month),
             expiryYear: Number(year),
             cvc: cardCVC,
@@ -158,7 +159,8 @@ export const usePaymentOrchestration = ({
             return
           }
           await bankTransferPayment.processBankTransferPayment(
-            bankAccountNumber,
+            // The form stores the masked value; the service needs digits.
+            bankAccountNumber.replace(/\D/g, ''),
           )
         }
       } catch (e: unknown) {

--- a/apps/skilavottord/web/server.ts
+++ b/apps/skilavottord/web/server.ts
@@ -1,4 +1,7 @@
-import { bootstrap } from '@island.is/infra-next-server'
+import {
+  bootstrap,
+  buildContentSecurityPolicy,
+} from '@island.is/infra-next-server'
 
 import proxyConfig from './proxy.conf.json'
 import { getServerRuntimeEnv } from './environments/runtimeEnvironment'
@@ -7,6 +10,7 @@ bootstrap({
   name: 'skilavottord',
   appDir: 'apps/skilavottord/web',
   proxyConfig,
+  csp: buildContentSecurityPolicy,
   externalEndpointDependencies: () => {
     const { graphqlEndpoint } = getServerRuntimeEnv()
     return [graphqlEndpoint]

--- a/apps/web/components/Charts/v2/renderers/ChartComponentRenderer.tsx
+++ b/apps/web/components/Charts/v2/renderers/ChartComponentRenderer.tsx
@@ -137,8 +137,7 @@ export const renderPieChartComponents = (
   const pieData = (data?.[0]?.statisticsForHeader ?? []).map((entry) => ({
     ...entry,
     name:
-      components.find((c) => c.sourceDataKey === entry.key)?.label ??
-      entry.key,
+      components.find((c) => c.sourceDataKey === entry.key)?.label ?? entry.key,
   }))
   const total = pieData.reduce(
     (total, { value }) => total + (value ? value : 0),

--- a/apps/web/components/Charts/v2/renderers/ChartComponentRenderer.tsx
+++ b/apps/web/components/Charts/v2/renderers/ChartComponentRenderer.tsx
@@ -132,7 +132,14 @@ export const renderPieChartComponents = (
   activeLocale: Locale,
   customStyleConfig: CustomStyleConfig,
 ) => {
-  const pieData = data?.[0]?.statisticsForHeader ?? []
+  // Tooltips resolve the segment name from the data entries (nameKey),
+  // not from Cell props — without this they fall back to the entry index.
+  const pieData = (data?.[0]?.statisticsForHeader ?? []).map((entry) => ({
+    ...entry,
+    name:
+      components.find((c) => c.sourceDataKey === entry.key)?.label ??
+      entry.key,
+  }))
   const total = pieData.reduce(
     (total, { value }) => total + (value ? value : 0),
     0,

--- a/libs/cms-translations/src/lib/cms-translations.service.ts
+++ b/libs/cms-translations/src/lib/cms-translations.service.ts
@@ -82,7 +82,10 @@ export class CmsTranslationsService {
       await this.cacheManager.set(
         namespace,
         messages,
-        this.config.memCacheExpiryMilliseconds + 120000 * Math.random(), // Add a random delay to avoid cache stampede
+        // Random jitter avoids a cache stampede; rounded because Redis
+        // rejects fractional PX values ("value is not an integer").
+        this.config.memCacheExpiryMilliseconds +
+          Math.round(120000 * Math.random()),
       )
 
       return messages

--- a/libs/island-ui/contentful/src/lib/RichTextRC/defaultRenderNode.tsx
+++ b/libs/island-ui/contentful/src/lib/RichTextRC/defaultRenderNode.tsx
@@ -1,4 +1,5 @@
 import cn from 'classnames'
+import { Children, isValidElement, ReactNode } from 'react'
 import { BLOCKS, INLINES } from '@contentful/rich-text-types'
 import { Asset } from 'contentful'
 import { RenderNode } from '@contentful/rich-text-react-renderer'
@@ -149,18 +150,34 @@ export const defaultRenderNodeObject: RenderNode = {
       <hr />
     </Box>
   ),
-  [BLOCKS.TABLE]: (_node, children) => (
-    <Box className={cn(styles.clearBoth, styles.tableContainer)}>
-      <T.Table>{children}</T.Table>
-    </Box>
-  ),
+  [BLOCKS.TABLE]: (_node, children) => {
+    // The HTML parser inserts the implied <tbody> when parsing the server
+    // HTML, and React 19 fails hydration on any structure the parser had to
+    // correct — so body rows must be wrapped in an explicit <tbody>.
+    const rows = Children.toArray(children as ReactNode)
+    const isHead = (row: unknown) => isValidElement(row) && row.type === T.Head
+    return (
+      <Box className={cn(styles.clearBoth, styles.tableContainer)}>
+        <T.Table>
+          {rows.filter(isHead)}
+          <T.Body>{rows.filter((row) => !isHead(row))}</T.Body>
+        </T.Table>
+      </Box>
+    )
+  },
   [BLOCKS.TABLE_ROW]: (_node, children) => {
     if (
       (children as { nodeType: string }[])?.every(
         (childNode) => childNode?.nodeType === BLOCKS.TABLE_HEADER_CELL,
       )
     ) {
-      return <T.Head>{children}</T.Head>
+      // Header cells need their row: bare <th> under <thead> is another
+      // parser-corrected structure that breaks React 19 hydration.
+      return (
+        <T.Head>
+          <T.Row>{children}</T.Row>
+        </T.Head>
+      )
     }
     return <T.Row>{children}</T.Row>
   },

--- a/libs/island-ui/core/src/lib/DropdownMenu/DropdownMenu.tsx
+++ b/libs/island-ui/core/src/lib/DropdownMenu/DropdownMenu.tsx
@@ -127,6 +127,10 @@ export const DropdownMenu = ({
         aria-label={menuLabel}
         className={cn(styles.menu, menuBoxStyle, menuClassName)}
         {...hoverProps}
+        // Hover menus shouldn't yank focus back to the disclosure when they
+        // close. Menu (a Dialog) consumes this option; the disclosure button
+        // doesn't, so it must not go into the shared hoverProps spread.
+        unstable_autoFocusOnHide={!openOnHover}
       >
         {items.map((item, index) => {
           let anchorProps = {}

--- a/libs/island-ui/core/src/lib/DropdownMenu/useMenuHoverProps.tsx
+++ b/libs/island-ui/core/src/lib/DropdownMenu/useMenuHoverProps.tsx
@@ -35,7 +35,6 @@ export const useMenuHoverProps = (
             }, MENU_LEAVE_DELAY)
           }
         },
-        unstable_autofocusOnhide: 'false',
       }
     : undefined
 }

--- a/libs/shared/vite/base.ts
+++ b/libs/shared/vite/base.ts
@@ -79,7 +79,10 @@ export const injectDevSiEnvironment = (): Plugin => ({
 export const nodeBuiltinPolyfills = () =>
   nodePolyfills({
     include: ['crypto', 'stream', 'buffer', 'events', 'string_decoder', 'vm'],
-    globals: { Buffer: true, global: false, process: false },
+    // The polyfilled crypto/stream modules reference the process global at
+    // runtime (process.nextTick, process.browser) — without the shim the
+    // chunks that bundle them throw "process is not defined" on load.
+    globals: { Buffer: true, global: false, process: true },
   })
 
 const assetMimeTypes: Record<string, string> = {


### PR DESCRIPTION
# Masked payment inputs corrupt digits under fast typing

## What

- Store the displayed masked value in form state for the card-number and bank-account fields; strip to digits in validators and the payment submit handlers.
- island-ui DropdownMenu: fix the mis-cased `unstable_autofocusOnhide` prop that leaked to the DOM.
- Web pie charts: put segment labels on the data entries so tooltips show them again.

## Why

- The masked fields stored stripped digits and fed them back re-masked through the `value` prop. Fast typing makes React batch keystrokes, the value diverges from what `@react-input/mask` rendered, and its internal state desyncs — every keystroke after that duplicates digits. The library is only controlled-safe when the stored value equals the displayed one.
- The DropdownMenu prop leak caused the React unknown-prop console warning on every page with a dropdown.
- recharts 3 no longer reads tooltip names from `Cell` props, so pie tooltips showed the entry index (`0: 522`) instead of the label (`Pappír: 522`).

## Screenshots / Gifs

N/A

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Improved card and bank transfer payment forms with more reliable masked input handling and submission processing.
  - Bank account numbers now support hyphenated formats while requiring exactly 12 digits.
  - Card validation better detects invalid characters and identifies card types.
  - Pie chart segments now display meaningful component labels.

- **Bug Fixes**
  - Hover menus no longer unexpectedly restore focus when closing, improving keyboard and pointer interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->