### PR TITLE
feat(new-primary-school): A child can't be its own relative.

### DIFF
--- a/libs/application/templates/new-primary-school/src/fields/RelativesTableRepeater/index.tsx
+++ b/libs/application/templates/new-primary-school/src/fields/RelativesTableRepeater/index.tsx
@@ -15,6 +15,7 @@ import { useFriggOptions } from '../../hooks/useFriggOptions'
 import { childrenNGuardiansMessages, sharedMessages } from '../../lib/messages'
 import { AgentType, OptionsType } from '../../utils/constants'
 import {
+  getApplicationAnswers,
   getApplicationExternalData,
   getOtherGuardian,
   getSelectedOptionLabel,
@@ -104,6 +105,12 @@ const RelativesTableRepeater: FC<React.PropsWithChildren<FieldBaseProps>> = ({
             defaultValue: (application: Application) =>
               getOtherGuardian(application.answers, application.externalData)
                 ?.nationalId,
+          },
+          childNationalId: {
+            component: 'hiddenInput',
+            displayInTable: false,
+            defaultValue: (application: Application) =>
+              getApplicationAnswers(application.answers).childNationalId,
           },
         },
         table: {

--- a/libs/application/templates/new-primary-school/src/lib/dataSchema.ts
+++ b/libs/application/templates/new-primary-school/src/lib/dataSchema.ts
@@ -555,6 +555,16 @@ export const dataSchema = z.object({
           : true,
       { path: ['other', 'nationalId'], params: errorMessages.nationalId },
     ),
+}).superRefine(({ childNationalId, relatives }, ctx) => {
+  relatives.forEach((relative, index) => {
+    if (relative.nationalIdWithName?.nationalId === childNationalId) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        params: errorMessages.relativeSameAsChild,
+        path: ['relatives', index, 'nationalIdWithName', 'nationalId'],
+      })
+    }
+  })
 })
 
 export type SchemaFormValues = z.infer<typeof dataSchema>

--- a/libs/application/templates/new-primary-school/src/lib/dataSchema.ts
+++ b/libs/application/templates/new-primary-school/src/lib/dataSchema.ts
@@ -85,6 +85,7 @@ export const dataSchema = z
           relation: z.string(),
           applicantNationalId: z.string().optional(),
           otherGuardianNationalId: z.string().optional(),
+          childNationalId: z.string().optional(),
         })
         .refine(
           ({
@@ -97,6 +98,14 @@ export const dataSchema = z
           {
             path: ['nationalIdWithName', 'nationalId'],
             params: errorMessages.relativeSameAsGuardian,
+          },
+        )
+        .refine(
+          ({ nationalIdWithName, childNationalId }) =>
+            nationalIdWithName?.nationalId !== childNationalId,
+          {
+            path: ['nationalIdWithName', 'nationalId'],
+            params: errorMessages.relativeSameAsChild,
           },
         ),
     ),
@@ -559,17 +568,6 @@ export const dataSchema = z
             : true,
         { path: ['other', 'nationalId'], params: errorMessages.nationalId },
       ),
-  })
-  .superRefine(({ childNationalId, relatives }, ctx) => {
-    relatives.forEach((relative, index) => {
-      if (relative.nationalIdWithName?.nationalId === childNationalId) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          params: errorMessages.relativeSameAsChild,
-          path: ['relatives', index, 'nationalIdWithName', 'nationalId'],
-        })
-      }
-    })
   })
 
 export type SchemaFormValues = z.infer<typeof dataSchema>

--- a/libs/application/templates/new-primary-school/src/lib/dataSchema.ts
+++ b/libs/application/templates/new-primary-school/src/lib/dataSchema.ts
@@ -35,536 +35,541 @@ const nameEmailSchema = z
   })
   .optional()
 
-export const dataSchema = z.object({
-  approveExternalData: z.boolean().refine((v) => v),
-  childNationalId: z.string().min(1),
-  applicationType: z.nativeEnum(ApplicationType),
-  childInfo: z
-    .object({
-      usePronounAndPreferredName: z.array(z.string()),
-      preferredName: z.string().optional(),
-      pronouns: z.array(z.string()).optional().nullable(),
-    })
-    .refine(
-      ({ usePronounAndPreferredName, preferredName, pronouns }) =>
-        usePronounAndPreferredName.includes(YES)
-          ? !!preferredName || (pronouns && pronouns.length > 0)
-          : true,
-      { path: ['preferredName'] },
-    )
-    .refine(
-      ({ usePronounAndPreferredName, pronouns, preferredName }) =>
-        usePronounAndPreferredName.includes(YES)
-          ? (!!pronouns && pronouns.length > 0) || !!preferredName
-          : true,
-      { path: ['pronouns'] },
-    ),
-  guardians: z.array(
-    z
+export const dataSchema = z
+  .object({
+    approveExternalData: z.boolean().refine((v) => v),
+    childNationalId: z.string().min(1),
+    applicationType: z.nativeEnum(ApplicationType),
+    childInfo: z
       .object({
-        email: z.string().email(),
-        phoneNumber: phoneNumberSchema,
-        requiresInterpreter: z.array(z.string()),
-        preferredLanguage: z.string().optional().nullable(),
+        usePronounAndPreferredName: z.array(z.string()),
+        preferredName: z.string().optional(),
+        pronouns: z.array(z.string()).optional().nullable(),
       })
       .refine(
-        ({ requiresInterpreter, preferredLanguage }) =>
-          requiresInterpreter.includes(YES) ? !!preferredLanguage : true,
+        ({ usePronounAndPreferredName, preferredName, pronouns }) =>
+          usePronounAndPreferredName.includes(YES)
+            ? !!preferredName || (pronouns && pronouns.length > 0)
+            : true,
+        { path: ['preferredName'] },
+      )
+      .refine(
+        ({ usePronounAndPreferredName, pronouns, preferredName }) =>
+          usePronounAndPreferredName.includes(YES)
+            ? (!!pronouns && pronouns.length > 0) || !!preferredName
+            : true,
+        { path: ['pronouns'] },
+      ),
+    guardians: z.array(
+      z
+        .object({
+          email: z.string().email(),
+          phoneNumber: phoneNumberSchema,
+          requiresInterpreter: z.array(z.string()),
+          preferredLanguage: z.string().optional().nullable(),
+        })
+        .refine(
+          ({ requiresInterpreter, preferredLanguage }) =>
+            requiresInterpreter.includes(YES) ? !!preferredLanguage : true,
+          {
+            path: ['preferredLanguage'],
+            params: errorMessages.languageRequired,
+          },
+        ),
+    ),
+    relatives: z.array(
+      z
+        .object({
+          nationalIdWithName: nationalIdWithNameSchema,
+          phoneNumber: phoneNumberSchema,
+          relation: z.string(),
+          applicantNationalId: z.string().optional(),
+          otherGuardianNationalId: z.string().optional(),
+        })
+        .refine(
+          ({
+            nationalIdWithName,
+            applicantNationalId,
+            otherGuardianNationalId,
+          }) =>
+            nationalIdWithName?.nationalId !== applicantNationalId &&
+            nationalIdWithName?.nationalId !== otherGuardianNationalId,
+          {
+            path: ['nationalIdWithName', 'nationalId'],
+            params: errorMessages.relativeSameAsGuardian,
+          },
+        ),
+    ),
+    currentNursery: z
+      .object({
+        hasCurrentNursery: z.enum([YES, NO]),
+        municipality: z.string().optional().nullable(),
+        nursery: z.string().optional().nullable(),
+      })
+      .refine(
+        ({ hasCurrentNursery, municipality }) =>
+          hasCurrentNursery === YES ? !!municipality : true,
+        {
+          path: ['municipality'],
+        },
+      )
+      .refine(
+        ({ hasCurrentNursery, nursery }) =>
+          hasCurrentNursery === YES ? !!nursery : true,
+        {
+          path: ['nursery'],
+        },
+      ),
+    reasonForApplication: z.object({
+      reason: z.string(),
+    }),
+    counsellingRegardingApplication: z.object({
+      counselling: z.string(),
+      hasVisitedSchool: z.enum([YES, NO]),
+    }),
+    currentSchool: z
+      .object({
+        hasCurrentSchool: z.enum([YES, NO]).optional(),
+        municipality: z.string().optional().nullable(),
+        school: z.string().optional().nullable(),
+      })
+      .refine(
+        ({ hasCurrentSchool, municipality }) =>
+          hasCurrentSchool === YES ? !!municipality : true,
+        {
+          path: ['municipality'],
+        },
+      )
+      .refine(
+        ({ hasCurrentSchool, school }) =>
+          hasCurrentSchool === YES ? !!school : true,
+        {
+          path: ['school'],
+        },
+      ),
+    newSchool: z.object({
+      municipality: z.string(),
+      school: z.string(),
+    }),
+    school: z.object({
+      applyForPreferredSchool: z.enum([YES, NO]),
+    }),
+    siblings: z
+      .array(
+        z.object({
+          nationalIdWithName: nationalIdWithNameSchema,
+        }),
+      )
+      .refine((r) => r === undefined || r.length > 0, {
+        params: errorMessages.siblingsRequired,
+      }),
+    startingSchool: z
+      .object({
+        expectedStartDate: z.string(),
+        temporaryStay: z.string().min(1).optional(),
+        expectedEndDate: z.string().optional(),
+      })
+      .refine(
+        ({ expectedStartDate, expectedEndDate, temporaryStay }) =>
+          !(
+            temporaryStay === YES &&
+            expectedEndDate &&
+            new Date(expectedStartDate) > new Date(expectedEndDate)
+          ),
+        {
+          path: ['expectedEndDate'],
+          params: errorMessages.expectedEndDateMessage,
+        },
+      )
+      .refine(
+        ({ expectedEndDate, temporaryStay }) =>
+          !(temporaryStay === YES && !expectedEndDate),
+        {
+          path: ['expectedEndDate'],
+          params: errorMessages.expectedEndDateRequired,
+        },
+      ),
+    languages: z
+      .object({
+        languageEnvironment: z.string(),
+        signLanguage: z.enum([YES, NO]),
+        selectedLanguages: z
+          .array(z.object({ code: z.string().nullish() }))
+          .optional(),
+        preferredLanguage: z.string().optional().nullable(),
+      })
+      .superRefine(({ languageEnvironment, selectedLanguages }, ctx) => {
+        // LanguageEnvironment is stored as <id>::<option> in the DB
+        const selectedLanguageEnvironment =
+          languageEnvironment.split('::')[1] ?? ''
+
+        const checkAndAddIssue = (index: number) => {
+          // If required 2 languages but the second language field is still hidden
+          // else check if applicant has selected a languages
+          if (index === 1 && selectedLanguages?.length === 1) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              params: errorMessages.twoLanguagesRequired,
+              path: ['selectedLanguages'],
+            })
+          } else if (!selectedLanguages?.[index]?.code) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              params: errorMessages.languageRequired,
+              path: ['selectedLanguages', index, 'code'],
+            })
+          }
+        }
+
+        if (
+          selectedLanguageEnvironment ===
+          LanguageEnvironmentOptions.ONLY_OTHER_THAN_ICELANDIC
+        ) {
+          checkAndAddIssue(0)
+        } else if (
+          selectedLanguageEnvironment ===
+          LanguageEnvironmentOptions.ICELANDIC_AND_OTHER
+        ) {
+          checkAndAddIssue(0)
+          checkAndAddIssue(1)
+        }
+      })
+      .refine(
+        ({ languageEnvironment, selectedLanguages, preferredLanguage }) => {
+          // LanguageEnvironment is stored as <id>::<option> in the DB
+          const selectedLanguageEnvironment =
+            languageEnvironment.split('::')[1] ?? ''
+
+          if (
+            (selectedLanguageEnvironment ===
+              LanguageEnvironmentOptions.ONLY_OTHER_THAN_ICELANDIC &&
+              !!selectedLanguages &&
+              selectedLanguages?.length >= 1) ||
+            (selectedLanguageEnvironment ===
+              LanguageEnvironmentOptions.ICELANDIC_AND_OTHER &&
+              !!selectedLanguages &&
+              selectedLanguages?.length >= 2)
+          ) {
+            return !!preferredLanguage
+          }
+
+          return true
+        },
         {
           path: ['preferredLanguage'],
           params: errorMessages.languageRequired,
         },
       ),
