### PR TITLE
fix(my-pages): Health questionnaire draft bugs

### DIFF
--- a/libs/api/domains/questionnaires/src/lib/transform-mappers/el/answer/mapToELAnswer.ts
+++ b/libs/api/domains/questionnaires/src/lib/transform-mappers/el/answer/mapToELAnswer.ts
@@ -69,10 +69,13 @@ export const mapToElAnswer = (
         entry.type === AnswerOptionType.scale ||
         entry.type === AnswerOptionType.thermometer
       ) {
-        const numericValue = parseFloat(answerValues[0])
-        // No real value entered - omit the reply instead of persisting a
+        const rawValue = answerValues[0].trim()
+        // Number() rejects partial parses like "12abc" that parseFloat
+        // would accept; the empty check must come first since Number('') is 0
+        const numericValue = Number(rawValue)
+        // No usable value entered - omit the reply instead of persisting a
         // fabricated 0, which is a valid, distinct answer from "unanswered"
-        if (isNaN(numericValue)) return []
+        if (!rawValue || !Number.isFinite(numericValue)) return []
 
         return {
           questionId,

--- a/libs/api/domains/questionnaires/src/lib/transform-mappers/el/answer/mapToELAnswer.ts
+++ b/libs/api/domains/questionnaires/src/lib/transform-mappers/el/answer/mapToELAnswer.ts
@@ -69,11 +69,14 @@ export const mapToElAnswer = (
         entry.type === AnswerOptionType.scale ||
         entry.type === AnswerOptionType.thermometer
       ) {
+        const numericValue = parseFloat(answerValues[0])
+        // No real value entered - omit the reply instead of persisting a
+        // fabricated 0, which is a valid, distinct answer from "unanswered"
+        if (isNaN(numericValue)) return []
+
         return {
           questionId,
-          answer: isNaN(parseFloat(answerValues[0]))
-            ? 0
-            : parseFloat(answerValues[0]),
+          answer: numericValue,
         }
       }
 

--- a/libs/api/domains/questionnaires/src/lib/transform-mappers/el/draft/mapToDraft.ts
+++ b/libs/api/domains/questionnaires/src/lib/transform-mappers/el/draft/mapToDraft.ts
@@ -123,30 +123,39 @@ export const mapDraftRepliesToAnswers = (
       }))
     } else if ('answer' in reply) {
       // Single value replies (String, Number, Boolean, Date)
-      let value: string
+      if (reply.answer === null || reply.answer === undefined) {
+        // No answer given yet - keep the draft entry empty rather than
+        // stringifying null/undefined into the literal text "null"/"undefined"
+        answerValue = []
+      } else {
+        let value: string
 
-      // Handle date formatting specifically
-      if (question.type === 'date' && reply.answer instanceof Date) {
-        // Format date as YYYY-MM-DD for DatePicker
-        value = reply.answer.toISOString().split('T')[0]
-      } else if (question.type === 'date' && typeof reply.answer === 'string') {
-        // If it's already a string, ensure it's in ISO format
-        try {
-          const date = new Date(reply.answer)
-          value = date.toISOString().split('T')[0]
-        } catch {
+        // Handle date formatting specifically
+        if (question.type === 'date' && reply.answer instanceof Date) {
+          // Format date as YYYY-MM-DD for DatePicker
+          value = reply.answer.toISOString().split('T')[0]
+        } else if (
+          question.type === 'date' &&
+          typeof reply.answer === 'string'
+        ) {
+          // If it's already a string, ensure it's in ISO format
+          try {
+            const date = new Date(reply.answer)
+            value = date.toISOString().split('T')[0]
+          } catch {
+            value = String(reply.answer)
+          }
+        } else {
           value = String(reply.answer)
         }
-      } else {
-        value = String(reply.answer)
-      }
 
-      answerValue = [
-        {
-          label: getOptionLabel(value),
-          value: value,
-        },
-      ]
+        answerValue = [
+          {
+            label: getOptionLabel(value),
+            value: value,
+          },
+        ]
+      }
     } else {
       // Skip invalid or unsupported replies (e.g., Attachment)
       return

--- a/libs/portals/my-pages/core/src/components/Questionnaires/Header.tsx
+++ b/libs/portals/my-pages/core/src/components/Questionnaires/Header.tsx
@@ -24,8 +24,10 @@ export const QuestionnaireHeader: FC<QuestionnaireHeaderProps> = ({
       borderColor="blue200"
       display="flex"
       justifyContent="spaceBetween"
-      alignItems="flexEnd"
+      alignItems={['center', 'center', 'center', 'flexEnd']}
       flexDirection="row"
+      flexWrap="wrap"
+      rowGap={2}
       columnGap={3}
       padding={[0, 0, 0, 3]}
     >
@@ -50,7 +52,7 @@ export const QuestionnaireHeader: FC<QuestionnaireHeaderProps> = ({
           </Text>
         </Box>
       </Box>
-      {buttonGroup && <Box>{buttonGroup}</Box>}
+      {buttonGroup && <Box flexShrink={0}>{buttonGroup}</Box>}
     </Box>
   )
 }


### PR DESCRIPTION
## What

Fix minor bugs in health questionnaire drafts and a mobile fix

## Why

Empty answers were being stringified to null and then parsed back to 0, which is wrong.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid numeric questionnaire answers are no longer saved as `0`.
  * Empty questionnaire answers no longer display as `"null"` or `"undefined"`.
* **Style**
  * Improved questionnaire header layout on smaller screens, including better wrapping, spacing, and button alignment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->