### PR TITLE
fix(j-s): Scope court of appeals ruling files to the current appeal

### DIFF
--- a/apps/judicial-system/web/src/components/FormProvider/case.graphql
+++ b/apps/judicial-system/web/src/components/FormProvider/case.graphql
@@ -447,6 +447,7 @@ query Case($input: CaseQueryInput!) {
       appealValidToDate
       isAppealCustodyIsolation
       appealIsolationToDate
+      rulingFileId
     }
     rulingOrderAppealCases {
       id

--- a/apps/judicial-system/web/src/components/FormProvider/limitedAccessCase.graphql
+++ b/apps/judicial-system/web/src/components/FormProvider/limitedAccessCase.graphql
@@ -247,6 +247,7 @@ query LimitedAccessCase($input: CaseQueryInput!) {
       appealRulingDecision
       appealConclusion
       appealRulingModifiedHistory
+      rulingFileId
     }
     rulingOrderAppealCases {
       id

--- a/apps/judicial-system/web/src/routes/CourtOfAppeal/Ruling/Ruling.spec.tsx
+++ b/apps/judicial-system/web/src/routes/CourtOfAppeal/Ruling/Ruling.spec.tsx
@@ -4,11 +4,17 @@ import { render, screen, waitFor } from '@testing-library/react'
 import {
   AppealCaseRulingDecision,
   AppealCaseState,
+  Case,
   CaseDecision,
+  CaseFile,
+  CaseFileCategory,
   CaseState,
   CaseType,
 } from '@island.is/judicial-system-web/src/graphql/schema'
-import { mockCase } from '@island.is/judicial-system-web/src/utils/mocks'
+import {
+  mockCase,
+  mockCaseFile,
+} from '@island.is/judicial-system-web/src/utils/mocks'
 import {
   FormContextWrapper,
   IntlProviderWrapper,
@@ -16,18 +22,22 @@ import {
 
 import Ruling from './Ruling'
 
+let mockRouterQuery: Record<string, string> = { id: 'test_id' }
+
 jest.mock('next/router', () => ({
   useRouter() {
     return {
       pathname: '',
-      query: {
-        id: 'test_id',
-      },
+      query: mockRouterQuery,
     }
   },
 }))
 
 describe('COA - Ruling', () => {
+  beforeEach(() => {
+    mockRouterQuery = { id: 'test_id' }
+  })
+
   it('should render fields to change validToDate and isolation if the case appeal ruling decision is CHANGED', async () => {
     render(
       <IntlProviderWrapper>
@@ -84,6 +94,97 @@ describe('COA - Ruling', () => {
       expect(
         screen.queryByTestId('caseDecisionSection'),
       ).not.toBeInTheDocument()
+    })
+  })
+
+  describe('appeal ruling upload box', () => {
+    // A dismissed indictment appealed at case level, on a case that also has an
+    // earlier appealed ruling order. Each appeal owns its own appeal ruling.
+    const rulingOrderAppealRuling = {
+      ...mockCaseFile(CaseFileCategory.APPEAL_RULING),
+      name: 'urskurdur-undir-rekstri.pdf',
+      rulingFileId: 'ruling_order_file_id',
+    }
+    const caseLevelAppealRuling = {
+      ...mockCaseFile(CaseFileCategory.APPEAL_RULING),
+      name: 'urskurdur-fravisun.pdf',
+      rulingFileId: null,
+    }
+    const appealCaseFields = {
+      appealState: AppealCaseState.RECEIVED,
+      appealRulingDecision: AppealCaseRulingDecision.ACCEPTING,
+      appealConclusion: 'Niðurstaða',
+    }
+
+    const renderRuling = (caseFiles: CaseFile[]) =>
+      render(
+        <IntlProviderWrapper>
+          <ApolloProvider
+            client={new ApolloClient({ cache: new InMemoryCache() })}
+          >
+            <FormContextWrapper
+              theCase={
+                {
+                  ...mockCase(CaseType.INDICTMENT),
+                  state: CaseState.COMPLETED,
+                  caseFiles,
+                  appealCase: {
+                    id: 'case_level_appeal_case_id',
+                    ...appealCaseFields,
+                  },
+                  rulingOrderAppealCases: [
+                    {
+                      id: 'ruling_order_appeal_case_id',
+                      rulingFileId: 'ruling_order_file_id',
+                      ...appealCaseFields,
+                    },
+                  ],
+                } as Case
+              }
+            >
+              <Ruling />
+            </FormContextWrapper>
+          </ApolloProvider>
+        </IntlProviderWrapper>,
+      )
+
+    it('should only show the case level appeal ruling on the case level appeal', async () => {
+      renderRuling([rulingOrderAppealRuling, caseLevelAppealRuling])
+
+      expect(
+        await screen.findByLabelText(`Opna ${caseLevelAppealRuling.name}`),
+      ).toBeInTheDocument()
+      expect(
+        screen.queryByLabelText(`Opna ${rulingOrderAppealRuling.name}`),
+      ).not.toBeInTheDocument()
+    })
+
+    it('should only show the ruling order appeal ruling on the ruling order appeal', async () => {
+      mockRouterQuery = {
+        id: 'test_id',
+        appealCaseId: 'ruling_order_appeal_case_id',
+      }
+
+      renderRuling([rulingOrderAppealRuling, caseLevelAppealRuling])
+
+      expect(
+        await screen.findByLabelText(`Opna ${rulingOrderAppealRuling.name}`),
+      ).toBeInTheDocument()
+      expect(
+        screen.queryByLabelText(`Opna ${caseLevelAppealRuling.name}`),
+      ).not.toBeInTheDocument()
+    })
+
+    it('should not allow the case level appeal to continue on another appeal ruling', async () => {
+      renderRuling([rulingOrderAppealRuling])
+
+      expect(await screen.findByTestId('continueButton')).toBeDisabled()
+    })
+
+    it('should allow the case level appeal to continue on its own appeal ruling', async () => {
+      renderRuling([caseLevelAppealRuling])
+
+      expect(await screen.findByTestId('continueButton')).not.toBeDisabled()
     })
   })
 })

--- a/apps/judicial-system/web/src/routes/CourtOfAppeal/Ruling/Ruling.tsx
+++ b/apps/judicial-system/web/src/routes/CourtOfAppeal/Ruling/Ruling.tsx
@@ -48,6 +48,7 @@ import {
 import {
   appendAppealCaseIdQuery,
   applyAppealCaseUpdate,
+  isMatchingAppealCourtFile,
 } from '@island.is/judicial-system-web/src/utils/utils'
 import {
   isCourtOfAppealRulingStepFieldsValid,
@@ -134,8 +135,11 @@ const Ruling = () => {
       AppealCaseRulingDecision.DISCONTINUED ||
       uploadFiles.some(
         (file) =>
-          file.category === CaseFileCategory.APPEAL_RULING &&
-          file.status === FileUploadStatus.done,
+          isMatchingAppealCourtFile(
+            file,
+            CaseFileCategory.APPEAL_RULING,
+            targetAppealCase?.rulingFileId,
+          ) && file.status === FileUploadStatus.done,
       ))
 
   const decisionOptions = [
@@ -244,9 +248,12 @@ const Ruling = () => {
             <SectionHeading title={formatMessage(strings.courtRecordHeading)} />
             <InputFileUpload
               name="appealCourtRecord"
-              files={uploadFiles.filter(
-                (file) =>
-                  file.category === CaseFileCategory.APPEAL_COURT_RECORD,
+              files={uploadFiles.filter((file) =>
+                isMatchingAppealCourtFile(
+                  file,
+                  CaseFileCategory.APPEAL_COURT_RECORD,
+                  targetAppealCase?.rulingFileId,
+                ),
               )}
               accept="application/pdf"
               title={formatMessage(strings.inputFieldLabel)}
@@ -258,6 +265,7 @@ const Ruling = () => {
                 handleUpload(
                   addUploadFiles(files, {
                     category: CaseFileCategory.APPEAL_COURT_RECORD,
+                    rulingFileId: targetAppealCase?.rulingFileId,
                   }),
                   updateUploadFile,
                 )
@@ -370,8 +378,12 @@ const Ruling = () => {
               />
               <InputFileUpload
                 name="appealRuling"
-                files={uploadFiles.filter(
-                  (file) => file.category === CaseFileCategory.APPEAL_RULING,
+                files={uploadFiles.filter((file) =>
+                  isMatchingAppealCourtFile(
+                    file,
+                    CaseFileCategory.APPEAL_RULING,
+                    targetAppealCase?.rulingFileId,
+                  ),
                 )}
                 accept="application/pdf"
                 title={formatMessage(strings.inputFieldLabel)}
@@ -383,6 +395,7 @@ const Ruling = () => {
                   handleUpload(
                     addUploadFiles(files, {
                       category: CaseFileCategory.APPEAL_RULING,
+                      rulingFileId: targetAppealCase?.rulingFileId,
                     }),
                     updateUploadFile,
                   )

--- a/apps/judicial-system/web/src/routes/CourtOfAppeal/WithdrawnAppealCase/WithdrawnAppealCase.tsx
+++ b/apps/judicial-system/web/src/routes/CourtOfAppeal/WithdrawnAppealCase/WithdrawnAppealCase.tsx
@@ -24,7 +24,10 @@ import {
   useTargetAppealCaseByAppealCaseId,
   useUploadFiles,
 } from '@island.is/judicial-system-web/src/utils/hooks'
-import { appendAppealCaseIdQuery } from '@island.is/judicial-system-web/src/utils/utils'
+import {
+  appendAppealCaseIdQuery,
+  isMatchingAppealCourtFile,
+} from '@island.is/judicial-system-web/src/utils/utils'
 
 import { CaseNumberInput } from '../components'
 import { strings } from './WithdrawnAppealCase.strings'
@@ -73,8 +76,12 @@ const WithdrawnAppealCase = () => {
           </Text>
           <InputFileUpload
             name="appealCourtRecord"
-            files={uploadFiles.filter(
-              (file) => file.category === CaseFileCategory.APPEAL_COURT_RECORD,
+            files={uploadFiles.filter((file) =>
+              isMatchingAppealCourtFile(
+                file,
+                CaseFileCategory.APPEAL_COURT_RECORD,
+                targetAppealCase?.rulingFileId,
+              ),
             )}
             accept={'application/pdf'}
             title={formatMessage(strings.uploadBoxTitle)}
@@ -86,6 +93,7 @@ const WithdrawnAppealCase = () => {
               handleUpload(
                 addUploadFiles(files, {
                   category: CaseFileCategory.APPEAL_COURT_RECORD,
+                  rulingFileId: targetAppealCase?.rulingFileId,
                 }),
                 updateUploadFile,
               )

--- a/apps/judicial-system/web/src/utils/utils.spec.ts
+++ b/apps/judicial-system/web/src/utils/utils.spec.ts
@@ -28,6 +28,7 @@ import {
   hasSentNotification,
   isAppealFileCategoryVisible,
   isCurrentAppellantRepresentative,
+  isMatchingAppealCourtFile,
   isSentToPublicProsecutor,
   mapStringToGender,
   reconcileAppealDecisionsForRulingFileChange,
@@ -1505,6 +1506,90 @@ describe('Utils', () => {
           undefined,
           file(CaseFileCategory.PROSECUTOR_APPEAL_BRIEF),
           otherUser,
+        ),
+      ).toBe(false)
+    })
+  })
+
+  describe('isMatchingAppealCourtFile', () => {
+    test('matches a case level appeal file when no ruling file id is given', () => {
+      expect(
+        isMatchingAppealCourtFile(
+          { category: CaseFileCategory.APPEAL_RULING, rulingFileId: null },
+          CaseFileCategory.APPEAL_RULING,
+          undefined,
+        ),
+      ).toBe(true)
+    })
+
+    test('matches a ruling order appeal file with the same ruling file id', () => {
+      expect(
+        isMatchingAppealCourtFile(
+          {
+            category: CaseFileCategory.APPEAL_RULING,
+            rulingFileId: 'ruling-1',
+          },
+          CaseFileCategory.APPEAL_RULING,
+          'ruling-1',
+        ),
+      ).toBe(true)
+    })
+
+    test('does not match a ruling order appeal file on a case level appeal', () => {
+      expect(
+        isMatchingAppealCourtFile(
+          {
+            category: CaseFileCategory.APPEAL_RULING,
+            rulingFileId: 'ruling-1',
+          },
+          CaseFileCategory.APPEAL_RULING,
+          null,
+        ),
+      ).toBe(false)
+    })
+
+    test('does not match a case level appeal file on a ruling order appeal', () => {
+      expect(
+        isMatchingAppealCourtFile(
+          { category: CaseFileCategory.APPEAL_RULING, rulingFileId: null },
+          CaseFileCategory.APPEAL_RULING,
+          'ruling-1',
+        ),
+      ).toBe(false)
+    })
+
+    test('does not match a file belonging to another ruling order appeal', () => {
+      expect(
+        isMatchingAppealCourtFile(
+          {
+            category: CaseFileCategory.APPEAL_RULING,
+            rulingFileId: 'ruling-1',
+          },
+          CaseFileCategory.APPEAL_RULING,
+          'ruling-2',
+        ),
+      ).toBe(false)
+    })
+
+    test('does not match another category on the same appeal', () => {
+      expect(
+        isMatchingAppealCourtFile(
+          {
+            category: CaseFileCategory.APPEAL_COURT_RECORD,
+            rulingFileId: 'ruling-1',
+          },
+          CaseFileCategory.APPEAL_RULING,
+          'ruling-1',
+        ),
+      ).toBe(false)
+    })
+
+    test('does not match a file without a category', () => {
+      expect(
+        isMatchingAppealCourtFile(
+          {},
+          CaseFileCategory.APPEAL_RULING,
+          undefined,
         ),
       ).toBe(false)
     })

--- a/apps/judicial-system/web/src/utils/utils.ts
+++ b/apps/judicial-system/web/src/utils/utils.ts
@@ -811,6 +811,22 @@ export const isAppealFileCategoryVisible = (
   }
 }
 
+// The court of appeals' own documents (APPEAL_RULING / APPEAL_COURT_RECORD) also
+// belong to exactly one appeal-case row: case-level appeals own the files with
+// no rulingFileId, ruling-order appeals own the files tagged with their own
+// rulingFileId. isMatchingAppealCaseFile cannot be used here as it is scoped to
+// the parties' files (kærugögn) and rejects court of appeals users.
+export const isMatchingAppealCourtFile = (
+  file: {
+    category?: CaseFileCategory | null
+    rulingFileId?: string | null
+  },
+  category: CaseFileCategory,
+  rulingFileId?: string | null,
+): boolean =>
+  file.category === category &&
+  (file.rulingFileId ?? null) === (rulingFileId ?? null)
+
 export const isMatchingAppealCaseFile = (
   workingCase: Case,
   categories: CaseFileCategory[],

--- a/apps/judicial-system/web/src/utils/validate.spec.ts
+++ b/apps/judicial-system/web/src/utils/validate.spec.ts
@@ -1,7 +1,10 @@
 import {
+  AppealCase,
+  AppealCaseRulingDecision,
   AppealDecisionPartyRole,
   Case,
   CaseAppealDecision,
+  CaseFileCategory,
   CourtSessionResponse,
   IndictmentCount,
   IndictmentCountOffense,
@@ -11,6 +14,7 @@ import {
 import {
   areAppealDecisionsComplete,
   getIndictmentCountWarningMessage,
+  isCourtOfAppealRulingStepValid,
   isIndictmentCountComplete,
   validate,
 } from './validate'
@@ -491,5 +495,61 @@ describe('areAppealDecisionsComplete', () => {
     expect(
       areAppealDecisionsComplete({} as CourtSessionResponse, baseCase),
     ).toBe(false)
+  })
+})
+
+describe('isCourtOfAppealRulingStepValid', () => {
+  const appealCase = {
+    appealRulingDecision: AppealCaseRulingDecision.ACCEPTING,
+    appealConclusion: 'Niðurstaða',
+  } as AppealCase
+
+  const appealRulingFile = (rulingFileId: string | null) => ({
+    category: CaseFileCategory.APPEAL_RULING,
+    rulingFileId,
+  })
+
+  it('is true when the case level appeal has its own appeal ruling', () => {
+    const workingCase = { caseFiles: [appealRulingFile(null)] } as Case
+
+    expect(isCourtOfAppealRulingStepValid(workingCase, appealCase)).toBe(true)
+  })
+
+  it('is false when the only appeal ruling belongs to a ruling order appeal', () => {
+    const workingCase = { caseFiles: [appealRulingFile('ruling-1')] } as Case
+
+    expect(isCourtOfAppealRulingStepValid(workingCase, appealCase)).toBe(false)
+  })
+
+  it('is true when the ruling order appeal has its own appeal ruling', () => {
+    const workingCase = { caseFiles: [appealRulingFile('ruling-1')] } as Case
+
+    expect(
+      isCourtOfAppealRulingStepValid(workingCase, {
+        ...appealCase,
+        rulingFileId: 'ruling-1',
+      } as AppealCase),
+    ).toBe(true)
+  })
+
+  it('is false when the appeal ruling belongs to another ruling order appeal', () => {
+    const workingCase = { caseFiles: [appealRulingFile('ruling-1')] } as Case
+
+    expect(
+      isCourtOfAppealRulingStepValid(workingCase, {
+        ...appealCase,
+        rulingFileId: 'ruling-2',
+      } as AppealCase),
+    ).toBe(false)
+  })
+
+  it('does not require an appeal ruling when the appeal was discontinued', () => {
+    const workingCase = { caseFiles: [] } as unknown as Case
+
+    expect(
+      isCourtOfAppealRulingStepValid(workingCase, {
+        appealRulingDecision: AppealCaseRulingDecision.DISCONTINUED,
+      } as AppealCase),
+    ).toBe(true)
   })
 })

--- a/apps/judicial-system/web/src/utils/validate.ts
+++ b/apps/judicial-system/web/src/utils/validate.ts
@@ -27,7 +27,11 @@ import {
 
 import { isNonEmptyArray } from './arrayHelpers'
 import { isCivilClaimantDefendantSelectionValid } from './civilClaimantUtils'
-import { caseLevelAppealDecision, isBusiness } from './utils'
+import {
+  caseLevelAppealDecision,
+  isBusiness,
+  isMatchingAppealCourtFile,
+} from './utils'
 
 export type Validation =
   | 'empty'
@@ -852,8 +856,12 @@ export const isCourtOfAppealRulingStepValid = (
     isCourtOfAppealRulingStepFieldsValid(appealCase) &&
       (appealCase?.appealRulingDecision ===
         AppealCaseRulingDecision.DISCONTINUED ||
-        workingCase.caseFiles?.some(
-          (file) => file.category === CaseFileCategory.APPEAL_RULING,
+        workingCase.caseFiles?.some((file) =>
+          isMatchingAppealCourtFile(
+            file,
+            CaseFileCategory.APPEAL_RULING,
+            appealCase?.rulingFileId,
+          ),
         )),
   )
 }


### PR DESCRIPTION
# Scope court of appeals ruling files to the current appeal

[LR - ef búið að úrskurða undir rekstri máls og mál endar með frávísun sem er líka kært þá hangir eldri úrskurður inni](https://app.asana.com/1/203394141643832/project/1199153462262248/task/1215526985946744)

The court of appeals upload boxes for its own documents (`APPEAL_RULING` and `APPEAL_COURT_RECORD`) filtered case files by category only, ignoring `rulingFileId`. Every appeal on a case therefore saw every other appeal's ruling and court record.

An indictment that gets a ruling during proceedings (úrskurður undir rekstri máls) which is appealed, and then ends in dismissal (frávísun) that is appealed too, has two appeals: the ruling-order appeal (`rulingFileId` set) and the case-level dismissal appeal (`rulingFileId` null — see `getIndictmentCaseLevelAppealInfo`). So when the court of appeals opened the ruling step for the dismissal appeal, the earlier appeal's ruling was already sitting in the upload box — with a live delete button, since `isAppealFileDeletionLocked` only covers the parties' files.

The rest of the code already scopes appeal files per appeal row (`isAppealFileCategoryVisible`, `isMatchingAppealCaseFile`, and the backend's delivery paths); only these screens were missed.

## Changes

- **`isMatchingAppealCourtFile`** in `utils.ts` — matches a court of appeals document against one appeal row by category + `rulingFileId`, normalising `null`/`undefined`. `isMatchingAppealCaseFile` could not be reused: it is scoped to the parties' files (kærugögn) and rejects court of appeals users.
- **`CourtOfAppeal/Ruling`** — both upload boxes and the "ruling uploaded" step gate filter on the target appeal's `rulingFileId`, and both `addUploadFiles` calls tag the optimistic row with it so an upload on a ruling-order appeal stays visible before the case refetches.
- **`CourtOfAppeal/WithdrawnAppealCase`** — same fix for its court record box.
- **`isCourtOfAppealRulingStepValid`** — same predicate, so the stepper no longer accepts another appeal's ruling as this appeal's.
- **`case.graphql` / `limitedAccessCase.graphql`** — the case-level `appealCase` now selects `rulingFileId` explicitly instead of relying on it being absent.

No backend change needed — `addMessagesForCompletedAppealCaseToQueue` and `deliverAppealToPolice` already scope by `rulingFileId`. No data backfill needed either: no ruling orders exist in production yet.

## Tests

16 new tests, all green:

- `utils.spec.ts` — the helper: `null`/`undefined` equivalence, both cross-appeal directions, another ruling-order appeal, wrong category, missing category.
- `validate.spec.ts` — `isCourtOfAppealRulingStepValid`, including the DISCONTINUED bypass.
- `Ruling.spec.tsx` — a dismissed indictment that also has an appealed ruling order: each appeal's box shows only its own ruling (driven through `?appealCaseId=`), and Continue stays disabled when only the other appeal has a ruling.

Full `judicial-system-web` suite passes (82 suites / 651 tests).

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Court of Appeal document handling by correctly linking uploaded ruling and court-record files to the relevant appeal.
  * Prevented unrelated files from appearing in upload lists or being used for validation.
  * Improved validation for case-level rulings, ruling-order appeals, mismatched documents, and discontinued appeals.

* **Tests**
  * Added coverage for appeal document selection, upload continuation, file matching, and ruling validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->