### PR TITLE
fix(j-s): send defenders the court-style email when R-cases are revoked

### DIFF
--- a/apps/judicial-system/backend/src/app/modules/notification/services/caseNotification/caseNotification.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/services/caseNotification/caseNotification.service.ts
@@ -1706,17 +1706,12 @@ export class CaseNotificationService extends BaseNotificationService {
       theCase.notifications,
     )
 
-    if (defenderWasNotified && theCase.defendants) {
+    if (defenderWasNotified && theCase.defendants && theCase.courtCaseNumber) {
       promises.push(
-        this.sendRevokedEmailNotificationToDefender(
-          theCase.type,
-          theCase.id,
-          theCase.creatingProsecutor?.institution?.name,
+        this.sendRevokedEmailNotificationToCourtForRequestCase(
+          theCase,
           theCase.defenderName,
           theCase.defenderEmail,
-          theCase.defenderNationalId,
-          theCase.court?.name,
-          theCase.courtCaseNumber,
         ),
       )
     }

--- a/apps/judicial-system/backend/src/app/modules/notification/services/caseNotification/caseNotification.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/services/caseNotification/caseNotification.service.ts
@@ -1626,7 +1626,7 @@ export class CaseNotificationService extends BaseNotificationService {
     })
   }
 
-  private sendRevokedEmailNotificationToCourtForRequestCase(
+  private sendRevokedEmailNotificationForRequestCase(
     theCase: Case,
     recipientName?: string,
     recipientEmail?: string,
@@ -1662,7 +1662,7 @@ export class CaseNotificationService extends BaseNotificationService {
     if (theCase.courtCaseNumber) {
       if (!theCase.judge && !theCase.registrar) {
         promises.push(
-          this.sendRevokedEmailNotificationToCourtForRequestCase(
+          this.sendRevokedEmailNotificationForRequestCase(
             theCase,
             theCase.court?.name,
             this.getCourtEmail(theCase.courtId),
@@ -1671,7 +1671,7 @@ export class CaseNotificationService extends BaseNotificationService {
       } else {
         if (theCase.judge) {
           promises.push(
-            this.sendRevokedEmailNotificationToCourtForRequestCase(
+            this.sendRevokedEmailNotificationForRequestCase(
               theCase,
               theCase.judge.name,
               theCase.judge.email,
@@ -1681,7 +1681,7 @@ export class CaseNotificationService extends BaseNotificationService {
 
         if (theCase.registrar) {
           promises.push(
-            this.sendRevokedEmailNotificationToCourtForRequestCase(
+            this.sendRevokedEmailNotificationForRequestCase(
               theCase,
               theCase.registrar.name,
               theCase.registrar.email,
@@ -1714,7 +1714,7 @@ export class CaseNotificationService extends BaseNotificationService {
 
       if (caseNumber) {
         promises.push(
-          this.sendRevokedEmailNotificationToCourtForRequestCase(
+          this.sendRevokedEmailNotificationForRequestCase(
             theCase,
             theCase.defenderName,
             theCase.defenderEmail,

--- a/apps/judicial-system/backend/src/app/modules/notification/services/caseNotification/caseNotification.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/services/caseNotification/caseNotification.service.ts
@@ -1630,9 +1630,10 @@ export class CaseNotificationService extends BaseNotificationService {
     theCase: Case,
     recipientName?: string,
     recipientEmail?: string,
+    caseNumber = theCase.courtCaseNumber,
   ): Promise<Recipient> {
-    const subject = `Krafa afturkölluð í máli ${theCase.courtCaseNumber}`
-    const body = `${theCase.creatingProsecutor?.institution?.name} hefur afturkallað kröfu í máli ${theCase.courtCaseNumber}.`
+    const subject = `Krafa afturkölluð í máli ${caseNumber}`
+    const body = `${theCase.creatingProsecutor?.institution?.name} hefur afturkallað kröfu í máli ${caseNumber}.`
 
     return this.sendEmail({
       subject,
@@ -1706,14 +1707,21 @@ export class CaseNotificationService extends BaseNotificationService {
       theCase.notifications,
     )
 
-    if (defenderWasNotified && theCase.defendants && theCase.courtCaseNumber) {
-      promises.push(
-        this.sendRevokedEmailNotificationToCourtForRequestCase(
-          theCase,
-          theCase.defenderName,
-          theCase.defenderEmail,
-        ),
-      )
+    if (defenderWasNotified && theCase.defendants) {
+      // We want to notify defenders even if the court case number has not been set yet, so we fall back to the police case number in that case
+      const caseNumber =
+        theCase.courtCaseNumber ?? theCase.policeCaseNumbers?.[0]
+
+      if (caseNumber) {
+        promises.push(
+          this.sendRevokedEmailNotificationToCourtForRequestCase(
+            theCase,
+            theCase.defenderName,
+            theCase.defenderEmail,
+            caseNumber,
+          ),
+        )
+      }
     }
 
     const recipients = await Promise.all(promises)

--- a/apps/judicial-system/backend/src/app/modules/notification/test/internalNotificationController/sendRevokedNotificationsForRequestCase.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/test/internalNotificationController/sendRevokedNotificationsForRequestCase.spec.ts
@@ -7,6 +7,7 @@ import { EmailService } from '@island.is/email-service'
 import {
   CaseType,
   RequestCaseNotificationType,
+  TrackedNotificationType,
 } from '@island.is/judicial-system/types'
 
 import {
@@ -30,7 +31,11 @@ type GivenWhenThen = (
 ) => Promise<Then>
 
 describe('InternalNotificationController - Send revoked notifications for request cases', () => {
-  const { judge, registrar } = createTestUsers(['judge', 'registrar'])
+  const { judge, registrar, defender } = createTestUsers([
+    'judge',
+    'registrar',
+    'defender',
+  ])
   const caseId = uuid()
   const courtId = 'd1e6e06f-dcfd-45e0-9a24-2fdabc2cc8bf'
   const prosecutorsOfficeName = uuid()
@@ -174,6 +179,102 @@ describe('InternalNotificationController - Send revoked notifications for reques
 
     it('should not send court email notification', () => {
       expect(mockEmailService.sendEmail).not.toHaveBeenCalled()
+      expect(then.result).toEqual({ delivered: true })
+    })
+  })
+
+  describe('when defender was previously notified', () => {
+    const theCase = {
+      id: caseId,
+      type: CaseType.TRAVEL_BAN,
+      courtId,
+      court: { name: courtName },
+      courtCaseNumber,
+      judge: { name: judge.name, email: judge.email },
+      creatingProsecutor: { institution: { name: prosecutorsOfficeName } },
+      defenderName: defender.name,
+      defenderEmail: defender.email,
+      defendants: [{ id: uuid() }],
+    }
+
+    const previousNotifications = [
+      {
+        type: TrackedNotificationType.READY_FOR_COURT,
+        recipients: [{ address: defender.email, success: true }],
+      } as Notification,
+    ]
+
+    describe('and the case has a court case number', () => {
+      let then: Then
+
+      beforeEach(async () => {
+        then = await givenWhenThen(theCase, previousNotifications)
+      })
+
+      it('should send the court revoked email to the defender without an RVG link', () => {
+        const subject = `Krafa afturkölluð í máli ${courtCaseNumber}`
+        const body = `${prosecutorsOfficeName} hefur afturkallað kröfu í máli ${courtCaseNumber}.`
+
+        expect(mockEmailService.sendEmail).toHaveBeenCalledWith(
+          expect.objectContaining({
+            to: [{ address: defender.email, name: defender.name }],
+            subject,
+            html: body,
+          }),
+        )
+        expect(mockEmailService.sendEmail).not.toHaveBeenCalledWith(
+          expect.objectContaining({
+            to: [{ address: defender.email, name: defender.name }],
+            html: expect.stringContaining('rettarvorslugatt.island.is'),
+          }),
+        )
+        expect(then.result).toEqual({ delivered: true })
+      })
+    })
+
+    describe('and the case has no court case number', () => {
+      let then: Then
+
+      beforeEach(async () => {
+        then = await givenWhenThen(
+          { ...theCase, courtCaseNumber: undefined },
+          previousNotifications,
+        )
+      })
+
+      it('should not send a revoked email to the defender', () => {
+        expect(mockEmailService.sendEmail).not.toHaveBeenCalled()
+        expect(then.result).toEqual({ delivered: true })
+      })
+    })
+  })
+
+  describe('when defender was not previously notified', () => {
+    let then: Then
+
+    const theCase = {
+      id: caseId,
+      type: CaseType.CUSTODY,
+      courtId,
+      court: { name: courtName },
+      courtCaseNumber,
+      judge: { name: judge.name, email: judge.email },
+      creatingProsecutor: { institution: { name: prosecutorsOfficeName } },
+      defenderName: defender.name,
+      defenderEmail: defender.email,
+      defendants: [{ id: uuid() }],
+    }
+
+    beforeEach(async () => {
+      then = await givenWhenThen(theCase)
+    })
+
+    it('should not send a revoked email to the defender', () => {
+      expect(mockEmailService.sendEmail).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          to: [{ address: defender.email, name: defender.name }],
+        }),
+      )
       expect(then.result).toEqual({ delivered: true })
     })
   })

--- a/apps/judicial-system/backend/src/app/modules/notification/test/internalNotificationController/sendRevokedNotificationsForRequestCase.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/test/internalNotificationController/sendRevokedNotificationsForRequestCase.spec.ts
@@ -41,6 +41,7 @@ describe('InternalNotificationController - Send revoked notifications for reques
   const prosecutorsOfficeName = uuid()
   const courtName = uuid()
   const courtCaseNumber = 'R-369/2025'
+  const policeCaseNumber = '007-2026-01'
 
   let mockEmailService: EmailService
   let mockNotificationModel: typeof Notification
@@ -190,6 +191,7 @@ describe('InternalNotificationController - Send revoked notifications for reques
       courtId,
       court: { name: courtName },
       courtCaseNumber,
+      policeCaseNumbers: [policeCaseNumber],
       judge: { name: judge.name, email: judge.email },
       creatingProsecutor: { institution: { name: prosecutorsOfficeName } },
       defenderName: defender.name,
@@ -242,8 +244,22 @@ describe('InternalNotificationController - Send revoked notifications for reques
         )
       })
 
-      it('should not send a revoked email to the defender', () => {
-        expect(mockEmailService.sendEmail).not.toHaveBeenCalled()
+      it('should send the court revoked email to the defender using the main police case number', () => {
+        const subject = `Krafa afturkölluð í máli ${policeCaseNumber}`
+        const body = `${prosecutorsOfficeName} hefur afturkallað kröfu í máli ${policeCaseNumber}.`
+
+        expect(mockEmailService.sendEmail).toHaveBeenCalledWith(
+          expect.objectContaining({
+            to: [{ address: defender.email, name: defender.name }],
+            subject,
+            html: body,
+          }),
+        )
+        expect(mockEmailService.sendEmail).not.toHaveBeenCalledWith(
+          expect.objectContaining({
+            to: [{ address: judge.email, name: judge.name }],
+          }),
+        )
         expect(then.result).toEqual({ delivered: true })
       })
     })


### PR DESCRIPTION
[Asana](https://app.asana.com/1/203394141643832/project/1212657017130395/task/1217186302636325?focus=true)

## What

Update the copy of the case revoked email to defenders. 

## Why

The old mail was a bit broken, had a link to the case but the case was gone from RVG so that didn´t make sense.



## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Cursor


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved revocation email notifications for defenders associated with request cases.
  * Emails now include the court case number when available, with the police case number used as a fallback.
  * Prevented unnecessary revocation emails for defenders who were not previously notified.
  * Ensured revocation notifications do not include an unintended RVG link or notify judges incorrectly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->