### PR TITLE
fix(j-s): Keep context menu trigger highlighted while menu is open

### DIFF
--- a/apps/judicial-system/web/src/components/ContextMenu/ContextMenu.spec.tsx
+++ b/apps/judicial-system/web/src/components/ContextMenu/ContextMenu.spec.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, render, screen } from '@testing-library/react'
 
+import IconButton from '../IconButton/IconButton'
 import ContextMenu from './ContextMenu'
 
 describe('ContextMenu', () => {
@@ -22,5 +23,28 @@ describe('ContextMenu', () => {
     const menuItemLink = await screen.findByText('Fyrirtæki')
     expect(menuItemButton?.tagName).toBe('BUTTON')
     expect(menuItemLink?.tagName).toBe('A')
+  })
+
+  it('marks the menu button as expanded while the menu is open', async () => {
+    render(
+      <ContextMenu
+        items={[{ title: 'Einstaklingur' }]}
+        render={
+          <IconButton
+            icon="ellipsisVertical"
+            colorScheme="transparent"
+            ariaLabel="Valmynd"
+          />
+        }
+      />,
+    )
+
+    const menuButton = await screen.findByRole('button', { name: 'Valmynd' })
+    expect(menuButton).toHaveAttribute('aria-expanded', 'false')
+
+    fireEvent.click(menuButton)
+
+    expect(await screen.findByRole('menu')).toBeInTheDocument()
+    expect(menuButton).toHaveAttribute('aria-expanded', 'true')
   })
 })

