### PR TITLE
feat(j-s): User repository service

### DIFF
--- a/apps/judicial-system/backend/src/app/modules/repository/index.ts
+++ b/apps/judicial-system/backend/src/app/modules/repository/index.ts
@@ -57,6 +57,11 @@ export {
   CreateRobotLog,
 } from './services/robotLogRepository.service'
 export { SubpoenaRepositoryService } from './services/subpoenaRepository.service'
+export {
+  UserRepositoryService,
+  CreateUser,
+  UpdateUser,
+} from './services/userRepository.service'
 export { VerdictRepositoryService } from './services/verdictRepository.service'
 
 export {

--- a/apps/judicial-system/backend/src/app/modules/repository/repository.module.ts
+++ b/apps/judicial-system/backend/src/app/modules/repository/repository.module.ts
@@ -28,6 +28,7 @@ import { Offense } from './models/offense.model'
 import { PoliceDigitalCaseFile } from './models/policeDigitalCaseFile.model'
 import { RobotLog } from './models/robotLog.model'
 import { Subpoena } from './models/subpoena.model'
+import { User } from './models/user.model'
 import { Verdict } from './models/verdict.model'
 import { Victim } from './models/victim.model'
 import { AppealCaseRepositoryService } from './services/appealCaseRepository.service'
@@ -46,6 +47,7 @@ import { MessageSuspensionRepositoryService } from './services/messageSuspension
 import { PoliceDigitalCaseFileRepositoryService } from './services/policeDigitalCaseFileRepository.service'
 import { RobotLogRepositoryService } from './services/robotLogRepository.service'
 import { SubpoenaRepositoryService } from './services/subpoenaRepository.service'
+import { UserRepositoryService } from './services/userRepository.service'
 import { VerdictRepositoryService } from './services/verdictRepository.service'
 import { repositoryModuleConfig } from './repository.config'
 
@@ -76,6 +78,7 @@ import { repositoryModuleConfig } from './repository.config'
       PoliceDigitalCaseFile,
       RobotLog,
       Subpoena,
+      User,
       Verdict,
       Victim,
     ]),
@@ -99,6 +102,7 @@ import { repositoryModuleConfig } from './repository.config'
     PoliceDigitalCaseFileRepositoryService,
     RobotLogRepositoryService,
     SubpoenaRepositoryService,
+    UserRepositoryService,
     VerdictRepositoryService,
   ],
   exports: [
@@ -118,6 +122,7 @@ import { repositoryModuleConfig } from './repository.config'
     PoliceDigitalCaseFileRepositoryService,
     RobotLogRepositoryService,
     SubpoenaRepositoryService,
+    UserRepositoryService,
     VerdictRepositoryService,
   ],
 })

