### PR TITLE
feat(j-s): Add spokesperson confirmation warning to civil claimants section

### DIFF
--- a/apps/judicial-system/web/src/routes/Court/Indictments/Advocates/Advocates.tsx
+++ b/apps/judicial-system/web/src/routes/Court/Indictments/Advocates/Advocates.tsx
@@ -1,6 +1,6 @@
-import { useCallback, useContext } from 'react'
+import { FC, useCallback, useContext } from 'react'
 import { useIntl } from 'react-intl'
-import { AnimatePresence, motion } from 'motion/react'
+import { motion } from 'motion/react'
 import { useRouter } from 'next/router'
 import { Tooltip, TooltipAnchor, TooltipProvider } from '@ariakit/react'
 
@@ -27,6 +27,50 @@ import SelectCivilClaimantAdvocate from './SelectCivilClaimantAdvocate'
 import SelectDefender from './SelectDefender'
 import { strings } from './Advocates.strings'
 
+// The warning stays mounted and animates via visibility so the lazily
+// loaded icon svg is fetched before the warning is first shown — otherwise
+// the entrance animation plays around an empty placeholder.
+const ConfirmationPendingWarning: FC<{
+  visible: boolean
+  tooltipText: string
+}> = ({ visible, tooltipText }) => (
+  <motion.div
+    initial="hidden"
+    animate={visible ? 'visible' : 'hidden'}
+    variants={{
+      visible: { opacity: 1, scale: 1, visibility: 'visible' },
+      hidden: {
+        opacity: 0,
+        scale: 0,
+        transitionEnd: { visibility: 'hidden' },
+      },
+    }}
+  >
+    <TooltipProvider timeout={0}>
+      <TooltipAnchor
+        render={
+          <Box display="flex">
+            <Icon icon="warning" size="large" color="red300" type="outline" />
+          </Box>
+        }
+      />
+      <Tooltip unmountOnHide>
+        <motion.div
+          initial={{ opacity: 0, y: 4, scale: 0.95 }}
+          animate={{ opacity: 1, y: 0, scale: 1 }}
+          transition={{ duration: 0.2, ease: 'easeOut' }}
+        >
+          <Box background="dark400" borderRadius="full" padding={1}>
+            <Text color="white" variant="small">
+              {tooltipText}
+            </Text>
+          </Box>
+        </motion.div>
+      </Tooltip>
+    </TooltipProvider>
+  </motion.div>
+)
+
 const Advocates = () => {
   const { workingCase, isLoadingWorkingCase, caseNotFound } =
     useContext(FormContext)
@@ -47,6 +91,11 @@ const Advocates = () => {
     workingCase.defendants?.every(
       (defendant) => defendant.isDefenderChoiceConfirmed,
     ) || false
+  const allSpokespersonsHaveBeenConfirmed =
+    workingCase.civilClaimants?.every(
+      (civilClaimant) =>
+        !civilClaimant.hasSpokesperson || civilClaimant.isSpokespersonConfirmed,
+    ) || false
 
   return (
     <PageLayout
@@ -63,43 +112,10 @@ const Advocates = () => {
 
         <Box display="flex" columnGap={1} alignItems="center" marginBottom={3}>
           <SectionHeading title="Verjendur varnaraðila" marginBottom={0} />
-          <AnimatePresence>
-            {!allDefendersHaveBeenConfirmed && (
-              <motion.div
-                initial={{ opacity: 0, scale: 0 }}
-                animate={{
-                  opacity: 1,
-                  scale: 1,
-                }}
-                exit={{
-                  opacity: 0,
-                  scale: 0,
-                }}
-              >
-                <TooltipProvider timeout={0}>
-                  <TooltipAnchor
-                    render={
-                      <Box display="flex">
-                        <Icon
-                          icon="warning"
-                          size="large"
-                          color="red300"
-                          type="outline"
-                        />
-                      </Box>
-                    }
-                  />
-                  <Tooltip>
-                    <Box background="dark400" borderRadius="full" padding={1}>
-                      <Text color="white" variant="small">
-                        Ákærunni hefur ekki verið deilt með öllum verjendum
-                      </Text>
-                    </Box>
-                  </Tooltip>
-                </TooltipProvider>
-              </motion.div>
-            )}
-          </AnimatePresence>
+          <ConfirmationPendingWarning
+            visible={!allDefendersHaveBeenConfirmed}
+            tooltipText="Ákærunni hefur ekki verið deilt með öllum verjendum"
+          />
         </Box>
         <div className={grid({ gap: 5, marginBottom: 10 })}>
           {workingCase.defendants?.map((defendant) => (
@@ -107,7 +123,21 @@ const Advocates = () => {
           ))}
           {hasCivilClaimants && (
             <Box component="section">
-              <SectionHeading title={formatMessage(strings.civilClaimants)} />
+              <Box
+                display="flex"
+                columnGap={1}
+                alignItems="center"
+                marginBottom={3}
+              >
+                <SectionHeading
+                  title={formatMessage(strings.civilClaimants)}
+                  marginBottom={0}
+                />
+                <ConfirmationPendingWarning
+                  visible={!allSpokespersonsHaveBeenConfirmed}
+                  tooltipText="Ákærunni hefur ekki verið deilt með öllum talsmönnum kröfuhafa"
+                />
+              </Box>
               <div className={grid({ gap: 5 })}>
                 {workingCase.civilClaimants?.map((civilClaimant) => (
                   <Box component="section" key={civilClaimant.id}>

--- a/apps/judicial-system/web/src/routes/Court/Indictments/Advocates/Advocates.tsx
+++ b/apps/judicial-system/web/src/routes/Court/Indictments/Advocates/Advocates.tsx
@@ -48,6 +48,8 @@ const ConfirmationPendingWarning: FC<{
   >
     <TooltipProvider timeout={0}>
       <TooltipAnchor
+        tabIndex={0}
+        aria-label={tooltipText}
         render={
           <Box display="flex">
             <Icon icon="warning" size="large" color="red300" type="outline" />


### PR DESCRIPTION
## What
- Added the "not shared with all advocates" warning icon + tooltip to the "Kröfuhafar" section heading on the advocates step in the district court indictment flow. It shows while any civil claimant has a spokesperson whose selection has not been confirmed (claimants without a spokesperson don't trigger it).
- Extracted the existing defender warning into a shared `ConfirmationPendingWarning` component used by both section headings.
- The warning now stays mounted and toggles via visibility variants instead of `AnimatePresence` mount/unmount. This preloads the lazily loaded warning icon svg, so the entrance animation no longer plays around an empty placeholder when the warning first appears (e.g. right after clicking "Bæta við lögmanni kröfuhafa").
- Added a fade/slide entrance animation to the tooltip on hover (`unmountOnHide` so it replays on every hover).

## Why
District court users had no indication on the "Kröfuhafar" section that the case hasn't been shared with all civil claimant spokespersons, unlike the defenders section. While adding it, the warning's entrance animation was fixed so it actually renders with the icon visible.

## Screenshots / Gifs
Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code
- [ ] No AI tools were used in preparing this pull request

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **User Interface Improvements**
  - Added consistent confirmation-pending warnings for defenders, spokespersons, and civil claimants.
  - Warnings now appear with smoother visibility and tooltip animations.
  - Improved visual consistency across advocate confirmation sections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->