### PR TITLE
feat(my-pages): Health conversation reply blocked reason

### DIFF
--- a/libs/portals/my-pages/health/src/lib/messages.ts
+++ b/libs/portals/my-pages/health/src/lib/messages.ts
@@ -2004,15 +2004,6 @@ export const messages = defineMessages({
     defaultMessage: 'Senda skilaboð',
     id: 'sp.health:health-message-send',
   },
-  healthConversationSentTitle: {
-    defaultMessage: 'Skilaboð móttekin',
-    id: 'sp.health:health-message-sent-title',
-  },
-  healthConversationSentText: {
-    defaultMessage:
-      'Við svörum á dagvinnutíma, yfirleitt innan þriggja virkra daga. Ef erindið er brátt og þarfnast svars í dag, hringdu í 1700. Ef um neyðartilfelli er að ræða, hringdu strax í 112.',
-    id: 'sp.health:health-message-sent-text',
-  },
   healthConversationsNoRecipient: {
     defaultMessage: 'Ekki er hægt að senda skilaboð eins og er',
     id: 'sp.health:health-messages-no-recipient',
@@ -2044,14 +2035,38 @@ export const messages = defineMessages({
       'Þessi þjónustuaðili býður ekki upp á skilaboð á Ísland.is.',
     id: 'sp.health:health-messages-messaging-not-allowed-text',
   },
-  healthConversationReplyClosedText: {
-    defaultMessage:
-      'Ekki er hægt að svara þessum skilaboðum því sendandi hefur lokað fyrir frekari svör.',
-    id: 'sp.health:health-message-reply-closed-text',
+  healthConversationReplyBlockedMissingRecipientText: {
+    defaultMessage: 'Ekki er hægt að svara þessum skilaboðum.',
+    id: 'sp.health:health-messages-reply-blocked-missing-recipient-text',
   },
-  healthConversationReplyClosedShortText: {
+  healthConversationReplyBlockedRepliesDisabledText: {
+    defaultMessage: 'Ekki er hægt að svara þessum skilaboðum.',
+    id: 'sp.health:health-messages-reply-blocked-replies-disabled-text',
+  },
+  healthConversationReplyBlockedNoReplyGroupText: {
     defaultMessage: 'Ekki er hægt að svara þessum skilaboðum',
-    id: 'sp.health:health-message-reply-closed-short-text',
+    id: 'sp.health:health-messages-reply-blocked-no-reply-group-text',
+  },
+  healthConversationReplyBlockedMessagingNotAllowedText: {
+    defaultMessage: 'Ekki er hægt að svara þessum skilaboðum',
+    id: 'sp.health:health-messages-reply-blocked-messaging-not-allowed-text',
+  },
+  healthConversationReplyBlockedOutsideWindowText: {
+    defaultMessage: 'Ekki er hægt að svara þessum skilaboðum',
+    id: 'sp.health:health-messages-reply-blocked-outside-window-text',
+  },
+  healthConversationReplyBlockedWindowExpiredText: {
+    defaultMessage: 'Ekki er hægt að svara þessum skilaboðum',
+    id: 'sp.health:health-messages-reply-blocked-window-expired-text',
+  },
+  healthConversationReplyBlockedAwaitingStaffReplyTitle: {
+    defaultMessage: 'Skilaboð móttekin',
+    id: 'sp.health:health-messages-reply-blocked-awaiting-staff-reply-title',
+  },
+  healthConversationReplyBlockedAwaitingStaffReplyText: {
+    defaultMessage:
+      'Við svörum á dagvinnutíma, yfirleitt innan þriggja virkra daga. Ef erindið er brátt og þarfnast svars í dag, hringdu í 1700. Ef um neyðartilfelli er að ræða, hringdu strax í 112.',
+    id: 'sp.health:health-messages-reply-blocked-awaiting-staff-reply-text',
   },
   myAppointments: {
     defaultMessage: 'Mínar tímabókanir',

--- a/libs/portals/my-pages/health/src/lib/messages.ts
+++ b/libs/portals/my-pages/health/src/lib/messages.ts
@@ -2059,6 +2059,10 @@ export const messages = defineMessages({
     defaultMessage: 'Ekki er hægt að svara þessum skilaboðum',
     id: 'sp.health:health-messages-reply-blocked-window-expired-text',
   },
+  healthConversationReplyBlockedGenericText: {
+    defaultMessage: 'Ekki er hægt að svara þessum skilaboðum',
+    id: 'sp.health:health-messages-reply-blocked-generic-text',
+  },
   healthConversationReplyBlockedAwaitingStaffReplyTitle: {
     defaultMessage: 'Skilaboð móttekin',
     id: 'sp.health:health-messages-reply-blocked-awaiting-staff-reply-title',

--- a/libs/portals/my-pages/health/src/screens/HealthConversations/HealthConversationDetail.graphql
+++ b/libs/portals/my-pages/health/src/screens/HealthConversations/HealthConversationDetail.graphql
@@ -46,6 +46,7 @@ query GetHealthConversationDetail($id: ID!) {
     isStarred
     isArchived
     patientCanReply
+    replyBlockedReason
     isRead
     organization {
       ...HealthConversationOrganizationFragment

--- a/libs/portals/my-pages/health/src/screens/HealthConversations/HealthConversationDetail.tsx
+++ b/libs/portals/my-pages/health/src/screens/HealthConversations/HealthConversationDetail.tsx
@@ -1,5 +1,4 @@
 import {
-  AlertMessage,
   Box,
   Button,
   Divider,
@@ -24,10 +23,11 @@ import ConversationCancelSubmit from './components/ConversationCancelSubmit'
 import ConversationMessageBody from './components/ConversationMessageBody'
 import ConversationReplyForm from './components/ConversationReplyForm'
 import MobileActionFooter from './components/MobileActionFooter'
+import ReplyBlockedAlert from './components/ReplyBlockedAlert'
 import { useUserInfo } from '@island.is/react-spa/bff'
 import { Problem } from '@island.is/react-spa/shared'
 import { useEffect, useRef, useState } from 'react'
-import { useLocation, useNavigate, useParams } from 'react-router-dom'
+import { useNavigate, useParams } from 'react-router-dom'
 import { messages } from '../../lib/messages'
 import { HealthPaths } from '../../lib/paths'
 import * as styles from './HealthConversations.css'
@@ -51,9 +51,6 @@ const HealthConversationDetail = () => {
   const { id } = useParams() as UseParams
   const userInfo = useUserInfo()
   const navigate = useNavigate()
-  const location = useLocation()
-  const justCreated =
-    (location.state as { justCreated?: boolean } | null)?.justCreated ?? false
   const { isPhoneWidth } = useIsPhoneWidth()
 
   const [replyOpen, setReplyOpen] = useState(false)
@@ -176,9 +173,6 @@ const HealthConversationDetail = () => {
       toast.error(formatMessage(m.errorTitle))
     }
   }
-
-  const lastMessageIsFromPatient =
-    item.messages[item.messages.length - 1]?.direction === 'PATIENT'
 
   /* There's no explicit "recipient" for an existing thread yet so we need this
   to approximate it */
@@ -340,21 +334,6 @@ const HealthConversationDetail = () => {
                   )
                 })}
 
-                {/* Sent confirmation banner */}
-                {justCreated && !replyOpen && (
-                  <Box marginTop={4}>
-                    <AlertMessage
-                      type="success"
-                      title={formatMessage(
-                        messages.healthConversationSentTitle,
-                      )}
-                      message={formatMessage(
-                        messages.healthConversationSentText,
-                      )}
-                    />
-                  </Box>
-                )}
-
                 {/* Reply form — desktop only; mobile branches above */}
                 {replyOpen && (
                   <ConversationReplyForm
@@ -382,14 +361,7 @@ const HealthConversationDetail = () => {
                   fluid={isPhoneWidth}
                 />
               ) : item.patientCanReply === false ? (
-                <AlertMessage
-                  type="info"
-                  message={formatMessage(
-                    lastMessageIsFromPatient
-                      ? messages.healthConversationReplyClosedShortText
-                      : messages.healthConversationReplyClosedText,
-                  )}
-                />
+                <ReplyBlockedAlert reason={item.replyBlockedReason} />
               ) : (
                 <Button
                   variant="ghost"

--- a/libs/portals/my-pages/health/src/screens/HealthConversations/NewHealthConversation.tsx
+++ b/libs/portals/my-pages/health/src/screens/HealthConversations/NewHealthConversation.tsx
@@ -169,7 +169,6 @@ const NewHealthConversation = () => {
     if (conversationId) {
       navigate(
         HealthPaths.HealthConversationsDetail.replace(':id', conversationId),
-        { state: { justCreated: true } },
       )
     } else {
       navigate(HealthPaths.HealthConversations)

--- a/libs/portals/my-pages/health/src/screens/HealthConversations/components/ReplyBlockedAlert.tsx
+++ b/libs/portals/my-pages/health/src/screens/HealthConversations/components/ReplyBlockedAlert.tsx
@@ -53,12 +53,15 @@ const reasonMessageMap: Record<
     },
 }
 
+const fallbackAlert: ReasonAlert = {
+  type: 'info',
+  text: messages.healthConversationReplyBlockedGenericText,
+}
+
 const ReplyBlockedAlert = ({ reason }: Props) => {
   const { formatMessage } = useLocale()
 
-  if (!reason) return null
-
-  const entry = reasonMessageMap[reason]
+  const entry = (reason && reasonMessageMap[reason]) || fallbackAlert
 
   return (
     <Box marginTop={4}>

--- a/libs/portals/my-pages/health/src/screens/HealthConversations/components/ReplyBlockedAlert.tsx
+++ b/libs/portals/my-pages/health/src/screens/HealthConversations/components/ReplyBlockedAlert.tsx
@@ -1,0 +1,74 @@
+import { MessageDescriptor } from 'react-intl'
+import { AlertMessage, AlertMessageType, Box } from '@island.is/island-ui/core'
+import { useLocale } from '@island.is/localization'
+import { HealthDirectorateHealthConversationReplyBlockedReason } from '@island.is/api/schema'
+import { messages } from '../../../lib/messages'
+
+interface Props {
+  reason?: HealthDirectorateHealthConversationReplyBlockedReason | null
+}
+
+interface ReasonAlert {
+  type: AlertMessageType
+  title?: MessageDescriptor
+  text: MessageDescriptor
+}
+
+const reasonMessageMap: Record<
+  HealthDirectorateHealthConversationReplyBlockedReason,
+  ReasonAlert
+> = {
+  [HealthDirectorateHealthConversationReplyBlockedReason.MISSING_RECIPIENT]: {
+    type: 'info',
+    text: messages.healthConversationReplyBlockedMissingRecipientText,
+  },
+  [HealthDirectorateHealthConversationReplyBlockedReason.REPLIES_DISABLED]: {
+    type: 'info',
+    text: messages.healthConversationReplyBlockedRepliesDisabledText,
+  },
+  [HealthDirectorateHealthConversationReplyBlockedReason.NO_REPLY_GROUP]: {
+    type: 'info',
+    text: messages.healthConversationReplyBlockedNoReplyGroupText,
+  },
+  [HealthDirectorateHealthConversationReplyBlockedReason.MESSAGING_NOT_ALLOWED]:
+    {
+      type: 'info',
+      text: messages.healthConversationReplyBlockedMessagingNotAllowedText,
+    },
+  [HealthDirectorateHealthConversationReplyBlockedReason.OUTSIDE_MESSAGING_WINDOW]:
+    {
+      type: 'info',
+      text: messages.healthConversationReplyBlockedOutsideWindowText,
+    },
+  [HealthDirectorateHealthConversationReplyBlockedReason.REPLY_WINDOW_EXPIRED]:
+    {
+      type: 'info',
+      text: messages.healthConversationReplyBlockedWindowExpiredText,
+    },
+  [HealthDirectorateHealthConversationReplyBlockedReason.AWAITING_STAFF_REPLY]:
+    {
+      type: 'success',
+      title: messages.healthConversationReplyBlockedAwaitingStaffReplyTitle,
+      text: messages.healthConversationReplyBlockedAwaitingStaffReplyText,
+    },
+}
+
+const ReplyBlockedAlert = ({ reason }: Props) => {
+  const { formatMessage } = useLocale()
+
+  if (!reason) return null
+
+  const entry = reasonMessageMap[reason]
+
+  return (
+    <Box marginTop={4}>
+      <AlertMessage
+        type={entry.type}
+        title={entry.title ? formatMessage(entry.title) : undefined}
+        message={formatMessage(entry.text)}
+      />
+    </Box>
+  )
+}
+
+export default ReplyBlockedAlert


### PR DESCRIPTION
## What

Map and display reasons why a user can't reply to a health conversation

## Why

So it's clear that replying isn't available and we can add more information about why depending on the specific reason.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clear, localized alerts explaining why replies are unavailable, including disabled messaging, expired windows, missing recipients, and pending staff responses.
  * Reply-blocking alerts now display the appropriate message and severity based on the conversation status.

* **Bug Fixes**
  * Removed outdated sent-message and generic reply-closed notifications.
  * Conversation details now accurately reflect the server-provided reason replies are blocked.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->