-  ),
-  relatives: z.array(
-    z
+    healthProtection: z
       .object({
-        nationalIdWithName: nationalIdWithNameSchema,
-        phoneNumber: phoneNumberSchema,
-        relation: z.string(),
-        applicantNationalId: z.string().optional(),
-        otherGuardianNationalId: z.string().optional(),
+        hasFoodAllergiesOrIntolerances: z.array(z.string()),
+        foodAllergiesOrIntolerances: z.array(z.string()).optional().nullable(),
+        hasOtherAllergies: z.array(z.string()),
+        otherAllergies: z.array(z.string()).optional().nullable(),
+        usesEpiPen: z.string().optional(),
+        hasConfirmedMedicalDiagnoses: z.enum([YES, NO]),
+        requestsMedicationAdministration: z.enum([YES, NO]),
       })
       .refine(
-        ({
-          nationalIdWithName,
-          applicantNationalId,
-          otherGuardianNationalId,
-        }) =>
-          nationalIdWithName?.nationalId !== applicantNationalId &&
-          nationalIdWithName?.nationalId !== otherGuardianNationalId,
+        ({ hasFoodAllergiesOrIntolerances, foodAllergiesOrIntolerances }) =>
+          hasFoodAllergiesOrIntolerances.includes(YES)
+            ? !!foodAllergiesOrIntolerances &&
+              foodAllergiesOrIntolerances.length > 0
+            : true,
         {
-          path: ['nationalIdWithName', 'nationalId'],
-          params: errorMessages.relativeSameAsGuardian,
+          path: ['foodAllergiesOrIntolerances'],
+          params: errorMessages.foodAllergiesOrIntolerancesRequired,
         },
+      )
+      .refine(
+        ({ hasOtherAllergies, otherAllergies }) =>
+          hasOtherAllergies.includes(YES)
+            ? !!otherAllergies && otherAllergies.length > 0
+            : true,
+        {
+          path: ['otherAllergies'],
+          params: errorMessages.otherAllergiesRequired,
+        },
+      )
+      .refine(
+        ({ hasFoodAllergiesOrIntolerances, hasOtherAllergies, usesEpiPen }) =>
+          hasFoodAllergiesOrIntolerances.includes(YES) ||
+          hasOtherAllergies.includes(YES)
+            ? !!usesEpiPen
+            : true,
+        { path: ['usesEpiPen'] },
       ),
-  ),
-  currentNursery: z
-    .object({
-      hasCurrentNursery: z.enum([YES, NO]),
-      municipality: z.string().optional().nullable(),
-      nursery: z.string().optional().nullable(),
-    })
-    .refine(
-      ({ hasCurrentNursery, municipality }) =>
-        hasCurrentNursery === YES ? !!municipality : true,
-      {
-        path: ['municipality'],
-      },
-    )
-    .refine(
-      ({ hasCurrentNursery, nursery }) =>
-        hasCurrentNursery === YES ? !!nursery : true,
-      {
-        path: ['nursery'],
-      },
-    ),
-  reasonForApplication: z.object({
-    reason: z.string(),
-  }),
-  counsellingRegardingApplication: z.object({
-    counselling: z.string(),
-    hasVisitedSchool: z.enum([YES, NO]),
-  }),
-  currentSchool: z
-    .object({
-      hasCurrentSchool: z.enum([YES, NO]).optional(),
-      municipality: z.string().optional().nullable(),
-      school: z.string().optional().nullable(),
-    })
-    .refine(
-      ({ hasCurrentSchool, municipality }) =>
-        hasCurrentSchool === YES ? !!municipality : true,
-      {
-        path: ['municipality'],
-      },
-    )
-    .refine(
-      ({ hasCurrentSchool, school }) =>
-        hasCurrentSchool === YES ? !!school : true,
-      {
-        path: ['school'],
-      },
-    ),
-  newSchool: z.object({
-    municipality: z.string(),
-    school: z.string(),
-  }),
-  school: z.object({
-    applyForPreferredSchool: z.enum([YES, NO]),
-  }),
-  siblings: z
-    .array(
-      z.object({
-        nationalIdWithName: nationalIdWithNameSchema,
-      }),
-    )
-    .refine((r) => r === undefined || r.length > 0, {
-      params: errorMessages.siblingsRequired,
-    }),
-  startingSchool: z
-    .object({
-      expectedStartDate: z.string(),
-      temporaryStay: z.string().min(1).optional(),
-      expectedEndDate: z.string().optional(),
-    })
-    .refine(
-      ({ expectedStartDate, expectedEndDate, temporaryStay }) =>
-        !(
-          temporaryStay === YES &&
-          expectedEndDate &&
-          new Date(expectedStartDate) > new Date(expectedEndDate)
-        ),
-      {
-        path: ['expectedEndDate'],
-        params: errorMessages.expectedEndDateMessage,
-      },
-    )
-    .refine(
-      ({ expectedEndDate, temporaryStay }) =>
-        !(temporaryStay === YES && !expectedEndDate),
-      {
-        path: ['expectedEndDate'],
-        params: errorMessages.expectedEndDateRequired,
-      },
-    ),
-  languages: z
-    .object({
-      languageEnvironment: z.string(),
-      signLanguage: z.enum([YES, NO]),
-      selectedLanguages: z
-        .array(z.object({ code: z.string().nullish() }))
-        .optional(),
-      preferredLanguage: z.string().optional().nullable(),
-    })
-    .superRefine(({ languageEnvironment, selectedLanguages }, ctx) => {
-      // LanguageEnvironment is stored as <id>::<option> in the DB
-      const selectedLanguageEnvironment =
-        languageEnvironment.split('::')[1] ?? ''
-
-      const checkAndAddIssue = (index: number) => {
-        // If required 2 languages but the second language field is still hidden
-        // else check if applicant has selected a languages
-        if (index === 1 && selectedLanguages?.length === 1) {
-          ctx.addIssue({
-            code: z.ZodIssueCode.custom,
-            params: errorMessages.twoLanguagesRequired,
-            path: ['selectedLanguages'],
-          })
-        } else if (!selectedLanguages?.[index]?.code) {
-          ctx.addIssue({
-            code: z.ZodIssueCode.custom,
-            params: errorMessages.languageRequired,
-            path: ['selectedLanguages', index, 'code'],
-          })
-        }
-      }
-
-      if (
-        selectedLanguageEnvironment ===
-        LanguageEnvironmentOptions.ONLY_OTHER_THAN_ICELANDIC
-      ) {
-        checkAndAddIssue(0)
-      } else if (
-        selectedLanguageEnvironment ===
-        LanguageEnvironmentOptions.ICELANDIC_AND_OTHER
-      ) {
-        checkAndAddIssue(0)
-        checkAndAddIssue(1)
-      }
-    })
-    .refine(
-      ({ languageEnvironment, selectedLanguages, preferredLanguage }) => {
-        // LanguageEnvironment is stored as <id>::<option> in the DB
-        const selectedLanguageEnvironment =
-          languageEnvironment.split('::')[1] ?? ''
-
-        if (
-          (selectedLanguageEnvironment ===
-            LanguageEnvironmentOptions.ONLY_OTHER_THAN_ICELANDIC &&
-            !!selectedLanguages &&
-            selectedLanguages?.length >= 1) ||
-          (selectedLanguageEnvironment ===
-            LanguageEnvironmentOptions.ICELANDIC_AND_OTHER &&
-            !!selectedLanguages &&
-            selectedLanguages?.length >= 2)
-        ) {
-          return !!preferredLanguage
-        }
-
-        return true
-      },
-      {
-        path: ['preferredLanguage'],
-        params: errorMessages.languageRequired,
-      },
-    ),
-  healthProtection: z
-    .object({
-      hasFoodAllergiesOrIntolerances: z.array(z.string()),
-      foodAllergiesOrIntolerances: z.array(z.string()).optional().nullable(),
-      hasOtherAllergies: z.array(z.string()),
-      otherAllergies: z.array(z.string()).optional().nullable(),
-      usesEpiPen: z.string().optional(),
-      hasConfirmedMedicalDiagnoses: z.enum([YES, NO]),
-      requestsMedicationAdministration: z.enum([YES, NO]),
-    })
-    .refine(
-      ({ hasFoodAllergiesOrIntolerances, foodAllergiesOrIntolerances }) =>
-        hasFoodAllergiesOrIntolerances.includes(YES)
-          ? !!foodAllergiesOrIntolerances &&
-            foodAllergiesOrIntolerances.length > 0
-          : true,
-      {
-        path: ['foodAllergiesOrIntolerances'],
-        params: errorMessages.foodAllergiesOrIntolerancesRequired,
-      },
-    )
-    .refine(
-      ({ hasOtherAllergies, otherAllergies }) =>
-        hasOtherAllergies.includes(YES)
-          ? !!otherAllergies && otherAllergies.length > 0
-          : true,
-      {
-        path: ['otherAllergies'],
-        params: errorMessages.otherAllergiesRequired,
-      },
-    )
-    .refine(
-      ({ hasFoodAllergiesOrIntolerances, hasOtherAllergies, usesEpiPen }) =>
-        hasFoodAllergiesOrIntolerances.includes(YES) ||
-        hasOtherAllergies.includes(YES)
-          ? !!usesEpiPen
-          : true,
-      { path: ['usesEpiPen'] },
-    ),
-  support: z
-    .object({
-      hasDiagnoses: z.enum([YES, NO]),
-      hasHadSupport: z.enum([YES, NO]),
-      hasWelfareContact: z.string().optional(),
-      welfareContact: nameEmailSchema,
-      hasCaseManager: z.string().optional(),
-      caseManager: nameEmailSchema,
-      hasIntegratedServices: z.string().optional(),
-      requestingMeeting: z.array(z.enum([YES, NO])).optional(),
-    })
-    .refine(
-      ({ hasDiagnoses, hasHadSupport, hasWelfareContact }) =>
-        hasDiagnoses === YES || hasHadSupport === YES
-          ? !!hasWelfareContact
-          : true,
-      { path: ['hasWelfareContact'] },
-    )
-    .refine(
-      ({ hasDiagnoses, hasHadSupport, hasWelfareContact, welfareContact }) =>
-        (hasDiagnoses === YES || hasHadSupport === YES) &&
-        hasWelfareContact === YES
-          ? welfareContact && !!welfareContact.name?.trim()
-          : true,
-      { path: ['welfareContact', 'name'] },
-    )
-    .refine(
-      ({ hasDiagnoses, hasHadSupport, hasWelfareContact, welfareContact }) =>
-        (hasDiagnoses === YES || hasHadSupport === YES) &&
-        hasWelfareContact === YES
-          ? welfareContact && !!welfareContact.email?.trim()
-          : true,
-      { path: ['welfareContact', 'email'] },
-    )
-    .refine(
-      ({ hasDiagnoses, hasHadSupport, hasWelfareContact, hasCaseManager }) =>
-        (hasDiagnoses === YES || hasHadSupport === YES) &&
-        hasWelfareContact === YES
-          ? !!hasCaseManager
-          : true,
-      { path: ['hasCaseManager'] },
-    )
-    .refine(
-      ({
-        hasDiagnoses,
-        hasHadSupport,
-        hasWelfareContact,
-        hasCaseManager,
-        caseManager,
-      }) =>
-        (hasDiagnoses === YES || hasHadSupport === YES) &&
-        hasWelfareContact === YES &&
-        hasCaseManager === YES
-          ? caseManager && !!caseManager.name?.trim()
-          : true,
-      { path: ['caseManager', 'name'] },
-    )
-    .refine(
-      ({
-        hasDiagnoses,
-        hasHadSupport,
-        hasWelfareContact,
-        hasCaseManager,
-        caseManager,
-      }) =>
-        (hasDiagnoses === YES || hasHadSupport === YES) &&
-        hasWelfareContact === YES &&
-        hasCaseManager === YES
-          ? caseManager && !!caseManager.email?.trim()
-          : true,
-      {
-        path: ['caseManager', 'email'],
-      },
-    )
-    .refine(
-      ({
-        hasDiagnoses,
-        hasHadSupport,
-        hasIntegratedServices,
-        hasWelfareContact,
-      }) =>
-        (hasDiagnoses === YES || hasHadSupport === YES) &&
-        hasWelfareContact === YES
-          ? !!hasIntegratedServices
-          : true,
-      { path: ['hasIntegratedServices'] },
-    ),
-  attachments: z.object({
-    answer: z.nativeEnum(AttachmentOptions),
-  }),
-  specialEducationSupport: z
-    .object({
-      hasWelfareContact: z.enum([YES, NO]),
-      welfareContact: nameEmailSchema,
-      hasCaseManager: z.enum([YES, NO]),
-      caseManager: nameEmailSchema,
-      hasIntegratedServices: z.enum([YES, NO]),
-      hasAssessmentOfSupportNeeds: z.enum([YES, NO]),
-      isAssessmentOfSupportNeedsInProgress: z.string().optional(),
-      supportNeedsAssessmentBy: z.string().optional(),
-      hasConfirmedDiagnosis: z.enum([YES, NO]),
-      isDiagnosisInProgress: z.string().optional(),
-      diagnosticians: z.array(z.string()).optional(),
-      hasOtherSpecialists: z.enum([YES, NO]),
-      specialists: z.array(z.string()).optional(),
-      hasReceivedServicesFromMunicipality: z.enum([YES, NO]),
-      servicesFromMunicipality: z.array(z.string()).optional(),
-      hasReceivedChildAndAdolescentPsychiatryServices: z
-        .string()
-        .min(1)
-        .optional(),
-      isOnWaitlistForServices: z.string().optional(),
-      childAndAdolescentPsychiatryDepartment: z.string().optional(),
-      childAndAdolescentPsychiatryServicesReceived: z
-        .array(z.string())
-        .optional(),
-      hasBeenReportedToChildProtectiveServices: z.string().min(1).optional(),
-      isCaseOpenWithChildProtectiveServices: z.string().optional(),
-    })
-    .refine(
-      ({ hasWelfareContact, welfareContact }) =>
-        hasWelfareContact === YES
-          ? welfareContact && !!welfareContact.name?.trim()
-          : true,
-      { path: ['welfareContact', 'name'] },
-    )
-    .refine(
-      ({ hasWelfareContact, welfareContact }) =>
-        hasWelfareContact === YES
-          ? welfareContact && !!welfareContact.email?.trim()
-          : true,
-      { path: ['welfareContact', 'email'] },
-    )
-    .refine(
-      ({ hasCaseManager, caseManager }) =>
-        hasCaseManager === YES
-          ? caseManager && !!caseManager.name?.trim()
-          : true,
-      { path: ['caseManager', 'name'] },
-    )
-    .refine(
-      ({ hasCaseManager, caseManager }) =>
-        hasCaseManager === YES
-          ? caseManager && !!caseManager.email?.trim()
-          : true,
-      { path: ['caseManager', 'email'] },
-    )
-    .refine(
-      ({ hasAssessmentOfSupportNeeds, isAssessmentOfSupportNeedsInProgress }) =>
-        hasAssessmentOfSupportNeeds === NO
-          ? !!isAssessmentOfSupportNeedsInProgress
-          : true,
-      { path: ['isAssessmentOfSupportNeedsInProgress'] },
-    )
-    .refine(
-      ({
-        hasAssessmentOfSupportNeeds,
-        isAssessmentOfSupportNeedsInProgress,
-        supportNeedsAssessmentBy,
-      }) =>
-        hasAssessmentOfSupportNeeds === YES ||
-        (hasAssessmentOfSupportNeeds === NO &&
-          isAssessmentOfSupportNeedsInProgress === YES)
-          ? !!supportNeedsAssessmentBy
-          : true,
-      { path: ['supportNeedsAssessmentBy'] },
-    )
-    .refine(
-      ({ hasConfirmedDiagnosis, isDiagnosisInProgress }) =>
-        hasConfirmedDiagnosis === NO ? !!isDiagnosisInProgress : true,
-      { path: ['isDiagnosisInProgress'] },
-    )
-    .refine(
-      ({ hasConfirmedDiagnosis, isDiagnosisInProgress, diagnosticians }) =>
-        hasConfirmedDiagnosis === YES ||
-        (hasConfirmedDiagnosis === NO && isDiagnosisInProgress === YES)
-          ? !!diagnosticians
-          : true,
-      { path: ['diagnosticians'] },
-    )
-    .refine(
-      ({ hasOtherSpecialists, specialists }) =>
-        hasOtherSpecialists === YES ? !!specialists : true,
-      { path: ['specialists'] },
-    )
-    .refine(
-      ({ hasReceivedServicesFromMunicipality, servicesFromMunicipality }) =>
-        hasReceivedServicesFromMunicipality === YES
-          ? !!servicesFromMunicipality
-          : true,
-      { path: ['servicesFromMunicipality'] },
-    )
-    .refine(
-      ({
-        hasReceivedChildAndAdolescentPsychiatryServices,
-        isOnWaitlistForServices,
-      }) =>
-        hasReceivedChildAndAdolescentPsychiatryServices === NO
-          ? !!isOnWaitlistForServices
-          : true,
-      { path: ['isOnWaitlistForServices'] },
-    )
-    .refine(
-      ({
-        hasReceivedChildAndAdolescentPsychiatryServices,
-        isOnWaitlistForServices,
-        childAndAdolescentPsychiatryDepartment,
-      }) =>
-        hasReceivedChildAndAdolescentPsychiatryServices === YES ||
-        (hasReceivedChildAndAdolescentPsychiatryServices === NO &&
-          isOnWaitlistForServices === YES)
-          ? !!childAndAdolescentPsychiatryDepartment
-          : true,
-      { path: ['childAndAdolescentPsychiatryDepartment'] },
-    )
-    .refine(
-      ({
-        hasReceivedChildAndAdolescentPsychiatryServices,
-        childAndAdolescentPsychiatryServicesReceived,
-      }) =>
-        hasReceivedChildAndAdolescentPsychiatryServices === YES
-          ? !!childAndAdolescentPsychiatryServicesReceived
-          : true,
-      { path: ['childAndAdolescentPsychiatryServicesReceived'] },
-    )
-    .refine(
-      ({
-        hasBeenReportedToChildProtectiveServices,
-        isCaseOpenWithChildProtectiveServices,
-      }) =>
-        hasBeenReportedToChildProtectiveServices === YES
-          ? !!isCaseOpenWithChildProtectiveServices
-          : true,
-      { path: ['isCaseOpenWithChildProtectiveServices'] },
-    ),
-  payer: z
-    .object({
-      option: z.nativeEnum(PayerOption),
-      other: z
-        .object({
-          name: z.string(),
-          nationalId: z.string(),
-        })
-        .optional(),
-    })
-    .refine(
-      ({ option, other }) =>
-        option === PayerOption.OTHER ? other && !!other.name?.trim() : true,
-      { path: ['other', 'name'] },
-    )
-    .refine(
-      ({ option, other }) =>
-        option === PayerOption.OTHER
-          ? other && kennitala.isValid(other.nationalId)
-          : true,
-      { path: ['other', 'nationalId'], params: errorMessages.nationalId },
-    ),
-}).superRefine(({ childNationalId, relatives }, ctx) => {
-  relatives.forEach((relative, index) => {
-    if (relative.nationalIdWithName?.nationalId === childNationalId) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        params: errorMessages.relativeSameAsChild,
-        path: ['relatives', index, 'nationalIdWithName', 'nationalId'],
+    support: z
+      .object({
+        hasDiagnoses: z.enum([YES, NO]),
+        hasHadSupport: z.enum([YES, NO]),
+        hasWelfareContact: z.string().optional(),
+        welfareContact: nameEmailSchema,
+        hasCaseManager: z.string().optional(),
+        caseManager: nameEmailSchema,
+        hasIntegratedServices: z.string().optional(),
+        requestingMeeting: z.array(z.enum([YES, NO])).optional(),
       })
-    }
+      .refine(
+        ({ hasDiagnoses, hasHadSupport, hasWelfareContact }) =>
+          hasDiagnoses === YES || hasHadSupport === YES
+            ? !!hasWelfareContact
+            : true,
+        { path: ['hasWelfareContact'] },
+      )
+      .refine(
+        ({ hasDiagnoses, hasHadSupport, hasWelfareContact, welfareContact }) =>
+          (hasDiagnoses === YES || hasHadSupport === YES) &&
+          hasWelfareContact === YES
+            ? welfareContact && !!welfareContact.name?.trim()
+            : true,
+        { path: ['welfareContact', 'name'] },
+      )
+      .refine(
+        ({ hasDiagnoses, hasHadSupport, hasWelfareContact, welfareContact }) =>
+          (hasDiagnoses === YES || hasHadSupport === YES) &&
+          hasWelfareContact === YES
+            ? welfareContact && !!welfareContact.email?.trim()
+            : true,
+        { path: ['welfareContact', 'email'] },
+      )
+      .refine(
+        ({ hasDiagnoses, hasHadSupport, hasWelfareContact, hasCaseManager }) =>
+          (hasDiagnoses === YES || hasHadSupport === YES) &&
+          hasWelfareContact === YES
+            ? !!hasCaseManager
+            : true,
+        { path: ['hasCaseManager'] },
+      )
+      .refine(
+        ({
+          hasDiagnoses,
+          hasHadSupport,
+          hasWelfareContact,
+          hasCaseManager,
+          caseManager,
+        }) =>
+          (hasDiagnoses === YES || hasHadSupport === YES) &&
+          hasWelfareContact === YES &&
+          hasCaseManager === YES
+            ? caseManager && !!caseManager.name?.trim()
+            : true,
+        { path: ['caseManager', 'name'] },
+      )
+      .refine(
+        ({
+          hasDiagnoses,
+          hasHadSupport,
+          hasWelfareContact,
+          hasCaseManager,
+          caseManager,
+        }) =>
+          (hasDiagnoses === YES || hasHadSupport === YES) &&
+          hasWelfareContact === YES &&
+          hasCaseManager === YES
+            ? caseManager && !!caseManager.email?.trim()
+            : true,
+        {
+          path: ['caseManager', 'email'],
+        },
+      )
+      .refine(
+        ({
+          hasDiagnoses,
+          hasHadSupport,
+          hasIntegratedServices,
+          hasWelfareContact,
+        }) =>
+          (hasDiagnoses === YES || hasHadSupport === YES) &&
+          hasWelfareContact === YES
+            ? !!hasIntegratedServices
+            : true,
+        { path: ['hasIntegratedServices'] },
+      ),
+    attachments: z.object({
+      answer: z.nativeEnum(AttachmentOptions),
+    }),
+    specialEducationSupport: z
+      .object({
+        hasWelfareContact: z.enum([YES, NO]),
+        welfareContact: nameEmailSchema,
+        hasCaseManager: z.enum([YES, NO]),
+        caseManager: nameEmailSchema,
+        hasIntegratedServices: z.enum([YES, NO]),
+        hasAssessmentOfSupportNeeds: z.enum([YES, NO]),
+        isAssessmentOfSupportNeedsInProgress: z.string().optional(),
+        supportNeedsAssessmentBy: z.string().optional(),
+        hasConfirmedDiagnosis: z.enum([YES, NO]),
+        isDiagnosisInProgress: z.string().optional(),
+        diagnosticians: z.array(z.string()).optional(),
+        hasOtherSpecialists: z.enum([YES, NO]),
+        specialists: z.array(z.string()).optional(),
+        hasReceivedServicesFromMunicipality: z.enum([YES, NO]),
+        servicesFromMunicipality: z.array(z.string()).optional(),
+        hasReceivedChildAndAdolescentPsychiatryServices: z
+          .string()
+          .min(1)
+          .optional(),
+        isOnWaitlistForServices: z.string().optional(),
+        childAndAdolescentPsychiatryDepartment: z.string().optional(),
+        childAndAdolescentPsychiatryServicesReceived: z
+          .array(z.string())
+          .optional(),
+        hasBeenReportedToChildProtectiveServices: z.string().min(1).optional(),
+        isCaseOpenWithChildProtectiveServices: z.string().optional(),
+      })
+      .refine(
+        ({ hasWelfareContact, welfareContact }) =>
+          hasWelfareContact === YES
+            ? welfareContact && !!welfareContact.name?.trim()
+            : true,
+        { path: ['welfareContact', 'name'] },
+      )
+      .refine(
+        ({ hasWelfareContact, welfareContact }) =>
+          hasWelfareContact === YES
+            ? welfareContact && !!welfareContact.email?.trim()
+            : true,
+        { path: ['welfareContact', 'email'] },
+      )
+      .refine(
+        ({ hasCaseManager, caseManager }) =>
+          hasCaseManager === YES
+            ? caseManager && !!caseManager.name?.trim()
+            : true,
+        { path: ['caseManager', 'name'] },
+      )
+      .refine(
+        ({ hasCaseManager, caseManager }) =>
+          hasCaseManager === YES
+            ? caseManager && !!caseManager.email?.trim()
+            : true,
+        { path: ['caseManager', 'email'] },
+      )
+      .refine(
+        ({
+          hasAssessmentOfSupportNeeds,
+          isAssessmentOfSupportNeedsInProgress,
+        }) =>
+          hasAssessmentOfSupportNeeds === NO
+            ? !!isAssessmentOfSupportNeedsInProgress
+            : true,
+        { path: ['isAssessmentOfSupportNeedsInProgress'] },
+      )
+      .refine(
+        ({
+          hasAssessmentOfSupportNeeds,
+          isAssessmentOfSupportNeedsInProgress,
+          supportNeedsAssessmentBy,
+        }) =>
+          hasAssessmentOfSupportNeeds === YES ||
+          (hasAssessmentOfSupportNeeds === NO &&
+            isAssessmentOfSupportNeedsInProgress === YES)
+            ? !!supportNeedsAssessmentBy
+            : true,
+        { path: ['supportNeedsAssessmentBy'] },
+      )
+      .refine(
+        ({ hasConfirmedDiagnosis, isDiagnosisInProgress }) =>
+          hasConfirmedDiagnosis === NO ? !!isDiagnosisInProgress : true,
+        { path: ['isDiagnosisInProgress'] },
+      )
+      .refine(
+        ({ hasConfirmedDiagnosis, isDiagnosisInProgress, diagnosticians }) =>
+          hasConfirmedDiagnosis === YES ||
+          (hasConfirmedDiagnosis === NO && isDiagnosisInProgress === YES)
+            ? !!diagnosticians
+            : true,
+        { path: ['diagnosticians'] },
+      )
+      .refine(
+        ({ hasOtherSpecialists, specialists }) =>
+          hasOtherSpecialists === YES ? !!specialists : true,
+        { path: ['specialists'] },
+      )
+      .refine(
+        ({ hasReceivedServicesFromMunicipality, servicesFromMunicipality }) =>
+          hasReceivedServicesFromMunicipality === YES
+            ? !!servicesFromMunicipality
+            : true,
+        { path: ['servicesFromMunicipality'] },
+      )
+      .refine(
+        ({
+          hasReceivedChildAndAdolescentPsychiatryServices,
+          isOnWaitlistForServices,
+        }) =>
+          hasReceivedChildAndAdolescentPsychiatryServices === NO
+            ? !!isOnWaitlistForServices
+            : true,
+        { path: ['isOnWaitlistForServices'] },
+      )
+      .refine(
+        ({
+          hasReceivedChildAndAdolescentPsychiatryServices,
+          isOnWaitlistForServices,
+          childAndAdolescentPsychiatryDepartment,
+        }) =>
+          hasReceivedChildAndAdolescentPsychiatryServices === YES ||
+          (hasReceivedChildAndAdolescentPsychiatryServices === NO &&
+            isOnWaitlistForServices === YES)
+            ? !!childAndAdolescentPsychiatryDepartment
+            : true,
+        { path: ['childAndAdolescentPsychiatryDepartment'] },
+      )
+      .refine(
+        ({
+          hasReceivedChildAndAdolescentPsychiatryServices,
+          childAndAdolescentPsychiatryServicesReceived,
+        }) =>
+          hasReceivedChildAndAdolescentPsychiatryServices === YES
+            ? !!childAndAdolescentPsychiatryServicesReceived
+            : true,
+        { path: ['childAndAdolescentPsychiatryServicesReceived'] },
+      )
+      .refine(
+        ({
+          hasBeenReportedToChildProtectiveServices,
+          isCaseOpenWithChildProtectiveServices,
+        }) =>
+          hasBeenReportedToChildProtectiveServices === YES
+            ? !!isCaseOpenWithChildProtectiveServices
+            : true,
+        { path: ['isCaseOpenWithChildProtectiveServices'] },
+      ),
+    payer: z
+      .object({
+        option: z.nativeEnum(PayerOption),
+        other: z
+          .object({
+            name: z.string(),
+            nationalId: z.string(),
+          })
+          .optional(),
+      })
+      .refine(
+        ({ option, other }) =>
+          option === PayerOption.OTHER ? other && !!other.name?.trim() : true,
+        { path: ['other', 'name'] },
+      )
+      .refine(
+        ({ option, other }) =>
+          option === PayerOption.OTHER
+            ? other && kennitala.isValid(other.nationalId)
+            : true,
+        { path: ['other', 'nationalId'], params: errorMessages.nationalId },
+      ),
   })
-})
+  .superRefine(({ childNationalId, relatives }, ctx) => {
+    relatives.forEach((relative, index) => {
+      if (relative.nationalIdWithName?.nationalId === childNationalId) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          params: errorMessages.relativeSameAsChild,
+          path: ['relatives', index, 'nationalIdWithName', 'nationalId'],
+        })
+      }
+    })
+  })
 
 export type SchemaFormValues = z.infer<typeof dataSchema>

