### PR TITLE
fix(payments): accept null market information on approved charges

### DIFF
--- a/apps/services/payments/src/types/cardPayment.spec.ts
+++ b/apps/services/payments/src/types/cardPayment.spec.ts
@@ -1,0 +1,40 @@
+import { CardPaymentSuccessSchema } from './cardPayment'
+
+describe('CardPaymentSuccessSchema', () => {
+  const approvedCharge = {
+    isSuccess: true,
+    responseCode: '00-I',
+    responseDescription: 'Approved or completed successfully',
+    responseTime: '00:00:01',
+    correlationID: '514ca62a-de5a-4ec6-88d5-0484ac8d7a6c',
+    acquirerReferenceNumber: 'arn',
+    transactionID: 'txn',
+    authorizationCode: 'auth',
+    transactionLifecycleId: 'tlc',
+    maskedCardNumber: '545721******0001',
+    cardInformation: {
+      cardScheme: 'M',
+      cardUsage: 'Credit',
+    },
+    authorizationIdentifier: 'authId',
+  }
+
+  it('accepts an approved charge with null market information fields', () => {
+    const result = CardPaymentSuccessSchema.safeParse({
+      ...approvedCharge,
+      marketInformation: {
+        merchantCountry: 'IS',
+        marketName: null,
+        acquirerRegion: null,
+      },
+    })
+
+    expect(result.success).toBe(true)
+  })
+
+  it('accepts an approved charge without market information', () => {
+    const result = CardPaymentSuccessSchema.safeParse(approvedCharge)
+
+    expect(result.success).toBe(true)
+  })
+})

