### PR TITLE
fix(j-s): Skip case-completed email for dismissed defendant defenders

### DIFF
--- a/apps/judicial-system/backend/src/app/modules/notification/services/caseNotification/caseNotification.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/services/caseNotification/caseNotification.service.ts
@@ -1264,10 +1264,19 @@ export class CaseNotificationService extends BaseNotificationService {
     const promises = [this.sendRulingEmailNotificationToProsecutor(theCase)]
 
     if (isIndictmentCase(theCase.type)) {
-      // DEFENDANTS
+      // DEFENDANTS — skip defenders of defendants whose indictment was
+      // already cancelled or dismissed while the case continued for others
       const uniqueDefendants = _uniqBy(
         theCase.defendants?.filter(
-          ({ isDefenderChoiceConfirmed }) => isDefenderChoiceConfirmed,
+          (defendant) =>
+            defendant.isDefenderChoiceConfirmed &&
+            !DefendantEventLog.getEventLogByEventType(
+              [
+                DefendantEventType.INDICTMENT_CANCELLED,
+                DefendantEventType.INDICTMENT_DISMISSED,
+              ],
+              defendant.eventLogs,
+            ),
         ) ?? [],
         ({ defenderEmail }) => defenderEmail,
       )

--- a/apps/judicial-system/backend/src/app/modules/notification/test/internalNotificationController/sendRulingNotifications.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/test/internalNotificationController/sendRulingNotifications.spec.ts
@@ -152,81 +152,87 @@ describe('InternalNotificationController - Send ruling notifications', () => {
     })
   })
 