--- a/apps/judicial-system/backend/src/app/modules/repository/services/userRepository.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/repository/services/userRepository.service.ts
@@ -1,0 +1,203 @@
+import { Op } from 'sequelize'
+
+import { Inject, Injectable } from '@nestjs/common'
+import { InjectModel } from '@nestjs/sequelize'
+
+import { type Logger, LOGGER_PROVIDER } from '@island.is/logging'
+
+import { InstitutionType, UserRole } from '@island.is/judicial-system/types'
+
+import { Institution } from '../models/institution.model'
+import { User } from '../models/user.model'
+
+// Declared here rather than imported from the user module: the repository must not
+// depend on a consumer's DTOs. The user module's CreateUserDto is structurally
+// assignable to this type.
+export type CreateUser = {
+  nationalId: string
+  name: string
+  title: string
+  mobileNumber: string
+  email: string
+  role: UserRole
+  institutionId: string
+  active: boolean
+  canConfirmIndictment: boolean
+  canManageMessageSuspension?: boolean
+}
+
+export type UpdateUser = {
+  name?: string
+  title?: string
+  mobileNumber?: string
+  email?: string
+  active?: boolean
+  canConfirmIndictment?: boolean
+  canManageMessageSuspension?: boolean
+}
+
+// The institution is always loaded with a user: it is a repository detail, never the
+// caller's choice.
+const includeInstitution = [{ model: Institution, as: 'institution' }]
+
+@Injectable()
+export class UserRepositoryService {
+  constructor(
+    @InjectModel(User) private readonly userModel: typeof User,
+    @Inject(LOGGER_PROVIDER) private readonly logger: Logger,
+  ) {}
+
+  async findById(userId: string): Promise<User | null> {
+    try {
+      this.logger.debug(`Finding user ${userId}`)
+
+      return await this.userModel.findByPk(userId, {
+        include: includeInstitution,
+      })
+    } catch (error) {
+      this.logger.error(`Error finding user ${userId}:`, { error })
+
+      throw error
+    }
+  }
+
+  async findActiveByNationalId(nationalId: string): Promise<User[]> {
+    try {
+      this.logger.debug('Finding all active users by national id')
+
+      return await this.userModel.findAll({
+        where: { nationalId, active: true },
+        include: includeInstitution,
+      })
+    } catch (error) {
+      this.logger.error('Error finding all active users by national id:', {
+        error,
+      })
+
+      throw error
+    }
+  }
+
+  async findAllActive(): Promise<User[]> {
+    try {
+      this.logger.debug('Finding all active users')
+
+      return await this.userModel.findAll({
+        order: ['name'],
+        where: { active: true },
+        include: includeInstitution,
+      })
+    } catch (error) {
+      this.logger.error('Error finding all active users:', { error })
+
+      throw error
+    }
+  }
+
+  async findAllForAdmin(
+    excludedRole: UserRole,
+    institutionTypes: InstitutionType[],
+  ): Promise<User[]> {
+    try {
+      this.logger.debug(
+        `Finding all users, excluding the ${excludedRole} role, in ${institutionTypes.length} institution type(s)`,
+      )
+
+      return await this.userModel.findAll({
+        order: ['name'],
+        where: {
+          role: { [Op.not]: excludedRole },
+          // A nested column filter on the included institution
+          '$institution.type$': institutionTypes,
+        },
+        include: includeInstitution,
+      })
+    } catch (error) {
+      this.logger.error(
+        `Error finding all users, excluding the ${excludedRole} role, in ${institutionTypes.length} institution type(s):`,
+        { error },
+      )
+
+      throw error
+    }
+  }
+
+  async findAllActiveWhoCanConfirmIndictments(
+    institutionId: string,
+  ): Promise<User[]> {
+    try {
+      this.logger.debug(
+        `Finding all active users who can confirm indictments in institution ${institutionId}`,
+      )
+
+      return await this.userModel.findAll({
+        where: { active: true, canConfirmIndictment: true, institutionId },
+      })
+    } catch (error) {
+      this.logger.error(
+        `Error finding all active users who can confirm indictments in institution ${institutionId}:`,
+        { error },
+      )
+
+      throw error
+    }
+  }
+
+  async findAllActiveProsecutors(institutionId: string): Promise<User[]> {
+    try {
+      this.logger.debug(
+        `Finding all active prosecutors in institution ${institutionId}`,
+      )
+
+      return await this.userModel.findAll({
+        where: {
+          active: true,
+          role: UserRole.PROSECUTOR,
+          institutionId,
+        },
+      })
+    } catch (error) {
+      this.logger.error(
+        `Error finding all active prosecutors in institution ${institutionId}:`,
+        { error },
+      )
+
+      throw error
+    }
+  }
+
+  async create(userToCreate: CreateUser): Promise<User> {
+    try {
+      this.logger.debug('Creating a user')
+
+      return await this.userModel.create({ ...userToCreate })
+    } catch (error) {
+      this.logger.error('Error creating a user:', { error })
+
+      throw error
+    }
+  }
+
+  async updateById(
+    userId: string,
+    update: UpdateUser,
+  ): Promise<{ numberOfAffectedRows: number; users: User[] }> {
+    try {
+      this.logger.debug(`Updating user ${userId}`)
+
+      const [numberOfAffectedRows, users] = await this.userModel.update(
+        update,
+        {
+          where: { id: userId },
+          returning: true,
+        },
+      )
+
+      return { numberOfAffectedRows, users }
+    } catch (error) {
+      this.logger.error(`Error updating user ${userId}:`, { error })
+
+      throw error
+    }
+  }
+}

