### PR TITLE
chore(j-s): Shorten driving license suspension email

### DIFF
--- a/apps/judicial-system/backend/src/app/modules/notification/services/indictmentCaseNotification/indictmentCaseNotification.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/services/indictmentCaseNotification/indictmentCaseNotification.service.ts
@@ -154,9 +154,7 @@ export class IndictmentCaseNotificationService extends BaseNotificationService {
       theCase.courtCaseNumber
     } í ${applyDativeCaseToCourtName(
       theCase.court?.name ?? 'héraðsdómi',
-    )}.<br><br>LÖKE númer: ${theCase.policeCaseNumbers.join(
-      ', ',
-    )}.`
+    )}.<br><br>LÖKE númer: ${theCase.policeCaseNumbers.join(', ')}.`
 
     const contactInfo = {
       name: theCase.prosecutorsOffice?.name,

--- a/apps/judicial-system/backend/src/app/modules/notification/services/indictmentCaseNotification/indictmentCaseNotification.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/services/indictmentCaseNotification/indictmentCaseNotification.service.ts
@@ -154,7 +154,7 @@ export class IndictmentCaseNotificationService extends BaseNotificationService {
       theCase.courtCaseNumber
     } í ${applyDativeCaseToCourtName(
       theCase.court?.name ?? 'héraðsdómi',
-    )}. Einn af dómfelldu í málinu var sviptur ökuréttinda.<br><br>LÖKE númer: ${theCase.policeCaseNumbers.join(
+    )}.<br><br>LÖKE númer: ${theCase.policeCaseNumbers.join(
       ', ',
     )}.`
 

--- a/apps/judicial-system/backend/src/app/modules/notification/test/internalNotificationController/indictmentCaseNotification/sendDrivingLicenseSuspensionNotifications.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/test/internalNotificationController/indictmentCaseNotification/sendDrivingLicenseSuspensionNotifications.spec.ts
@@ -100,7 +100,7 @@ describe('IndictmentCaseService - sendDrivingLicenseSuspensionNotifications', ()
             },
           ],
           subject: `Svipting í máli ${courtCaseNumber}`,
-          html: `Skrá skal sviptingu ökuréttinda í ökuskírteinaskrá vegna máls ${courtCaseNumber} í Héraðsdómi Reykjavíkur. Einn af dómfelldu í málinu var sviptur ökuréttinda.<br><br>LÖKE númer: ${policeCaseNumbers.join(
+          html: `Skrá skal sviptingu ökuréttinda í ökuskírteinaskrá vegna máls ${courtCaseNumber} í Héraðsdómi Reykjavíkur.<br><br>LÖKE númer: ${policeCaseNumbers.join(
             ', ',
           )}.`,
         }),


### PR DESCRIPTION
[Asana](https://app.asana.com/1/203394141643832/project/1199153462262248/task/1217186302636377?focus=true)

## What

Remove "Einn af dómfelldu í málinu var sviptur ökuréttinda." from the body of the email

## Why

It had a grammatical error (ökuréttinda) which prompted a discussion and eventually we decided it would be cleaner to just omit this sentence entirely.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Cursor


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Updates**
  - Clarified driving-license suspension notifications by removing the statement that a convicted person was disqualified from driving.
  - Notifications now instruct recipients to record the disqualification and include the relevant LÖKE number.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->