### PR TITLE
feat(j-s): Notification repository service

### DIFF
--- a/apps/judicial-system/backend/src/app/modules/notification/notification.module.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/notification.module.ts
@@ -1,11 +1,9 @@
 import { forwardRef, Module } from '@nestjs/common'
-import { SequelizeModule } from '@nestjs/sequelize'
 
 import { CmsTranslationsModule } from '@island.is/cms-translations'
 import { EmailModule } from '@island.is/email-service'
 import { SmsModule } from '@island.is/nova-sms'
 
-import { Notification } from '../repository'
 import {
   CaseModule,
   CourtModule,
@@ -41,7 +39,6 @@ import { NotificationController } from './notification.controller'
     forwardRef(() => EventModule),
     forwardRef(() => DefendantModule),
     forwardRef(() => RepositoryModule),
-    SequelizeModule.forFeature([Notification]),
   ],
   controllers: [NotificationController, InternalNotificationController],
   providers: [

--- a/apps/judicial-system/backend/src/app/modules/notification/services/appealCaseNotification/appealCaseNotification.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/services/appealCaseNotification/appealCaseNotification.service.ts
@@ -3,7 +3,6 @@ import {
   Injectable,
   InternalServerErrorException,
 } from '@nestjs/common'
-import { InjectModel } from '@nestjs/sequelize'
 
 import { IntlService } from '@island.is/cms-translations'
 import { EmailService } from '@island.is/email-service'
@@ -49,7 +48,7 @@ import { EventService } from '../../../event'
 import {
   type AppealCase,
   type Case,
-  Notification,
+  NotificationRepositoryService,
   Recipient,
 } from '../../../repository'
 import { DeliverResponse } from '../../models/deliver.response'
@@ -65,8 +64,7 @@ interface RecipientInfo {
 @Injectable()
 export class AppealCaseNotificationService extends BaseNotificationService {
   constructor(
-    @InjectModel(Notification)
-    notificationModel: typeof Notification,
+    notificationRepositoryService: NotificationRepositoryService,
     @Inject(notificationModuleConfig.KEY)
     config: ConfigType<typeof notificationModuleConfig>,
     @Inject(LOGGER_PROVIDER) logger: Logger,
@@ -78,7 +76,7 @@ export class AppealCaseNotificationService extends BaseNotificationService {
     private readonly defendantService: DefendantService,
   ) {
     super(
-      notificationModel,
+      notificationRepositoryService,
       emailService,
       intlService,
       courtService,

--- a/apps/judicial-system/backend/src/app/modules/notification/services/baseNotification.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/services/baseNotification.service.ts
@@ -23,7 +23,13 @@ import {
 import { notifications } from '../../../messages'
 import { CourtService } from '../../court'
 import { EventService } from '../../event'
-import { Case, DateLog, Notification, Recipient } from '../../repository'
+import {
+  Case,
+  DateLog,
+  Notification,
+  NotificationRepositoryService,
+  Recipient,
+} from '../../repository'
 import { DeliverResponse } from '../models/deliver.response'
 import { notificationModuleConfig } from '../notification.config'
 
@@ -36,7 +42,7 @@ interface Attachment {
 @Injectable()
 export abstract class BaseNotificationService {
   constructor(
-    private readonly notificationModel: typeof Notification,
+    private readonly notificationRepositoryService: NotificationRepositoryService,
     private readonly emailService: EmailService,
     private readonly intlService: IntlService,
     private readonly courtService: CourtService,
@@ -176,7 +182,7 @@ export abstract class BaseNotificationService {
     type: TrackedNotificationType,
     recipients: Recipient[],
   ): Promise<DeliverResponse> {
-    await this.notificationModel.create({
+    await this.notificationRepositoryService.create({
       caseId,
       type,
       recipients,

--- a/apps/judicial-system/backend/src/app/modules/notification/services/caseNotification/caseNotification.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/services/caseNotification/caseNotification.service.ts
@@ -5,7 +5,6 @@ import {
   Injectable,
   InternalServerErrorException,
 } from '@nestjs/common'
-import { InjectModel } from '@nestjs/sequelize'
 
 import { IntlService } from '@island.is/cms-translations'
 import { EmailService } from '@island.is/email-service'
@@ -86,7 +85,7 @@ import {
   DefendantEventLog,
   EventLog,
   InstitutionContactRepositoryService,
-  Notification,
+  NotificationRepositoryService,
   Recipient,
 } from '../../../repository'
 import { DeliverResponse } from '../../models/deliver.response'
@@ -96,8 +95,7 @@ import { BaseNotificationService } from '../baseNotification.service'
 @Injectable()
 export class CaseNotificationService extends BaseNotificationService {
   constructor(
-    @InjectModel(Notification)
-    notificationModel: typeof Notification,
+    notificationRepositoryService: NotificationRepositoryService,
     @Inject(notificationModuleConfig.KEY)
     config: ConfigType<typeof notificationModuleConfig>,
     @Inject(LOGGER_PROVIDER) logger: Logger,
@@ -110,7 +108,7 @@ export class CaseNotificationService extends BaseNotificationService {
     private readonly institutionContactRepositoryService: InstitutionContactRepositoryService,
   ) {
     super(
-      notificationModel,
+      notificationRepositoryService,
       emailService,
       intlService,
       courtService,

--- a/apps/judicial-system/backend/src/app/modules/notification/services/civilClaimantNotification/civilClaimantNotification.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/services/civilClaimantNotification/civilClaimantNotification.service.ts
@@ -5,7 +5,6 @@ import {
   Injectable,
   InternalServerErrorException,
 } from '@nestjs/common'
-import { InjectModel } from '@nestjs/sequelize'
 
 import { IntlService } from '@island.is/cms-translations'
 import { EmailService } from '@island.is/email-service'
@@ -25,7 +24,7 @@ import { EventService } from '../../../event'
 import {
   Case,
   CivilClaimant,
-  Notification,
+  NotificationRepositoryService,
   Recipient,
 } from '../../../repository'
 import { DeliverResponse } from '../../models/deliver.response'
@@ -36,8 +35,7 @@ import { strings } from './civilClaimantNotification.strings'
 @Injectable()
 export class CivilClaimantNotificationService extends BaseNotificationService {
   constructor(
-    @InjectModel(Notification)
-    notificationModel: typeof Notification,
+    notificationRepositoryService: NotificationRepositoryService,
     @Inject(notificationModuleConfig.KEY)
     config: ConfigType<typeof notificationModuleConfig>,
     @Inject(LOGGER_PROVIDER) logger: Logger,
@@ -47,7 +45,7 @@ export class CivilClaimantNotificationService extends BaseNotificationService {
     courtService: CourtService,
   ) {
     super(
-      notificationModel,
+      notificationRepositoryService,
       emailService,
       intlService,
       courtService,

--- a/apps/judicial-system/backend/src/app/modules/notification/services/defendantNotification/defendantNotification.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/services/defendantNotification/defendantNotification.service.ts
@@ -5,7 +5,6 @@ import {
   Injectable,
   InternalServerErrorException,
 } from '@nestjs/common'
-import { InjectModel } from '@nestjs/sequelize'
 
 import { IntlService } from '@island.is/cms-translations'
 import { EmailService } from '@island.is/email-service'
@@ -40,7 +39,7 @@ import {
   Defendant,
   DefendantEventLog,
   InstitutionContactRepositoryService,
-  Notification,
+  NotificationRepositoryService,
   Recipient,
 } from '../../../repository'
 import { DeliverResponse } from '../../models/deliver.response'
@@ -51,8 +50,7 @@ import { strings } from './defendantNotification.strings'
 @Injectable()
 export class DefendantNotificationService extends BaseNotificationService {
   constructor(
-    @InjectModel(Notification)
-    notificationModel: typeof Notification,
+    notificationRepositoryService: NotificationRepositoryService,
     @Inject(notificationModuleConfig.KEY)
     config: ConfigType<typeof notificationModuleConfig>,
     @Inject(LOGGER_PROVIDER) logger: Logger,
@@ -63,7 +61,7 @@ export class DefendantNotificationService extends BaseNotificationService {
     private readonly institutionContactRepositoryService: InstitutionContactRepositoryService,
   ) {
     super(
-      notificationModel,
+      notificationRepositoryService,
       emailService,
       intlService,
       courtService,

--- a/apps/judicial-system/backend/src/app/modules/notification/services/indictmentCaseNotification/indictmentCaseNotification.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/services/indictmentCaseNotification/indictmentCaseNotification.service.ts
@@ -5,7 +5,6 @@ import {
   Injectable,
   InternalServerErrorException,
 } from '@nestjs/common'
-import { InjectModel } from '@nestjs/sequelize'
 
 import { IntlService } from '@island.is/cms-translations'
 import { EmailService } from '@island.is/email-service'
@@ -36,7 +35,7 @@ import {
   DateLog,
   Defendant,
   InstitutionContactRepositoryService,
-  Notification,
+  NotificationRepositoryService,
   Recipient,
 } from '../../../repository'
 import { DeliverResponse } from '../../models/deliver.response'
@@ -53,8 +52,7 @@ interface Attachment {
 @Injectable()
 export class IndictmentCaseNotificationService extends BaseNotificationService {
   constructor(
-    @InjectModel(Notification)
-    notificationModel: typeof Notification,
+    notificationRepositoryService: NotificationRepositoryService,
     @Inject(notificationModuleConfig.KEY)
     config: ConfigType<typeof notificationModuleConfig>,
     @Inject(LOGGER_PROVIDER) logger: Logger,
@@ -65,7 +63,7 @@ export class IndictmentCaseNotificationService extends BaseNotificationService {
     private readonly institutionContactRepositoryService: InstitutionContactRepositoryService,
   ) {
     super(
-      notificationModel,
+      notificationRepositoryService,
       emailService,
       intlService,
       courtService,

--- a/apps/judicial-system/backend/src/app/modules/notification/services/institutionNotification/institutionNotification.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/services/institutionNotification/institutionNotification.service.ts
@@ -5,7 +5,6 @@ import {
   Injectable,
   InternalServerErrorException,
 } from '@nestjs/common'
-import { InjectModel } from '@nestjs/sequelize'
 
 import { IntlService } from '@island.is/cms-translations'
 import { EmailService } from '@island.is/email-service'
@@ -23,7 +22,7 @@ import { nowFactory } from '../../../../factories'
 import { InternalCaseService } from '../../../case'
 import { CourtService } from '../../../court'
 import { EventService } from '../../../event'
-import { Notification, type User } from '../../../repository'
+import { NotificationRepositoryService, type User } from '../../../repository'
 import { UserService } from '../../../user'
 import { DeliverResponse } from '../../models/deliver.response'
 import { notificationModuleConfig } from '../../notification.config'
@@ -33,8 +32,7 @@ import { strings } from './institutionNotification.strings'
 @Injectable()
 export class InstitutionNotificationService extends BaseNotificationService {
   constructor(
-    @InjectModel(Notification)
-    notificationModel: typeof Notification,
+    notificationRepositoryService: NotificationRepositoryService,
     @Inject(notificationModuleConfig.KEY)
     config: ConfigType<typeof notificationModuleConfig>,
     @Inject(LOGGER_PROVIDER) logger: Logger,
@@ -46,7 +44,7 @@ export class InstitutionNotificationService extends BaseNotificationService {
     private readonly userService: UserService,
   ) {
     super(
-      notificationModel,
+      notificationRepositoryService,
       emailService,
       intlService,
       courtService,

--- a/apps/judicial-system/backend/src/app/modules/notification/services/subpoenaNotification/subpoenaNotification.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/services/subpoenaNotification/subpoenaNotification.service.ts
@@ -5,7 +5,6 @@ import {
   Injectable,
   InternalServerErrorException,
 } from '@nestjs/common'
-import { InjectModel } from '@nestjs/sequelize'
 
 import { IntlService } from '@island.is/cms-translations'
 import { EmailService } from '@island.is/email-service'
@@ -20,7 +19,11 @@ import {
 
 import { CourtService } from '../../../court'
 import { EventService } from '../../../event'
-import { Case, Notification, Recipient } from '../../../repository'
+import {
+  Case,
+  NotificationRepositoryService,
+  Recipient,
+} from '../../../repository'
 import { DeliverResponse } from '../../models/deliver.response'
 import { notificationModuleConfig } from '../../notification.config'
 import { BaseNotificationService } from '../baseNotification.service'
@@ -29,8 +32,7 @@ import { strings } from './subpoenaNotification.strings'
 @Injectable()
 export class SubpoenaNotificationService extends BaseNotificationService {
   constructor(
-    @InjectModel(Notification)
-    notificationModel: typeof Notification,
+    notificationRepositoryService: NotificationRepositoryService,
     @Inject(notificationModuleConfig.KEY)
     config: ConfigType<typeof notificationModuleConfig>,
     @Inject(LOGGER_PROVIDER) logger: Logger,
@@ -40,7 +42,7 @@ export class SubpoenaNotificationService extends BaseNotificationService {
     courtService: CourtService,
   ) {
     super(
-      notificationModel,
+      notificationRepositoryService,
       emailService,
       intlService,
       courtService,

--- a/apps/judicial-system/backend/src/app/modules/notification/test/createTestingNotificationModule.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/test/createTestingNotificationModule.ts
@@ -1,7 +1,6 @@
 import { mock } from 'jest-mock-extended'
 import { v4 as uuid } from 'uuid'
 
-import { getModelToken } from '@nestjs/sequelize'
 import { Test } from '@nestjs/testing'
 
 import { IntlService } from '@island.is/cms-translations'
@@ -29,7 +28,7 @@ import { eventModuleConfig, EventService } from '../../event'
 import { InstitutionService } from '../../institution'
 import {
   InstitutionContactRepositoryService,
-  Notification,
+  NotificationRepositoryService,
 } from '../../repository'
 import { UserService } from '../../user'
 import { InternalNotificationController } from '../internalNotification.controller'
@@ -128,7 +127,10 @@ export const createTestingNotificationModule = async () => {
           error: jest.fn(),
         },
       },
-      { provide: getModelToken(Notification), useValue: { create: jest.fn() } },
+      {
+        provide: NotificationRepositoryService,
+        useValue: { create: jest.fn() },
+      },
       {
         provide: DefendantService,
         useValue: { isDefendantInActiveCustody: jest.fn() },
@@ -175,8 +177,8 @@ export const createTestingNotificationModule = async () => {
     notificationConfig: notificationModule.get<
       ConfigType<typeof notificationModuleConfig>
     >(notificationModuleConfig.KEY),
-    notificationModel: notificationModule.get<typeof Notification>(
-      getModelToken(Notification),
+    notificationRepositoryService: notificationModule.get(
+      NotificationRepositoryService,
     ),
     notificationController: notificationModule.get(NotificationController),
     internalNotificationController: notificationModule.get(

--- a/apps/judicial-system/backend/src/app/modules/notification/test/internalNotificationController/civilClaimantNotification/sendSpokespersonAssignedNotifications.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/test/internalNotificationController/civilClaimantNotification/sendSpokespersonAssignedNotifications.spec.ts
@@ -11,7 +11,11 @@ import {
 
 import { createTestingNotificationModule } from '../../createTestingNotificationModule'
 
-import { Case, CivilClaimant, Notification } from '../../../../repository'
+import {
+  Case,
+  CivilClaimant,
+  NotificationRepositoryService,
+} from '../../../../repository'
 import { CivilClaimantNotificationDto } from '../../../dto/civilClaimantNotification.dto'
 import { DeliverResponse } from '../../../models/deliver.response'
 import { notificationModuleConfig } from '../../../notification.config'
@@ -38,7 +42,7 @@ describe('InternalNotificationController - Send spokesperson assigned notificati
 
   let mockEmailService: EmailService
   let mockConfig: ConfigType<typeof notificationModuleConfig>
-  let mockNotificationModel: typeof Notification
+  let mockNotificationRepositoryService: NotificationRepositoryService
   let givenWhenThen: GivenWhenThen
 
   let civilClaimantNotificationDTO: CivilClaimantNotificationDto
@@ -48,7 +52,7 @@ describe('InternalNotificationController - Send spokesperson assigned notificati
       emailService,
       notificationConfig,
       internalNotificationController,
-      notificationModel,
+      notificationRepositoryService,
     } = await createTestingNotificationModule()
 
     civilClaimantNotificationDTO = {
@@ -57,7 +61,7 @@ describe('InternalNotificationController - Send spokesperson assigned notificati
 
     mockEmailService = emailService
     mockConfig = notificationConfig
-    mockNotificationModel = notificationModel
+    mockNotificationRepositoryService = notificationRepositoryService
 
     givenWhenThen = async (
       caseId: string,
@@ -145,17 +149,21 @@ describe('InternalNotificationController - Send spokesperson assigned notificati
               `Héraðsdómur Reykjavíkur hefur skráð þig lögmann einkaréttarkröfuhafa í máli R-123-456`,
             ),
           })
-          expect(mockNotificationModel.create).toHaveBeenCalledTimes(1)
-          expect(mockNotificationModel.create).toHaveBeenCalledWith({
-            caseId,
-            type: civilClaimantNotificationDTO.type,
-            recipients: [
-              {
-                address: civilClaimant.spokespersonEmail,
-                success: shouldSendEmail,
-              },
-            ],
-          })
+          expect(
+            mockNotificationRepositoryService.create,
+          ).toHaveBeenCalledTimes(1)
+          expect(mockNotificationRepositoryService.create).toHaveBeenCalledWith(
+            {
+              caseId,
+              type: civilClaimantNotificationDTO.type,
+              recipients: [
+                {
+                  address: civilClaimant.spokespersonEmail,
+                  success: shouldSendEmail,
+                },
+              ],
+            },
+          )
         } else {
           expect(mockEmailService.sendEmail).not.toHaveBeenCalled()
         }

--- a/apps/judicial-system/backend/src/app/modules/notification/test/internalNotificationController/civilClaimantNotification/sendSpokespersonCourtDateFollowUpNotifications.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/test/internalNotificationController/civilClaimantNotification/sendSpokespersonCourtDateFollowUpNotifications.spec.ts
@@ -18,7 +18,7 @@ import {
   Case,
   CivilClaimant,
   DateLog,
-  Notification,
+  NotificationRepositoryService,
 } from '../../../../repository'
 import { CivilClaimantNotificationDto } from '../../../dto/civilClaimantNotification.dto'
 import { DeliverResponse } from '../../../models/deliver.response'
@@ -52,7 +52,7 @@ describe('InternalNotificationController - Send spokesperson court date follow u
   const pastDate = new Date(Date.now() - 100 * 60 * 1000)
 
   let mockEmailService: EmailService
-  let mockNotificationModel: typeof Notification
+  let mockNotificationRepositoryService: NotificationRepositoryService
   let givenWhenThen: GivenWhenThen
 
   let civilClaimantNotificationDTO: CivilClaimantNotificationDto
@@ -79,8 +79,11 @@ describe('InternalNotificationController - Send spokesperson court date follow u
   } as CivilClaimant
 
   beforeEach(async () => {
-    const { emailService, internalNotificationController, notificationModel } =
-      await createTestingNotificationModule()
+    const {
+      emailService,
+      internalNotificationController,
+      notificationRepositoryService,
+    } = await createTestingNotificationModule()
 
     civilClaimantNotificationDTO = {
       type: CivilClaimantNotificationType.SPOKESPERSON_COURT_DATE_FOLLOW_UP,
@@ -88,7 +91,7 @@ describe('InternalNotificationController - Send spokesperson court date follow u
     }
 
     mockEmailService = emailService
-    mockNotificationModel = notificationModel
+    mockNotificationRepositoryService = notificationRepositoryService
 
     givenWhenThen = async (
       caseId: string,
@@ -150,8 +153,8 @@ describe('InternalNotificationController - Send spokesperson court date follow u
     })
 
     it('should record the follow up notification', () => {
-      expect(mockNotificationModel.create).toHaveBeenCalledTimes(1)
-      expect(mockNotificationModel.create).toHaveBeenCalledWith({
+      expect(mockNotificationRepositoryService.create).toHaveBeenCalledTimes(1)
+      expect(mockNotificationRepositoryService.create).toHaveBeenCalledWith({
         caseId,
         type: CivilClaimantNotificationType.SPOKESPERSON_COURT_DATE_FOLLOW_UP,
         recipients: [
@@ -238,7 +241,7 @@ describe('InternalNotificationController - Send spokesperson court date follow u
     })
 
     it('should not record a notification', () => {
-      expect(mockNotificationModel.create).not.toHaveBeenCalled()
+      expect(mockNotificationRepositoryService.create).not.toHaveBeenCalled()
     })
   })
 

--- a/apps/judicial-system/backend/src/app/modules/notification/test/internalNotificationController/defendantNotification/sendDefendantDelegatedDefenderCoiceNotifications.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/test/internalNotificationController/defendantNotification/sendDefendantDelegatedDefenderCoiceNotifications.spec.ts
@@ -14,7 +14,11 @@ import {
   createTestUsers,
 } from '../../createTestingNotificationModule'
 
-import { Case, Defendant, Notification } from '../../../../repository'
+import {
+  Case,
+  Defendant,
+  NotificationRepositoryService,
+} from '../../../../repository'
 import { DefendantNotificationDto } from '../../../dto/defendantNotification.dto'
 import { DeliverResponse } from '../../../models/deliver.response'
 import { notificationModuleConfig } from '../../../notification.config'
@@ -42,7 +46,7 @@ describe('InternalNotificationController - Send defendant delegated defender cho
 
   let mockEmailService: EmailService
   let mockConfig: ConfigType<typeof notificationModuleConfig>
-  let mockNotificationModel: typeof Notification
+  let mockNotificationRepositoryService: NotificationRepositoryService
   let givenWhenThen: GivenWhenThen
 
   let defendantNotificationDTO: DefendantNotificationDto
@@ -52,7 +56,7 @@ describe('InternalNotificationController - Send defendant delegated defender cho
       emailService,
       notificationConfig,
       internalNotificationController,
-      notificationModel,
+      notificationRepositoryService,
     } = await createTestingNotificationModule()
 
     defendantNotificationDTO = {
@@ -61,7 +65,7 @@ describe('InternalNotificationController - Send defendant delegated defender cho
 
     mockEmailService = emailService
     mockConfig = notificationConfig
-    mockNotificationModel = notificationModel
+    mockNotificationRepositoryService = notificationRepositoryService
 
     givenWhenThen = async (
       caseId: string,
@@ -166,8 +170,8 @@ describe('InternalNotificationController - Send defendant delegated defender cho
     })
 
     it('should record notification', () => {
-      expect(mockNotificationModel.create).toHaveBeenCalledTimes(1)
-      expect(mockNotificationModel.create).toHaveBeenCalledWith({
+      expect(mockNotificationRepositoryService.create).toHaveBeenCalledTimes(1)
+      expect(mockNotificationRepositoryService.create).toHaveBeenCalledWith({
         caseId,
         type: defendantNotificationDTO.type,
         recipients: [

--- a/apps/judicial-system/backend/src/app/modules/notification/test/internalNotificationController/defendantNotification/sendDefenderAssignedNotifications.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/test/internalNotificationController/defendantNotification/sendDefenderAssignedNotifications.spec.ts
@@ -14,7 +14,11 @@ import {
   createTestUsers,
 } from '../../createTestingNotificationModule'
 
-import { Case, Defendant, Notification } from '../../../../repository'
+import {
+  Case,
+  Defendant,
+  NotificationRepositoryService,
+} from '../../../../repository'
 import { DefendantNotificationDto } from '../../../dto/defendantNotification.dto'
 import { DeliverResponse } from '../../../models/deliver.response'
 import { notificationModuleConfig } from '../../../notification.config'
@@ -43,7 +47,7 @@ describe('InternalNotificationController - Send defender assigned notifications'
 
   let mockEmailService: EmailService
   let mockConfig: ConfigType<typeof notificationModuleConfig>
-  let mockNotificationModel: typeof Notification
+  let mockNotificationRepositoryService: NotificationRepositoryService
   let givenWhenThen: GivenWhenThen
 
   let defendantNotificationDTO: DefendantNotificationDto
@@ -53,7 +57,7 @@ describe('InternalNotificationController - Send defender assigned notifications'
       emailService,
       notificationConfig,
       internalNotificationController,
-      notificationModel,
+      notificationRepositoryService,
     } = await createTestingNotificationModule()
 
     defendantNotificationDTO = {
@@ -62,7 +66,7 @@ describe('InternalNotificationController - Send defender assigned notifications'
 
     mockEmailService = emailService
     mockConfig = notificationConfig
-    mockNotificationModel = notificationModel
+    mockNotificationRepositoryService = notificationRepositoryService
 
     givenWhenThen = async (
       caseId: string,
@@ -144,8 +148,8 @@ describe('InternalNotificationController - Send defender assigned notifications'
     })
 
     it('should record notification', () => {
-      expect(mockNotificationModel.create).toHaveBeenCalledTimes(1)
-      expect(mockNotificationModel.create).toHaveBeenCalledWith({
+      expect(mockNotificationRepositoryService.create).toHaveBeenCalledTimes(1)
+      expect(mockNotificationRepositoryService.create).toHaveBeenCalledWith({
         caseId,
         type: defendantNotificationDTO.type,
         recipients: [
@@ -184,7 +188,7 @@ describe('InternalNotificationController - Send defender assigned notifications'
     })
 
     it('should not record notification', () => {
-      expect(mockNotificationModel.create).not.toHaveBeenCalled()
+      expect(mockNotificationRepositoryService.create).not.toHaveBeenCalled()
     })
   })
 

--- a/apps/judicial-system/backend/src/app/modules/notification/test/internalNotificationController/defendantNotification/sendDefenderCourtDateFollowUpNotifications.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/test/internalNotificationController/defendantNotification/sendDefenderCourtDateFollowUpNotifications.spec.ts
@@ -14,7 +14,12 @@ import {
   createTestUsers,
 } from '../../createTestingNotificationModule'
 
-import { Case, DateLog, Defendant, Notification } from '../../../../repository'
+import {
+  Case,
+  DateLog,
+  Defendant,
+  NotificationRepositoryService,
+} from '../../../../repository'
 import { DefendantNotificationDto } from '../../../dto/defendantNotification.dto'
 import { DeliverResponse } from '../../../models/deliver.response'
 
@@ -44,7 +49,7 @@ describe('InternalNotificationController - Send defender court date follow up no
   const pastDate = new Date(Date.now() - 100 * 60 * 1000)
 
   let mockEmailService: EmailService
-  let mockNotificationModel: typeof Notification
+  let mockNotificationRepositoryService: NotificationRepositoryService
   let givenWhenThen: GivenWhenThen
 
   let defendantNotificationDTO: DefendantNotificationDto
@@ -69,8 +74,11 @@ describe('InternalNotificationController - Send defender court date follow up no
   } as Defendant
 
   beforeEach(async () => {
-    const { emailService, internalNotificationController, notificationModel } =
-      await createTestingNotificationModule()
+    const {
+      emailService,
+      internalNotificationController,
+      notificationRepositoryService,
+    } = await createTestingNotificationModule()
 
     defendantNotificationDTO = {
       type: DefendantNotificationType.DEFENDER_COURT_DATE_FOLLOW_UP,
@@ -78,7 +86,7 @@ describe('InternalNotificationController - Send defender court date follow up no
     }
 
     mockEmailService = emailService
-    mockNotificationModel = notificationModel
+    mockNotificationRepositoryService = notificationRepositoryService
 
     givenWhenThen = async (
       caseId: string,
@@ -140,8 +148,8 @@ describe('InternalNotificationController - Send defender court date follow up no
     })
 
     it('should record the follow up notification', () => {
-      expect(mockNotificationModel.create).toHaveBeenCalledTimes(1)
-      expect(mockNotificationModel.create).toHaveBeenCalledWith({
+      expect(mockNotificationRepositoryService.create).toHaveBeenCalledTimes(1)
+      expect(mockNotificationRepositoryService.create).toHaveBeenCalledWith({
         caseId,
         type: DefendantNotificationType.DEFENDER_COURT_DATE_FOLLOW_UP,
         recipients: [
@@ -182,7 +190,7 @@ describe('InternalNotificationController - Send defender court date follow up no
     })
 
     it('should record the follow up notification', () => {
-      expect(mockNotificationModel.create).toHaveBeenCalledWith({
+      expect(mockNotificationRepositoryService.create).toHaveBeenCalledWith({
         caseId,
         type: DefendantNotificationType.DEFENDER_COURT_DATE_FOLLOW_UP,
         recipients: [
@@ -238,7 +246,7 @@ describe('InternalNotificationController - Send defender court date follow up no
     })
 
     it('should not record a notification', () => {
-      expect(mockNotificationModel.create).not.toHaveBeenCalled()
+      expect(mockNotificationRepositoryService.create).not.toHaveBeenCalled()
     })
   })
 

--- a/apps/judicial-system/backend/src/app/modules/notification/test/internalNotificationController/defendantNotification/sendIndictmentSentToPrisonAdminNotification.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/test/internalNotificationController/defendantNotification/sendIndictmentSentToPrisonAdminNotification.spec.ts
@@ -10,7 +10,11 @@ import {
 
 import { createTestingNotificationModule } from '../../createTestingNotificationModule'
 
-import { Case, Defendant, Notification } from '../../../../repository'
+import {
+  Case,
+  Defendant,
+  NotificationRepositoryService,
+} from '../../../../repository'
 import { DefendantNotificationDto } from '../../../dto/defendantNotification.dto'
 import { DeliverResponse } from '../../../models/deliver.response'
 
@@ -34,7 +38,7 @@ describe('InternalNotificationController - Defendant - Send indictment sent to p
   const defendantId = uuid()
 
   let mockEmailService: EmailService
-  let mockNotificationModel: typeof Notification
+  let mockNotificationRepositoryService: NotificationRepositoryService
   let defendantNotificationDTO: DefendantNotificationDto
 
   let givenWhenThen: GivenWhenThen
@@ -43,7 +47,7 @@ describe('InternalNotificationController - Defendant - Send indictment sent to p
     const {
       emailService,
       internalNotificationController,
-      notificationModel,
+      notificationRepositoryService,
       institutionContactRepositoryService,
     } = await createTestingNotificationModule()
 
@@ -58,7 +62,7 @@ describe('InternalNotificationController - Defendant - Send indictment sent to p
     }
 
     mockEmailService = emailService
-    mockNotificationModel = notificationModel
+    mockNotificationRepositoryService = notificationRepositoryService
 
     givenWhenThen = async (
       caseId: string,
@@ -131,8 +135,8 @@ describe('InternalNotificationController - Defendant - Send indictment sent to p
     })
 
     it('should record notification', () => {
-      expect(mockNotificationModel.create).toHaveBeenCalledTimes(1)
-      expect(mockNotificationModel.create).toHaveBeenCalledWith({
+      expect(mockNotificationRepositoryService.create).toHaveBeenCalledTimes(1)
+      expect(mockNotificationRepositoryService.create).toHaveBeenCalledWith({
         caseId,
         type: defendantNotificationDTO.type,
         recipients: [

--- a/apps/judicial-system/backend/src/app/modules/notification/test/internalNotificationController/defendantNotification/sendIndictmentWithdrawnFromPrisonAdminNotifications.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/test/internalNotificationController/defendantNotification/sendIndictmentWithdrawnFromPrisonAdminNotifications.spec.ts
@@ -9,7 +9,11 @@ import {
 
 import { createTestingNotificationModule } from '../../createTestingNotificationModule'
 
-import { Case, Defendant, Notification } from '../../../../repository'
+import {
+  Case,
+  Defendant,
+  NotificationRepositoryService,
+} from '../../../../repository'
 import { DefendantNotificationDto } from '../../../dto/defendantNotification.dto'
 import { DeliverResponse } from '../../../models/deliver.response'
 
@@ -33,7 +37,7 @@ describe('InternalNotificationController - Defendant - Send indictment withdrawn
   const defendantId = uuid()
 
   let mockEmailService: EmailService
-  let mockNotificationModel: typeof Notification
+  let mockNotificationRepositoryService: NotificationRepositoryService
   let defendantNotificationDTO: DefendantNotificationDto
 
   let givenWhenThen: GivenWhenThen
@@ -42,7 +46,7 @@ describe('InternalNotificationController - Defendant - Send indictment withdrawn
     const {
       emailService,
       internalNotificationController,
-      notificationModel,
+      notificationRepositoryService,
       institutionContactRepositoryService,
     } = await createTestingNotificationModule()
 
@@ -57,7 +61,7 @@ describe('InternalNotificationController - Defendant - Send indictment withdrawn
     }
 
     mockEmailService = emailService
-    mockNotificationModel = notificationModel
+    mockNotificationRepositoryService = notificationRepositoryService
 
     givenWhenThen = async (
       caseId: string,
@@ -127,8 +131,8 @@ describe('InternalNotificationController - Defendant - Send indictment withdrawn
     })
 
     it('should record notification', () => {
-      expect(mockNotificationModel.create).toHaveBeenCalledTimes(1)
-      expect(mockNotificationModel.create).toHaveBeenCalledWith({
+      expect(mockNotificationRepositoryService.create).toHaveBeenCalledTimes(1)
+      expect(mockNotificationRepositoryService.create).toHaveBeenCalledWith({
         caseId,
         type: defendantNotificationDTO.type,
         recipients: [

--- a/apps/judicial-system/backend/src/app/modules/notification/test/internalNotificationController/indictmentCaseNotification/sendDrivingLicenseSuspensionNotifications.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/test/internalNotificationController/indictmentCaseNotification/sendDrivingLicenseSuspensionNotifications.spec.ts
@@ -9,7 +9,7 @@ import {
   createTestUsers,
 } from '../../createTestingNotificationModule'
 
-import { Case, Notification } from '../../../../repository'
+import { Case, NotificationRepositoryService } from '../../../../repository'
 import { DeliverResponse } from '../../../models/deliver.response'
 
 interface Then {
@@ -31,7 +31,7 @@ describe('IndictmentCaseService - sendDrivingLicenseSuspensionNotifications', ()
   const policeCaseNumbers = ['LÖKE-2024-001', 'LÖKE-2024-002']
 
   let mockEmailService: EmailService
-  let mockNotificationModel: typeof Notification
+  let mockNotificationRepositoryService: NotificationRepositoryService
   let givenWhenThen: GivenWhenThen
 
   beforeEach(async () => {
@@ -41,7 +41,7 @@ describe('IndictmentCaseService - sendDrivingLicenseSuspensionNotifications', ()
       emailService,
       indictmentCaseNotificationService,
       institutionContactRepositoryService,
-      notificationModel,
+      notificationRepositoryService,
     } = await createTestingNotificationModule()
 
     const getInstitutionContactMock = jest.mocked(
@@ -51,7 +51,7 @@ describe('IndictmentCaseService - sendDrivingLicenseSuspensionNotifications', ()
     getInstitutionContactMock.mockResolvedValue('extra@omnitrix.is')
 
     mockEmailService = emailService
-    mockNotificationModel = notificationModel
+    mockNotificationRepositoryService = notificationRepositoryService
 
     givenWhenThen = async (
       theCase: Case,
@@ -108,8 +108,8 @@ describe('IndictmentCaseService - sendDrivingLicenseSuspensionNotifications', ()
     })
 
     it('should record notification', () => {
-      expect(mockNotificationModel.create).toHaveBeenCalledTimes(1)
-      expect(mockNotificationModel.create).toHaveBeenCalledWith({
+      expect(mockNotificationRepositoryService.create).toHaveBeenCalledTimes(1)
+      expect(mockNotificationRepositoryService.create).toHaveBeenCalledWith({
         caseId,
         type: IndictmentCaseNotificationType.DRIVING_LICENSE_SUSPENSION,
         recipients: ['extra@omnitrix.is'].map((email) => ({

--- a/apps/judicial-system/backend/src/app/modules/notification/test/internalNotificationController/sendAppealWithdrawnNotifications.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/test/internalNotificationController/sendAppealWithdrawnNotifications.spec.ts
@@ -16,7 +16,12 @@ import {
   createTestUsers,
 } from '../createTestingNotificationModule'
 
-import { AppealCase, Case, Notification } from '../../../repository'
+import {
+  AppealCase,
+  Case,
+  Notification,
+  NotificationRepositoryService,
+} from '../../../repository'
 import { DeliverResponse } from '../../models/deliver.response'
 import { notificationModuleConfig } from '../../notification.config'
 
@@ -64,7 +69,7 @@ describe('InternalNotificationController - Send appeal withdrawn notifications',
   const receivedDate = new Date()
 
   let mockEmailService: EmailService
-  let mockNotificationModel: typeof Notification
+  let mockNotificationRepositoryService: NotificationRepositoryService
   let givenWhenThen: GivenWhenThen
 
   beforeEach(async () => {
@@ -74,12 +79,12 @@ describe('InternalNotificationController - Send appeal withdrawn notifications',
       emailService,
       internalNotificationController,
       notificationConfig,
-      notificationModel,
+      notificationRepositoryService,
     } = await createTestingNotificationModule()
 
     mockConfig = notificationConfig
     mockEmailService = emailService
-    mockNotificationModel = notificationModel
+    mockNotificationRepositoryService = notificationRepositoryService
 
     givenWhenThen = async (
       userRole,
@@ -181,7 +186,7 @@ describe('InternalNotificationController - Send appeal withdrawn notifications',
     let then: Then
 
     beforeEach(async () => {
-      const mockCreate = mockNotificationModel.create as jest.Mock
+      const mockCreate = mockNotificationRepositoryService.create as jest.Mock
       mockCreate.mockResolvedValueOnce({} as Notification)
 
       then = await givenWhenThen(UserRole.PROSECUTOR, receivedDate, [

--- a/apps/judicial-system/backend/src/app/modules/notification/test/internalNotificationController/sendCourtDateNotifications.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/test/internalNotificationController/sendCourtDateNotifications.spec.ts
@@ -22,7 +22,11 @@ import {
   createTestUsers,
 } from '../createTestingNotificationModule'
 
-import { Case, Notification } from '../../../repository'
+import {
+  Case,
+  Notification,
+  NotificationRepositoryService,
+} from '../../../repository'
 import { CaseNotificationDto } from '../../dto/caseNotification.dto'
 import { DeliverResponse } from '../../models/deliver.response'
 import { notificationModuleConfig } from '../../notification.config'
@@ -56,7 +60,7 @@ describe('InternalNotificationController - Send court date notifications', () =>
   let mockConfig: ConfigType<typeof notificationModuleConfig>
 
   let mockEmailService: EmailService
-  let mockNotificationModel: typeof Notification
+  let mockNotificationRepositoryService: NotificationRepositoryService
   let givenWhenThen: GivenWhenThen
 
   beforeEach(async () => {
@@ -64,12 +68,12 @@ describe('InternalNotificationController - Send court date notifications', () =>
       emailService,
       internalNotificationController,
       notificationConfig,
-      notificationModel,
+      notificationRepositoryService,
     } = await createTestingNotificationModule()
 
     mockConfig = notificationConfig
     mockEmailService = emailService
-    mockNotificationModel = notificationModel
+    mockNotificationRepositoryService = notificationRepositoryService
 
     givenWhenThen = async (
       theCase: Case,
@@ -158,7 +162,7 @@ describe('InternalNotificationController - Send court date notifications', () =>
     } as Case
 
     beforeEach(async () => {
-      const mockCreate = mockNotificationModel.create as jest.Mock
+      const mockCreate = mockNotificationRepositoryService.create as jest.Mock
       mockCreate.mockResolvedValueOnce({} as Notification)
 
       then = await givenWhenThen(
@@ -214,7 +218,7 @@ describe('InternalNotificationController - Send court date notifications', () =>
     } as Case
 
     beforeEach(async () => {
-      const mockCreate = mockNotificationModel.create as jest.Mock
+      const mockCreate = mockNotificationRepositoryService.create as jest.Mock
       mockCreate.mockResolvedValueOnce({} as Notification)
 
       await givenWhenThen(theCase, notificationDto)

--- a/apps/judicial-system/backend/src/app/modules/notification/test/internalNotificationController/sendReadyForCourtNotifications.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/test/internalNotificationController/sendReadyForCourtNotifications.spec.ts
@@ -26,7 +26,12 @@ import {
 } from '../createTestingNotificationModule'
 
 import { randomDate } from '../../../../test'
-import { Case, Institution, Notification, Recipient } from '../../../repository'
+import {
+  Case,
+  Institution,
+  NotificationRepositoryService,
+  Recipient,
+} from '../../../repository'
 import { CaseNotificationDto } from '../../dto/caseNotification.dto'
 import { DeliverResponse } from '../../models/deliver.response'
 import { notificationModuleConfig } from '../../notification.config'
@@ -275,7 +280,7 @@ describe('InternalNotificationController - Send ready for court notifications fo
 
   let mockEmailService: EmailService
   let mockNotificationConfig: ConfigType<typeof notificationModuleConfig>
-  let mockNotificationModel: typeof Notification
+  let mockNotificationRepositoryService: NotificationRepositoryService
   let givenWhenThen: GivenWhenThen
 
   beforeEach(async () => {
@@ -284,12 +289,12 @@ describe('InternalNotificationController - Send ready for court notifications fo
     const {
       emailService,
       notificationConfig,
-      notificationModel,
+      notificationRepositoryService,
       internalNotificationController,
     } = await createTestingNotificationModule()
 
     mockEmailService = emailService
-    mockNotificationModel = notificationModel
+    mockNotificationRepositoryService = notificationRepositoryService
     mockNotificationConfig = notificationConfig
 
     givenWhenThen = async (caseId, theCase, notification) => {
@@ -344,7 +349,7 @@ describe('InternalNotificationController - Send ready for court notifications fo
           html: `Lögreglan á höfuðborgarsvæðinu hefur sent inn nýja ákæru. Ákæran varðar eftirfarandi brot: manndráp. Ákæran og öll skjöl málsins eru <a href="${mockNotificationConfig.clientUrl}${DISTRICT_COURT_INDICTMENT_CASE_COURT_OVERVIEW_ROUTE}/${caseId}">aðgengileg í Réttarvörslugátt.</a>`,
         }),
       )
-      expect(mockNotificationModel.create).toHaveBeenCalledWith({
+      expect(mockNotificationRepositoryService.create).toHaveBeenCalledWith({
         caseId,
         type: RequestCaseNotificationType.READY_FOR_COURT,
         recipients: [
@@ -400,7 +405,7 @@ describe('InternalNotificationController - Send ready for court notifications fo
           html: `Lögreglan á höfuðborgarsvæðinu hefur sent inn nýja ákæru. Ákæran varðar eftirfarandi brot: manndráp, gripdeild og þjófnaður. Ákæran og öll skjöl málsins eru <a href="${mockNotificationConfig.clientUrl}${DISTRICT_COURT_INDICTMENT_CASE_COURT_OVERVIEW_ROUTE}/${caseId}">aðgengileg í Réttarvörslugátt.</a>`,
         }),
       )
-      expect(mockNotificationModel.create).toHaveBeenCalledWith({
+      expect(mockNotificationRepositoryService.create).toHaveBeenCalledWith({
         caseId,
         type: RequestCaseNotificationType.READY_FOR_COURT,
         recipients: [

--- a/apps/judicial-system/backend/src/app/modules/notification/test/internalNotificationController/sendRevokedNotifications.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/test/internalNotificationController/sendRevokedNotifications.spec.ts
@@ -15,7 +15,11 @@ import {
   createTestUsers,
 } from '../createTestingNotificationModule'
 
-import { Case, Notification } from '../../../repository'
+import {
+  Case,
+  Notification,
+  NotificationRepositoryService,
+} from '../../../repository'
 import { CaseNotificationDto } from '../../dto/caseNotification.dto'
 import { DeliverResponse } from '../../models/deliver.response'
 import { notificationModuleConfig } from '../../notification.config'
@@ -61,19 +65,19 @@ describe('InternalNotificationController - Send revoked notifications for indict
   }
 
   let mockEmailService: EmailService
-  let mockNotificationModel: typeof Notification
+  let mockNotificationRepositoryService: NotificationRepositoryService
   let givenWhenThen: GivenWhenThen
 
   beforeEach(async () => {
     const {
       emailService,
-      notificationModel,
+      notificationRepositoryService,
       internalNotificationController,
       notificationConfig,
     } = await createTestingNotificationModule()
 
     mockEmailService = emailService
-    mockNotificationModel = notificationModel
+    mockNotificationRepositoryService = notificationRepositoryService
     mockConfig = notificationConfig
 
     givenWhenThen = async (notifications?: Notification[]) => {
@@ -128,7 +132,7 @@ describe('InternalNotificationController - Send revoked notifications for indict
           html: `${prosecutorsOfficeName} hefur afturkallað ákæru í máli ${courtCaseNumber}.<br /><br />Hægt er að nálgast yfirlitssíðu málsins á <a href="${mockConfig.clientUrl}/verjandi/akaera/${theCase.id}">rettarvorslugatt.island.is</a>.`,
         }),
       )
-      expect(mockNotificationModel.create).toHaveBeenCalledWith({
+      expect(mockNotificationRepositoryService.create).toHaveBeenCalledWith({
         caseId: caseId,
         type: RequestCaseNotificationType.REVOKED,
         recipients: [

--- a/apps/judicial-system/backend/src/app/modules/notification/test/internalNotificationController/sendRevokedNotificationsForRequestCase.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/test/internalNotificationController/sendRevokedNotificationsForRequestCase.spec.ts
@@ -14,7 +14,11 @@ import {
   createTestUsers,
 } from '../createTestingNotificationModule'
 
-import { Case, Notification } from '../../../repository'
+import {
+  Case,
+  Notification,
+  NotificationRepositoryService,
+} from '../../../repository'
 import { CaseNotificationDto } from '../../dto/caseNotification.dto'
 import { DeliverResponse } from '../../models/deliver.response'
 import { notificationModuleConfig } from '../../notification.config'
@@ -38,20 +42,20 @@ describe('InternalNotificationController - Send revoked notifications for reques
   const courtCaseNumber = 'R-369/2025'
 
   let mockEmailService: EmailService
-  let mockNotificationModel: typeof Notification
+  let mockNotificationRepositoryService: NotificationRepositoryService
   let mockConfig: ConfigType<typeof notificationModuleConfig>
   let givenWhenThen: GivenWhenThen
 
   beforeEach(async () => {
     const {
       emailService,
-      notificationModel,
+      notificationRepositoryService,
       internalNotificationController,
       notificationConfig,
     } = await createTestingNotificationModule()
 
     mockEmailService = emailService
-    mockNotificationModel = notificationModel
+    mockNotificationRepositoryService = notificationRepositoryService
     mockConfig = notificationConfig
 
     givenWhenThen = async (theCase: object, notifications?: Notification[]) => {
@@ -106,7 +110,7 @@ describe('InternalNotificationController - Send revoked notifications for reques
           html: body,
         }),
       )
-      expect(mockNotificationModel.create).toHaveBeenCalledWith({
+      expect(mockNotificationRepositoryService.create).toHaveBeenCalledWith({
         caseId,
         type: RequestCaseNotificationType.REVOKED,
         recipients: [
@@ -146,7 +150,7 @@ describe('InternalNotificationController - Send revoked notifications for reques
           html: body,
         }),
       )
-      expect(mockNotificationModel.create).toHaveBeenCalledWith({
+      expect(mockNotificationRepositoryService.create).toHaveBeenCalledWith({
         caseId,
         type: RequestCaseNotificationType.REVOKED,
         recipients: [{ address: courtEmail, success: true }],

--- a/apps/judicial-system/backend/src/app/modules/repository/index.ts
+++ b/apps/judicial-system/backend/src/app/modules/repository/index.ts
@@ -51,6 +51,10 @@ export {
   LawyerRegistryData,
 } from './services/lawyerRegistryRepository.service'
 export { MessageSuspensionRepositoryService } from './services/messageSuspensionRepository.service'
+export {
+  NotificationRepositoryService,
+  CreateNotification,
+} from './services/notificationRepository.service'
 export { PoliceDigitalCaseFileRepositoryService } from './services/policeDigitalCaseFileRepository.service'
 export {
   RobotLogRepositoryService,

--- a/apps/judicial-system/backend/src/app/modules/repository/repository.module.ts
+++ b/apps/judicial-system/backend/src/app/modules/repository/repository.module.ts
@@ -24,6 +24,7 @@ import { IndictmentCount } from './models/indictmentCount.model'
 import { InstitutionContact } from './models/institutionContact.model'
 import { LawyerRegistry } from './models/lawyerRegistry.model'
 import { MessageSuspension } from './models/messageSuspension.model'
+import { Notification } from './models/notification.model'
 import { Offense } from './models/offense.model'
 import { PoliceDigitalCaseFile } from './models/policeDigitalCaseFile.model'
 import { RobotLog } from './models/robotLog.model'
@@ -43,6 +44,7 @@ import { DefendantRepositoryService } from './services/defendantRepository.servi
 import { InstitutionContactRepositoryService } from './services/institutionContactRepository.service'
 import { LawyerRegistryRepositoryService } from './services/lawyerRegistryRepository.service'
 import { MessageSuspensionRepositoryService } from './services/messageSuspensionRepository.service'
+import { NotificationRepositoryService } from './services/notificationRepository.service'
 import { PoliceDigitalCaseFileRepositoryService } from './services/policeDigitalCaseFileRepository.service'
 import { RobotLogRepositoryService } from './services/robotLogRepository.service'
 import { SubpoenaRepositoryService } from './services/subpoenaRepository.service'
@@ -72,6 +74,7 @@ import { repositoryModuleConfig } from './repository.config'
       InstitutionContact,
       LawyerRegistry,
       MessageSuspension,
+      Notification,
       Offense,
       PoliceDigitalCaseFile,
       RobotLog,
@@ -96,6 +99,7 @@ import { repositoryModuleConfig } from './repository.config'
     InstitutionContactRepositoryService,
     LawyerRegistryRepositoryService,
     MessageSuspensionRepositoryService,
+    NotificationRepositoryService,
     PoliceDigitalCaseFileRepositoryService,
     RobotLogRepositoryService,
     SubpoenaRepositoryService,
@@ -115,6 +119,7 @@ import { repositoryModuleConfig } from './repository.config'
     InstitutionContactRepositoryService,
     LawyerRegistryRepositoryService,
     MessageSuspensionRepositoryService,
+    NotificationRepositoryService,
     PoliceDigitalCaseFileRepositoryService,
     RobotLogRepositoryService,
     SubpoenaRepositoryService,

--- a/apps/judicial-system/backend/src/app/modules/repository/services/notificationRepository.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/repository/services/notificationRepository.service.ts
@@ -1,0 +1,42 @@
+import { Inject, Injectable } from '@nestjs/common'
+import { InjectModel } from '@nestjs/sequelize'
+
+import { type Logger, LOGGER_PROVIDER } from '@island.is/logging'
+
+import { TrackedNotificationType } from '@island.is/judicial-system/types'
+
+import { Notification, Recipient } from '../models/notification.model'
+
+export type CreateNotification = {
+  caseId: string
+  type: TrackedNotificationType
+  recipients: Recipient[]
+}
+
+@Injectable()
+export class NotificationRepositoryService {
+  constructor(
+    @InjectModel(Notification)
+    private readonly notificationModel: typeof Notification,
+    @Inject(LOGGER_PROVIDER) private readonly logger: Logger,
+  ) {}
+
+  async create(notification: CreateNotification): Promise<Notification> {
+    const { caseId, type, recipients } = notification
+
+    try {
+      this.logger.debug(
+        `Creating a ${type} notification for case ${caseId} with ${recipients.length} recipient(s)`,
+      )
+
+      return await this.notificationModel.create({ caseId, type, recipients })
+    } catch (error) {
+      this.logger.error(
+        `Error creating a ${type} notification for case ${caseId}:`,
+        { error },
+      )
+
+      throw error
+    }
+  }
+}

--- a/apps/judicial-system/backend/src/app/modules/repository/test/notificationRepository.service.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/repository/test/notificationRepository.service.spec.ts
@@ -1,0 +1,68 @@
+import { getModelToken } from '@nestjs/sequelize'
+import { Test } from '@nestjs/testing'
+
+import { LOGGER_PROVIDER } from '@island.is/logging'
+
+import { TrackedNotificationType } from '@island.is/judicial-system/types'
+
+import { Notification } from '../models/notification.model'
+import { NotificationRepositoryService } from '../services/notificationRepository.service'
+
+describe('NotificationRepositoryService', () => {
+  const caseId = 'a5f7e3d1-0000-4000-8000-000000000001'
+  const recipients = [{ address: 'recipient@example.com', success: true }]
+
+  let service: NotificationRepositoryService
+  let model: { create: jest.Mock }
+  let logger: { debug: jest.Mock; error: jest.Mock }
+
+  beforeEach(async () => {
+    model = { create: jest.fn() }
+    logger = { debug: jest.fn(), error: jest.fn() }
+
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        { provide: LOGGER_PROVIDER, useValue: logger },
+        { provide: getModelToken(Notification), useValue: model },
+        NotificationRepositoryService,
+      ],
+    }).compile()
+
+    service = moduleRef.get(NotificationRepositoryService)
+  })
+
+  describe('create', () => {
+    it('creates the notification and returns the created row', async () => {
+      const createdNotification = { id: 'some id' } as Notification
+      model.create.mockResolvedValueOnce(createdNotification)
+
+      const result = await service.create({
+        caseId,
+        type: TrackedNotificationType.READY_FOR_COURT,
+        recipients,
+      })
+
+      expect(model.create).toHaveBeenCalledWith({
+        caseId,
+        type: TrackedNotificationType.READY_FOR_COURT,
+        recipients,
+      })
+      expect(result).toBe(createdNotification)
+    })
+
+    it('rethrows when the model fails', async () => {
+      const error = new Error('Some error')
+      model.create.mockRejectedValueOnce(error)
+
+      await expect(
+        service.create({
+          caseId,
+          type: TrackedNotificationType.READY_FOR_COURT,
+          recipients,
+        }),
+      ).rejects.toBe(error)
+
+      expect(logger.error).toHaveBeenCalled()
+    })
+  })
+})


### PR DESCRIPTION
# Notification repository service

[Repository þjónusta fyrir Notification](https://app.asana.com/1/203394141643832/project/1199153462262248/task/1217598564283335)

Moves the `Notification` model behind the repository boundary — the last model in chunk C of the repository-pattern migration. After this PR the model is registered in `SequelizeModule.forFeature` and injected in exactly one place: `RepositoryModule`.

Broad but shallow: there was **one** raw model call, spread across a class hierarchy.

- **New `NotificationRepositoryService`** with a single domain-intent method, `create({ caseId, type, recipients })`, replacing the raw `notificationModel.create` in `BaseNotificationService`. It follows the module convention: `debug` before the call, `return await` inside the `try`, contextual `logger.error` and a rethrow in the `catch`, no personal identifiers in the log messages.
- **`BaseNotificationService`** takes the repository service instead of `typeof Notification`, and the **seven** concrete notification services (`caseNotification`, `appealCaseNotification`, `indictmentCaseNotification`, `defendantNotification`, `civilClaimantNotification`, `institutionNotification`, `subpoenaNotification`) pass it up through `super(...)` — a plain provider, so the `@InjectModel` decorator and the `@nestjs/sequelize` import are gone from all seven.
- **`NotificationModule`** no longer registers any Sequelize models, so its `SequelizeModule.forFeature` call is removed entirely.

Nothing else moves: message formatting, email and SMS dispatch, the `Recipient` bookkeeping and everything under `notificationDispatch.service.ts` stay where they are. `Notification` remains a declared type in a few places (`notifications?: Notification[]`); models as an API-edge type is a separate decision, not part of this slice.

## Testing

- New spec for `NotificationRepositoryService`: `create` passes the fields through and returns the created row, and rethrows when the model fails.
- `createTestingNotificationModule` now provides a mocked `NotificationRepositoryService` instead of a `getModelToken(Notification)` mock, and 13 notification specs assert on the repository call rather than on the model — which is the point of the migration.
- `yarn nx test judicial-system-backend --testPathPatterns='app/modules/(notification|repository)/'` → 58 suites, 262 tests, all passing.
- `npx tsc --noEmit -p apps/judicial-system/backend/tsconfig.app.json` clean; the only spec-config type errors in the touched files pre-exist on `main` (verified by re-running against a stashed tree).
- `yarn nx run judicial-system-backend:codegen/backend-schema` boots the real Nest module graph (so the DI wiring is proven, not just the types) and leaves `openapi.yaml` byte-identical.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a centralized notification service for creating and recording notifications.
  * Notification creation now includes improved success and error logging.
* **Bug Fixes**
  * Preserved existing notification behavior across appeals, cases, defendants, claimants, institutions, subpoenas, and indictments.
* **Tests**
  * Expanded coverage for successful notification creation, error handling, and notification delivery scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->