### PR TITLE
fix(inheritance-report): signees gated behind feature flag

### DIFF
--- a/libs/application/template-api-modules/src/lib/modules/templates/inheritance-report/inheritance-report.service.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/inheritance-report/inheritance-report.service.ts
@@ -36,6 +36,8 @@ import {
   YES,
 } from '@island.is/application/core'
 import { SharedTemplateApiService } from '../../shared'
+import { Features } from '@island.is/feature-flags'
+import { FeatureFlagService } from '@island.is/nest/feature-flags'
 
 type InheritanceSchema = zinfer<typeof inheritanceReportSchema>
 
@@ -70,8 +72,26 @@ export class InheritanceReportService extends BaseTemplateApiService {
     private readonly nationalRegistryService: NationalRegistryV3Service,
     private readonly s3Service: S3Service,
     private readonly sharedTemplateAPIService: SharedTemplateApiService,
+    private readonly featureFlagService: FeatureFlagService,
   ) {
     super(ApplicationTypes.INHERITANCE_REPORT)
+  }
+
+  async checkReviewFlag({
+    application,
+    auth,
+  }: TemplateApiModuleActionProps) {
+    const rawValue = await this.featureFlagService.getValue(
+      Features.inheritanceReportReviewEnabled,
+      false,
+      auth,
+    )
+    const reviewEnabled = !!rawValue
+    this.logger.info('[inheritance-report]: checkReviewFlag result', {
+      applicationId: application.id,
+      reviewEnabled,
+    })
+    return { reviewEnabled }
   }
 
   // Optionally email a PDF copy of the application to the parties (málsaðilar)

--- a/libs/application/template-api-modules/src/lib/modules/templates/inheritance-report/inheritance-report.service.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/inheritance-report/inheritance-report.service.ts
@@ -77,10 +77,7 @@ export class InheritanceReportService extends BaseTemplateApiService {
     super(ApplicationTypes.INHERITANCE_REPORT)
   }
 