--- a/apps/judicial-system/web/src/components/IconButton/IconButton.css.ts
+++ b/apps/judicial-system/web/src/components/IconButton/IconButton.css.ts
@@ -13,8 +13,11 @@ export const iconButtonContainer = style({
   flexShrink: 0,
   transition: 'filter .2s, background-color .2s',
 
-  ':hover': {
-    filter: 'brightness(0.9)',
+  selectors: {
+    // The open state of a menu the button controls should look the same as hover
+    '&:hover, &[aria-expanded="true"]': {
+      filter: 'brightness(0.9)',
+    },
   },
 })
 
@@ -22,14 +25,18 @@ export const buttonDisabled = style({
   cursor: 'not-allowed',
   opacity: 0.5,
 
-  ':hover': {
-    filter: 'brightness(1)',
+  selectors: {
+    '&:hover, &[aria-expanded="true"]': {
+      filter: 'brightness(1)',
+    },
   },
 })
 
 export const transparent = style({
-  ':hover': {
-    backgroundColor: theme.color.blue200,
-    filter: 'brightness(1)',
+  selectors: {
+    '&:hover, &[aria-expanded="true"]': {
+      backgroundColor: theme.color.blue200,
+      filter: 'brightness(1)',
+    },
   },
 })

--- a/apps/judicial-system/web/src/components/IconButton/IconButton.spec.tsx
+++ b/apps/judicial-system/web/src/components/IconButton/IconButton.spec.tsx
@@ -35,6 +35,23 @@ describe('IconButton', () => {
     expect(onClick).toHaveBeenCalledTimes(1)
   })
 
+  it('forwards remaining button props to the underlying button', async () => {
+    render(
+      <IconButton
+        icon="ellipsisVertical"
+        colorScheme="transparent"
+        ariaLabel="Valmynd"
+        aria-expanded={true}
+        aria-haspopup="menu"
+      />,
+    )
+
+    const button = await screen.findByRole('button', { name: 'Valmynd' })
+
+    expect(button).toHaveAttribute('aria-expanded', 'true')
+    expect(button).toHaveAttribute('aria-haspopup', 'menu')
+  })
+
   it('still exposes the accessible name when wrapped in a tooltip', async () => {
     render(
       <IconButton

--- a/apps/judicial-system/web/src/components/IconButton/IconButton.tsx
+++ b/apps/judicial-system/web/src/components/IconButton/IconButton.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, MouseEvent } from 'react'
+import { ComponentPropsWithoutRef, forwardRef, MouseEvent } from 'react'
 import cn from 'classnames'
 import { Button } from '@ariakit/react/button'
 
@@ -6,7 +6,9 @@ import { Box, Icon, IconMapIcon, Tooltip } from '@island.is/island-ui/core'
 
 import * as styles from './IconButton.css'
 
-interface Props {
+// Remaining button props (aria attributes, event handlers, ...) are forwarded to
+// the underlying button so components like ContextMenu can drive it.
+interface Props extends Omit<ComponentPropsWithoutRef<'button'>, 'onClick'> {
   icon: IconMapIcon
   colorScheme: 'blue' | 'red' | 'transparent'
   onClick?: (evt: MouseEvent) => void
@@ -16,20 +18,18 @@ interface Props {
   ariaLabel: string
 }
 
-interface RenderButtonProps {
-  icon: IconMapIcon
-  colorScheme: 'blue' | 'red' | 'transparent'
-  onClick?: (evt: MouseEvent) => void
-  disabled?: boolean
-  ariaLabel: string
-}
+type RenderButtonProps = Omit<Props, 'tooltipText'>
 
 const RenderButton = forwardRef<HTMLButtonElement, RenderButtonProps>(
-  ({ icon, colorScheme, onClick, disabled, ariaLabel }, ref) => (
+  (
+    { icon, colorScheme, onClick, disabled, ariaLabel, className, ...rest },
+    ref,
+  ) => (
     <Box
+      {...rest}
       component={Button}
       ref={ref}
-      className={cn(styles.iconButtonContainer, {
+      className={cn(styles.iconButtonContainer, className, {
         [styles.buttonDisabled]: disabled,
         [styles.transparent]: colorScheme === 'transparent',
       })}
@@ -57,32 +57,17 @@ const RenderButton = forwardRef<HTMLButtonElement, RenderButtonProps>(
   ),
 )
 
-const IconButton = forwardRef<HTMLButtonElement, Props>(({ ...props }, ref) => {
-  const { icon, colorScheme, onClick, disabled, tooltipText, ariaLabel } = props
-
-  return tooltipText ? (
-    <Tooltip placement="top" text={tooltipText}>
-      <span>
-        <RenderButton
-          icon={icon}
-          colorScheme={colorScheme}
-          onClick={onClick}
-          disabled={disabled}
-          ariaLabel={ariaLabel}
-          ref={ref}
-        />
-      </span>
-    </Tooltip>
-  ) : (
-    <RenderButton
-      icon={icon}
-      colorScheme={colorScheme}
-      onClick={onClick}
-      disabled={disabled}
-      ariaLabel={ariaLabel}
-      ref={ref}
-    />
-  )
-})
+const IconButton = forwardRef<HTMLButtonElement, Props>(
+  ({ tooltipText, ...props }, ref) =>
+    tooltipText ? (
+      <Tooltip placement="top" text={tooltipText}>
+        <span>
+          <RenderButton {...props} ref={ref} />
+        </span>
+      </Tooltip>
+    ) : (
+      <RenderButton {...props} ref={ref} />
+    ),
+)
 
 export default IconButton

--- a/apps/judicial-system/web/src/components/Table/Table.css.ts
+++ b/apps/judicial-system/web/src/components/Table/Table.css.ts
@@ -69,11 +69,11 @@ export const contextMenuButton = style({
   cursor: 'pointer',
   transition: 'background-color .2s',
 
-  ':hover': {
-    backgroundColor: theme.color.blue200,
-  },
-
   selectors: {
+    // The open state of the context menu should look the same as hover
+    '&:hover, &[aria-expanded="true"]': {
+      backgroundColor: theme.color.blue200,
+    },
     '&:focus-visible': {
       outline: 'none',
       boxShadow: `0 0 0 ${theme.border.width.large}px ${theme.border.color.focus}`,


### PR DESCRIPTION
# Context menu trigger keeps its hover style while the menu is open

## What

The context menu trigger only showed its hover style on hover, so the button faded back to its resting state as soon as the pointer moved into the open menu — nothing tied the open menu back to the button it belongs to.

Both trigger variants now keep that style while the menu is open:

- `contextMenuButton` in the case/file tables (`GenericTable`, `CaseFileTable`)
- `IconButton` with `colorScheme="transparent"` (`ContextMenuCard`, `RulingOrderFileRow`)

Rather than duplicating the styles, their existing hover rules are keyed off `aria-expanded`, which Ariakit already sets on the menu button — so hover and open can't drift apart.

`IconButton` needed one fix for that to work: it was swallowing every prop it did not explicitly destructure, so `aria-expanded` never reached the DOM button. It now forwards the remaining button props, which also means Ariakit's `aria-haspopup` and keyboard handlers reach the button for the first time.

## Why

Feedback on the context menu: the trigger should stay highlighted while its menu is open, so it is clear which button the open menu belongs to.

## Screenshots / Gifs


https://github.com/user-attachments/assets/efc6a9d7-dcae-4b8a-80cd-8ac62131ad4b

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Icon buttons now support standard button attributes, including menu state indicators.
  - Context menu buttons clearly reflect their expanded state with consistent visual styling.

- **Bug Fixes**
  - Improved hover and active-state styling for icon buttons, including disabled and transparent variants.
  - Table context menu buttons now retain the correct highlighted appearance while open.

- **Tests**
  - Added coverage confirming accessibility attributes are forwarded and updated correctly as menus open and close.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->