--- a/apps/judicial-system/backend/src/app/modules/repository/test/userRepository.service.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/repository/test/userRepository.service.spec.ts
@@ -1,0 +1,289 @@
+import { Op } from 'sequelize'
+
+import { getModelToken } from '@nestjs/sequelize'
+import { Test } from '@nestjs/testing'
+
+import { LOGGER_PROVIDER } from '@island.is/logging'
+
+import { InstitutionType, UserRole } from '@island.is/judicial-system/types'
+
+import { Institution } from '../models/institution.model'
+import { User } from '../models/user.model'
+import {
+  CreateUser,
+  UserRepositoryService,
+} from '../services/userRepository.service'
+
+describe('UserRepositoryService', () => {
+  const userId = 'b1f7e3d1-0000-4000-8000-000000000001'
+  const institutionId = 'b1f7e3d1-0000-4000-8000-000000000002'
+  const nationalId = '0000000000'
+  const include = [{ model: Institution, as: 'institution' }]
+
+  let service: UserRepositoryService
+  let logger: { debug: jest.Mock; error: jest.Mock }
+  let model: {
+    findByPk: jest.Mock
+    findAll: jest.Mock
+    create: jest.Mock
+    update: jest.Mock
+  }
+
+  beforeEach(async () => {
+    logger = { debug: jest.fn(), error: jest.fn() }
+
+    model = {
+      findByPk: jest.fn().mockResolvedValue(null),
+      findAll: jest.fn().mockResolvedValue([]),
+      create: jest.fn().mockResolvedValue(null),
+      update: jest.fn().mockResolvedValue([0, []]),
+    }
+
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        { provide: LOGGER_PROVIDER, useValue: logger },
+        { provide: getModelToken(User), useValue: model },
+        UserRepositoryService,
+      ],
+    }).compile()
+
+    service = moduleRef.get(UserRepositoryService)
+  })
+
+  describe('findById', () => {
+    it('loads the user with its institution', async () => {
+      const user = { id: userId }
+      model.findByPk.mockResolvedValueOnce(user)
+
+      const result = await service.findById(userId)
+
+      expect(model.findByPk).toHaveBeenCalledWith(userId, { include })
+      expect(result).toBe(user)
+    })
+
+    it('returns null when the user does not exist', async () => {
+      model.findByPk.mockResolvedValueOnce(null)
+
+      const result = await service.findById(userId)
+
+      expect(result).toBeNull()
+    })
+
+    it('logs and rethrows when the lookup fails', async () => {
+      const error = new Error('Some error')
+      model.findByPk.mockRejectedValueOnce(error)
+
+      await expect(service.findById(userId)).rejects.toBe(error)
+      expect(logger.error).toHaveBeenCalled()
+    })
+  })
+
+  describe('findActiveByNationalId', () => {
+    it('filters on the national id and active users', async () => {
+      const users = [{ id: userId }]
+      model.findAll.mockResolvedValueOnce(users)
+
+      const result = await service.findActiveByNationalId(nationalId)
+
+      expect(model.findAll).toHaveBeenCalledWith({
+        where: { nationalId, active: true },
+        include,
+      })
+      expect(result).toBe(users)
+    })
+
+    it('returns an empty list when no user matches', async () => {
+      model.findAll.mockResolvedValueOnce([])
+
+      const result = await service.findActiveByNationalId(nationalId)
+
+      expect(result).toEqual([])
+    })
+
+    it('keeps the national id out of the logs', async () => {
+      const error = new Error('Some error')
+      model.findAll.mockRejectedValueOnce(error)
+
+      await expect(service.findActiveByNationalId(nationalId)).rejects.toBe(
+        error,
+      )
+      const logged = [...logger.debug.mock.calls, ...logger.error.mock.calls]
+        .flat()
+        .map((argument) => JSON.stringify(argument))
+        .join(' ')
+      expect(logged).not.toContain(nationalId)
+    })
+  })
+
+  describe('findAllActive', () => {
+    it('filters on active users and orders by name', async () => {
+      const users = [{ id: userId }]
+      model.findAll.mockResolvedValueOnce(users)
+
+      const result = await service.findAllActive()
+
+      expect(model.findAll).toHaveBeenCalledWith({
+        order: ['name'],
+        where: { active: true },
+        include,
+      })
+      expect(result).toBe(users)
+    })
+
+    it('logs and rethrows when the lookup fails', async () => {
+      const error = new Error('Some error')
+      model.findAll.mockRejectedValueOnce(error)
+
+      await expect(service.findAllActive()).rejects.toBe(error)
+      expect(logger.error).toHaveBeenCalled()
+    })
+  })
+
+  describe('findAllForAdmin', () => {
+    it('excludes the given role and narrows to the given institution types', async () => {
+      const users = [{ id: userId }]
+      model.findAll.mockResolvedValueOnce(users)
+
+      const result = await service.findAllForAdmin(UserRole.LOCAL_ADMIN, [
+        InstitutionType.POLICE_PROSECUTORS_OFFICE,
+      ])
+
+      expect(model.findAll).toHaveBeenCalledWith({
+        order: ['name'],
+        where: {
+          role: { [Op.not]: UserRole.LOCAL_ADMIN },
+          '$institution.type$': [InstitutionType.POLICE_PROSECUTORS_OFFICE],
+        },
+        include,
+      })
+      expect(result).toBe(users)
+    })
+
+    it('logs and rethrows when the lookup fails', async () => {
+      const error = new Error('Some error')
+      model.findAll.mockRejectedValueOnce(error)
+
+      await expect(
+        service.findAllForAdmin(UserRole.ADMIN, Object.values(InstitutionType)),
+      ).rejects.toBe(error)
+      expect(logger.error).toHaveBeenCalled()
+    })
+  })
+
+  describe('findAllActiveWhoCanConfirmIndictments', () => {
+    it('filters on active confirmers in the institution', async () => {
+      const users = [{ id: userId }]
+      model.findAll.mockResolvedValueOnce(users)
+
+      const result = await service.findAllActiveWhoCanConfirmIndictments(
+        institutionId,
+      )
+
+      expect(model.findAll).toHaveBeenCalledWith({
+        where: { active: true, canConfirmIndictment: true, institutionId },
+      })
+      expect(result).toBe(users)
+    })
+
+    it('logs and rethrows when the lookup fails', async () => {
+      const error = new Error('Some error')
+      model.findAll.mockRejectedValueOnce(error)
+
+      await expect(
+        service.findAllActiveWhoCanConfirmIndictments(institutionId),
+      ).rejects.toBe(error)
+      expect(logger.error).toHaveBeenCalled()
+    })
+  })
+
+  describe('findAllActiveProsecutors', () => {
+    it('filters on active prosecutors in the institution', async () => {
+      const users = [{ id: userId }]
+      model.findAll.mockResolvedValueOnce(users)
+
+      const result = await service.findAllActiveProsecutors(institutionId)
+
+      expect(model.findAll).toHaveBeenCalledWith({
+        where: { active: true, role: UserRole.PROSECUTOR, institutionId },
+      })
+      expect(result).toBe(users)
+    })
+
+    it('logs and rethrows when the lookup fails', async () => {
+      const error = new Error('Some error')
+      model.findAll.mockRejectedValueOnce(error)
+
+      await expect(
+        service.findAllActiveProsecutors(institutionId),
+      ).rejects.toBe(error)
+      expect(logger.error).toHaveBeenCalled()
+    })
+  })
+
+  describe('create', () => {
+    const userToCreate: CreateUser = {
+      nationalId,
+      name: 'Guðrún Jónsdóttir',
+      title: 'saksóknari',
+      mobileNumber: '5555555',
+      email: 'gudrun@example.is',
+      role: UserRole.PROSECUTOR,
+      institutionId,
+      active: true,
+      canConfirmIndictment: false,
+    }
+
+    it('creates the user', async () => {
+      const user = { id: userId }
+      model.create.mockResolvedValueOnce(user)
+
+      const result = await service.create(userToCreate)
+
+      expect(model.create).toHaveBeenCalledWith({ ...userToCreate })
+      expect(result).toBe(user)
+    })
+
+    it('logs and rethrows without the created user in the message', async () => {
+      const error = new Error('Some error')
+      model.create.mockRejectedValueOnce(error)
+
+      await expect(service.create(userToCreate)).rejects.toBe(error)
+      expect(logger.error).toHaveBeenCalledWith('Error creating a user:', {
+        error,
+      })
+    })
+  })
+
+  describe('updateById', () => {
+    it('returns the affected row count and rows as a named object', async () => {
+      const user = { id: userId }
+      model.update.mockResolvedValueOnce([1, [user]])
+
+      const result = await service.updateById(userId, { name: 'Nýtt nafn' })
+
+      expect(model.update).toHaveBeenCalledWith(
+        { name: 'Nýtt nafn' },
+        { where: { id: userId }, returning: true },
+      )
+      expect(result).toEqual({ numberOfAffectedRows: 1, users: [user] })
+    })
+
+    it('reports no affected rows without throwing', async () => {
+      model.update.mockResolvedValueOnce([0, []])
+
+      const result = await service.updateById(userId, { active: false })
+
+      expect(result).toEqual({ numberOfAffectedRows: 0, users: [] })
+    })
+
+    it('logs and rethrows when the update fails', async () => {
+      const error = new Error('Some error')
+      model.update.mockRejectedValueOnce(error)
+
+      await expect(service.updateById(userId, { active: false })).rejects.toBe(
+        error,
+      )
+      expect(logger.error).toHaveBeenCalled()
+    })
+  })
+})