--- a/apps/services/payments/src/types/cardPayment.spec.ts
+++ b/apps/services/payments/src/types/cardPayment.spec.ts
@@ -19,46 +19,13 @@ describe('CardPaymentSuccessSchema', () => {
     authorizationIdentifier: 'authId',
   }
 
-  const fullMarketInformation = {
-    merchantCountry: 'IS',
-    marketName: 'Iceland',
-    acquirerRegion: 'EU',
-  }
-
-  it.each(['merchantCountry', 'marketName', 'acquirerRegion'] as const)(
-    'accepts an approved charge with null %s',
-    (field) => {
-      const result = CardPaymentSuccessSchema.safeParse({
-        ...approvedCharge,
-        marketInformation: { ...fullMarketInformation, [field]: null },
-      })
-
-      expect(result.success).toBe(true)
-    },
-  )
-
-  it.each(['merchantCountry', 'marketName', 'acquirerRegion'] as const)(
-    'accepts an approved charge with omitted %s',
-    (field) => {
-      const { [field]: _omitted, ...partialMarketInformation } =
-        fullMarketInformation
-
-      const result = CardPaymentSuccessSchema.safeParse({
-        ...approvedCharge,
-        marketInformation: partialMarketInformation,
-      })
-
-      expect(result.success).toBe(true)
-    },
-  )
-
-  it('accepts an approved charge with all market information fields null', () => {
+  it('accepts an approved charge with null marketName', () => {
     const result = CardPaymentSuccessSchema.safeParse({
       ...approvedCharge,
       marketInformation: {
-        merchantCountry: null,
+        merchantCountry: 'IS',
         marketName: null,
-        acquirerRegion: null,
+        acquirerRegion: 'EU',
       },
     })
 

--- a/apps/services/payments/src/types/cardPayment.spec.ts
+++ b/apps/services/payments/src/types/cardPayment.spec.ts
@@ -19,11 +19,44 @@ describe('CardPaymentSuccessSchema', () => {
     authorizationIdentifier: 'authId',
   }
 
-  it('accepts an approved charge with null market information fields', () => {
+  const fullMarketInformation = {
+    merchantCountry: 'IS',
+    marketName: 'Iceland',
+    acquirerRegion: 'EU',
+  }
+
+  it.each(['merchantCountry', 'marketName', 'acquirerRegion'] as const)(
+    'accepts an approved charge with null %s',
+    (field) => {
+      const result = CardPaymentSuccessSchema.safeParse({
+        ...approvedCharge,
+        marketInformation: { ...fullMarketInformation, [field]: null },
+      })
+
+      expect(result.success).toBe(true)
+    },
+  )
+
+  it.each(['merchantCountry', 'marketName', 'acquirerRegion'] as const)(
+    'accepts an approved charge with omitted %s',
+    (field) => {
+      const { [field]: _omitted, ...partialMarketInformation } =
+        fullMarketInformation
+
+      const result = CardPaymentSuccessSchema.safeParse({
+        ...approvedCharge,
+        marketInformation: partialMarketInformation,
+      })
+
+      expect(result.success).toBe(true)
+    },
+  )
+
+  it('accepts an approved charge with all market information fields null', () => {
     const result = CardPaymentSuccessSchema.safeParse({
       ...approvedCharge,
       marketInformation: {
-        merchantCountry: 'IS',
+        merchantCountry: null,
         marketName: null,
         acquirerRegion: null,
       },

--- a/apps/services/payments/src/types/cardPayment.ts
+++ b/apps/services/payments/src/types/cardPayment.ts
@@ -42,9 +42,9 @@ const CardInformationSchema = z.object({
 })
 
 const MarketInformationSchema = z.object({
-  merchantCountry: z.string().optional().nullable(),
-  marketName: z.string().optional().nullable(),
-  acquirerRegion: z.string().optional().nullable(),
+  merchantCountry: z.string(),
+  marketName: z.string().nullable(),
+  acquirerRegion: z.string(),
 })
 
 const PaymentGatewayApiResponseSchema = z.object({

--- a/apps/services/payments/src/types/cardPayment.ts
+++ b/apps/services/payments/src/types/cardPayment.ts
@@ -41,10 +41,13 @@ const CardInformationSchema = z.object({
   cardProductCategory: z.string().optional().nullable(),
 })
 
+// Informational only (not consumed anywhere) — the gateway returns null for
+// these fields on some transactions, and an approved charge must never be
+// treated as failed because of them.
 const MarketInformationSchema = z.object({
-  merchantCountry: z.string(),
-  marketName: z.string(),
-  acquirerRegion: z.string(),
+  merchantCountry: z.string().optional().nullable(),
+  marketName: z.string().optional().nullable(),
+  acquirerRegion: z.string().optional().nullable(),
 })
 
 const PaymentGatewayApiResponseSchema = z.object({

--- a/apps/services/payments/src/types/cardPayment.ts
+++ b/apps/services/payments/src/types/cardPayment.ts
@@ -41,9 +41,6 @@ const CardInformationSchema = z.object({
   cardProductCategory: z.string().optional().nullable(),
 })
 
-// Informational only (not consumed anywhere) — the gateway returns null for
-// these fields on some transactions, and an approved charge must never be
-// treated as failed because of them.
 const MarketInformationSchema = z.object({
   merchantCountry: z.string().optional().nullable(),
   marketName: z.string().optional().nullable(),


### PR DESCRIPTION
## What
Allow `marketInformation.marketName` to be null in the card payment gateway response schema. The field is informational and not consumed anywhere in the service.

## Why
On a successful charge, ValitorPay UAT returns `marketInformation.marketName: null`. The strict schema fails parsing, so the saga marks the payment failed **after the charge was approved** — the customer is charged while the flow reports "Óvænt villa", and rollback has nothing to compensate.

The Datadog error from the failing charge ([logs](https://app.datadoghq.eu/logs?query=service%3Aservices-payments%20%22Failed%20to%20parse%20payment%20gateway%20response%22), trace `6a845ee3000000006f544f843de550f6`):

```
message: "Failed to parse payment gateway response"
responseCode: "00-I"  responseDescription: "Approved or completed successfully"
parseError: ZodError — marketInformation.marketName: Expected string, received null
```

The same error has fired on every approved dev charge in the 90-day log retention (also pre-upgrade, e.g. Aug 7 and Aug 11 on flow `204b525b`), and never on staging/prod — production Valitor appears to always populate the field, dev/UAT does not.

## Verified
- Unit tests: null `marketName` and omitted `marketInformation` both parse.
- Feature deployment: full happy-path card payment (verify → frictionless 3DS → callback → charge) completed against ValitorPay UAT with `00-I Approved`, transaction and authorization ids returned — the first fully green card payment on this environment in the log retention window.

## Checklist:

- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Card payment validation now accepts a null market name when market information is provided.
  * Successful card payments can also be processed without market information.

* **Tests**
  * Added coverage for approved card payments with null market details and without market information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->