--- a/libs/application/templates/new-primary-school/src/lib/dataSchema.ts
+++ b/libs/application/templates/new-primary-school/src/lib/dataSchema.ts
@@ -35,539 +35,535 @@ const nameEmailSchema = z
   })
   .optional()
 
-export const dataSchema = z
-  .object({
-    approveExternalData: z.boolean().refine((v) => v),
-    childNationalId: z.string().min(1),
-    applicationType: z.nativeEnum(ApplicationType),
-    childInfo: z
-      .object({
-        usePronounAndPreferredName: z.array(z.string()),
-        preferredName: z.string().optional(),
-        pronouns: z.array(z.string()).optional().nullable(),
-      })
-      .refine(
-        ({ usePronounAndPreferredName, preferredName, pronouns }) =>
-          usePronounAndPreferredName.includes(YES)
-            ? !!preferredName || (pronouns && pronouns.length > 0)
-            : true,
-        { path: ['preferredName'] },
-      )
-      .refine(
-        ({ usePronounAndPreferredName, pronouns, preferredName }) =>
-          usePronounAndPreferredName.includes(YES)
-            ? (!!pronouns && pronouns.length > 0) || !!preferredName
-            : true,
-        { path: ['pronouns'] },
-      ),
-    guardians: z.array(
-      z
-        .object({
-          email: z.string().email(),
-          phoneNumber: phoneNumberSchema,
-          requiresInterpreter: z.array(z.string()),
-          preferredLanguage: z.string().optional().nullable(),
-        })
-        .refine(
-          ({ requiresInterpreter, preferredLanguage }) =>
-            requiresInterpreter.includes(YES) ? !!preferredLanguage : true,
-          {
-            path: ['preferredLanguage'],
-            params: errorMessages.languageRequired,
-          },
-        ),
+export const dataSchema = z.object({
+  approveExternalData: z.boolean().refine((v) => v),
+  childNationalId: z.string().min(1),
+  applicationType: z.nativeEnum(ApplicationType),
+  childInfo: z
+    .object({
+      usePronounAndPreferredName: z.array(z.string()),
+      preferredName: z.string().optional(),
+      pronouns: z.array(z.string()).optional().nullable(),
+    })
+    .refine(
+      ({ usePronounAndPreferredName, preferredName, pronouns }) =>
+        usePronounAndPreferredName.includes(YES)
+          ? !!preferredName || (pronouns && pronouns.length > 0)
+          : true,
+      { path: ['preferredName'] },
+    )
+    .refine(
+      ({ usePronounAndPreferredName, pronouns, preferredName }) =>
+        usePronounAndPreferredName.includes(YES)
+          ? (!!pronouns && pronouns.length > 0) || !!preferredName
+          : true,
+      { path: ['pronouns'] },
     ),
-    relatives: z.array(
-      z
-        .object({
-          nationalIdWithName: nationalIdWithNameSchema,
-          phoneNumber: phoneNumberSchema,
-          relation: z.string(),
-          applicantNationalId: z.string().optional(),
-          otherGuardianNationalId: z.string().optional(),
-          childNationalId: z.string().optional(),
-        })
-        .refine(
-          ({
-            nationalIdWithName,
-            applicantNationalId,
-            otherGuardianNationalId,
-          }) =>
-            nationalIdWithName?.nationalId !== applicantNationalId &&
-            nationalIdWithName?.nationalId !== otherGuardianNationalId,
-          {
-            path: ['nationalIdWithName', 'nationalId'],
-            params: errorMessages.relativeSameAsGuardian,
-          },
-        )
-        .refine(
-          ({ nationalIdWithName, childNationalId }) =>
-            nationalIdWithName?.nationalId !== childNationalId,
-          {
-            path: ['nationalIdWithName', 'nationalId'],
-            params: errorMessages.relativeSameAsChild,
-          },
-        ),
-    ),
-    currentNursery: z
+  guardians: z.array(
+    z
       .object({
-        hasCurrentNursery: z.enum([YES, NO]),
-        municipality: z.string().optional().nullable(),
-        nursery: z.string().optional().nullable(),
-      })
-      .refine(
-        ({ hasCurrentNursery, municipality }) =>
-          hasCurrentNursery === YES ? !!municipality : true,
-        {
-          path: ['municipality'],
-        },
-      )
-      .refine(
-        ({ hasCurrentNursery, nursery }) =>
-          hasCurrentNursery === YES ? !!nursery : true,
-        {
-          path: ['nursery'],
-        },
-      ),
-    reasonForApplication: z.object({
-      reason: z.string(),
-    }),
-    counsellingRegardingApplication: z.object({
-      counselling: z.string(),
-      hasVisitedSchool: z.enum([YES, NO]),
-    }),
-    currentSchool: z
-      .object({
-        hasCurrentSchool: z.enum([YES, NO]).optional(),
-        municipality: z.string().optional().nullable(),
-        school: z.string().optional().nullable(),
-      })
-      .refine(
-        ({ hasCurrentSchool, municipality }) =>
-          hasCurrentSchool === YES ? !!municipality : true,
-        {
-          path: ['municipality'],
-        },
-      )
-      .refine(
-        ({ hasCurrentSchool, school }) =>
-          hasCurrentSchool === YES ? !!school : true,
-        {
-          path: ['school'],
-        },
-      ),
-    newSchool: z.object({
-      municipality: z.string(),
-      school: z.string(),
-    }),
-    school: z.object({
-      applyForPreferredSchool: z.enum([YES, NO]),
-    }),
-    siblings: z
-      .array(
-        z.object({
-          nationalIdWithName: nationalIdWithNameSchema,
-        }),
-      )
-      .refine((r) => r === undefined || r.length > 0, {
-        params: errorMessages.siblingsRequired,
-      }),
-    startingSchool: z
-      .object({
-        expectedStartDate: z.string(),
-        temporaryStay: z.string().min(1).optional(),
-        expectedEndDate: z.string().optional(),
-      })
-      .refine(
-        ({ expectedStartDate, expectedEndDate, temporaryStay }) =>
-          !(
-            temporaryStay === YES &&
-            expectedEndDate &&
-            new Date(expectedStartDate) > new Date(expectedEndDate)
-          ),
-        {
-          path: ['expectedEndDate'],
-          params: errorMessages.expectedEndDateMessage,
-        },
-      )
-      .refine(
-        ({ expectedEndDate, temporaryStay }) =>
-          !(temporaryStay === YES && !expectedEndDate),
-        {
-          path: ['expectedEndDate'],
-          params: errorMessages.expectedEndDateRequired,
-        },
-      ),
-    languages: z
-      .object({
-        languageEnvironment: z.string(),
-        signLanguage: z.enum([YES, NO]),
-        selectedLanguages: z
-          .array(z.object({ code: z.string().nullish() }))
-          .optional(),
+        email: z.string().email(),
+        phoneNumber: phoneNumberSchema,
+        requiresInterpreter: z.array(z.string()),
         preferredLanguage: z.string().optional().nullable(),
       })
-      .superRefine(({ languageEnvironment, selectedLanguages }, ctx) => {
-        // LanguageEnvironment is stored as <id>::<option> in the DB
-        const selectedLanguageEnvironment =
-          languageEnvironment.split('::')[1] ?? ''
-
-        const checkAndAddIssue = (index: number) => {
-          // If required 2 languages but the second language field is still hidden
-          // else check if applicant has selected a languages
-          if (index === 1 && selectedLanguages?.length === 1) {
-            ctx.addIssue({
-              code: z.ZodIssueCode.custom,
-              params: errorMessages.twoLanguagesRequired,
-              path: ['selectedLanguages'],
-            })
-          } else if (!selectedLanguages?.[index]?.code) {
-            ctx.addIssue({
-              code: z.ZodIssueCode.custom,
-              params: errorMessages.languageRequired,
-              path: ['selectedLanguages', index, 'code'],
-            })
-          }
-        }
-
-        if (
-          selectedLanguageEnvironment ===
-          LanguageEnvironmentOptions.ONLY_OTHER_THAN_ICELANDIC
-        ) {
-          checkAndAddIssue(0)
-        } else if (
-          selectedLanguageEnvironment ===
-          LanguageEnvironmentOptions.ICELANDIC_AND_OTHER
-        ) {
-          checkAndAddIssue(0)
-          checkAndAddIssue(1)
-        }
-      })
       .refine(
-        ({ languageEnvironment, selectedLanguages, preferredLanguage }) => {
-          // LanguageEnvironment is stored as <id>::<option> in the DB
-          const selectedLanguageEnvironment =
-            languageEnvironment.split('::')[1] ?? ''
-
-          if (
-            (selectedLanguageEnvironment ===
-              LanguageEnvironmentOptions.ONLY_OTHER_THAN_ICELANDIC &&
-              !!selectedLanguages &&
-              selectedLanguages?.length >= 1) ||
-            (selectedLanguageEnvironment ===
-              LanguageEnvironmentOptions.ICELANDIC_AND_OTHER &&
-              !!selectedLanguages &&
-              selectedLanguages?.length >= 2)
-          ) {
-            return !!preferredLanguage
-          }
-
-          return true
-        },
+        ({ requiresInterpreter, preferredLanguage }) =>
+          requiresInterpreter.includes(YES) ? !!preferredLanguage : true,
         {
           path: ['preferredLanguage'],
           params: errorMessages.languageRequired,
         },
       ),
-    healthProtection: z
+  ),
+  relatives: z.array(
+    z
       .object({
-        hasFoodAllergiesOrIntolerances: z.array(z.string()),
-        foodAllergiesOrIntolerances: z.array(z.string()).optional().nullable(),
-        hasOtherAllergies: z.array(z.string()),
-        otherAllergies: z.array(z.string()).optional().nullable(),
-        usesEpiPen: z.string().optional(),
-        hasConfirmedMedicalDiagnoses: z.enum([YES, NO]),
-        requestsMedicationAdministration: z.enum([YES, NO]),
+        nationalIdWithName: nationalIdWithNameSchema,
+        phoneNumber: phoneNumberSchema,
+        relation: z.string(),
+        applicantNationalId: z.string().optional(),
+        otherGuardianNationalId: z.string().optional(),
+        childNationalId: z.string().optional(),
       })
       .refine(
-        ({ hasFoodAllergiesOrIntolerances, foodAllergiesOrIntolerances }) =>
-          hasFoodAllergiesOrIntolerances.includes(YES)
-            ? !!foodAllergiesOrIntolerances &&
-              foodAllergiesOrIntolerances.length > 0
-            : true,
+        ({
+          nationalIdWithName,
+          applicantNationalId,
+          otherGuardianNationalId,
+        }) =>
+          nationalIdWithName?.nationalId !== applicantNationalId &&
+          nationalIdWithName?.nationalId !== otherGuardianNationalId,
         {
-          path: ['foodAllergiesOrIntolerances'],
-          params: errorMessages.foodAllergiesOrIntolerancesRequired,
+          path: ['nationalIdWithName', 'nationalId'],
+          params: errorMessages.relativeSameAsGuardian,
         },
       )
       .refine(
-        ({ hasOtherAllergies, otherAllergies }) =>
-          hasOtherAllergies.includes(YES)
-            ? !!otherAllergies && otherAllergies.length > 0
-            : true,
+        ({ nationalIdWithName, childNationalId }) =>
+          nationalIdWithName?.nationalId !== childNationalId,
         {
-          path: ['otherAllergies'],
-          params: errorMessages.otherAllergiesRequired,
+          path: ['nationalIdWithName', 'nationalId'],
+          params: errorMessages.relativeSameAsChild,
         },
-      )
-      .refine(
-        ({ hasFoodAllergiesOrIntolerances, hasOtherAllergies, usesEpiPen }) =>
-          hasFoodAllergiesOrIntolerances.includes(YES) ||
-          hasOtherAllergies.includes(YES)
-            ? !!usesEpiPen
-            : true,
-        { path: ['usesEpiPen'] },
       ),
-    support: z
-      .object({
-        hasDiagnoses: z.enum([YES, NO]),
-        hasHadSupport: z.enum([YES, NO]),
-        hasWelfareContact: z.string().optional(),
-        welfareContact: nameEmailSchema,
-        hasCaseManager: z.string().optional(),
-        caseManager: nameEmailSchema,
-        hasIntegratedServices: z.string().optional(),
-        requestingMeeting: z.array(z.enum([YES, NO])).optional(),
-      })
-      .refine(
-        ({ hasDiagnoses, hasHadSupport, hasWelfareContact }) =>
-          hasDiagnoses === YES || hasHadSupport === YES
-            ? !!hasWelfareContact
-            : true,
-        { path: ['hasWelfareContact'] },
-      )
-      .refine(
-        ({ hasDiagnoses, hasHadSupport, hasWelfareContact, welfareContact }) =>
-          (hasDiagnoses === YES || hasHadSupport === YES) &&
-          hasWelfareContact === YES
-            ? welfareContact && !!welfareContact.name?.trim()
-            : true,
-        { path: ['welfareContact', 'name'] },
-      )
-      .refine(
-        ({ hasDiagnoses, hasHadSupport, hasWelfareContact, welfareContact }) =>
-          (hasDiagnoses === YES || hasHadSupport === YES) &&
-          hasWelfareContact === YES
-            ? welfareContact && !!welfareContact.email?.trim()
-            : true,
-        { path: ['welfareContact', 'email'] },
-      )
-      .refine(
-        ({ hasDiagnoses, hasHadSupport, hasWelfareContact, hasCaseManager }) =>
-          (hasDiagnoses === YES || hasHadSupport === YES) &&
-          hasWelfareContact === YES
-            ? !!hasCaseManager
-            : true,
-        { path: ['hasCaseManager'] },
-      )
-      .refine(
-        ({
-          hasDiagnoses,
-          hasHadSupport,
-          hasWelfareContact,
-          hasCaseManager,
-          caseManager,
-        }) =>
-          (hasDiagnoses === YES || hasHadSupport === YES) &&
-          hasWelfareContact === YES &&
-          hasCaseManager === YES
-            ? caseManager && !!caseManager.name?.trim()
-            : true,
-        { path: ['caseManager', 'name'] },
-      )
-      .refine(
-        ({
-          hasDiagnoses,
-          hasHadSupport,
-          hasWelfareContact,
-          hasCaseManager,
-          caseManager,
-        }) =>
-          (hasDiagnoses === YES || hasHadSupport === YES) &&
-          hasWelfareContact === YES &&
-          hasCaseManager === YES
-            ? caseManager && !!caseManager.email?.trim()
-            : true,
-        {
-          path: ['caseManager', 'email'],
-        },
-      )
-      .refine(
-        ({
-          hasDiagnoses,
-          hasHadSupport,
-          hasIntegratedServices,
-          hasWelfareContact,
-        }) =>
-          (hasDiagnoses === YES || hasHadSupport === YES) &&
-          hasWelfareContact === YES
-            ? !!hasIntegratedServices
-            : true,
-        { path: ['hasIntegratedServices'] },
-      ),
-    attachments: z.object({
-      answer: z.nativeEnum(AttachmentOptions),
+  ),
+  currentNursery: z
+    .object({
+      hasCurrentNursery: z.enum([YES, NO]),
+      municipality: z.string().optional().nullable(),
+      nursery: z.string().optional().nullable(),
+    })
+    .refine(
+      ({ hasCurrentNursery, municipality }) =>
+        hasCurrentNursery === YES ? !!municipality : true,
+      {
+        path: ['municipality'],
+      },
+    )
+    .refine(
+      ({ hasCurrentNursery, nursery }) =>
+        hasCurrentNursery === YES ? !!nursery : true,
+      {
+        path: ['nursery'],
+      },
+    ),
+  reasonForApplication: z.object({
+    reason: z.string(),
+  }),
+  counsellingRegardingApplication: z.object({
+    counselling: z.string(),
+    hasVisitedSchool: z.enum([YES, NO]),
+  }),
+  currentSchool: z
+    .object({
+      hasCurrentSchool: z.enum([YES, NO]).optional(),
+      municipality: z.string().optional().nullable(),
+      school: z.string().optional().nullable(),
+    })
+    .refine(
+      ({ hasCurrentSchool, municipality }) =>
+        hasCurrentSchool === YES ? !!municipality : true,
+      {
+        path: ['municipality'],
+      },
+    )
+    .refine(
+      ({ hasCurrentSchool, school }) =>
+        hasCurrentSchool === YES ? !!school : true,
+      {
+        path: ['school'],
+      },
+    ),
+  newSchool: z.object({
+    municipality: z.string(),
+    school: z.string(),
+  }),
+  school: z.object({
+    applyForPreferredSchool: z.enum([YES, NO]),
+  }),
+  siblings: z
+    .array(
+      z.object({
+        nationalIdWithName: nationalIdWithNameSchema,
+      }),
+    )
+    .refine((r) => r === undefined || r.length > 0, {
+      params: errorMessages.siblingsRequired,
     }),
-    specialEducationSupport: z
-      .object({
-        hasWelfareContact: z.enum([YES, NO]),
-        welfareContact: nameEmailSchema,
-        hasCaseManager: z.enum([YES, NO]),
-        caseManager: nameEmailSchema,
-        hasIntegratedServices: z.enum([YES, NO]),
-        hasAssessmentOfSupportNeeds: z.enum([YES, NO]),
-        isAssessmentOfSupportNeedsInProgress: z.string().optional(),
-        supportNeedsAssessmentBy: z.string().optional(),
-        hasConfirmedDiagnosis: z.enum([YES, NO]),
-        isDiagnosisInProgress: z.string().optional(),
-        diagnosticians: z.array(z.string()).optional(),
-        hasOtherSpecialists: z.enum([YES, NO]),
-        specialists: z.array(z.string()).optional(),
-        hasReceivedServicesFromMunicipality: z.enum([YES, NO]),
-        servicesFromMunicipality: z.array(z.string()).optional(),
-        hasReceivedChildAndAdolescentPsychiatryServices: z
-          .string()
-          .min(1)
-          .optional(),
-        isOnWaitlistForServices: z.string().optional(),
-        childAndAdolescentPsychiatryDepartment: z.string().optional(),
-        childAndAdolescentPsychiatryServicesReceived: z
-          .array(z.string())
-          .optional(),
-        hasBeenReportedToChildProtectiveServices: z.string().min(1).optional(),
-        isCaseOpenWithChildProtectiveServices: z.string().optional(),
-      })
-      .refine(
-        ({ hasWelfareContact, welfareContact }) =>
-          hasWelfareContact === YES
-            ? welfareContact && !!welfareContact.name?.trim()
-            : true,
-        { path: ['welfareContact', 'name'] },
-      )
-      .refine(
-        ({ hasWelfareContact, welfareContact }) =>
-          hasWelfareContact === YES
-            ? welfareContact && !!welfareContact.email?.trim()
-            : true,
-        { path: ['welfareContact', 'email'] },
-      )
-      .refine(
-        ({ hasCaseManager, caseManager }) =>
-          hasCaseManager === YES
-            ? caseManager && !!caseManager.name?.trim()
-            : true,
-        { path: ['caseManager', 'name'] },
-      )
-      .refine(
-        ({ hasCaseManager, caseManager }) =>
-          hasCaseManager === YES
-            ? caseManager && !!caseManager.email?.trim()
-            : true,
-        { path: ['caseManager', 'email'] },
-      )
-      .refine(
-        ({
-          hasAssessmentOfSupportNeeds,
-          isAssessmentOfSupportNeedsInProgress,
-        }) =>
-          hasAssessmentOfSupportNeeds === NO
-            ? !!isAssessmentOfSupportNeedsInProgress
-            : true,
-        { path: ['isAssessmentOfSupportNeedsInProgress'] },
-      )
-      .refine(
-        ({
-          hasAssessmentOfSupportNeeds,
-          isAssessmentOfSupportNeedsInProgress,
-          supportNeedsAssessmentBy,
-        }) =>
-          hasAssessmentOfSupportNeeds === YES ||
-          (hasAssessmentOfSupportNeeds === NO &&
-            isAssessmentOfSupportNeedsInProgress === YES)
-            ? !!supportNeedsAssessmentBy
-            : true,
-        { path: ['supportNeedsAssessmentBy'] },
-      )
-      .refine(
-        ({ hasConfirmedDiagnosis, isDiagnosisInProgress }) =>
-          hasConfirmedDiagnosis === NO ? !!isDiagnosisInProgress : true,
-        { path: ['isDiagnosisInProgress'] },
-      )
-      .refine(
-        ({ hasConfirmedDiagnosis, isDiagnosisInProgress, diagnosticians }) =>
-          hasConfirmedDiagnosis === YES ||
-          (hasConfirmedDiagnosis === NO && isDiagnosisInProgress === YES)
-            ? !!diagnosticians
-            : true,
-        { path: ['diagnosticians'] },
-      )
-      .refine(
-        ({ hasOtherSpecialists, specialists }) =>
-          hasOtherSpecialists === YES ? !!specialists : true,
-        { path: ['specialists'] },
-      )
-      .refine(
-        ({ hasReceivedServicesFromMunicipality, servicesFromMunicipality }) =>
-          hasReceivedServicesFromMunicipality === YES
-            ? !!servicesFromMunicipality
-            : true,
-        { path: ['servicesFromMunicipality'] },
-      )
-      .refine(
-        ({
-          hasReceivedChildAndAdolescentPsychiatryServices,
-          isOnWaitlistForServices,
-        }) =>
-          hasReceivedChildAndAdolescentPsychiatryServices === NO
-            ? !!isOnWaitlistForServices
-            : true,
-        { path: ['isOnWaitlistForServices'] },
-      )
-      .refine(
-        ({
-          hasReceivedChildAndAdolescentPsychiatryServices,
-          isOnWaitlistForServices,
-          childAndAdolescentPsychiatryDepartment,
-        }) =>
-          hasReceivedChildAndAdolescentPsychiatryServices === YES ||
-          (hasReceivedChildAndAdolescentPsychiatryServices === NO &&
-            isOnWaitlistForServices === YES)
-            ? !!childAndAdolescentPsychiatryDepartment
-            : true,
-        { path: ['childAndAdolescentPsychiatryDepartment'] },
-      )
-      .refine(
-        ({
-          hasReceivedChildAndAdolescentPsychiatryServices,
-          childAndAdolescentPsychiatryServicesReceived,
-        }) =>
-          hasReceivedChildAndAdolescentPsychiatryServices === YES
-            ? !!childAndAdolescentPsychiatryServicesReceived
-            : true,
-        { path: ['childAndAdolescentPsychiatryServicesReceived'] },
-      )
-      .refine(
-        ({
-          hasBeenReportedToChildProtectiveServices,
-          isCaseOpenWithChildProtectiveServices,
-        }) =>
-          hasBeenReportedToChildProtectiveServices === YES
-            ? !!isCaseOpenWithChildProtectiveServices
-            : true,
-        { path: ['isCaseOpenWithChildProtectiveServices'] },
-      ),
-    payer: z
-      .object({
-        option: z.nativeEnum(PayerOption),
-        other: z
-          .object({
-            name: z.string(),
-            nationalId: z.string(),
+  startingSchool: z
+    .object({
+      expectedStartDate: z.string(),
+      temporaryStay: z.string().min(1).optional(),
+      expectedEndDate: z.string().optional(),
+    })
+    .refine(
+      ({ expectedStartDate, expectedEndDate, temporaryStay }) =>
+        !(
+          temporaryStay === YES &&
+          expectedEndDate &&
+          new Date(expectedStartDate) > new Date(expectedEndDate)
+        ),
+      {
+        path: ['expectedEndDate'],
+        params: errorMessages.expectedEndDateMessage,
+      },
+    )
+    .refine(
+      ({ expectedEndDate, temporaryStay }) =>
+        !(temporaryStay === YES && !expectedEndDate),
+      {
+        path: ['expectedEndDate'],
+        params: errorMessages.expectedEndDateRequired,
+      },
+    ),
+  languages: z
+    .object({
+      languageEnvironment: z.string(),
+      signLanguage: z.enum([YES, NO]),
+      selectedLanguages: z
+        .array(z.object({ code: z.string().nullish() }))
+        .optional(),
+      preferredLanguage: z.string().optional().nullable(),
+    })
+    .superRefine(({ languageEnvironment, selectedLanguages }, ctx) => {
+      // LanguageEnvironment is stored as <id>::<option> in the DB
+      const selectedLanguageEnvironment =
+        languageEnvironment.split('::')[1] ?? ''
+
+      const checkAndAddIssue = (index: number) => {
+        // If required 2 languages but the second language field is still hidden
+        // else check if applicant has selected a languages
+        if (index === 1 && selectedLanguages?.length === 1) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            params: errorMessages.twoLanguagesRequired,
+            path: ['selectedLanguages'],
           })
-          .optional(),
-      })
-      .refine(
-        ({ option, other }) =>
-          option === PayerOption.OTHER ? other && !!other.name?.trim() : true,
-        { path: ['other', 'name'] },
-      )
-      .refine(
-        ({ option, other }) =>
-          option === PayerOption.OTHER
-            ? other && kennitala.isValid(other.nationalId)
-            : true,
-        { path: ['other', 'nationalId'], params: errorMessages.nationalId },
-      ),
-  })
+        } else if (!selectedLanguages?.[index]?.code) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            params: errorMessages.languageRequired,
+            path: ['selectedLanguages', index, 'code'],
+          })
+        }
+      }
+
+      if (
+        selectedLanguageEnvironment ===
+        LanguageEnvironmentOptions.ONLY_OTHER_THAN_ICELANDIC
+      ) {
+        checkAndAddIssue(0)
+      } else if (
+        selectedLanguageEnvironment ===
+        LanguageEnvironmentOptions.ICELANDIC_AND_OTHER
+      ) {
+        checkAndAddIssue(0)
+        checkAndAddIssue(1)
+      }
+    })
+    .refine(
+      ({ languageEnvironment, selectedLanguages, preferredLanguage }) => {
+        // LanguageEnvironment is stored as <id>::<option> in the DB
+        const selectedLanguageEnvironment =
+          languageEnvironment.split('::')[1] ?? ''
+
+        if (
+          (selectedLanguageEnvironment ===
+            LanguageEnvironmentOptions.ONLY_OTHER_THAN_ICELANDIC &&
+            !!selectedLanguages &&
+            selectedLanguages?.length >= 1) ||
+          (selectedLanguageEnvironment ===
+            LanguageEnvironmentOptions.ICELANDIC_AND_OTHER &&
+            !!selectedLanguages &&
+            selectedLanguages?.length >= 2)
+        ) {
+          return !!preferredLanguage
+        }
+
+        return true
+      },
+      {
+        path: ['preferredLanguage'],
+        params: errorMessages.languageRequired,
+      },
+    ),
+  healthProtection: z
+    .object({
+      hasFoodAllergiesOrIntolerances: z.array(z.string()),
+      foodAllergiesOrIntolerances: z.array(z.string()).optional().nullable(),
+      hasOtherAllergies: z.array(z.string()),
+      otherAllergies: z.array(z.string()).optional().nullable(),
+      usesEpiPen: z.string().optional(),
+      hasConfirmedMedicalDiagnoses: z.enum([YES, NO]),
+      requestsMedicationAdministration: z.enum([YES, NO]),
+    })
+    .refine(
+      ({ hasFoodAllergiesOrIntolerances, foodAllergiesOrIntolerances }) =>
+        hasFoodAllergiesOrIntolerances.includes(YES)
+          ? !!foodAllergiesOrIntolerances &&
+            foodAllergiesOrIntolerances.length > 0
+          : true,
+      {
+        path: ['foodAllergiesOrIntolerances'],
+        params: errorMessages.foodAllergiesOrIntolerancesRequired,
+      },
+    )
+    .refine(
+      ({ hasOtherAllergies, otherAllergies }) =>
+        hasOtherAllergies.includes(YES)
+          ? !!otherAllergies && otherAllergies.length > 0
+          : true,
+      {
+        path: ['otherAllergies'],
+        params: errorMessages.otherAllergiesRequired,
+      },
+    )
+    .refine(
+      ({ hasFoodAllergiesOrIntolerances, hasOtherAllergies, usesEpiPen }) =>
+        hasFoodAllergiesOrIntolerances.includes(YES) ||
+        hasOtherAllergies.includes(YES)
+          ? !!usesEpiPen
+          : true,
+      { path: ['usesEpiPen'] },
+    ),
+  support: z
+    .object({
+      hasDiagnoses: z.enum([YES, NO]),
+      hasHadSupport: z.enum([YES, NO]),
+      hasWelfareContact: z.string().optional(),
+      welfareContact: nameEmailSchema,
+      hasCaseManager: z.string().optional(),
+      caseManager: nameEmailSchema,
+      hasIntegratedServices: z.string().optional(),
+      requestingMeeting: z.array(z.enum([YES, NO])).optional(),
+    })
+    .refine(
+      ({ hasDiagnoses, hasHadSupport, hasWelfareContact }) =>
+        hasDiagnoses === YES || hasHadSupport === YES
+          ? !!hasWelfareContact
+          : true,
+      { path: ['hasWelfareContact'] },
+    )
+    .refine(
+      ({ hasDiagnoses, hasHadSupport, hasWelfareContact, welfareContact }) =>
+        (hasDiagnoses === YES || hasHadSupport === YES) &&
+        hasWelfareContact === YES
+          ? welfareContact && !!welfareContact.name?.trim()
+          : true,
+      { path: ['welfareContact', 'name'] },
+    )
+    .refine(
+      ({ hasDiagnoses, hasHadSupport, hasWelfareContact, welfareContact }) =>
+        (hasDiagnoses === YES || hasHadSupport === YES) &&
+        hasWelfareContact === YES
+          ? welfareContact && !!welfareContact.email?.trim()
+          : true,
+      { path: ['welfareContact', 'email'] },
+    )
+    .refine(
+      ({ hasDiagnoses, hasHadSupport, hasWelfareContact, hasCaseManager }) =>
+        (hasDiagnoses === YES || hasHadSupport === YES) &&
+        hasWelfareContact === YES
+          ? !!hasCaseManager
+          : true,
+      { path: ['hasCaseManager'] },
+    )
+    .refine(
+      ({
+        hasDiagnoses,
+        hasHadSupport,
+        hasWelfareContact,
+        hasCaseManager,
+        caseManager,
+      }) =>
+        (hasDiagnoses === YES || hasHadSupport === YES) &&
+        hasWelfareContact === YES &&
+        hasCaseManager === YES
+          ? caseManager && !!caseManager.name?.trim()
+          : true,
+      { path: ['caseManager', 'name'] },
+    )
+    .refine(
+      ({
+        hasDiagnoses,
+        hasHadSupport,
+        hasWelfareContact,
+        hasCaseManager,
+        caseManager,
+      }) =>
+        (hasDiagnoses === YES || hasHadSupport === YES) &&
+        hasWelfareContact === YES &&
+        hasCaseManager === YES
+          ? caseManager && !!caseManager.email?.trim()
+          : true,
+      {
+        path: ['caseManager', 'email'],
+      },
+    )
+    .refine(
+      ({
+        hasDiagnoses,
+        hasHadSupport,
+        hasIntegratedServices,
+        hasWelfareContact,
+      }) =>
+        (hasDiagnoses === YES || hasHadSupport === YES) &&
+        hasWelfareContact === YES
+          ? !!hasIntegratedServices
+          : true,
+      { path: ['hasIntegratedServices'] },
+    ),
+  attachments: z.object({
+    answer: z.nativeEnum(AttachmentOptions),
+  }),
+  specialEducationSupport: z
+    .object({
+      hasWelfareContact: z.enum([YES, NO]),
+      welfareContact: nameEmailSchema,
+      hasCaseManager: z.enum([YES, NO]),
+      caseManager: nameEmailSchema,
+      hasIntegratedServices: z.enum([YES, NO]),
+      hasAssessmentOfSupportNeeds: z.enum([YES, NO]),
+      isAssessmentOfSupportNeedsInProgress: z.string().optional(),
+      supportNeedsAssessmentBy: z.string().optional(),
+      hasConfirmedDiagnosis: z.enum([YES, NO]),
+      isDiagnosisInProgress: z.string().optional(),
+      diagnosticians: z.array(z.string()).optional(),
+      hasOtherSpecialists: z.enum([YES, NO]),
+      specialists: z.array(z.string()).optional(),
+      hasReceivedServicesFromMunicipality: z.enum([YES, NO]),
+      servicesFromMunicipality: z.array(z.string()).optional(),
+      hasReceivedChildAndAdolescentPsychiatryServices: z
+        .string()
+        .min(1)
+        .optional(),
+      isOnWaitlistForServices: z.string().optional(),
+      childAndAdolescentPsychiatryDepartment: z.string().optional(),
+      childAndAdolescentPsychiatryServicesReceived: z
+        .array(z.string())
+        .optional(),
+      hasBeenReportedToChildProtectiveServices: z.string().min(1).optional(),
+      isCaseOpenWithChildProtectiveServices: z.string().optional(),
+    })
+    .refine(
+      ({ hasWelfareContact, welfareContact }) =>
+        hasWelfareContact === YES
+          ? welfareContact && !!welfareContact.name?.trim()
+          : true,
+      { path: ['welfareContact', 'name'] },
+    )
+    .refine(
+      ({ hasWelfareContact, welfareContact }) =>
+        hasWelfareContact === YES
+          ? welfareContact && !!welfareContact.email?.trim()
+          : true,
+      { path: ['welfareContact', 'email'] },
+    )
+    .refine(
+      ({ hasCaseManager, caseManager }) =>
+        hasCaseManager === YES
+          ? caseManager && !!caseManager.name?.trim()
+          : true,
+      { path: ['caseManager', 'name'] },
+    )
+    .refine(
+      ({ hasCaseManager, caseManager }) =>
+        hasCaseManager === YES
+          ? caseManager && !!caseManager.email?.trim()
+          : true,
+      { path: ['caseManager', 'email'] },
+    )
+    .refine(
+      ({ hasAssessmentOfSupportNeeds, isAssessmentOfSupportNeedsInProgress }) =>
+        hasAssessmentOfSupportNeeds === NO
+          ? !!isAssessmentOfSupportNeedsInProgress
+          : true,
+      { path: ['isAssessmentOfSupportNeedsInProgress'] },
+    )
+    .refine(
+      ({
+        hasAssessmentOfSupportNeeds,
+        isAssessmentOfSupportNeedsInProgress,
+        supportNeedsAssessmentBy,
+      }) =>
+        hasAssessmentOfSupportNeeds === YES ||
+        (hasAssessmentOfSupportNeeds === NO &&
+          isAssessmentOfSupportNeedsInProgress === YES)
+          ? !!supportNeedsAssessmentBy
+          : true,
+      { path: ['supportNeedsAssessmentBy'] },
+    )
+    .refine(
+      ({ hasConfirmedDiagnosis, isDiagnosisInProgress }) =>
+        hasConfirmedDiagnosis === NO ? !!isDiagnosisInProgress : true,
+      { path: ['isDiagnosisInProgress'] },
+    )
+    .refine(
+      ({ hasConfirmedDiagnosis, isDiagnosisInProgress, diagnosticians }) =>
+        hasConfirmedDiagnosis === YES ||
+        (hasConfirmedDiagnosis === NO && isDiagnosisInProgress === YES)
+          ? !!diagnosticians
+          : true,
+      { path: ['diagnosticians'] },
+    )
+    .refine(
+      ({ hasOtherSpecialists, specialists }) =>
+        hasOtherSpecialists === YES ? !!specialists : true,
+      { path: ['specialists'] },
+    )
+    .refine(
+      ({ hasReceivedServicesFromMunicipality, servicesFromMunicipality }) =>
+        hasReceivedServicesFromMunicipality === YES
+          ? !!servicesFromMunicipality
+          : true,
+      { path: ['servicesFromMunicipality'] },
+    )
+    .refine(
+      ({
+        hasReceivedChildAndAdolescentPsychiatryServices,
+        isOnWaitlistForServices,
+      }) =>
+        hasReceivedChildAndAdolescentPsychiatryServices === NO
+          ? !!isOnWaitlistForServices
+          : true,
+      { path: ['isOnWaitlistForServices'] },
+    )
+    .refine(
+      ({
+        hasReceivedChildAndAdolescentPsychiatryServices,
+        isOnWaitlistForServices,
+        childAndAdolescentPsychiatryDepartment,
+      }) =>
+        hasReceivedChildAndAdolescentPsychiatryServices === YES ||
+        (hasReceivedChildAndAdolescentPsychiatryServices === NO &&
+          isOnWaitlistForServices === YES)
+          ? !!childAndAdolescentPsychiatryDepartment
+          : true,
+      { path: ['childAndAdolescentPsychiatryDepartment'] },
+    )
+    .refine(
+      ({
+        hasReceivedChildAndAdolescentPsychiatryServices,
+        childAndAdolescentPsychiatryServicesReceived,
+      }) =>
+        hasReceivedChildAndAdolescentPsychiatryServices === YES
+          ? !!childAndAdolescentPsychiatryServicesReceived
+          : true,
+      { path: ['childAndAdolescentPsychiatryServicesReceived'] },
+    )
+    .refine(
+      ({
+        hasBeenReportedToChildProtectiveServices,
+        isCaseOpenWithChildProtectiveServices,
+      }) =>
+        hasBeenReportedToChildProtectiveServices === YES
+          ? !!isCaseOpenWithChildProtectiveServices
+          : true,
+      { path: ['isCaseOpenWithChildProtectiveServices'] },
+    ),
+  payer: z
+    .object({
+      option: z.nativeEnum(PayerOption),
+      other: z
+        .object({
+          name: z.string(),
+          nationalId: z.string(),
+        })
+        .optional(),
+    })
+    .refine(
+      ({ option, other }) =>
+        option === PayerOption.OTHER ? other && !!other.name?.trim() : true,
+      { path: ['other', 'name'] },
+    )
+    .refine(
+      ({ option, other }) =>
+        option === PayerOption.OTHER
+          ? other && kennitala.isValid(other.nationalId)
+          : true,
+      { path: ['other', 'nationalId'], params: errorMessages.nationalId },
+    ),
+})
 
 export type SchemaFormValues = z.infer<typeof dataSchema>

