### PR TITLE
fix(j-s): Detect a list-only incident description as rich text

### DIFF
--- a/libs/judicial-system/formatters/src/lib/formatters.spec.ts
+++ b/libs/judicial-system/formatters/src/lib/formatters.spec.ts
@@ -422,6 +422,13 @@ describe('containsHtml', () => {
     expect(containsHtml('bla<br />bla')).toBe(true)
   })
 
+  test('should detect a list that contains no other markup', () => {
+    // A list authored in the editor carries no <p>, so without ul/ol/li the
+    // markup was rendered as literal text instead of as rich text.
+    expect(containsHtml('<ul><li>eitt</li><li>tvö</li></ul>')).toBe(true)
+    expect(containsHtml('<ol><li>eitt</li></ol>')).toBe(true)
+  })
+
   test('should not detect plain text as html', () => {
     expect(containsHtml('fyrir umferðarlagabrot með því að hafa ekið')).toBe(
       false,
@@ -433,6 +440,8 @@ describe('containsHtml', () => {
   test('should not detect angle-bracket placeholders as html', () => {
     expect(containsHtml('ökumaðurinn <nafn ökumanns> ók')).toBe(false)
     expect(containsHtml('með kennitöluna <kennitala>')).toBe(false)
+    // Placeholders that merely start with a list tag's letters.
+    expect(containsHtml('<liður 1> og <ólöglegur akstur>')).toBe(false)
   })
 })
 

--- a/libs/judicial-system/formatters/src/lib/formatters.ts
+++ b/libs/judicial-system/formatters/src/lib/formatters.ts
@@ -646,4 +646,4 @@ export const getVerdictAppealDecision = (
 // containing angle-bracket placeholders (e.g. "<nafn ökumanns>") is not
 // mistaken for HTML.
 export const containsHtml = (str: string): boolean =>
-  /<\/?(?:p|strong|em|b|i|span|br)(?:[\s/>])/i.test(str)
+  /<\/?(?:p|strong|em|b|i|span|br|ul|ol|li)(?:[\s/>])/i.test(str)


### PR DESCRIPTION
Follow-up to #23381.

## What

An Atvikalýsing consisting solely of a list rendered in the indictment PDF as
literal markup:

```
<ul>
<li>kjansd nasd</li>
<li>kjnads kjnasd</li>
</ul>
```

`containsHtml` now recognises `ul`, `ol` and `li` as well, so such content takes
the rich text branch and renders as a real list.

## Why

`indictmentPdf.ts` routes between rich text and plain text on `containsHtml`,
because older indictments store the incident description as plain text. That
check recognised only `p`, `strong`, `em`, `b`, `i`, `span` and `br`. A list
authored in the editor produces `<ul><li>…</li></ul>` and nothing else — no
paragraph — so it matched none of them, fell through to
`addNormalPlusJustifiedText`, and the markup was printed verbatim.

The list handling added in #23381 was fine; the content simply never reached it.

Bókanir on the court record was unaffected: `indictmentCourtRecordPdf.ts` calls
`addRichText` unconditionally. Atvikalýsing is the only field with the guard.

This also fixes `textToHtml` on the web side, which would otherwise HTML-escape
a list-only description when loading it back into the editor.

## Notes for the reviewer

- The trailing `[\s/>]` in the pattern is what keeps plain text containing
  angle-bracket placeholders from being mistaken for markup. `ul`/`ol`/`li` are
  short enough to be worth pinning, so there is a test asserting that
  `<liður 1>` and `<ólöglegur akstur>` still read as plain text.
- Worth testing both a list-only description and one mixing a paragraph with a
  list — the latter took the rich text branch all along and already worked.

## Screenshots / Gifs

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTML detection for additional inline and list elements, including `span`, unordered lists, ordered lists, and list items.
  * Reduced false positives for angle-bracket placeholders that resemble HTML tags.
* **Tests**
  * Added coverage for standalone ordered and unordered lists and tag-like placeholders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->