-  describe('email to defenders when one defendant was previously dismissed', () => {
-    const caseId = uuid()
-    const prosecutor = {
-      name: testProsecutor.name,
-      email: testProsecutor.email,
-    }
-    const dismissedDefendantDefender = {
-      name: 'Verjandi A',
-      email: 'defender-a@omnitrix.is',
-    }
-    const remainingDefendantDefender = {
-      name: 'Verjandi B',
-      email: 'defender-b@omnitrix.is',
-    }
-    const theCase = {
-      id: caseId,
-      type: CaseType.INDICTMENT,
-      courtCaseNumber: '007-2022-07',
-      court: { name: 'Héraðsdómur Reykjavíkur' },
-      indictmentRulingDecision: CaseIndictmentRulingDecision.RULING,
-      prosecutor,
-      defendants: [
-        {
-          isDefenderChoiceConfirmed: true,
-          defenderName: dismissedDefendantDefender.name,
-          defenderEmail: dismissedDefendantDefender.email,
-          eventLogs: [
-            {
-              eventType: DefendantEventType.INDICTMENT_CANCELLED,
-              created: new Date('2026-02-20T12:00:00.000Z'),
-            },
-          ],
-        },
-        {
-          isDefenderChoiceConfirmed: true,
-          defenderName: remainingDefendantDefender.name,
-          defenderEmail: remainingDefendantDefender.email,
-          eventLogs: [],
-        },
-      ],
-    } as Case
+  describe.each([
+    DefendantEventType.INDICTMENT_CANCELLED,
+    DefendantEventType.INDICTMENT_DISMISSED,
+  ])(
+    'email to defenders when one defendant was previously concluded (%s)',
+    (concludedEventType) => {
+      const caseId = uuid()
+      const prosecutor = {
+        name: testProsecutor.name,
+        email: testProsecutor.email,
+      }
+      const concludedDefendantDefender = {
+        name: 'Verjandi A',
+        email: 'defender-a@omnitrix.is',
+      }
+      const remainingDefendantDefender = {
+        name: 'Verjandi B',
+        email: 'defender-b@omnitrix.is',
+      }
+      const theCase = {
+        id: caseId,
+        type: CaseType.INDICTMENT,
+        courtCaseNumber: '007-2022-07',
+        court: { name: 'Héraðsdómur Reykjavíkur' },
+        indictmentRulingDecision: CaseIndictmentRulingDecision.RULING,
+        prosecutor,
+        defendants: [
+          {
+            isDefenderChoiceConfirmed: true,
+            defenderName: concludedDefendantDefender.name,
+            defenderEmail: concludedDefendantDefender.email,
+            eventLogs: [
+              {
+                eventType: concludedEventType,
+                created: new Date('2026-02-20T12:00:00.000Z'),
+              },
+            ],
+          },
+          {
+            isDefenderChoiceConfirmed: true,
+            defenderName: remainingDefendantDefender.name,
+            defenderEmail: remainingDefendantDefender.email,
+            eventLogs: [],
+          },
+        ],
+      } as Case
 
-    beforeEach(async () => {
-      await givenWhenThen(caseId, theCase, notificationDto)
-    })
+      beforeEach(async () => {
+        await givenWhenThen(caseId, theCase, notificationDto)
+      })
 
-    it('should notify the remaining defendant defender but not the dismissed defendant defender', () => {
-      expect(mockEmailService.sendEmail).toHaveBeenCalledTimes(2)
-      expect(mockEmailService.sendEmail).toHaveBeenCalledWith(
-        expect.objectContaining({
-          to: [{ name: prosecutor.name, address: prosecutor.email }],
-        }),
-      )
-      expect(mockEmailService.sendEmail).toHaveBeenCalledWith(
-        expect.objectContaining({
-          to: [
-            {
-              name: remainingDefendantDefender.name,
-              address: remainingDefendantDefender.email,
-            },
-          ],
-        }),
-      )
-      expect(mockEmailService.sendEmail).not.toHaveBeenCalledWith(
-        expect.objectContaining({
-          to: [
-            {
-              name: dismissedDefendantDefender.name,
-              address: dismissedDefendantDefender.email,
-            },
-          ],
-        }),
-      )
-    })
-  })
+      it('should notify the remaining defendant defender but not the concluded defendant defender', () => {
+        expect(mockEmailService.sendEmail).toHaveBeenCalledTimes(2)
+        expect(mockEmailService.sendEmail).toHaveBeenCalledWith(
+          expect.objectContaining({
+            to: [{ name: prosecutor.name, address: prosecutor.email }],
+          }),
+        )
+        expect(mockEmailService.sendEmail).toHaveBeenCalledWith(
+          expect.objectContaining({
+            to: [
+              {
+                name: remainingDefendantDefender.name,
+                address: remainingDefendantDefender.email,
+              },
+            ],
+          }),
+        )
+        expect(mockEmailService.sendEmail).not.toHaveBeenCalledWith(
+          expect.objectContaining({
+            to: [
+              {
+                name: concludedDefendantDefender.name,
+                address: concludedDefendantDefender.email,
+              },
+            ],
+          }),
+        )
+      })
+    },
+  )
 
   describe('email to prosecutor for restriction case', () => {
     const caseId = uuid()

--- a/apps/judicial-system/backend/src/app/modules/notification/test/internalNotificationController/sendRulingNotifications.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/test/internalNotificationController/sendRulingNotifications.spec.ts
@@ -12,6 +12,7 @@ import {
   CaseIndictmentRulingDecision,
   CaseState,
   CaseType,
+  DefendantEventType,
   RequestCaseNotificationType,
   User,
 } from '@island.is/judicial-system/types'
@@ -146,6 +147,82 @@ describe('InternalNotificationController - Send ruling notifications', () => {
           to: [{ name: prosecutor.name, address: prosecutor.email }],
           subject: 'Máli lokið 007-2022-07',
           html: `Máli 007-2022-07 hjá Héraðsdómi Reykjavíkur hefur verið lokið.<br /><br />Niðurstaða: Frávísun<br /><br />Skjöl málsins eru aðgengileg á ${expectedLink}yfirlitssíðu málsins í Réttarvörslugátt</a>.<br /><br />Hægt er að kæra úrskurðinn og senda greinargerðir og gögn í gegnum Réttarvörslugátt ef við á.`,
+        }),
+      )
+    })
+  })
+
+  describe('email to defenders when one defendant was previously dismissed', () => {
+    const caseId = uuid()
+    const prosecutor = {
+      name: testProsecutor.name,
+      email: testProsecutor.email,
+    }
+    const dismissedDefendantDefender = {
+      name: 'Verjandi A',
+      email: 'defender-a@omnitrix.is',
+    }
+    const remainingDefendantDefender = {
+      name: 'Verjandi B',
+      email: 'defender-b@omnitrix.is',
+    }
+    const theCase = {
+      id: caseId,
+      type: CaseType.INDICTMENT,
+      courtCaseNumber: '007-2022-07',
+      court: { name: 'Héraðsdómur Reykjavíkur' },
+      indictmentRulingDecision: CaseIndictmentRulingDecision.RULING,
+      prosecutor,
+      defendants: [
+        {
+          isDefenderChoiceConfirmed: true,
+          defenderName: dismissedDefendantDefender.name,
+          defenderEmail: dismissedDefendantDefender.email,
+          eventLogs: [
+            {
+              eventType: DefendantEventType.INDICTMENT_CANCELLED,
+              created: new Date('2026-02-20T12:00:00.000Z'),
+            },
+          ],
+        },
+        {
+          isDefenderChoiceConfirmed: true,
+          defenderName: remainingDefendantDefender.name,
+          defenderEmail: remainingDefendantDefender.email,
+          eventLogs: [],
+        },
+      ],
+    } as Case
+
+    beforeEach(async () => {
+      await givenWhenThen(caseId, theCase, notificationDto)
+    })
+
+    it('should notify the remaining defendant defender but not the dismissed defendant defender', () => {
+      expect(mockEmailService.sendEmail).toHaveBeenCalledTimes(2)
+      expect(mockEmailService.sendEmail).toHaveBeenCalledWith(
+        expect.objectContaining({
+          to: [{ name: prosecutor.name, address: prosecutor.email }],
+        }),
+      )
+      expect(mockEmailService.sendEmail).toHaveBeenCalledWith(
+        expect.objectContaining({
+          to: [
+            {
+              name: remainingDefendantDefender.name,
+              address: remainingDefendantDefender.email,
+            },
+          ],
+        }),
+      )
+      expect(mockEmailService.sendEmail).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          to: [
+            {
+              name: dismissedDefendantDefender.name,
+              address: dismissedDefendantDefender.email,
+            },
+          ],
         }),
       )
     })


### PR DESCRIPTION
[Verjandi fær tilkynningu sem hann á ekki að fá](https://app.asana.com/1/203394141643832/project/1199153462262248/task/1216234302245291)

## What

When an indictment case is completed, skip the case-completed email for defenders of defendants whose indictment was already cancelled or dismissed (via defendant event log). Other parties (prosecutor, remaining defendants' defenders, civil claimant spokespersons) are unchanged.

## Why

If defendant A was dismissed earlier and the case later finishes with a judgment for defendant B, A's defender was incorrectly receiving the case-completed notification. They should only have been notified when A's indictment was concluded.

## Screenshots / Gifs

N/A

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Cursor


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Indictment ruling notifications are no longer sent to defenders whose defendants’ cases were cancelled or dismissed.
  - Confirmed defenders for other defendants and prosecutors continue to receive the appropriate notifications.
- **Tests**
  - Added coverage for ruling notifications when a defendant’s case was previously cancelled or dismissed, confirming that only eligible recipients are notified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->