### PR TITLE
feat(j-s): Debounce merged case entries and require them before confirming

### DIFF
--- a/apps/judicial-system/backend/src/app/modules/court-session/courtSession.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/court-session/courtSession.service.ts
@@ -26,6 +26,7 @@ import {
   CaseAppealDecision,
   CaseFileCategory,
   CourtSessionRulingType,
+  CourtSessionStringType,
   EventType,
   IndictmentCaseNotificationType,
   type User as TUser,
@@ -221,6 +222,10 @@ export class CourtSessionService {
         ? normalizedUpdate.rulingFileId
         : existingCourtSession.rulingFileId
 
+    if (becomingConfirmed) {
+      this.validateMergedCaseEntriesComplete(existingCourtSession)
+    }
+
     if (
       becomingConfirmed &&
       effectiveRulingType === CourtSessionRulingType.ORDER &&
@@ -301,6 +306,31 @@ export class CourtSessionService {
     }
 
     return updatedCourtSession
+  }
+
+  // Each merged case with documents in a session gets its own entries booking
+  // in the court record, and each is required before the session can be
+  // confirmed. The set is derived from the filed documents rather than from the
+  // strings, so a merged case nobody has written about is missing rather than
+  // absent. Mirrors areMergedCaseEntriesComplete in the web client.
+  private validateMergedCaseEntriesComplete(courtSession: CourtSession): void {
+    const mergedCaseIds = new Set(
+      courtSession.mergedFiledDocuments?.map((document) => document.caseId),
+    )
+
+    for (const mergedCaseId of mergedCaseIds) {
+      const entries = courtSession.courtSessionStrings?.find(
+        (courtSessionString) =>
+          courtSessionString.mergedCaseId === mergedCaseId &&
+          courtSessionString.stringType === CourtSessionStringType.ENTRIES,
+      )
+
+      if (!entries?.value?.trim()) {
+        throw new BadRequestException(
+          `Merged case ${mergedCaseId} must have entries before the court session can be confirmed`,
+        )
+      }
+    }
   }
 
   // Every party (each defendant, each civil claimant and the prosecution) must

--- a/apps/judicial-system/backend/src/app/modules/court-session/test/courtSessionController/confirmMergedCaseEntries.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/court-session/test/courtSessionController/confirmMergedCaseEntries.spec.ts
@@ -1,0 +1,222 @@
+import { Transaction } from 'sequelize'
+import { v4 as uuid } from 'uuid'
+
+import { BadRequestException } from '@nestjs/common'
+
+import { CourtSessionStringType } from '@island.is/judicial-system/types'
+
+import { createTestingCourtSessionModule } from '../createTestingCourtSessionModule'
+
+import {
+  Case,
+  CourtDocument,
+  CourtSession,
+  CourtSessionRepositoryService,
+  CourtSessionString,
+} from '../../../repository'
+import { UpdateCourtSessionDto } from '../../dto/updateCourtSession.dto'
+
+jest.mock('@island.is/judicial-system/message', () => ({
+  ...jest.requireActual('@island.is/judicial-system/message'),
+  addMessagesToQueue: jest.fn(),
+}))
+
+interface Then {
+  result: CourtSession | null
+  error: Error
+}
+
+type GivenWhenThen = (
+  courtSessionToUpdate: UpdateCourtSessionDto,
+) => Promise<Then>
+
+// A merged case's entries are the court's record of why the cases were joined,
+// so a session cannot be confirmed while any of them is blank. The web client
+// disables the confirm button on the same rule; this is the server side of it.
+describe('CourtSessionController - Confirm with merged case entries', () => {
+  const caseId = uuid()
+  const courtSessionId = uuid()
+  const mergedCaseId = uuid()
+  const otherMergedCaseId = uuid()
+
+  let mockCourtSessionRepositoryService: CourtSessionRepositoryService
+  let givenWhenThen: GivenWhenThen
+
+  let existingCourtSession: {
+    id: string
+    isConfirmed: boolean | undefined
+    mergedFiledDocuments?: Partial<CourtDocument>[]
+    courtSessionStrings?: Partial<CourtSessionString>[]
+  }
+
+  const entries = (mergedCaseId: string, value: string) => ({
+    mergedCaseId,
+    value,
+    stringType: CourtSessionStringType.ENTRIES,
+  })
+
+  beforeEach(async () => {
+    const { sequelize, courtSessionRepositoryService, courtSessionController } =
+      await createTestingCourtSessionModule()
+
+    const mockTransaction = sequelize.transaction as jest.Mock
+    mockTransaction.mockImplementationOnce(
+      (fn: (transaction: Transaction) => unknown) => fn({} as Transaction),
+    )
+
+    mockCourtSessionRepositoryService = courtSessionRepositoryService
+    const mockUpdate = mockCourtSessionRepositoryService.update as jest.Mock
+    mockUpdate.mockResolvedValue({ id: courtSessionId, caseId })
+
+    existingCourtSession = { id: courtSessionId, isConfirmed: false }
+
+    givenWhenThen = async (courtSessionToUpdate: UpdateCourtSessionDto) => {
+      const then = {} as Then
+      const theCase = { id: caseId, caseFiles: [] } as unknown as Case
+
+      try {
+        then.result = await courtSessionController.update(
+          caseId,
+          courtSessionId,
+          courtSessionToUpdate,
+          {} as never,
+          theCase,
+          existingCourtSession as unknown as CourtSession,
+        )
+      } catch (error) {
+        then.error = error as Error
+      }
+
+      return then
+    }
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('a merged case with no entries at all', () => {
+    let then: Then
+
+    beforeEach(async () => {
+      existingCourtSession.mergedFiledDocuments = [{ caseId: mergedCaseId }]
+
+      then = await givenWhenThen({ isConfirmed: true })
+    })
+
+    it('should reject the confirmation', () => {
+      expect(then.error).toBeInstanceOf(BadRequestException)
+      expect(then.error.message).toBe(
+        `Merged case ${mergedCaseId} must have entries before the court session can be confirmed`,
+      )
+    })
+
+    it('should not write the court session', () => {
+      expect(mockCourtSessionRepositoryService.update).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('a merged case with blank entries', () => {
+    let then: Then
+
+    beforeEach(async () => {
+      existingCourtSession.mergedFiledDocuments = [{ caseId: mergedCaseId }]
+      existingCourtSession.courtSessionStrings = [entries(mergedCaseId, '   ')]
+
+      then = await givenWhenThen({ isConfirmed: true })
+    })
+
+    it('should reject the confirmation', () => {
+      expect(then.error).toBeInstanceOf(BadRequestException)
+    })
+  })
+
+  describe('one of two merged cases missing entries', () => {
+    let then: Then
+
+    beforeEach(async () => {
+      existingCourtSession.mergedFiledDocuments = [
+        { caseId: mergedCaseId },
+        { caseId: otherMergedCaseId },
+      ]
+      existingCourtSession.courtSessionStrings = [
+        entries(mergedCaseId, 'Málin sameinuð'),
+      ]
+
+      then = await givenWhenThen({ isConfirmed: true })
+    })
+
+    it('should reject the confirmation naming the missing case', () => {
+      expect(then.error).toBeInstanceOf(BadRequestException)
+      expect(then.error.message).toBe(
+        `Merged case ${otherMergedCaseId} must have entries before the court session can be confirmed`,
+      )
+    })
+  })
+
+  describe('every merged case has entries', () => {
+    let then: Then
+
+    beforeEach(async () => {
+      existingCourtSession.mergedFiledDocuments = [
+        { caseId: mergedCaseId },
+        { caseId: otherMergedCaseId },
+      ]
+      existingCourtSession.courtSessionStrings = [
+        entries(mergedCaseId, 'Málin sameinuð'),
+        entries(otherMergedCaseId, 'Málin sameinuð'),
+      ]
+
+      then = await givenWhenThen({ isConfirmed: true })
+    })
+
+    it('should confirm the court session', () => {
+      expect(then.error).toBeUndefined()
+      expect(mockCourtSessionRepositoryService.update).toHaveBeenCalled()
+    })
+  })
+
+  describe('a session with no merged documents', () => {
+    let then: Then
+
+    beforeEach(async () => {
+      then = await givenWhenThen({ isConfirmed: true })
+    })
+
+    it('should confirm the court session', () => {
+      expect(then.error).toBeUndefined()
+      expect(mockCourtSessionRepositoryService.update).toHaveBeenCalled()
+    })
+  })
+
+  describe('an update that does not confirm', () => {
+    let then: Then
+
+    beforeEach(async () => {
+      existingCourtSession.mergedFiledDocuments = [{ caseId: mergedCaseId }]
+
+      then = await givenWhenThen({ location: 'Updated Location' })
+    })
+
+    it('should not be blocked by missing entries', () => {
+      expect(then.error).toBeUndefined()
+      expect(mockCourtSessionRepositoryService.update).toHaveBeenCalled()
+    })
+  })
+
+  describe('a session that is already confirmed', () => {
+    let then: Then
+
+    beforeEach(async () => {
+      existingCourtSession.isConfirmed = true
+      existingCourtSession.mergedFiledDocuments = [{ caseId: mergedCaseId }]
+
+      then = await givenWhenThen({ isConfirmed: true })
+    })
+
+    it('should not re-run the check', () => {
+      expect(then.error).toBeUndefined()
+      expect(mockCourtSessionRepositoryService.update).toHaveBeenCalled()
+    })
+  })
+})

--- a/apps/judicial-system/web/src/routes/Court/Indictments/CourtRecord/CourtSessionAccordionItem.tsx
+++ b/apps/judicial-system/web/src/routes/Court/Indictments/CourtRecord/CourtSessionAccordionItem.tsx
@@ -259,39 +259,46 @@ const CourtSessionAccordionItem: FC<Props> = (props) => {
       updatedCourtSessionString: Pick<CourtSessionString, 'value'>,
       { persist = false } = {},
     ) => {
-      const targetCourtSessionString = courtSession.courtSessionStrings?.find(
-        (courtSessionString) =>
-          courtSessionString.courtSessionId === courtSessionId &&
-          courtSessionString.mergedCaseId === mergedCaseId &&
-          courtSessionString.stringType === CourtSessionStringType.ENTRIES,
-      )
-
-      const updatedCourtSessionsStrings = targetCourtSessionString
-        ? courtSession.courtSessionStrings?.map((courtSessionString) =>
-            courtSessionString.id === targetCourtSessionString?.id
-              ? {
-                  ...courtSessionString,
-                  value: updatedCourtSessionString.value,
-                }
-              : courtSessionString,
-          )
-        : [
-            ...(courtSession.courtSessionStrings ?? []),
-            {
-              caseId: workingCase.id,
-              courtSessionId,
-              mergedCaseId,
-              stringType: CourtSessionStringType.ENTRIES,
-              value: updatedCourtSessionString.value,
-            } as CourtSessionString,
-          ]
+      // The strings are read off `prev` rather than the render this call was
+      // created in. A debounced save fires up to `delay` after the keystroke
+      // that scheduled it, so a closed-over array can be stale by then - and
+      // rebuilding from it would revert an edit made to a sibling merged case
+      // in the meantime.
       setWorkingCase((prev) => ({
         ...prev,
-        courtSessions: prev.courtSessions?.map((session) =>
-          session.id === courtSessionId
-            ? { ...session, courtSessionStrings: updatedCourtSessionsStrings }
-            : session,
-        ),
+        courtSessions: prev.courtSessions?.map((session) => {
+          if (session.id !== courtSessionId) {
+            return session
+          }
+
+          const targetCourtSessionString = session.courtSessionStrings?.find(
+            (courtSessionString) =>
+              courtSessionString.mergedCaseId === mergedCaseId &&
+              courtSessionString.stringType === CourtSessionStringType.ENTRIES,
+          )
+
+          const courtSessionStrings = targetCourtSessionString
+            ? session.courtSessionStrings?.map((courtSessionString) =>
+                courtSessionString.id === targetCourtSessionString.id
+                  ? {
+                      ...courtSessionString,
+                      value: updatedCourtSessionString.value,
+                    }
+                  : courtSessionString,
+              )
+            : [
+                ...(session.courtSessionStrings ?? []),
+                {
+                  caseId: workingCase.id,
+                  courtSessionId,
+                  mergedCaseId,
+                  stringType: CourtSessionStringType.ENTRIES,
+                  value: updatedCourtSessionString.value,
+                } as CourtSessionString,
+              ]
+
+          return { ...session, courtSessionStrings }
+        }),
       }))
 
       if (persist) {
@@ -304,12 +311,7 @@ const CourtSessionAccordionItem: FC<Props> = (props) => {
         })
       }
     },
-    [
-      courtSession.courtSessionStrings,
-      setWorkingCase,
-      updateCourtSessionString,
-      workingCase.id,
-    ],
+    [setWorkingCase, updateCourtSessionString, workingCase.id],
   )
 
   const getInitialAttendees = useCallback(() => {
@@ -1329,7 +1331,11 @@ const CourtSessionAccordionItem: FC<Props> = (props) => {
                     )
 
                   return (
-                    <Box key={`merged-case-${courtCaseNumber}`}>
+                    // Keyed by merged case id, not court case number: the
+                    // number falls back to an empty string, so two unnumbered
+                    // merged cases would collide and React would hand one
+                    // row's debounced entries to the other.
+                    <Box key={`merged-case-${mergeDocumentsPerCase.caseId}`}>
                       <CourtSessionMergedCaseEntries
                         courtSessionId={courtSession.id}
                         courtCaseNumber={courtCaseNumber ?? ''}

--- a/apps/judicial-system/web/src/routes/Court/Indictments/CourtRecord/CourtSessionMergedCaseEntries.spec.tsx
+++ b/apps/judicial-system/web/src/routes/Court/Indictments/CourtRecord/CourtSessionMergedCaseEntries.spec.tsx
@@ -1,0 +1,144 @@
+import { act, fireEvent, render, screen } from '@testing-library/react'
+
+import { CourtSessionString } from '@island.is/judicial-system-web/src/graphql/schema'
+import { IntlProviderWrapper } from '@island.is/judicial-system-web/src/utils/testHelpers'
+
+import { CourtSessionMergedCaseEntries } from './CourtSessionMergedCaseEntries'
+
+const DELAY = 500
+const COURT_SESSION_ID = 'court-session-1'
+const MERGED_CASE_ID = 'merged-case-1'
+
+describe('CourtSessionMergedCaseEntries', () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  const advance = (ms: number) => act(() => jest.advanceTimersByTime(ms))
+
+  const renderEntries = (value?: string) => {
+    const patchCourtSessionStrings = jest.fn()
+
+    const view = render(
+      <IntlProviderWrapper>
+        <CourtSessionMergedCaseEntries
+          courtSessionId={COURT_SESSION_ID}
+          courtCaseNumber="S-1/2025"
+          courtSessionString={
+            value === undefined ? undefined : ({ value } as CourtSessionString)
+          }
+          mergedCaseId={MERGED_CASE_ID}
+          disabled={false}
+          patchCourtSessionStrings={patchCourtSessionStrings}
+        />
+      </IntlProviderWrapper>,
+    )
+
+    return { patchCourtSessionStrings, view }
+  }
+
+  const persistedCalls = (patchCourtSessionStrings: jest.Mock) =>
+    patchCourtSessionStrings.mock.calls.filter(
+      ([, , , options]) => options?.persist,
+    )
+
+  const entriesInput = () =>
+    screen.getByRole('textbox', {
+      name: /Bókanir um sameiningu máls/,
+    })
+
+  it('should write optimistically on every keystroke but persist once', () => {
+    const { patchCourtSessionStrings } = renderEntries('')
+
+    fireEvent.change(entriesInput(), { target: { value: 'Málin sameinuð' } })
+
+    expect(patchCourtSessionStrings).toHaveBeenCalledWith(
+      COURT_SESSION_ID,
+      MERGED_CASE_ID,
+      { value: 'Málin sameinuð' },
+    )
+    expect(persistedCalls(patchCourtSessionStrings)).toHaveLength(0)
+
+    advance(DELAY)
+
+    expect(persistedCalls(patchCourtSessionStrings)).toEqual([
+      [
+        COURT_SESSION_ID,
+        MERGED_CASE_ID,
+        { value: 'Málin sameinuð' },
+        { persist: true },
+      ],
+    ])
+  })
+
+  it('should persist immediately on blur', () => {
+    const { patchCourtSessionStrings } = renderEntries('')
+    const input = entriesInput()
+
+    fireEvent.change(input, { target: { value: 'Málin sameinuð' } })
+    fireEvent.blur(input)
+
+    expect(persistedCalls(patchCourtSessionStrings)).toHaveLength(1)
+  })
+
+  it('should not persist on a blur that follows no edit', () => {
+    const { patchCourtSessionStrings } = renderEntries('Málin sameinuð')
+
+    fireEvent.blur(entriesInput())
+
+    expect(patchCourtSessionStrings).not.toHaveBeenCalled()
+  })
+
+  it('should flush a pending edit on unmount', () => {
+    const { patchCourtSessionStrings, view } = renderEntries('')
+
+    fireEvent.change(entriesInput(), { target: { value: 'Málin sameinuð' } })
+    view.unmount()
+
+    expect(persistedCalls(patchCourtSessionStrings)).toEqual([
+      [
+        COURT_SESSION_ID,
+        MERGED_CASE_ID,
+        { value: 'Málin sameinuð' },
+        { persist: true },
+      ],
+    ])
+  })
+
+  it('should not persist an empty value, since the entries are required', () => {
+    const { patchCourtSessionStrings } = renderEntries('Málin sameinuð')
+    const input = entriesInput()
+
+    fireEvent.change(input, { target: { value: '' } })
+    advance(DELAY)
+    fireEvent.blur(input)
+
+    expect(persistedCalls(patchCourtSessionStrings)).toHaveLength(0)
+    expect(screen.getByText('Reitur má ekki vera tómur')).toBeTruthy()
+  })
+
+  it('should adopt a value that arrives after mount', () => {
+    const { view } = renderEntries(undefined)
+
+    expect(entriesInput()).toHaveValue('')
+
+    view.rerender(
+      <IntlProviderWrapper>
+        <CourtSessionMergedCaseEntries
+          courtSessionId={COURT_SESSION_ID}
+          courtCaseNumber="S-1/2025"
+          courtSessionString={{ value: 'Málin sameinuð' } as CourtSessionString}
+          mergedCaseId={MERGED_CASE_ID}
+          disabled={false}
+          patchCourtSessionStrings={jest.fn()}
+        />
+      </IntlProviderWrapper>,
+    )
+
+    expect(entriesInput()).toHaveValue('Málin sameinuð')
+  })
+})

--- a/apps/judicial-system/web/src/routes/Court/Indictments/CourtRecord/CourtSessionMergedCaseEntries.tsx
+++ b/apps/judicial-system/web/src/routes/Court/Indictments/CourtRecord/CourtSessionMergedCaseEntries.tsx
@@ -1,9 +1,7 @@
-import { useState } from 'react'
-
 import { Box, Input } from '@island.is/island-ui/core'
 import { SectionHeading } from '@island.is/judicial-system-web/src/components'
 import { CourtSessionString } from '@island.is/judicial-system-web/src/graphql/schema'
-import { validateAndSetErrorMessage } from '@island.is/judicial-system-web/src/utils/formHelper'
+import { useDebouncedField } from '@island.is/judicial-system-web/src/utils/hooks'
 
 export const CourtSessionMergedCaseEntries = ({
   courtSessionId,
@@ -29,8 +27,21 @@ export const CourtSessionMergedCaseEntries = ({
     },
   ) => void
 }) => {
-  const [mergedEntriesErrorMessage, setMergedEntriesErrorMessage] =
-    useState<string>('')
+  // One instance per merged case, so the caller keys the row by merged case id
+  // - otherwise a removed or reordered row would inherit this edit.
+  const entriesField = useDebouncedField({
+    value: courtSessionString?.value,
+    validations: ['empty'],
+    onChange: (value) =>
+      patchCourtSessionStrings(courtSessionId, mergedCaseId, { value }),
+    onSave: (value) =>
+      patchCourtSessionStrings(
+        courtSessionId,
+        mergedCaseId,
+        { value },
+        { persist: true },
+      ),
+  })
 
   return (
     <Box paddingBottom={3}>
@@ -38,43 +49,12 @@ export const CourtSessionMergedCaseEntries = ({
       <Input
         name="merged-case-entries"
         label={`Bókanir um sameiningu máls ${courtCaseNumber}`}
-        value={courtSessionString?.value ?? ''}
+        value={entriesField.value}
         placeholder="Hér er hægt að bóka um sameiningu máls"
-        onChange={(event) => {
-          setMergedEntriesErrorMessage('')
-
-          const updatedValue = event.target.value
-          const updatedCaseSessionString = {
-            value: updatedValue,
-          }
-
-          patchCourtSessionStrings(
-            courtSessionId,
-            mergedCaseId,
-            updatedCaseSessionString,
-          )
-        }}
-        onBlur={(event) => {
-          const updatedValue = event.target.value
-          validateAndSetErrorMessage(
-            ['empty'],
-            updatedValue,
-            setMergedEntriesErrorMessage,
-          )
-
-          const updatedCaseSessionString = {
-            value: updatedValue,
-          }
-
-          patchCourtSessionStrings(
-            courtSessionId,
-            mergedCaseId,
-            updatedCaseSessionString,
-            { persist: true },
-          )
-        }}
-        hasError={mergedEntriesErrorMessage !== ''}
-        errorMessage={mergedEntriesErrorMessage}
+        onChange={(event) => entriesField.onChange(event.target.value)}
+        onBlur={(event) => entriesField.onBlur(event.target.value)}
+        hasError={entriesField.hasError}
+        errorMessage={entriesField.errorMessage}
         rows={15}
         disabled={disabled}
         textarea

--- a/apps/judicial-system/web/src/utils/areMergedCaseEntriesComplete.spec.ts
+++ b/apps/judicial-system/web/src/utils/areMergedCaseEntriesComplete.spec.ts
@@ -1,0 +1,84 @@
+import {
+  CourtDocumentResponse,
+  CourtSessionResponse,
+  CourtSessionString,
+  CourtSessionStringType,
+} from '@island.is/judicial-system-web/src/graphql/schema'
+
+import { areMergedCaseEntriesComplete } from './validate'
+
+describe('areMergedCaseEntriesComplete', () => {
+  const document = (caseId: string) => ({ caseId } as CourtDocumentResponse)
+
+  const entries = (mergedCaseId: string, value: string) =>
+    ({
+      mergedCaseId,
+      value,
+      stringType: CourtSessionStringType.ENTRIES,
+    } as CourtSessionString)
+
+  const session = (
+    mergedFiledDocuments?: CourtDocumentResponse[],
+    courtSessionStrings?: CourtSessionString[],
+  ) => ({ mergedFiledDocuments, courtSessionStrings } as CourtSessionResponse)
+
+  it('should be complete when the session has no merged documents', () => {
+    expect(areMergedCaseEntriesComplete(session())).toBe(true)
+    expect(areMergedCaseEntriesComplete(session([]))).toBe(true)
+  })
+
+  it('should be incomplete when a merged case has no entries at all', () => {
+    expect(areMergedCaseEntriesComplete(session([document('case-1')]))).toBe(
+      false,
+    )
+  })
+
+  it('should be incomplete when a merged case has empty entries', () => {
+    expect(
+      areMergedCaseEntriesComplete(
+        session([document('case-1')], [entries('case-1', '')]),
+      ),
+    ).toBe(false)
+  })
+
+  it('should be complete when every merged case has entries', () => {
+    expect(
+      areMergedCaseEntriesComplete(
+        session(
+          [document('case-1'), document('case-2')],
+          [entries('case-1', 'Sameinað'), entries('case-2', 'Sameinað')],
+        ),
+      ),
+    ).toBe(true)
+  })
+
+  it('should be incomplete when only one of two merged cases has entries', () => {
+    expect(
+      areMergedCaseEntriesComplete(
+        session(
+          [document('case-1'), document('case-2')],
+          [entries('case-1', 'Sameinað')],
+        ),
+      ),
+    ).toBe(false)
+  })
+
+  it('should count a merged case once however many documents it has', () => {
+    expect(
+      areMergedCaseEntriesComplete(
+        session(
+          [document('case-1'), document('case-1'), document('case-1')],
+          [entries('case-1', 'Sameinað')],
+        ),
+      ),
+    ).toBe(true)
+  })
+
+  it('should ignore entries belonging to another merged case', () => {
+    expect(
+      areMergedCaseEntriesComplete(
+        session([document('case-1')], [entries('case-2', 'Sameinað')]),
+      ),
+    ).toBe(false)
+  })
+})

--- a/apps/judicial-system/web/src/utils/validate.ts
+++ b/apps/judicial-system/web/src/utils/validate.ts
@@ -14,6 +14,7 @@ import {
   CaseType,
   CourtSessionResponse,
   CourtSessionRulingType,
+  CourtSessionStringType,
   DateLog,
   Defendant,
   DefenderChoice,
@@ -685,6 +686,7 @@ export const isCourtSessionValid = (
     (courtSession.isAttestingWitness
       ? courtSession.attestingWitnessId
       : true) &&
+    areMergedCaseEntriesComplete(courtSession) &&
     validate([
       [courtSession.startDate, ['empty', 'date-format']],
       [courtSession.location, ['empty']],
@@ -693,6 +695,32 @@ export const isCourtSessionValid = (
       [courtSession.rulingType, ['empty']],
       [courtSession.endDate, ['empty', 'date-format']],
     ]).isValid
+  )
+}
+
+// Each merged case with documents in a session gets its own entries booking in
+// the court record, and each is required. The set is derived from the filed
+// documents rather than from the strings, so a merged case that has never been
+// written about is missing rather than absent.
+export const areMergedCaseEntriesComplete = (
+  courtSession: CourtSessionResponse,
+): boolean => {
+  const mergedCaseIds = new Set(
+    courtSession.mergedFiledDocuments?.map((document) => document.caseId),
+  )
+
+  return Array.from(mergedCaseIds).every(
+    (mergedCaseId) =>
+      validate([
+        [
+          courtSession.courtSessionStrings?.find(
+            (courtSessionString) =>
+              courtSessionString.mergedCaseId === mergedCaseId &&
+              courtSessionString.stringType === CourtSessionStringType.ENTRIES,
+          )?.value,
+          ['empty'],
+        ],
+      ]).isValid,
   )
 }
 


### PR DESCRIPTION
# Merged case entries: debounced, and actually required

Stacked on #23363, which is itself stacked on #23338 — **base is `js/debounce-court-session-fields`, not `main`.** Review the two below it first. The base moves down a level each time one of them merges.

Two commits, two separate stories. The second came out of manually testing the first.

## 1. Debounce the field (`713faea48c3`)

*Bókanir um sameiningu máls* ([CourtSessionMergedCaseEntries](apps/judicial-system/web/src/routes/Court/Indictments/CourtRecord/CourtSessionMergedCaseEntries.tsx), textarea rows=15) moves onto `useDebouncedField` — the last textarea on the indictment court record page still saving on every blur, so the page is now done. Same bug as #23338: an edit made within 500 ms of navigating away was dropped, and the optimistic value went with it on the next route change.

The field was missed by the original survey, filed alongside the TinyMCE *Bókanir* field, which genuinely is out of scope. This one is a plain `Input`.

### Two prerequisites in `CourtSessionAccordionItem`

Neither is reachable on `main` — one needs the debounce, the other needs a hook holding local state — so these are prerequisites, not drive-by fixes. Both would have surfaced later as intermittent, hard-to-attribute bugs.

**`patchCourtSessionStrings` rebuilt from a stale closure.** It computed the new `courtSessionStrings` array from the props value *outside* `setWorkingCase`. Correct for a handler recreated every render and run on blur; wrong once a save can fire 500 ms after the keystroke that scheduled it. With two merged cases in one session, editing A then B inside that window would have had A's save write back an array still holding B's old text. Now derived from `prev` inside the updater.

**The row key could collide.** Rows were keyed `merged-case-${courtCaseNumber}`, which falls back to `''`, so two unnumbered merged cases produced identical keys and React would show one row's debounced text in the other. Now keyed by `mergeDocumentsPerCase.caseId`.

## 2. Require the entries before confirming (`891febd83c6`)

The field was already marked `required`, but nothing enforced it. `isCourtSessionValid` never read `courtSessionStrings`, so **Staðfesta þingbók** stayed enabled with the booking empty — and the server accepted the confirmation. The required star was decorative.

That mattered more once the field was debounced, because a debounced required field doesn't persist an empty value: clearing it left the old text on the server, the field showing empty, and the confirm button happily enabled. Making the rule real resolves that inconsistency.

- **Client** — `areMergedCaseEntriesComplete` in [validate.ts](apps/judicial-system/web/src/utils/validate.ts), wired into `isCourtSessionValid`, so the button disables while any booking is blank.
- **Server** — `validateMergedCaseEntriesComplete` in [courtSession.service.ts](apps/judicial-system/backend/src/app/modules/court-session/courtSession.service.ts), a pre-check on the becoming-confirmed transition that throws `BadRequestException` before anything is written. It sits ahead of the ORDER-specific appeal-decision block because this rule applies to every session type.

Both derive the required set from the session's **filed documents**, not from the strings — one entry per distinct `caseId` with documents in the session, exactly the set the court record renders a field for. Deriving from the strings would let a merged case nobody has written about count as satisfied, since there would be no row to check. Both associations are already eager-loaded via `caseInclude`, so the server check costs no extra query.

Keying off the transition rather than the state means editing a field on a session with incomplete entries still works, and correcting an already-confirmed session is not retroactively blocked.

**Note on existing data:** sessions with merged documents whose bookings were never filled in can no longer be confirmed until someone writes one. That is the intent of the rule and has been accepted.

## Tests

- `CourtSessionMergedCaseEntries.spec.tsx` — 6: one persist per burst, blur persisting immediately, an untouched blur persisting nothing, unmount flush, a cleared required field not persisting, a value arriving after mount still adopted.
- `areMergedCaseEntriesComplete.spec.ts` — 7: no merged documents, no row at all, an empty row, two complete, one of two, one case with several documents counted once, a row belonging to another merged case not counting.
- `confirmMergedCaseEntries.spec.ts` — 8: missing, blank and whitespace entries rejected; the error naming the right case when one of two is missing; all present confirming; no merged documents confirming; a non-confirming update not blocked; an already-confirmed session not re-checked.

Full suites green — web **651 / 84**, backend **97,623 / 418**.

## Screenshots / Gifs

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code