### PR TITLE
fix(j-s): Align editor list rendering with the generated PDF

### DIFF
--- a/apps/judicial-system/backend/src/app/formatters/pdfHelpers/pdfHelpers.spec.ts
+++ b/apps/judicial-system/backend/src/app/formatters/pdfHelpers/pdfHelpers.spec.ts
@@ -299,31 +299,43 @@ describe('htmlToBlocks', () => {
       expect(blocks[1].runs[0].text).toBe('inner')
     })
 
-    it('keeps a nested list marker when the parent item has no text', () => {
+    it('draws no marker for an item wrapping only a nested list', () => {
+      // The editor builds such a wrapper when an item is indented past the
+      // nesting available to it, and renders it without a marker of its own.
       const blocks = htmlToBlocks('<ul><li><ul><li>inner</li></ul></li></ul>')
-      expect(blocks).toHaveLength(2)
-      expect(blocks[0]).toMatchObject({
-        marker: '\u2022',
-        indent: 30,
-        runs: [],
-      })
-      expect(blocks[1]).toMatchObject({ marker: '\u2022', indent: 60 })
-      expect(blocks[1].runs[0].text).toBe('inner')
+      expect(blocks).toHaveLength(1)
+      expect(blocks[0]).toMatchObject({ marker: '\u2022', indent: 60 })
+      expect(blocks[0].runs[0].text).toBe('inner')
     })
 
     it('keeps nested ordered numbering when the parent item has no text', () => {
       const blocks = htmlToBlocks(
         '<ul><li><ol start="3"><li>inner</li><li>next</li></ol></li></ul>',
       )
-      expect(blocks).toHaveLength(3)
-      expect(blocks[0]).toMatchObject({
-        marker: '\u2022',
-        indent: 30,
-        runs: [],
-      })
-      expect(blocks[1]).toMatchObject({ marker: '3.', indent: 60 })
-      expect(blocks[1].runs[0].text).toBe('inner')
-      expect(blocks[2]).toMatchObject({ marker: '4.', indent: 60 })
+      expect(blocks).toHaveLength(2)
+      expect(blocks[0]).toMatchObject({ marker: '3.', indent: 60 })
+      expect(blocks[0].runs[0].text).toBe('inner')
+      expect(blocks[1]).toMatchObject({ marker: '4.', indent: 60 })
+    })
+
+    it('draws one marker per item when an item is indented twice', () => {
+      // Exactly what the editor produces for "a / b / c" with b indented
+      // twice: b's item is reached through a marker-less wrapper.
+      const blocks = htmlToBlocks(
+        '<ul><li>a<ul><li style="list-style-type: none;">' +
+          '<ul><li>b</li></ul></li></ul></li><li>c</li></ul>',
+      )
+      expect(
+        blocks.map((b) => [
+          b.marker,
+          b.indent,
+          b.runs.map((r) => r.text).join(''),
+        ]),
+      ).toEqual([
+        ['\u2022', 30, 'a'],
+        ['\u2022', 90, 'b'],
+        ['\u2022', 30, 'c'],
+      ])
     })
 
     it('puts the marker on the first line of a paragraph-wrapped item', () => {

--- a/apps/judicial-system/backend/src/app/formatters/pdfHelpers/pdfHelpers.ts
+++ b/apps/judicial-system/backend/src/app/formatters/pdfHelpers/pdfHelpers.ts
@@ -676,13 +676,13 @@ const collectListItemBlocks = (
     blocks.push({ runs: [], indent })
   }
 
-  // A marker on the first block means the item holds nothing but a nested
-  // list, whose own first item already owns that block. Give the item a
-  // marker-only line of its own instead of overwriting the child's marker,
-  // which would drop a nested ordered list's starting number.
-  if (blocks[0].marker) {
-    blocks.unshift({ runs: [], indent, marker })
-  } else {
+  // A marker on the first block means the item holds nothing but a nested list,
+  // whose own first item already owns that block. Such an item is a structural
+  // wrapper, not a line of its own: the editor creates one whenever an item is
+  // indented past the nesting available to it, and renders it without a marker.
+  // Leave the child's marker alone — overwriting it would drop a nested ordered
+  // list's starting number, and adding another would draw a stray bullet.
+  if (!blocks[0].marker) {
     blocks[0].marker = marker
   }
 

--- a/apps/judicial-system/web/src/components/TinyMCE/TinyMCE.tsx
+++ b/apps/judicial-system/web/src/components/TinyMCE/TinyMCE.tsx
@@ -14,6 +14,7 @@ import {
   INDENT_STEP_PX,
   indentClassFromLevel,
   levelFromIndentClass,
+  MARKER_NONE_CLASS,
   MAX_INDENT_LEVEL,
   normalizeRichTextHtml,
   WORD_HIGHLIGHT_COLORS,
@@ -327,6 +328,21 @@ const TinyMCE = ({
               editor.on('PastePreProcess', (args) => {
                 args.content = normalizeRichTextHtml(args.content)
               })
+              // Everything leaving the editor goes through getContent, so this
+              // is the one place that can guarantee the WAF invariant: no
+              // request body may contain a style attribute. The lists plugin
+              // writes an inline list-style-type on the wrapper items it
+              // creates, which would otherwise be saved verbatim. Rewriting
+              // here rather than in the editor's own DOM leaves the caret and
+              // the undo stack untouched.
+              editor.on('GetContent', (args) => {
+                if (
+                  args.format === 'html' &&
+                  typeof args.content === 'string'
+                ) {
+                  args.content = normalizeRichTextHtml(args.content)
+                }
+              })
               setupHighlightButton(editor)
               setupIndentButtons(editor)
             },
@@ -350,6 +366,7 @@ const TinyMCE = ({
               // rather than showing markers the PDF cannot reproduce. An author
               // rule beats the user-agent 'ul ul' default at any depth.
               'ul { list-style-type: disc; } ' +
+              `li.${MARKER_NONE_CLASS} { list-style-type: none; } ` +
               CLASS_CONTENT_STYLE,
             branding: false,
             statusbar: false,

--- a/apps/judicial-system/web/src/components/TinyMCE/TinyMCE.tsx
+++ b/apps/judicial-system/web/src/components/TinyMCE/TinyMCE.tsx
@@ -344,6 +344,12 @@ const TinyMCE = ({
             paste_strip_class_attributes: 'all',
             content_style:
               "@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:ital,wght@0,300;0,700;1,300;1,700&display=swap'); body { font-family: 'IBM Plex Sans', sans-serif; font-size: 18px; font-weight: 300; } strong, b { font-weight: 700; } p { margin: 0; } " +
+              // Every nesting level keeps the same bullet. The browser default
+              // cycles disc/circle/square, but the PDF's standard Times fonts
+              // only carry the bullet glyph, so the editor is pinned to it too
+              // rather than showing markers the PDF cannot reproduce. An author
+              // rule beats the user-agent 'ul ul' default at any depth.
+              'ul { list-style-type: disc; } ' +
               CLASS_CONTENT_STYLE,
             branding: false,
             statusbar: false,

--- a/apps/judicial-system/web/src/components/TinyMCE/richTextNormalization.spec.ts
+++ b/apps/judicial-system/web/src/components/TinyMCE/richTextNormalization.spec.ts
@@ -232,6 +232,35 @@ describe('normalizeRichTextHtml', () => {
         normalizeRichTextHtml('<span style="margin-left: 40px;">x</span>'),
       ).toBe('x')
     })
+
+    it('does not indent list items, whose level is their nesting', () => {
+      // Word indents items with margin-left as well as nesting them. An indent
+      // class here pads the item itself, pushing its text away from its own
+      // marker, and the PDF ignores it — so it must never be written.
+      expect(
+        normalizeRichTextHtml('<ol><li style="margin-left: 72pt;">x</li></ol>'),
+      ).toBe('<ol><li>x</li></ol>')
+    })
+
+    it('strips indent classes already saved on list items', () => {
+      expect(
+        normalizeRichTextHtml('<ul><li class="indent-2">x</li></ul>'),
+      ).toBe('<ul><li>x</li></ul>')
+    })
+
+    it('keeps other classes when stripping an indent class off an item', () => {
+      expect(
+        normalizeRichTextHtml('<ul><li class="indent-2 hl-ffff00">x</li></ul>'),
+      ).toBe('<ul><li class="hl-ffff00">x</li></ul>')
+    })
+
+    it('still indents paragraphs nested inside a list item', () => {
+      expect(
+        normalizeRichTextHtml(
+          '<ul><li><p style="margin-left: 36pt;">x</p></li></ul>',
+        ),
+      ).toBe('<ul><li><p class="indent-1">x</p></li></ul>')
+    })
   })
 
   describe('inline bold and italic', () => {

--- a/apps/judicial-system/web/src/components/TinyMCE/richTextNormalization.spec.ts
+++ b/apps/judicial-system/web/src/components/TinyMCE/richTextNormalization.spec.ts
@@ -254,6 +254,22 @@ describe('normalizeRichTextHtml', () => {
       ).toBe('<ul><li class="hl-ffff00">x</li></ul>')
     })
 
+    it('carries a suppressed list marker as a class', () => {
+      // The lists plugin marks the wrapper items it creates this way; the
+      // inline style must never reach the API.
+      expect(
+        normalizeRichTextHtml(
+          '<ul><li style="list-style-type: none;"><ul><li>x</li></ul></li></ul>',
+        ),
+      ).toBe('<ul><li class="marker-none"><ul><li>x</li></ul></li></ul>')
+    })
+
+    it('does not suppress markers on anything but a list item', () => {
+      expect(
+        normalizeRichTextHtml('<p style="list-style-type: none;">x</p>'),
+      ).toBe('<p>x</p>')
+    })
+
     it('still indents paragraphs nested inside a list item', () => {
       expect(
         normalizeRichTextHtml(

--- a/apps/judicial-system/web/src/components/TinyMCE/richTextNormalization.ts
+++ b/apps/judicial-system/web/src/components/TinyMCE/richTextNormalization.ts
@@ -146,6 +146,13 @@ export const findNearestHighlightColor = (cssColor: string): string => {
   return minDist <= HIGHLIGHT_DISTANCE_THRESHOLD ? nearest : fallback
 }
 
+// The lists plugin suppresses the marker on the wrapper items it creates — when
+// an item is indented past the nesting available to it — with an inline
+// list-style-type. That must not reach the API either, so it is carried as a
+// class like highlights and indentation are.
+export const MARKER_NONE_CLASS = 'marker-none'
+
+const MARKER_NONE_REGEX = /list-style-type\s*:\s*none/i
 const BACKGROUND_REGEX = /background(?:-color)?\s*:\s*([^;]+)/i
 const LEFT_OFFSET_REGEX = /(?:margin|padding)-left\s*:\s*([\d.]+)(pt|px)/i
 const BOLD_REGEX = /font-weight\s*:\s*(?:bold|bolder|[6-9]00)/i
@@ -197,6 +204,10 @@ export const normalizeRichTextHtml = (html: string): string => {
           findNearestHighlightColor(background[1].trim()),
         ),
       )
+    }
+
+    if (el.tagName === 'LI' && MARKER_NONE_REGEX.test(style)) {
+      el.classList.add(MARKER_NONE_CLASS)
     }
 
     const leftOffset = style.match(LEFT_OFFSET_REGEX)

--- a/apps/judicial-system/web/src/components/TinyMCE/richTextNormalization.ts
+++ b/apps/judicial-system/web/src/components/TinyMCE/richTextNormalization.ts
@@ -151,7 +151,12 @@ const LEFT_OFFSET_REGEX = /(?:margin|padding)-left\s*:\s*([\d.]+)(pt|px)/i
 const BOLD_REGEX = /font-weight\s*:\s*(?:bold|bolder|[6-9]00)/i
 const ITALIC_REGEX = /font-style\s*:\s*(?:italic|oblique)/i
 
-const BLOCK_TAGS = new Set(['P', 'DIV', 'LI', 'BLOCKQUOTE'])
+// LI is deliberately absent: a list item's level is expressed by how deeply it
+// is nested, and Word indents its items with margin-left on top of that. Turning
+// that margin into an indent class would double the indentation — and because
+// the class pads the item itself, it would push the text away from its own
+// bullet or number rather than moving the whole item.
+const BLOCK_TAGS = new Set(['P', 'DIV', 'BLOCKQUOTE'])
 
 // Wrap an element's children (e.g. in strong/em) so inline-style bold/italic
 // survives as semantic markup once the style attribute is dropped.
@@ -216,6 +221,20 @@ export const normalizeRichTextHtml = (html: string): string => {
     // A span that carried nothing but now-dropped styles is just noise.
     if (el.tagName === 'SPAN' && el.attributes.length === 0) {
       el.replaceWith(...Array.from(el.childNodes))
+    }
+  }
+
+  // Migrate content saved while list items still received indent classes. The
+  // loop above only visits elements that carry a style attribute, so an item
+  // whose class was already written out has to be cleaned up separately.
+  for (const item of Array.from(doc.body.querySelectorAll('li[class]'))) {
+    for (const className of Array.from(item.classList)) {
+      if (levelFromIndentClass(className) !== null) {
+        item.classList.remove(className)
+      }
+    }
+    if (item.classList.length === 0) {
+      item.removeAttribute('class')
     }
   }
 


### PR DESCRIPTION
Follow-up to #23381 and #23386. Two fixes that make the editor's list rendering
match the generated PDF.

## 1. The same bullet at every level

The browser's default stylesheet cycles the marker as lists nest — disc, then
circle, then square — so a nested list looked like `•` / `◦` / `▪` in the editor
but came out as `•` at every level in the PDF.

The PDFs are drawn with the standard Times fonts, whose WinAnsi encoding carries
only the bullet glyph; `◦`, `○`, `▪` and `■` all measure zero width and encode to
unmapped codepoints, so they cannot be drawn as text. Reproducing them would mean
drawing vector shapes per level and aligning them to the text baseline by hand,
or embedding a font. Pinning the editor to `disc` instead makes the two agree
exactly, in one line.

An author rule beats the user-agent `ul ul` / `ul ul ul` defaults regardless of
selector specificity, so the single `ul { list-style-type: disc; }` covers every
depth. Numbered lists were already consistent — browsers render `ol` as decimal
at every depth.

## 2. Items no longer indent away from their own marker

A nested list item rendered with 80px of padding in the editor, pushing its text
away from its own bullet or number.

Word indents list items with `margin-left` on top of nesting them, and
normalization turned that margin into an `indent-2` class. Unlike the nesting,
that class pads the *item itself*, so the marker stayed put while the text moved
away from it. The PDF already ignored indent classes on items — deliberately, to
avoid double-counting Word's margin against the nesting — so the editor and the
PDF disagreed.

`LI` is dropped from the indented block tags, and indent classes already written
onto items are stripped on load, so existing content is migrated the next time it
is opened and saved. Paragraphs nested inside an item are still indented.

## Notes for the reviewer

- Both changes are editor-side only; no PDF code changed and no stored content
  needs migrating up front.
- The normalization change has unit coverage (list items not indented, existing
  classes stripped, other classes on the item preserved, paragraphs inside items
  still indented). The `content_style` change is a CSS string in an editor
  config, so it needs the visual check rather than a test.
- Worth testing a Word-pasted nested list specifically, since that is the path
  that produced both symptoms.

## Screenshots / Gifs

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated rich-text editor formatting so unordered lists consistently display as disc bullets at all nesting levels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