--- a/libs/application/templates/new-primary-school/src/lib/messages/error.ts
+++ b/libs/application/templates/new-primary-school/src/lib/messages/error.ts
@@ -16,6 +16,11 @@ export const errorMessages = defineMessages({
     defaultMessage: 'Aðstandandi má ekki vera forsjáraðili',
     description: 'A relative may not be a guardian',
   },
+  relativeSameAsChild: {
+    id: 'nps.application:error.relativeSameAsChild',
+    defaultMessage: 'Barn getur ekki verið eigin aðstandandi',
+    description: 'A child cannot be their own relative',
+  },
   siblingsRequired: {
     id: 'nps.application:error.siblingsRequired',
     defaultMessage: 'Nauðsynlegt er að bæta við að minnsta kosti einu systkini',

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/mani/Documents/repos/island.is/node_modules

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/mani/Documents/repos/island.is/node_modules


### PR DESCRIPTION
## What

Add validation to the New Primary School application so a child's national ID cannot be entered as one of their own relatives. Includes a new error message (`relativeSameAsChild`) shown on the relative's national ID field when this happens.

## Why

Nothing previously stopped an applicant from accidentally registering the child as their own relative, which is a nonsensical data state.


## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: claude code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Added validation to prevent a child’s national ID from being entered for a relative.
  - Displays a clear error message when a relative is identified as the child.
  - Relative records now retain the child’s national ID for consistent validation while keeping this value hidden from the table view.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->