### PR TITLE
feat(application-system): Make AlertMessageFormField alertType a dynamic field

### DIFF
--- a/libs/application/types/src/lib/Fields.ts
+++ b/libs/application/types/src/lib/Fields.ts
@@ -48,7 +48,7 @@ export type TextFieldVariant =
   | 'tel'
   | 'textarea'
   | 'currency'
-type AlertType = 'default' | 'warning' | 'error' | 'info' | 'success'
+export type AlertType = 'default' | 'warning' | 'error' | 'info' | 'success'
 
 export type Context = {
   application: Application
@@ -712,7 +712,7 @@ export interface ExpandableDescriptionField extends BaseField {
 export interface AlertMessageField extends BaseField {
   readonly type: FieldTypes.ALERT_MESSAGE
   component: FieldComponents.ALERT_MESSAGE
-  alertType?: AlertType
+  alertType?: MaybeWithApplicationAndFieldAndLocale<AlertType>
   message?: FormTextWithLocale
   links?: AlertMessageLink[]
   shouldBlockInSetBeforeSubmitCallback?: boolean

--- a/libs/application/ui-fields/src/lib/AlertMessageFormField/AlertMessageFormField.tsx
+++ b/libs/application/ui-fields/src/lib/AlertMessageFormField/AlertMessageFormField.tsx
@@ -9,7 +9,7 @@ import {
   getTextStyles,
 } from '@island.is/island-ui/core'
 import { useLocale } from '@island.is/localization'
-import React, { FC, useEffect, useRef } from 'react'
+import React, { FC, useEffect, useRef, useMemo } from 'react'
 import { Markdown } from '@island.is/shared/components'
 import { AlertMessageField, FieldBaseProps } from '@island.is/application/types'
 import { Locale } from '@island.is/shared/types'
@@ -32,11 +32,29 @@ export const AlertMessageFormField: FC<React.PropsWithChildren<Props>> = ({
   const { formatMessage, lang: locale } = useLocale()
   const { getValues } = useFormContext()
   const user = useUserInfo()
+  const values = getValues()
 
   // Persist callback ID across renders to prevent duplicate registration
   const callbackIdRef = useRef(`AlertMessageFormField-${uuid()}`)
 
   const showAlertMessage = useRef(!field.shouldBlockInSetBeforeSubmitCallback)
+
+  const updatedApplication = useMemo(() => {
+    return {
+      ...application,
+      answers: {
+        ...application.answers,
+        ...values,
+      },
+    }
+  }, [application, values])
+
+  const finalAlertType = useMemo(() => {
+    const maybeAlertType = field.alertType ?? 'default'
+    return typeof maybeAlertType === 'function'
+      ? maybeAlertType(updatedApplication, field, locale)
+      : maybeAlertType
+  }, [updatedApplication, field, locale])
 
   useEffect(() => {
     if (field.shouldBlockInSetBeforeSubmitCallback) {
@@ -77,16 +95,10 @@ export const AlertMessageFormField: FC<React.PropsWithChildren<Props>> = ({
         marginBottom={field.marginBottom ?? 2}
       >
         <AlertMessage
-          type={field.alertType ?? 'default'}
+          type={finalAlertType}
           title={formatTextWithLocale(
             field.title ?? '',
-            {
-              ...application,
-              answers: {
-                ...application.answers,
-                ...getValues(),
-              },
-            },
+            updatedApplication,
             locale as Locale,
             formatMessage,
           )}
@@ -98,13 +110,7 @@ export const AlertMessageFormField: FC<React.PropsWithChildren<Props>> = ({
                     <Markdown>
                       {formatTextWithLocale(
                         field.message,
-                        {
-                          ...application,
-                          answers: {
-                            ...application.answers,
-                            ...getValues(),
-                          },
-                        },
+                        updatedApplication,
                         locale as Locale,
                         formatMessage,
                       )}


### PR DESCRIPTION
## What

Updated the `AlertMessageFormField` to support dynamic `alertType`

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [x] No AI tools were used in preparing this pull request
- [ ] AI tools were used in preparing this pull request
      Tools used:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Alert message fields now support dynamic alert types based on the current application, field, and locale.
  - Available alert styles include default, warning, error, info, and success.

- **Improvements**
  - Alert titles, messages, and styles are resolved consistently using the latest form responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->