### PR TITLE
fix(ids-admin): back button crash on detail screens after react-router upgrade

### DIFF
--- a/libs/portals/admin/ids-admin/src/screens/IDSAdmin.tsx
+++ b/libs/portals/admin/ids-admin/src/screens/IDSAdmin.tsx
@@ -1,10 +1,4 @@
-import {
-  Outlet,
-  useNavigate,
-  useLocation,
-  matchPath,
-  useMatches,
-} from 'react-router-dom'
+import { Outlet, useNavigate, useLocation, useMatches } from 'react-router-dom'
 
 import { Stack } from '@island.is/island-ui/core'
 import { replaceParams } from '@island.is/react-spa/shared'
@@ -30,19 +24,19 @@ const IDSAdmin = () => {
       return
     }
 
+    // match.pathname is decoded (react-router 6.14+) while location.pathname
+    // keeps the raw encoding, so compare decoded values.
+    const normalize = (pathname: string) =>
+      decodeURIComponent(pathname).replace(/\/+$/, '')
+
     const backRouteMatch = matches.find(
       (match) =>
         Boolean((match.handle as IDSAdminRouteHandle)?.backPath) &&
-        matchPath(
-          {
-            path: location.pathname,
-            end: true,
-          },
-          match.pathname,
-        ),
+        normalize(match.pathname) === normalize(location.pathname),
     )
 
-    const backPath = (backRouteMatch?.handle as IDSAdminRouteHandle).backPath
+    const backPath = (backRouteMatch?.handle as IDSAdminRouteHandle | undefined)
+      ?.backPath
 
     if (backRouteMatch && backPath) {
       const backRoutePath = replaceParams({

--- a/libs/portals/admin/ids-admin/src/screens/IDSAdmin.tsx
+++ b/libs/portals/admin/ids-admin/src/screens/IDSAdmin.tsx
@@ -6,6 +6,7 @@ import { BackButton } from '@island.is/portals/admin/core'
 
 import { IDSAdminRouteHandle } from '../module'
 import { IDSAdminPaths } from '../lib/paths'
+import { decodeRouterPath } from '../utils/decodeRouterPath'
 import { DelegationProvidersProvider } from '../context/DelegationProviders/DelegationProvidersContext'
 
 const IDSAdmin = () => {
@@ -25,14 +26,13 @@ const IDSAdmin = () => {
     }
 
     // match.pathname is decoded (react-router 6.14+) while location.pathname
-    // keeps the raw encoding, so compare decoded values.
-    const normalize = (pathname: string) =>
-      decodeURIComponent(pathname).replace(/\/+$/, '')
+    // keeps the raw encoding, so decode it the same way before comparing.
+    const strip = (pathname: string) => pathname.replace(/\/+$/, '')
 
     const backRouteMatch = matches.find(
       (match) =>
         Boolean((match.handle as IDSAdminRouteHandle)?.backPath) &&
-        normalize(match.pathname) === normalize(location.pathname),
+        strip(decodeRouterPath(location.pathname)) === strip(match.pathname),
     )
 
     const backPath = (backRouteMatch?.handle as IDSAdminRouteHandle | undefined)

--- a/libs/portals/admin/ids-admin/src/utils/decodeRouterPath.spec.ts
+++ b/libs/portals/admin/ids-admin/src/utils/decodeRouterPath.spec.ts
@@ -1,0 +1,31 @@
+import { decodeRouterPath } from './decodeRouterPath'
+
+describe('decodeRouterPath', () => {
+  it('decodes encoded characters like react-router does', () => {
+    expect(decodeRouterPath('/tenant/%4064artic.is/rettindi')).toBe(
+      '/tenant/@64artic.is/rettindi',
+    )
+  })
+
+  it('keeps encoded slashes inside a segment as %2F', () => {
+    expect(decodeRouterPath('/rettindi/%4064artic.is%2Fgg-01-test')).toBe(
+      '/rettindi/@64artic.is%2Fgg-01-test',
+    )
+  })
+
+  it('only decodes one level of encoding', () => {
+    expect(decodeRouterPath('/tenant/foo%2540bar')).toBe('/tenant/foo%40bar')
+  })
+
+  it('returns the raw pathname when a segment is malformed', () => {
+    expect(decodeRouterPath('/tenant/foo%ZZbar/%40ok')).toBe(
+      '/tenant/foo%ZZbar/%40ok',
+    )
+  })
+
+  it('leaves already-decoded pathnames unchanged', () => {
+    expect(decodeRouterPath('/tenant/@64artic.is/rettindi')).toBe(
+      '/tenant/@64artic.is/rettindi',
+    )
+  })
+})

--- a/libs/portals/admin/ids-admin/src/utils/decodeRouterPath.ts
+++ b/libs/portals/admin/ids-admin/src/utils/decodeRouterPath.ts
@@ -1,0 +1,16 @@
+/**
+ * Decodes a raw location.pathname the same way react-router (6.14+) decodes
+ * match.pathname: per segment, keeping "/" inside params encoded as %2F, and
+ * returning the raw pathname untouched if any segment is malformed (see
+ * decodePath in @remix-run/router).
+ */
+export const decodeRouterPath = (pathname: string) => {
+  try {
+    return pathname
+      .split('/')
+      .map((segment) => decodeURIComponent(segment).replace(/\//g, '%2F'))
+      .join('/')
+  } catch {
+    return pathname
+  }
+}


### PR DESCRIPTION
# Back button crash on detail screens after react-router upgrade

## What

- Fix the "Til baka" button doing nothing on the client and API scope detail screens in IDS admin.

## Why

- react-router 6.14+ (bumped in #23240) decodes `match.pathname` while `location.pathname` keeps the raw encoding, so `navigateBack()` never found the route's `backPath` on screens whose params contain encoded characters — and a missing optional chain turned that into a crash.

## Screenshots / Gifs

N/A

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved back-navigation route matching for paths with trailing slashes or encoded characters.
  - Prevented errors when a back-navigation route does not include a route handle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->