### PR TITLE
fix(payments): log response metadata when the card gateway returns non-JSON

### DIFF
--- a/apps/services/payments/src/app/cardPayment/cardPayment.controller.ts
+++ b/apps/services/payments/src/app/cardPayment/cardPayment.controller.ts
@@ -105,6 +105,13 @@ export class CardPaymentController {
         correlationId: correlationID,
       } as VerifyCardResponse
     } catch (e) {
+      // The update log below only keeps e.message, which cannot distinguish
+      // between the gateway call and the FJS/X-Road calls when both fail with
+      // a JSON parse error — the stack names the throwing module.
+      this.logger.error(`[${paymentFlowId}] Card verification failed`, {
+        error: e.message,
+        stack: e.stack,
+      })
       try {
         await this.paymentFlowService.logPaymentFlowUpdate({
           paymentFlowId: paymentFlowId,

--- a/apps/services/payments/src/app/cardPayment/cardPayment.service.ts
+++ b/apps/services/payments/src/app/cardPayment/cardPayment.service.ts
@@ -812,7 +812,27 @@ export class CardPaymentService {
       throw new BadRequestException(response.statusText)
     }
 
-    const rawData = await response.json()
+    let rawData: unknown
+
+    try {
+      rawData = await response.json()
+    } catch (parseError) {
+      // A 2xx non-JSON body means the response did not come from the gateway
+      // API itself (e.g. a maintenance page reached through a silent redirect).
+      // Log enough response metadata to identify the actual origin.
+      this.logger.error(
+        `${logPrefix}Payment gateway returned non-JSON response`,
+        {
+          status: response.status,
+          contentType: response.headers?.get?.('content-type'),
+          server: response.headers?.get?.('server'),
+          cfRay: response.headers?.get?.('cf-ray'),
+          finalUrl: response.url,
+          redirected: response.redirected,
+        },
+      )
+      throw parseError
+    }
 
     const successParsed = schema.safeParse(rawData)
 


### PR DESCRIPTION
## What
Card verification on dev is failing with `Unexpected token '<', "<html><hea"... is not valid JSON` and the current logging only keeps the message, so we can't tell which upstream call (ValitorPay or FJS/X-Road) returned HTML or where it came from.

- Log status, content-type, final URL and redirect flag when the gateway response body isn't JSON
- Log the error stack when card verification fails, so the throwing call site is identifiable

## Why
All card verifications on dev have failed this way since Aug 17 (flows `283c8e1a`, `d93ce335`, `c63af812`). Replaying the same requests against uat.valitorpay.com from the same pod always returns valid JSON, so the HTML likely comes from another hop — this makes the next occurrence tell us which one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of payment gateway responses that are not valid JSON.
  - Added clearer diagnostic logging when card verification or response parsing fails.
  - Payment errors continue through the standard failure and exception-handling flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist:

- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code
