### PR TITLE
fix(web): stop category accordion remounting on toggle

### DIFF
--- a/apps/web/screens/Category/Category/Category.tsx
+++ b/apps/web/screens/Category/Category/Category.tsx
@@ -330,7 +330,7 @@ const Category: Screen<CategoryProps> = ({
         </Box>
         <Stack space={2}>
           {groups.map((group, index) => (
-            <React.Fragment key={group.slug ?? index}>
+            <React.Fragment key={group.slug}>
               {renderPageGroup(group, index)}
             </React.Fragment>
           ))}

--- a/apps/web/screens/Category/Category/Category.tsx
+++ b/apps/web/screens/Category/Category/Category.tsx
@@ -122,13 +122,10 @@ const Category: Screen<CategoryProps> = ({
     window.location.href = `#${getHashString(updatedArr)}`
   }
 
-  const PageGroupComponent = ({
-    group,
-    index,
-  }: {
-    group: CategoryGroups[number]
-    index: number
-  }) => {
+  // Plain render function, not a component: defining a component inside the
+  // render gives it a new identity every render, remounting each AccordionCard
+  // on toggle and breaking the open/close animation.
+  const renderPageGroup = (group: CategoryGroups[number], index: number) => {
     const groupSlug = group.slug
     const expanded = hashArray.includes(groupSlug)
 
@@ -336,7 +333,9 @@ const Category: Screen<CategoryProps> = ({
         </Box>
         <Stack space={2}>
           {groups.map((group, index) => (
-            <PageGroupComponent group={group} index={index} key={index} />
+            <React.Fragment key={group.slug ?? index}>
+              {renderPageGroup(group, index)}
+            </React.Fragment>
           ))}
           {lifeEvents.map(
             (

--- a/apps/web/screens/Category/Category/Category.tsx
+++ b/apps/web/screens/Category/Category/Category.tsx
@@ -119,12 +119,9 @@ const Category: Screen<CategoryProps> = ({
   const handleAccordionClick = (groupSlug: string) => {
     const updatedArr = updateHashArray(hashArray, groupSlug)
     setHashArray(updatedArr)
-    window.location.href = `#${getHashString(updatedArr)}`
+    window.history.replaceState(null, '', `#${getHashString(updatedArr)}`)
   }
 
-  // Plain render function, not a component: defining a component inside the
-  // render gives it a new identity every render, remounting each AccordionCard
-  // on toggle and breaking the open/close animation.
   const renderPageGroup = (group: CategoryGroups[number], index: number) => {
     const groupSlug = group.slug
     const expanded = hashArray.includes(groupSlug)


### PR DESCRIPTION
## What
- Render category page groups through a plain function instead of a component defined inside the render
- Update the URL hash with `replaceState` instead of assigning `window.location.href`

## Why
The inline component made every accordion remount on toggle, so the open/close animation didn't run. The `location.href` assignment scrolled the page to the toggled accordion.

Before (on prerelease)

https://github.com/user-attachments/assets/ed49ebb8-f413-4850-85d0-c2ee4e12c4de

After

https://github.com/user-attachments/assets/306dc7ac-48f6-4475-9bf3-3af23e03e970


## Checklist:

- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code