--- a/apps/judicial-system/backend/src/app/modules/user/test/create.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/user/test/create.spec.ts
@@ -8,7 +8,7 @@ import { UserRole } from '@island.is/judicial-system/types'
 import { createTestingUserModule } from './createTestingUserModule'
 
 import { randomEnum } from '../../../test'
-import { User } from '../../repository'
+import { User, UserRepositoryService } from '../../repository'
 
 interface Then {
   result: User
@@ -27,13 +27,14 @@ describe('UserController - Create', () => {
   const institutionId = uuid()
   const active = true
   const canConfirmIndictment = false
-  let mockUserModel: typeof User
+  let mockUserRepositoryService: UserRepositoryService
   let givenWhenThen: GivenWhenThen
 
   beforeEach(async () => {
-    const { userModel, userController } = await createTestingUserModule()
+    const { userRepositoryService, userController } =
+      await createTestingUserModule()
 
-    mockUserModel = userModel
+    mockUserRepositoryService = userRepositoryService
 
     givenWhenThen = async () => {
       const then = {} as Then
@@ -62,14 +63,14 @@ describe('UserController - Create', () => {
     let then: Then
 
     beforeEach(async () => {
-      const mockCreate = mockUserModel.create as jest.Mock
+      const mockCreate = mockUserRepositoryService.create as jest.Mock
       mockCreate.mockResolvedValueOnce(user)
 
       then = await givenWhenThen()
     })
 
     it('should return the created user', () => {
-      expect(mockUserModel.create).toHaveBeenCalledWith({
+      expect(mockUserRepositoryService.create).toHaveBeenCalledWith({
         nationalId,
         name,
         title,
@@ -88,7 +89,7 @@ describe('UserController - Create', () => {
     let then: Then
 
     beforeEach(async () => {
-      const mockCreate = mockUserModel.create as jest.Mock
+      const mockCreate = mockUserRepositoryService.create as jest.Mock
       mockCreate.mockRejectedValueOnce(new UniqueConstraintError({}))
 
       then = await givenWhenThen()
@@ -107,7 +108,7 @@ describe('UserController - Create', () => {
     let then: Then
 
     beforeEach(async () => {
-      const mockCreate = mockUserModel.create as jest.Mock
+      const mockCreate = mockUserRepositoryService.create as jest.Mock
       mockCreate.mockRejectedValueOnce(error)
 
       then = await givenWhenThen()

--- a/apps/judicial-system/backend/src/app/modules/user/test/createTestingUserModule.ts
+++ b/apps/judicial-system/backend/src/app/modules/user/test/createTestingUserModule.ts
@@ -1,6 +1,5 @@
 import { mock } from 'jest-mock-extended'
 
-import { getModelToken } from '@nestjs/sequelize'
 import { Test } from '@nestjs/testing'
 
 import { LOGGER_PROVIDER } from '@island.is/logging'
@@ -11,7 +10,7 @@ import {
   sharedAuthModuleConfig,
 } from '@island.is/judicial-system/auth'
 
-import { User } from '../../repository'
+import { UserRepositoryService } from '../../repository'
 import { userModuleConfig } from '../user.config'
 import { UserController } from '../user.controller'
 import { UserService } from '../user.service'
@@ -35,14 +34,22 @@ export const createTestingUserModule = async () => {
         },
       },
       {
-        provide: getModelToken(User),
+        provide: UserRepositoryService,
         useValue: {
-          findOne: jest.fn().mockRejectedValue(new Error('Some found')),
-          findAll: jest.fn().mockRejectedValue(new Error('Some found')),
-          create: jest.fn().mockRejectedValue(new Error('Some found')),
-          update: jest.fn().mockRejectedValue(new Error('Some found')),
-          destroy: jest.fn().mockRejectedValue(new Error('Some found')),
-          findByPk: jest.fn().mockRejectedValue(new Error('Some found')),
+          findById: jest.fn().mockRejectedValue(new Error('Some error')),
+          findActiveByNationalId: jest
+            .fn()
+            .mockRejectedValue(new Error('Some error')),
+          findAllActive: jest.fn().mockRejectedValue(new Error('Some error')),
+          findAllForAdmin: jest.fn().mockRejectedValue(new Error('Some error')),
+          findAllActiveWhoCanConfirmIndictments: jest
+            .fn()
+            .mockRejectedValue(new Error('Some error')),
+          findAllActiveProsecutors: jest
+            .fn()
+            .mockRejectedValue(new Error('Some error')),
+          create: jest.fn().mockRejectedValue(new Error('Some error')),
+          updateById: jest.fn().mockRejectedValue(new Error('Some error')),
         },
       },
       UserService,
@@ -55,7 +62,9 @@ export const createTestingUserModule = async () => {
     })
     .compile()
 
-  const userModel = await userModule.resolve<typeof User>(getModelToken(User))
+  const userRepositoryService = userModule.get<UserRepositoryService>(
+    UserRepositoryService,
+  )
 
   const userService = userModule.get<UserService>(UserService)
 
@@ -64,7 +73,7 @@ export const createTestingUserModule = async () => {
   userModule.close()
 
   return {
-    userModel,
+    userRepositoryService,
     userService,
     userController,
   }

--- a/apps/judicial-system/backend/src/app/modules/user/test/getAll.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/user/test/getAll.spec.ts
@@ -1,4 +1,3 @@
-import { Op } from 'sequelize'
 import { v4 as uuid } from 'uuid'
 
 import {
@@ -9,7 +8,7 @@ import {
 
 import { createTestingUserModule } from './createTestingUserModule'
 
-import { Institution, User } from '../../repository'
+import { User, UserRepositoryService } from '../../repository'
 
 interface Then {
   result: User[]
@@ -19,13 +18,14 @@ interface Then {
 type GivenWhenThen = (role: UserRole) => Promise<Then>
 
 describe('UserController - Get all', () => {
-  let mockUserModel: typeof User
+  let mockUserRepositoryService: UserRepositoryService
   let givenWhenThen: GivenWhenThen
 
   beforeEach(async () => {
-    const { userModel, userController } = await createTestingUserModule()
+    const { userRepositoryService, userController } =
+      await createTestingUserModule()
 
-    mockUserModel = userModel
+    mockUserRepositoryService = userRepositoryService
 
     givenWhenThen = async (role: UserRole) => {
       const then = {} as Then
@@ -47,21 +47,18 @@ describe('UserController - Get all', () => {
     let then: Then
 
     beforeEach(async () => {
-      const mockFindAll = mockUserModel.findAll as jest.Mock
-      mockFindAll.mockResolvedValueOnce(users)
+      const mockFindAllForAdmin =
+        mockUserRepositoryService.findAllForAdmin as jest.Mock
+      mockFindAllForAdmin.mockResolvedValueOnce(users)
 
       then = await givenWhenThen(UserRole.ADMIN)
     })
 
     it('should return all users', () => {
-      expect(mockUserModel.findAll).toHaveBeenCalledWith({
-        order: ['name'],
-        include: [{ model: Institution, as: 'institution' }],
-        where: {
-          role: { [Op.not]: UserRole.ADMIN },
-          '$institution.type$': Object.values(InstitutionType),
-        },
-      })
+      expect(mockUserRepositoryService.findAllForAdmin).toHaveBeenCalledWith(
+        UserRole.ADMIN,
+        Object.values(InstitutionType),
+      )
       expect(then.result).toEqual(users)
     })
   })
@@ -71,21 +68,18 @@ describe('UserController - Get all', () => {
     let then: Then
 
     beforeEach(async () => {
-      const mockFindAll = mockUserModel.findAll as jest.Mock
-      mockFindAll.mockResolvedValueOnce(users)
+      const mockFindAllForAdmin =
+        mockUserRepositoryService.findAllForAdmin as jest.Mock
+      mockFindAllForAdmin.mockResolvedValueOnce(users)
 
       then = await givenWhenThen(UserRole.LOCAL_ADMIN)
     })
 
     it('should return all users', () => {
-      expect(mockUserModel.findAll).toHaveBeenCalledWith({
-        order: ['name'],
-        include: [{ model: Institution, as: 'institution' }],
-        where: {
-          role: { [Op.not]: UserRole.LOCAL_ADMIN },
-          '$institution.type$': [InstitutionType.POLICE_PROSECUTORS_OFFICE],
-        },
-      })
+      expect(mockUserRepositoryService.findAllForAdmin).toHaveBeenCalledWith(
+        UserRole.LOCAL_ADMIN,
+        [InstitutionType.POLICE_PROSECUTORS_OFFICE],
+      )
       expect(then.result).toEqual(users)
     })
   })
@@ -99,18 +93,15 @@ describe('UserController - Get all', () => {
     let then: Then
 
     beforeEach(async () => {
-      const mockFindAll = mockUserModel.findAll as jest.Mock
-      mockFindAll.mockResolvedValueOnce(users)
+      const mockFindAllActive =
+        mockUserRepositoryService.findAllActive as jest.Mock
+      mockFindAllActive.mockResolvedValueOnce(users)
 
       then = await givenWhenThen(role)
     })
 
     it('should return all active users', () => {
-      expect(mockUserModel.findAll).toHaveBeenCalledWith({
-        order: ['name'],
-        where: { active: true },
-        include: [{ model: Institution, as: 'institution' }],
-      })
+      expect(mockUserRepositoryService.findAllActive).toHaveBeenCalled()
       expect(then.result).toEqual(users)
     })
   })

--- a/apps/judicial-system/backend/src/app/modules/user/test/getById.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/user/test/getById.spec.ts
@@ -2,7 +2,7 @@ import { v4 as uuid } from 'uuid'
 
 import { createTestingUserModule } from './createTestingUserModule'
 
-import { Institution, User } from '../../repository'
+import { User, UserRepositoryService } from '../../repository'
 
 interface Then {
   result: User
@@ -13,13 +13,14 @@ type GivenWhenThen = () => Promise<Then>
 
 describe('UserController - Get by id', () => {
   const userId = uuid()
-  let mockUserModel: typeof User
+  let mockUserRepositoryService: UserRepositoryService
   let givenWhenThen: GivenWhenThen
 
   beforeEach(async () => {
-    const { userModel, userController } = await createTestingUserModule()
+    const { userRepositoryService, userController } =
+      await createTestingUserModule()
 
-    mockUserModel = userModel
+    mockUserRepositoryService = userRepositoryService
 
     givenWhenThen = async () => {
       const then = {} as Then
@@ -38,16 +39,14 @@ describe('UserController - Get by id', () => {
     let then: Then
 
     beforeEach(async () => {
-      const mockFindByPk = mockUserModel.findByPk as jest.Mock
-      mockFindByPk.mockResolvedValueOnce(user)
+      const mockFindById = mockUserRepositoryService.findById as jest.Mock
+      mockFindById.mockResolvedValueOnce(user)
 
       then = await givenWhenThen()
     })
 
     it('should return the user', () => {
-      expect(mockUserModel.findByPk).toHaveBeenCalledWith(userId, {
-        include: [{ model: Institution, as: 'institution' }],
-      })
+      expect(mockUserRepositoryService.findById).toHaveBeenCalledWith(userId)
       expect(then.result).toBe(user)
     })
   })

--- a/apps/judicial-system/backend/src/app/modules/user/test/getByNationalId.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/user/test/getByNationalId.spec.ts
@@ -6,7 +6,7 @@ import { createTestingUserModule } from './createTestingUserModule'
 
 import { nowFactory } from '../../../factories'
 import { randomDate } from '../../../test'
-import { Institution, User } from '../../repository'
+import { User, UserRepositoryService } from '../../repository'
 
 jest.mock('../../../factories')
 
@@ -19,13 +19,14 @@ type GivenWhenThen = (nationalId: string) => Promise<Then>
 
 describe('UserController - Get by national id', () => {
   const date = randomDate()
-  let mockUserModel: typeof User
+  let mockUserRepositoryService: UserRepositoryService
   let givenWhenThen: GivenWhenThen
 
   beforeEach(async () => {
-    const { userModel, userController } = await createTestingUserModule()
+    const { userRepositoryService, userController } =
+      await createTestingUserModule()
 
-    mockUserModel = userModel
+    mockUserRepositoryService = userRepositoryService
 
     const mockToday = nowFactory as jest.Mock
     mockToday.mockReturnValue(date)
@@ -76,17 +77,17 @@ describe('UserController - Get by national id', () => {
     let then: Then
 
     beforeEach(async () => {
-      const mockFindOne = mockUserModel.findAll as jest.Mock
-      mockFindOne.mockResolvedValueOnce([user1, user2])
+      const mockFindActiveByNationalId =
+        mockUserRepositoryService.findActiveByNationalId as jest.Mock
+      mockFindActiveByNationalId.mockResolvedValueOnce([user1, user2])
 
       then = await givenWhenThen(nationalId)
     })
 
     it('should return the user', () => {
-      expect(mockUserModel.findAll).toHaveBeenCalledWith({
-        where: { nationalId, active: true },
-        include: [{ model: Institution, as: 'institution' }],
-      })
+      expect(
+        mockUserRepositoryService.findActiveByNationalId,
+      ).toHaveBeenCalledWith(nationalId)
       expect(then.result).toEqual([user1, user2])
     })
   })

--- a/apps/judicial-system/backend/src/app/modules/user/test/update.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/user/test/update.spec.ts
@@ -2,7 +2,7 @@ import { v4 as uuid } from 'uuid'
 
 import { createTestingUserModule } from './createTestingUserModule'
 
-import { User } from '../../repository'
+import { User, UserRepositoryService } from '../../repository'
 
 interface Then {
   result: User
@@ -15,13 +15,14 @@ describe('UserController - Update', () => {
   const userId = uuid()
   const name = uuid()
   const title = uuid()
-  let mockUserModel: typeof User
+  let mockUserRepositoryService: UserRepositoryService
   let givenWhenThen: GivenWhenThen
 
   beforeEach(async () => {
-    const { userModel, userController } = await createTestingUserModule()
+    const { userRepositoryService, userController } =
+      await createTestingUserModule()
 
-    mockUserModel = userModel
+    mockUserRepositoryService = userRepositoryService
 
     givenWhenThen = async () => {
       const then = {} as Then
@@ -40,16 +41,19 @@ describe('UserController - Update', () => {
     let then: Then
 
     beforeEach(async () => {
-      const mockUpdate = mockUserModel.update as jest.Mock
-      mockUpdate.mockResolvedValueOnce([1, [user]])
+      const mockUpdateById = mockUserRepositoryService.updateById as jest.Mock
+      mockUpdateById.mockResolvedValueOnce({
+        numberOfAffectedRows: 1,
+        users: [user],
+      })
 
       then = await givenWhenThen()
     })
 
     it('should return the updated user', () => {
-      expect(mockUserModel.update).toHaveBeenCalledWith(
+      expect(mockUserRepositoryService.updateById).toHaveBeenCalledWith(
+        userId,
         { name, title },
-        { where: { id: userId }, returning: true },
       )
       expect(then.result).toBe(user)
     })

--- a/apps/judicial-system/backend/src/app/modules/user/user.module.ts
+++ b/apps/judicial-system/backend/src/app/modules/user/user.module.ts
@@ -1,8 +1,6 @@
 import { forwardRef, Module } from '@nestjs/common'
-import { SequelizeModule } from '@nestjs/sequelize'
 
-import { User } from '../repository'
-import { EventLogModule, InstitutionModule } from '..'
+import { EventLogModule, InstitutionModule, RepositoryModule } from '..'
 import { UserController } from './user.controller'
 import { UserService } from './user.service'
 
@@ -10,7 +8,7 @@ import { UserService } from './user.service'
   imports: [
     forwardRef(() => EventLogModule),
     forwardRef(() => InstitutionModule),
-    SequelizeModule.forFeature([User]),
+    forwardRef(() => RepositoryModule),
   ],
   providers: [UserService],
   controllers: [UserController],

--- a/apps/judicial-system/backend/src/app/modules/user/user.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/user/user.service.ts
@@ -1,4 +1,4 @@
-import { Op, UniqueConstraintError } from 'sequelize'
+import { UniqueConstraintError } from 'sequelize'
 
 import {
   ConflictException,
@@ -6,7 +6,6 @@ import {
   Injectable,
   NotFoundException,
 } from '@nestjs/common'
-import { InjectModel } from '@nestjs/sequelize'
 
 import type { Logger } from '@island.is/logging'
 import { LOGGER_PROVIDER } from '@island.is/logging'
@@ -20,7 +19,7 @@ import {
 } from '@island.is/judicial-system/types'
 
 import { nowFactory } from '../../factories'
-import { Institution, User } from '../repository'
+import { User, UserRepositoryService } from '../repository'
 import { CreateUserDto } from './dto/createUser.dto'
 import { UpdateUserDto } from './dto/updateUser.dto'
 import { userModuleConfig } from './user.config'
@@ -30,35 +29,25 @@ export class UserService {
   constructor(
     @Inject(userModuleConfig.KEY)
     private readonly config: ConfigType<typeof userModuleConfig>,
-    @InjectModel(User) private readonly userModel: typeof User,
+    private readonly userRepositoryService: UserRepositoryService,
     @Inject(LOGGER_PROVIDER) private readonly logger: Logger,
   ) {}
 
   async getAll(user: TUser): Promise<User[]> {
     if (isAdminUser(user)) {
-      return this.userModel.findAll({
-        order: ['name'],
-        include: [{ model: Institution, as: 'institution' }],
-        // Local admins can only see users from a select list of institutions
-        // and they do not see local admins
-        where: {
-          role: { [Op.not]: user.role },
-          '$institution.type$': getAdminUserInstitutionScope(user),
-        },
-      })
+      // Local admins can only see users from a select list of institutions
+      // and they do not see local admins
+      return this.userRepositoryService.findAllForAdmin(
+        user.role,
+        getAdminUserInstitutionScope(user),
+      )
     }
 
-    return this.userModel.findAll({
-      order: ['name'],
-      where: { active: true },
-      include: [{ model: Institution, as: 'institution' }],
-    })
+    return this.userRepositoryService.findAllActive()
   }
 
   async getById(userId: string): Promise<User | null> {
-    return this.userModel.findByPk(userId, {
-      include: [{ model: Institution, as: 'institution' }],
-    })
+    return this.userRepositoryService.findById(userId)
   }
 
   async findById(userId: string): Promise<User> {
@@ -100,10 +89,9 @@ export class UserService {
       this.logger.error('Failed to parse admin users', { error })
     }
 
-    const users = await this.userModel.findAll({
-      where: { nationalId, active: true },
-      include: [{ model: Institution, as: 'institution' }],
-    })
+    const users = await this.userRepositoryService.findActiveByNationalId(
+      nationalId,
+    )
 
     if (!users || users.length === 0) {
       throw new NotFoundException('User does not exist')
@@ -114,7 +102,7 @@ export class UserService {
 
   async create(userToCreate: CreateUserDto): Promise<User> {
     try {
-      return await this.userModel.create({ ...userToCreate })
+      return await this.userRepositoryService.create(userToCreate)
     } catch (error) {
       if (error instanceof UniqueConstraintError) {
         throw new ConflictException(
@@ -127,10 +115,8 @@ export class UserService {
   }
 
   async update(userId: string, update: UpdateUserDto): Promise<User> {
-    const [numberOfAffectedRows, users] = await this.userModel.update(update, {
-      where: { id: userId },
-      returning: true,
-    })
+    const { numberOfAffectedRows, users } =
+      await this.userRepositoryService.updateById(userId, update)
 
     if (numberOfAffectedRows > 1) {
       // Tolerate failure, but log error
@@ -147,22 +133,14 @@ export class UserService {
   getUsersWhoCanConfirmIndictments(
     prosecutorsOfficeId: string,
   ): Promise<User[]> {
-    return this.userModel.findAll({
-      where: {
-        active: true,
-        canConfirmIndictment: true,
-        institutionId: prosecutorsOfficeId,
-      },
-    })
+    return this.userRepositoryService.findAllActiveWhoCanConfirmIndictments(
+      prosecutorsOfficeId,
+    )
   }
 
   async getProsecutorUsers(prosecutorsOfficeId: string): Promise<User[]> {
-    return this.userModel.findAll({
-      where: {
-        active: true,
-        role: UserRole.PROSECUTOR,
-        institutionId: prosecutorsOfficeId,
-      },
-    })
+    return this.userRepositoryService.findAllActiveProsecutors(
+      prosecutorsOfficeId,
+    )
   }
 }


### PR DESCRIPTION
# User repository service

[Repository þjónusta fyrir User model](https://app.asana.com/1/203394141643832/project/1199153462262248/task/1217581832097338)

Continues the repository-pattern migration (chunk C). `User` was the last
substantial chunk C model, and the one with the largest call surface so far:
eight raw model calls in one consumer.

## What changed

- **New `UserRepositoryService`** with eight intent-named methods — `findById`,
  `findActiveByNationalId`, `findAllActive`, `findAllForAdmin`,
  `findAllActiveWhoCanConfirmIndictments`, `findAllActiveProsecutors`, `create`,
  `updateById`. No method accepts `where`, `include`, `order` or `limit` from its
  caller, and every one wraps its data access in `try`/`catch` that logs and
  rethrows.
- The `{ model: Institution, as: 'institution' }` include is a repository detail, so
  it is a module-level constant rather than an argument. The two institution-scoped
  lookups deliberately keep **no** include, matching their behaviour before this PR.
- The nested-column filter that motivated the domain-intent convention —
  `role: { [Op.not]: excludedRole }` together with `'$institution.type$'` — moves out
  of `UserService` into the repository. `UserService` keeps deciding *who* is an admin
  (`isAdminUser`) and *what* their scope is (`getAdminUserInstitutionScope`); the
  repository does not know what a local admin is.
- `updateById` returns `{ numberOfAffectedRows, users }` rather than Sequelize's
  `[count, rows]` tuple, so the caller never destructures a driver-shaped result.
- `User` is registered in `RepositoryModule.forFeature` and dropped from
  `UserModule`; `UserService` no longer uses `@InjectModel`.
- `UserService`'s public API is unchanged, so its consumers (notably
  `institutionNotification.service.ts`) are untouched.

## What deliberately stayed in `UserService`

- `NotFoundException` for a missing user, and for an empty national-id lookup.
- The `UniqueConstraintError` → `ConflictException` translation. Mapping a driver
  error to an HTTP status is a business decision, and moving it would drag
  `ConflictException` into the data layer — so `user.service.ts` still has one
  `import { UniqueConstraintError } from 'sequelize'`. That is intentional, not an
  oversight; it is a known residue for the later "retire the Sequelize passthrough"
  work.
- The admin-users config parsing and its `nowFactory` defaults.

`findAllActiveWhoCanConfirmIndictments` and `findAllActiveProsecutors` are kept as
two methods rather than collapsed into one parameterised
`findAllActiveInInstitution(institutionId, { … })` — an options bag is what the
convention exists to avoid.

## Tests

- New `userRepository.service.spec.ts` covering all eight methods: the `where` shape
  of each, that the institution include is applied where it was applied before, that
  `findAllForAdmin` emits both `Op.not` and the `$institution.type$` key, that
  `findAllActive` orders by name, that `findById` returns `null` when absent, that
  `updateById` maps the tuple onto the named object, and that a national id never
  reaches the logs.
- `createTestingUserModule` now provides a mocked `UserRepositoryService` instead of
  the `User` model token, and the five controller specs that asserted on Sequelize
  option objects now assert on repository method calls instead. The guard and
  roles-rules specs are untouched.
- `26` suites / `122` tests green for `modules/user` and `modules/repository`;
  `tsc --noEmit` and `nx lint` clean.

## Note on size

At ~610 added lines this is above the ~400-line guideline the migration usually holds
to. The driver is arity, not scope creep: eight methods where the previous slices had
two to four, and the consumer spec rework is mandatory rather than optional (the five
specs reference the test seam that had to change). The diff is uniform and mechanical.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added centralized user data access for lookups, creation, updates, and filtered user lists.
  * Improved support for administrator, prosecutor, and indictment-confirmation user queries.
* **Refactor**
  * User operations now use a consistent repository layer, improving separation between business logic and data access.
* **Tests**
  * Expanded coverage for user operations, filtering, error handling, logging, and update results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->