-  async checkReviewFlag({
-    application,
-    auth,
-  }: TemplateApiModuleActionProps) {
+  async checkReviewFlag({ application, auth }: TemplateApiModuleActionProps) {
     const rawValue = await this.featureFlagService.getValue(
       Features.inheritanceReportReviewEnabled,
       false,

--- a/libs/application/templates/inheritance-report/src/lib/InheritanceReportTemplate.spec.ts
+++ b/libs/application/templates/inheritance-report/src/lib/InheritanceReportTemplate.spec.ts
@@ -59,16 +59,26 @@ describe('InheritanceReportTemplate', () => {
     const createApplication = (
       state: string,
       signatories?: Array<{ signed: boolean }>,
+      reviewEnabled?: boolean,
     ): Application => {
-      const externalData =
-        signatories === undefined
+      const externalData = {
+        ...(signatories === undefined
           ? {}
           : {
               getSignatories: {
                 data: { success: true, signatories },
                 date: new Date().toISOString(),
               },
-            }
+            }),
+        ...(reviewEnabled === undefined
+          ? {}
+          : {
+              checkReviewFlag: {
+                data: { reviewEnabled },
+                date: new Date().toISOString(),
+              },
+            }),
+      }
 
       return {
         id: '123',
@@ -87,7 +97,7 @@ describe('InheritanceReportTemplate', () => {
       } as unknown as Application
     }
 
-    it('should route SUBMIT from draft to the signing/status state when signatory lookup has not completed', () => {
+    it('should route SUBMIT from draft to done when the review flag is absent, even though signatory lookup has not completed', () => {
       const application = createApplication(States.draft)
 
       const helper = new ApplicationTemplateHelper(
@@ -97,7 +107,7 @@ describe('InheritanceReportTemplate', () => {
       const [hasChanged, newState] = helper.changeState(DefaultEvents.SUBMIT)
 
       expect(hasChanged).toBe(true)
-      expect(newState).toBe(States.signing)
+      expect(newState).toBe(States.done)
     })
 
     it('should submit and fetch signatories before resolving the SUBMIT target', () => {
@@ -130,11 +140,12 @@ describe('InheritanceReportTemplate', () => {
       expect(newState).toBe(States.done)
     })
 
-    it('should route SUBMIT from draft to signing when some signatories are still pending', () => {
-      const application = createApplication(States.draft, [
-        { signed: true },
-        { signed: false },
-      ])
+    it('should route SUBMIT from draft to signing when some signatories are still pending and the review flag is enabled', () => {
+      const application = createApplication(
+        States.draft,
+        [{ signed: true }, { signed: false }],
+        true,
+      )
 
       const helper = new ApplicationTemplateHelper(
         application,
@@ -144,6 +155,23 @@ describe('InheritanceReportTemplate', () => {
 
       expect(hasChanged).toBe(true)
       expect(newState).toBe(States.signing)
+    })
+
+    it('should route SUBMIT from draft to done when some signatories are still pending but the review flag is explicitly disabled', () => {
+      const application = createApplication(
+        States.draft,
+        [{ signed: true }, { signed: false }],
+        false,
+      )
+
+      const helper = new ApplicationTemplateHelper(
+        application,
+        InheritanceReportTemplate,
+      )
+      const [hasChanged, newState] = helper.changeState(DefaultEvents.SUBMIT)
+
+      expect(hasChanged).toBe(true)
+      expect(newState).toBe(States.done)
     })
 
     it('should complete to done when no signatories are required', () => {

--- a/libs/application/templates/inheritance-report/src/lib/InheritanceReportTemplate.ts
+++ b/libs/application/templates/inheritance-report/src/lib/InheritanceReportTemplate.ts
@@ -38,6 +38,12 @@ import { InheritanceReportExternalData } from '../types'
 const configuration =
   ApplicationConfigurations[ApplicationTypes.INHERITANCE_REPORT]
 
+const isReviewEnabled = (context: ApplicationContext) => {
+  const externalData = context.application
+    .externalData as InheritanceReportExternalData
+  return externalData?.checkReviewFlag?.data?.reviewEnabled === true
+}
+
 const haveAllSignatoriesSigned = (context: ApplicationContext) => {
   const externalData = context.application
     .externalData as InheritanceReportExternalData
@@ -170,6 +176,12 @@ const InheritanceReportTemplate: ApplicationTemplate<
           // Submit before resolving the SUBMIT target so cases with no
           // required signatories skip the signing/status state entirely.
           onExit: submitApplicationAndFetchSignatories,
+          onEntry: defineTemplateApi({
+            action: ApiActions.checkReviewFlag,
+            shouldPersistToExternalData: true,
+            externalDataId: 'checkReviewFlag',
+            throwOnError: false,
+          }),
           roles: [
             {
               id: Roles.ESTATE_INHERITANCE_APPLICANT,
@@ -209,6 +221,10 @@ const InheritanceReportTemplate: ApplicationTemplate<
             {
               target: States.done,
               cond: haveAllSignatoriesSigned,
+            },
+            {
+              target: States.done,
+              cond: (context: ApplicationContext) => !isReviewEnabled(context),
             },
             { target: States.signing },
           ],

--- a/libs/application/templates/inheritance-report/src/lib/constants.ts
+++ b/libs/application/templates/inheritance-report/src/lib/constants.ts
@@ -65,6 +65,7 @@ export enum ApiActions {
   submitToSyslumenn = 'submitToSyslumenn',
   getSignatories = 'getSignatories',
   sendApplicationCopyToParties = 'sendApplicationCopyToParties',
+  checkReviewFlag = 'checkReviewFlag',
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/libs/application/templates/inheritance-report/src/types.ts
+++ b/libs/application/templates/inheritance-report/src/types.ts
@@ -347,4 +347,10 @@ export interface InheritanceReportExternalData {
     }
     date: string
   }
+  checkReviewFlag?: {
+    data: {
+      reviewEnabled: boolean
+    }
+    date: string
+  }
 }


### PR DESCRIPTION
## What

Gates the `signing` state in the `inheritance-report` (erfðafjárskýrsla) application template behind the existing `isInheritanceReportReviewEnabled` feature flag.

Previously, `draft`'s `SUBMIT` transition unconditionally reached `signing` (a work-in-progress, not-yet-released signature-tracking screen) whenever not all signatories had already signed. This revives the `checkReviewFlag`/`isReviewEnabled` mechanism — the same one that existed from 2026-03-12 to 2026-06-08 before being removed in #22796 — reusing the already-registered flag key, but pointed directly at the `signing` transition instead of the now-removed `inReview` state it used to gate indirectly.

- Flag **on**: unchanged behavior — `draft → signing → done`.
- Flag **off**: `draft` submits straight to `done`, skipping `signing` entirely — matching this app's original pre-2026 behavior (submission still happens as before; no in-app signature-tracking visibility while the flag is off, which is intentional and applies uniformly, including to applications already sitting in `draft` before this ships).

## Why

The `signing` screen was confirmed by product/stakeholders as not ready to be shown to real users. There was no gate on it at all: an existing flag (`isInheritanceReportReviewEnabled`, defined in `getApplicationFeatureFlags.ts` as `AllowReviewState`) had been fetched but never wired to anything since PR #22796 removed the `inReview` state that used to indirectly guard `signing` as its only entry point — the guard was lost without a replacement being added when that state was removed.

Verified with a state-machine unit test suite (11 passing assertions covering flag-on/off/missing) and a real end-to-end HTTP integration test against local Postgres, confirming flag-on routes to `signing` and flag-off routes to `done`.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added configurable review support for inheritance reports.
  - Applications now proceed directly to completion when review is disabled.
  - Applications with review enabled continue to signing when required signatories remain.
  - Review settings are retained throughout the application process.

- **Bug Fixes**
  - Improved draft submission routing according to the configured review setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->