### PR TITLE
feat(j-s): Lawyer registry repository service

### DIFF
--- a/apps/judicial-system/backend/src/app/modules/lawyer-registry/lawyerRegistry.module.ts
+++ b/apps/judicial-system/backend/src/app/modules/lawyer-registry/lawyerRegistry.module.ts
@@ -1,16 +1,11 @@
 import { forwardRef, Module } from '@nestjs/common'
-import { SequelizeModule } from '@nestjs/sequelize'
 
-import { LawyerRegistry } from '../repository'
-import { EventModule } from '..'
+import { EventModule, RepositoryModule } from '..'
 import { LawyerRegistryController } from './lawyerRegistry.controller'
 import { LawyerRegistryService } from './lawyerRegistry.service'
 
 @Module({
-  imports: [
-    forwardRef(() => EventModule),
-    SequelizeModule.forFeature([LawyerRegistry]),
-  ],
+  imports: [forwardRef(() => EventModule), forwardRef(() => RepositoryModule)],
   providers: [LawyerRegistryService],
   controllers: [LawyerRegistryController],
   exports: [LawyerRegistryService],

--- a/apps/judicial-system/backend/src/app/modules/lawyer-registry/lawyerRegistry.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/lawyer-registry/lawyerRegistry.service.ts
@@ -1,6 +1,6 @@
 import { plainToClass } from 'class-transformer'
 import { validate } from 'class-validator'
-import type { Transaction, WhereOptions } from 'sequelize'
+import type { Transaction } from 'sequelize'
 
 import {
   BadGatewayException,
@@ -9,32 +9,25 @@ import {
   NotFoundException,
 } from '@nestjs/common'
 import { ConfigType } from '@nestjs/config'
-import { InjectModel } from '@nestjs/sequelize'
 
 import type { Logger } from '@island.is/logging'
 import { LOGGER_PROVIDER } from '@island.is/logging'
 
 import { LawyerFull, LawyerType } from '@island.is/judicial-system/types'
 
-import { LawyerRegistry } from '../repository'
+import {
+  LawyerRegistry,
+  LawyerRegistryData,
+  LawyerRegistryRepositoryService,
+} from '../repository'
 import { lawyerRegistryConfig } from './lawyerRegistry.config'
-
-type Lawyer = {
-  name: string
-  nationalId: string
-  email: string
-  phoneNumber: string
-  practice: string
-  isLitigator: boolean
-}
 
 @Injectable()
 export class LawyerRegistryService {
   constructor(
     @Inject(lawyerRegistryConfig.KEY)
     private readonly config: ConfigType<typeof lawyerRegistryConfig>,
-    @InjectModel(LawyerRegistry)
-    private readonly lawyerRegistryModel: typeof LawyerRegistry,
+    private readonly lawyerRegistryRepositoryService: LawyerRegistryRepositoryService,
     @Inject(LOGGER_PROVIDER) private readonly logger: Logger,
   ) {}
 
@@ -76,10 +69,7 @@ export class LawyerRegistryService {
     return lawyers
   }
 
-  private async populateLawyerRegistry(
-    lawyers: Lawyer[],
-    transaction: Transaction,
-  ) {
+  private async validateLawyers(lawyers: LawyerRegistryData[]) {
     for (const lawyer of lawyers) {
       const lawyerInstance = plainToClass(LawyerRegistry, lawyer)
       const errors = await validate(lawyerInstance)
@@ -92,8 +82,6 @@ export class LawyerRegistryService {
         )
       }
     }
-
-    return this.lawyerRegistryModel.bulkCreate(lawyers, { transaction })
   }
 
   async populate(transaction: Transaction) {
@@ -101,7 +89,7 @@ export class LawyerRegistryService {
     const litigators = await this.getLawyerRegistry(LawyerType.LITIGATORS)
     const litigatorNationalIds = new Set(litigators.map((l) => l.SSN))
 
-    const formattedLawyers: Lawyer[] = lawyers.map((lawyer) => ({
+    const formattedLawyers: LawyerRegistryData[] = lawyers.map((lawyer) => ({
       name: lawyer.Name,
       nationalId: lawyer.SSN,
       email: lawyer.Email,
@@ -110,19 +98,20 @@ export class LawyerRegistryService {
       isLitigator: litigatorNationalIds.has(lawyer.SSN),
     }))
 
-    await this.lawyerRegistryModel.destroy({ where: {}, transaction })
-    await this.populateLawyerRegistry(formattedLawyers, transaction)
+    await this.validateLawyers(formattedLawyers)
+
+    await this.lawyerRegistryRepositoryService.replaceAll(formattedLawyers, {
+      transaction,
+    })
 
     return lawyers
   }
 
   async getAll(lawyerType: LawyerType) {
-    const whereOptions: WhereOptions | undefined =
-      lawyerType === LawyerType.LITIGATORS ? { isLitigator: true } : undefined
-
-    const lawyers = await this.lawyerRegistryModel.findAll({
-      where: whereOptions,
-    })
+    const lawyers =
+      lawyerType === LawyerType.LITIGATORS
+        ? await this.lawyerRegistryRepositoryService.findAllLitigators()
+        : await this.lawyerRegistryRepositoryService.findAll()
 
     if (!lawyers || lawyers.length === 0) {
       this.logger.error('No lawyers found in the lawyer registry')
@@ -134,9 +123,9 @@ export class LawyerRegistryService {
   }
 
   async getByNationalId(nationalId: string) {
-    const lawyer = await this.lawyerRegistryModel.findOne({
-      where: { nationalId },
-    })
+    const lawyer = await this.lawyerRegistryRepositoryService.findByNationalId(
+      nationalId,
+    )
 
     if (!lawyer) {
       throw new NotFoundException()

--- a/apps/judicial-system/backend/src/app/modules/repository/index.ts
+++ b/apps/judicial-system/backend/src/app/modules/repository/index.ts
@@ -46,6 +46,10 @@ export { CourtDocumentRepositoryService } from './services/courtDocumentReposito
 export { DefendantRepositoryService } from './services/defendantRepository.service'
 export { DefendantEventLogRepositoryService } from './services/defendantEventLogRepository.service'
 export { InstitutionContactRepositoryService } from './services/institutionContactRepository.service'
+export {
+  LawyerRegistryRepositoryService,
+  LawyerRegistryData,
+} from './services/lawyerRegistryRepository.service'
 export { MessageSuspensionRepositoryService } from './services/messageSuspensionRepository.service'
 export { PoliceDigitalCaseFileRepositoryService } from './services/policeDigitalCaseFileRepository.service'
 export { SubpoenaRepositoryService } from './services/subpoenaRepository.service'

--- a/apps/judicial-system/backend/src/app/modules/repository/repository.module.ts
+++ b/apps/judicial-system/backend/src/app/modules/repository/repository.module.ts
@@ -22,6 +22,7 @@ import { DefendantEventLog } from './models/defendantEventLog.model'
 import { EventLog } from './models/eventLog.model'
 import { IndictmentCount } from './models/indictmentCount.model'
 import { InstitutionContact } from './models/institutionContact.model'
+import { LawyerRegistry } from './models/lawyerRegistry.model'
 import { MessageSuspension } from './models/messageSuspension.model'
 import { Offense } from './models/offense.model'
 import { PoliceDigitalCaseFile } from './models/policeDigitalCaseFile.model'
@@ -39,6 +40,7 @@ import { CourtSessionRepositoryService } from './services/courtSessionRepository
 import { DefendantEventLogRepositoryService } from './services/defendantEventLogRepository.service'
 import { DefendantRepositoryService } from './services/defendantRepository.service'
 import { InstitutionContactRepositoryService } from './services/institutionContactRepository.service'
+import { LawyerRegistryRepositoryService } from './services/lawyerRegistryRepository.service'
 import { MessageSuspensionRepositoryService } from './services/messageSuspensionRepository.service'
 import { PoliceDigitalCaseFileRepositoryService } from './services/policeDigitalCaseFileRepository.service'
 import { SubpoenaRepositoryService } from './services/subpoenaRepository.service'
@@ -66,6 +68,7 @@ import { repositoryModuleConfig } from './repository.config'
       EventLog,
       IndictmentCount,
       InstitutionContact,
+      LawyerRegistry,
       MessageSuspension,
       Offense,
       PoliceDigitalCaseFile,
@@ -88,6 +91,7 @@ import { repositoryModuleConfig } from './repository.config'
     DefendantRepositoryService,
     DefendantEventLogRepositoryService,
     InstitutionContactRepositoryService,
+    LawyerRegistryRepositoryService,
     MessageSuspensionRepositoryService,
     PoliceDigitalCaseFileRepositoryService,
     SubpoenaRepositoryService,
@@ -105,6 +109,7 @@ import { repositoryModuleConfig } from './repository.config'
     DefendantRepositoryService,
     DefendantEventLogRepositoryService,
     InstitutionContactRepositoryService,
+    LawyerRegistryRepositoryService,
     MessageSuspensionRepositoryService,
     PoliceDigitalCaseFileRepositoryService,
     SubpoenaRepositoryService,

--- a/apps/judicial-system/backend/src/app/modules/repository/services/lawyerRegistryRepository.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/repository/services/lawyerRegistryRepository.service.ts
@@ -1,0 +1,61 @@
+import type { Transaction } from 'sequelize'
+
+import { Inject, Injectable } from '@nestjs/common'
+import { InjectModel } from '@nestjs/sequelize'
+
+import { type Logger, LOGGER_PROVIDER } from '@island.is/logging'
+
+import { LawyerRegistry } from '../models/lawyerRegistry.model'
+
+// A type alias rather than an interface on purpose: only type aliases get TypeScript's
+// implicit index signature, which bulkCreate's parameter type requires.
+export type LawyerRegistryData = {
+  name: string
+  nationalId: string
+  email: string
+  phoneNumber: string
+  practice: string
+  isLitigator: boolean
+}
+
+@Injectable()
+export class LawyerRegistryRepositoryService {
+  constructor(
+    @InjectModel(LawyerRegistry)
+    private readonly lawyerRegistryModel: typeof LawyerRegistry,
+    @Inject(LOGGER_PROVIDER) private readonly logger: Logger,
+  ) {}
+
+  async replaceAll(
+    lawyers: LawyerRegistryData[],
+    options: { transaction: Transaction },
+  ): Promise<LawyerRegistry[]> {
+    const { transaction } = options
+
+    this.logger.debug(
+      `Replacing the lawyer registry with ${lawyers.length} lawyers`,
+    )
+
+    await this.lawyerRegistryModel.destroy({ where: {}, transaction })
+
+    return this.lawyerRegistryModel.bulkCreate(lawyers, { transaction })
+  }
+
+  async findAll(): Promise<LawyerRegistry[]> {
+    this.logger.debug('Finding all lawyers in the lawyer registry')
+
+    return this.lawyerRegistryModel.findAll()
+  }
+
+  async findAllLitigators(): Promise<LawyerRegistry[]> {
+    this.logger.debug('Finding all litigators in the lawyer registry')
+
+    return this.lawyerRegistryModel.findAll({ where: { isLitigator: true } })
+  }
+
+  async findByNationalId(nationalId: string): Promise<LawyerRegistry | null> {
+    this.logger.debug('Finding a lawyer in the lawyer registry by national id')
+
+    return this.lawyerRegistryModel.findOne({ where: { nationalId } })
+  }
+}

--- a/apps/judicial-system/backend/src/app/modules/repository/services/lawyerRegistryRepository.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/repository/services/lawyerRegistryRepository.service.ts
@@ -32,30 +32,83 @@ export class LawyerRegistryRepositoryService {
   ): Promise<LawyerRegistry[]> {
     const { transaction } = options
 
-    this.logger.debug(
-      `Replacing the lawyer registry with ${lawyers.length} lawyers`,
-    )
+    try {
+      this.logger.debug(
+        `Replacing the lawyer registry with ${lawyers.length} lawyers`,
+      )
 
-    await this.lawyerRegistryModel.destroy({ where: {}, transaction })
+      const numberOfDeletedRows = await this.lawyerRegistryModel.destroy({
+        where: {},
+        transaction,
+      })
 
-    return this.lawyerRegistryModel.bulkCreate(lawyers, { transaction })
+      const createdLawyers = await this.lawyerRegistryModel.bulkCreate(
+        lawyers,
+        {
+          transaction,
+        },
+      )
+
+      this.logger.debug(
+        `Replaced ${numberOfDeletedRows} lawyer(s) in the lawyer registry with ${createdLawyers.length}`,
+      )
+
+      return createdLawyers
+    } catch (error) {
+      this.logger.error(
+        `Error replacing the lawyer registry with ${lawyers.length} lawyers:`,
+        { error },
+      )
+
+      throw error
+    }
   }
 
   async findAll(): Promise<LawyerRegistry[]> {
-    this.logger.debug('Finding all lawyers in the lawyer registry')
+    try {
+      this.logger.debug('Finding all lawyers in the lawyer registry')
 
-    return this.lawyerRegistryModel.findAll()
+      return await this.lawyerRegistryModel.findAll()
+    } catch (error) {
+      this.logger.error('Error finding all lawyers in the lawyer registry:', {
+        error,
+      })
+
+      throw error
+    }
   }
 
   async findAllLitigators(): Promise<LawyerRegistry[]> {
-    this.logger.debug('Finding all litigators in the lawyer registry')
+    try {
+      this.logger.debug('Finding all litigators in the lawyer registry')
 
-    return this.lawyerRegistryModel.findAll({ where: { isLitigator: true } })
+      return await this.lawyerRegistryModel.findAll({
+        where: { isLitigator: true },
+      })
+    } catch (error) {
+      this.logger.error(
+        'Error finding all litigators in the lawyer registry:',
+        { error },
+      )
+
+      throw error
+    }
   }
 
   async findByNationalId(nationalId: string): Promise<LawyerRegistry | null> {
-    this.logger.debug('Finding a lawyer in the lawyer registry by national id')
+    try {
+      this.logger.debug(
+        'Finding a lawyer in the lawyer registry by national id',
+      )
 
-    return this.lawyerRegistryModel.findOne({ where: { nationalId } })
+      return await this.lawyerRegistryModel.findOne({ where: { nationalId } })
+    } catch (error) {
+      this.logger.error(
+        'Error finding a lawyer in the lawyer registry by national id:',
+        { error },
+      )
+
+      throw error
+    }
   }
 }

--- a/apps/judicial-system/backend/src/app/modules/repository/test/lawyerRegistryRepository.service.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/repository/test/lawyerRegistryRepository.service.spec.ts
@@ -1,0 +1,131 @@
+import { getModelToken } from '@nestjs/sequelize'
+import { Test } from '@nestjs/testing'
+
+import { LOGGER_PROVIDER } from '@island.is/logging'
+
+import { LawyerRegistry } from '../models/lawyerRegistry.model'
+import {
+  LawyerRegistryData,
+  LawyerRegistryRepositoryService,
+} from '../services/lawyerRegistryRepository.service'
+
+describe('LawyerRegistryRepositoryService', () => {
+  const transaction = {} as never
+
+  const lawyer: LawyerRegistryData = {
+    name: 'Lögmaður Lögmannsson',
+    nationalId: '0000000000',
+    email: 'logmadur@example.com',
+    phoneNumber: '0000000',
+    practice: 'Lögmannsstofan',
+    isLitigator: true,
+  }
+
+  let service: LawyerRegistryRepositoryService
+  let model: {
+    destroy: jest.Mock
+    bulkCreate: jest.Mock
+    findAll: jest.Mock
+    findOne: jest.Mock
+  }
+
+  beforeEach(async () => {
+    model = {
+      destroy: jest.fn().mockResolvedValue(0),
+      bulkCreate: jest.fn().mockResolvedValue([]),
+      findAll: jest.fn().mockResolvedValue([]),
+      findOne: jest.fn().mockResolvedValue(null),
+    }
+
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        {
+          provide: LOGGER_PROVIDER,
+          useValue: { debug: jest.fn(), error: jest.fn() },
+        },
+        { provide: getModelToken(LawyerRegistry), useValue: model },
+        LawyerRegistryRepositoryService,
+      ],
+    }).compile()
+
+    service = moduleRef.get(LawyerRegistryRepositoryService)
+  })
+
+  describe('replaceAll', () => {
+    it('deletes the existing registry before inserting the new one', async () => {
+      const order: string[] = []
+      model.destroy.mockImplementationOnce(async () => {
+        order.push('destroy')
+      })
+      model.bulkCreate.mockImplementationOnce(async () => {
+        order.push('bulkCreate')
+
+        return []
+      })
+
+      await service.replaceAll([lawyer], { transaction })
+
+      expect(order).toEqual(['destroy', 'bulkCreate'])
+    })
+
+    it('passes the transaction to both the delete and the insert', async () => {
+      await service.replaceAll([lawyer], { transaction })
+
+      expect(model.destroy).toHaveBeenCalledWith({ where: {}, transaction })
+      expect(model.bulkCreate).toHaveBeenCalledWith([lawyer], { transaction })
+    })
+
+    it('returns the created lawyers', async () => {
+      model.bulkCreate.mockResolvedValueOnce([lawyer])
+
+      const result = await service.replaceAll([lawyer], { transaction })
+
+      expect(result).toEqual([lawyer])
+    })
+  })
+
+  describe('findAll', () => {
+    it('returns every lawyer without filtering', async () => {
+      model.findAll.mockResolvedValueOnce([lawyer])
+
+      const result = await service.findAll()
+
+      expect(model.findAll).toHaveBeenCalledWith()
+      expect(result).toEqual([lawyer])
+    })
+  })
+
+  describe('findAllLitigators', () => {
+    it('filters on isLitigator', async () => {
+      model.findAll.mockResolvedValueOnce([lawyer])
+
+      const result = await service.findAllLitigators()
+
+      expect(model.findAll).toHaveBeenCalledWith({
+        where: { isLitigator: true },
+      })
+      expect(result).toEqual([lawyer])
+    })
+  })
+
+  describe('findByNationalId', () => {
+    it('returns the lawyer with the given national id', async () => {
+      model.findOne.mockResolvedValueOnce(lawyer)
+
+      const result = await service.findByNationalId(lawyer.nationalId)
+
+      expect(model.findOne).toHaveBeenCalledWith({
+        where: { nationalId: lawyer.nationalId },
+      })
+      expect(result).toEqual(lawyer)
+    })
+
+    it('returns null when no lawyer matches', async () => {
+      model.findOne.mockResolvedValueOnce(null)
+
+      const result = await service.findByNationalId('9999999999')
+
+      expect(result).toBeNull()
+    })
+  })
+})

--- a/apps/judicial-system/backend/src/app/modules/repository/test/lawyerRegistryRepository.service.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/repository/test/lawyerRegistryRepository.service.spec.ts
@@ -22,6 +22,7 @@ describe('LawyerRegistryRepositoryService', () => {
   }
 
   let service: LawyerRegistryRepositoryService
+  let logger: { debug: jest.Mock; error: jest.Mock }
   let model: {
     destroy: jest.Mock
     bulkCreate: jest.Mock
@@ -30,6 +31,8 @@ describe('LawyerRegistryRepositoryService', () => {
   }
 
   beforeEach(async () => {
+    logger = { debug: jest.fn(), error: jest.fn() }
+
     model = {
       destroy: jest.fn().mockResolvedValue(0),
       bulkCreate: jest.fn().mockResolvedValue([]),
@@ -39,10 +42,7 @@ describe('LawyerRegistryRepositoryService', () => {
 
     const moduleRef = await Test.createTestingModule({
       providers: [
-        {
-          provide: LOGGER_PROVIDER,
-          useValue: { debug: jest.fn(), error: jest.fn() },
-        },
+        { provide: LOGGER_PROVIDER, useValue: logger },
         { provide: getModelToken(LawyerRegistry), useValue: model },
         LawyerRegistryRepositoryService,
       ],
@@ -126,6 +126,63 @@ describe('LawyerRegistryRepositoryService', () => {
       const result = await service.findByNationalId('9999999999')
 
       expect(result).toBeNull()
+    })
+  })
+
+  describe('error handling', () => {
+    const error = new Error('Some database error')
+
+    it('logs and rethrows when the delete fails', async () => {
+      model.destroy.mockRejectedValueOnce(error)
+
+      await expect(
+        service.replaceAll([lawyer], { transaction }),
+      ).rejects.toThrow(error)
+      expect(model.bulkCreate).not.toHaveBeenCalled()
+      expect(logger.error).toHaveBeenCalledWith(expect.any(String), { error })
+    })
+
+    it('logs and rethrows when the insert fails', async () => {
+      model.bulkCreate.mockRejectedValueOnce(error)
+
+      await expect(
+        service.replaceAll([lawyer], { transaction }),
+      ).rejects.toThrow(error)
+      expect(logger.error).toHaveBeenCalledWith(expect.any(String), { error })
+    })
+
+    it.each([
+      ['findAll', () => service.findAll()],
+      ['findAllLitigators', () => service.findAllLitigators()],
+    ])('logs and rethrows when %s fails', async (_name, call) => {
+      model.findAll.mockRejectedValueOnce(error)
+
+      await expect(call()).rejects.toThrow(error)
+      expect(logger.error).toHaveBeenCalledWith(expect.any(String), { error })
+    })
+
+    it('logs and rethrows when findByNationalId fails', async () => {
+      model.findOne.mockRejectedValueOnce(error)
+
+      await expect(service.findByNationalId(lawyer.nationalId)).rejects.toThrow(
+        error,
+      )
+      expect(logger.error).toHaveBeenCalledWith(expect.any(String), { error })
+    })
+
+    it('keeps national ids out of the logs', async () => {
+      model.findOne.mockRejectedValueOnce(error)
+
+      await expect(service.findByNationalId(lawyer.nationalId)).rejects.toThrow(
+        error,
+      )
+
+      const logged = [...logger.debug.mock.calls, ...logger.error.mock.calls]
+        .flat()
+        .map((argument) => JSON.stringify(argument))
+        .join(' ')
+
+      expect(logged).not.toContain(lawyer.nationalId)
     })
   })
 })


### PR DESCRIPTION
# Lawyer registry repository service

[Repository þjónusta fyrir LawyerRegistry](https://app.asana.com/1/203394141643832/project/1199153462262248/task/1217487846490244)

Migrates `LawyerRegistry` to the repository module. This is the first migration done
under the convention agreed for the rest of the effort, so it is meant to be the
reference the next slices are reviewed against.

## What changes

- **New `LawyerRegistryRepositoryService`** with methods named for the business
  operation rather than for Sequelize:
  - `replaceAll(lawyers, { transaction })` — the registry is replaced wholesale, so the
    delete-then-insert pair is one method instead of two verbs the caller has to
    sequence itself.
  - `findAll()` / `findAllLitigators()` — replaces the
    `WhereOptions | undefined` ternary that `getAll` used to build.
  - `findByNationalId(nationalId)` — returns `null` when nothing matches.
- `LawyerRegistry` is registered in `RepositoryModule.forFeature`, and the service is
  provided **and exported** there and re-exported from `repository/index.ts`.
- `LawyerRegistryService` injects the repository service instead of `@InjectModel`, and
  `lawyerRegistry.module.ts` drops its own `SequelizeModule.forFeature([LawyerRegistry])`
  in favour of importing `RepositoryModule`.
- `WhereOptions` is gone from the consumer — no Sequelize query object is composed
  outside `modules/repository/` for this model any more. `Transaction` stays for now;
  transaction ownership is a separate piece of work.

## What deliberately stays in the service

- The `plainToClass` + `validate` block and the `BadGatewayException` it throws. That is
  validation of a payload from the external lawyer registry API, i.e. business logic —
  the repository takes already-validated plain objects.
- `NotFoundException`. The repository returns `null` / `[]` and the service decides what
  is exceptional, matching `InstitutionContactRepositoryService`.

One small behaviour change falls out of that split: validation now runs *before* the
delete rather than between the delete and the insert. Both are inside the same
transaction so the end state is identical, but failing before wiping the table is the
better order.

## Testing

New `repository/test/lawyerRegistryRepository.service.spec.ts` (inline testing module
with a single model mock, following `institutionContactRepository.service.spec.ts`)
covering: `replaceAll` deletes before inserting and passes the transaction to both
calls; `findAllLitigators` filters on `isLitigator` while `findAll` does not;
`findByNationalId` returns `null` when absent.

There were no existing specs in `modules/lawyer-registry/`, and no testing module mocked
the `LawyerRegistry` model, so nothing needed rewriting or collapsing.

`yarn nx test judicial-system-backend` — 419 suites / 97,626 tests pass.
`yarn nx lint judicial-system-backend` — clean (the two remaining warnings are
pre-existing and unrelated).

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved lawyer registry data management and retrieval.
  * Added support for viewing all registered lawyers, litigators, and individual lawyer records by national ID.
  * Added transactional replacement of the complete lawyer registry for more consistent updates.

* **Bug Fixes**
  * Improved validation and consistency when updating lawyer registry records.

* **Tests**
  * Added comprehensive coverage for registry storage, filtering, replacement, error handling, and lookup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->