### PR TITLE
chore(health-directorate): Add internal scope to health message endpoints

### DIFF
--- a/apps/download-service/src/app/modules/health/conversations-attachment.controller.ts
+++ b/apps/download-service/src/app/modules/health/conversations-attachment.controller.ts
@@ -21,7 +21,7 @@ import { ApiOkResponse } from '@nestjs/swagger'
 import { Response } from 'express'
 
 @UseGuards(IdsUserGuard, ScopesGuard)
-@Scopes(ApiScope.health)
+@Scopes(ApiScope.internal, ApiScope.health)
 @Controller('health/conversations')
 export class HealthConversationsAttachmentController {
   constructor(

--- a/libs/api/domains/health-directorate/src/lib/resolvers/healthConversations.resolver.ts
+++ b/libs/api/domains/health-directorate/src/lib/resolvers/healthConversations.resolver.ts
@@ -56,7 +56,7 @@ export class HealthConversationsResolver {
     nullable: true,
   })
   @Audit()
-  @Scopes(ApiScope.health)
+  @Scopes(ApiScope.internal, ApiScope.health)
   @FeatureFlag(Features.isServicePortalHealthMessagesPageEnabled)
   getHealthConversations(
     @Args('input', {
@@ -74,7 +74,7 @@ export class HealthConversationsResolver {
     nullable: true,
   })
   @Audit()
-  @Scopes(ApiScope.health)
+  @Scopes(ApiScope.internal, ApiScope.health)
   @FeatureFlag(Features.isServicePortalHealthMessagesPageEnabled)
   getHealthConversation(
     @Args('id', { type: () => ID }) id: string,
@@ -88,7 +88,7 @@ export class HealthConversationsResolver {
     nullable: true,
   })
   @Audit()
-  @Scopes(ApiScope.health)
+  @Scopes(ApiScope.internal, ApiScope.health)
   @FeatureFlag(Features.isServicePortalHealthMessagesPageEnabled)
   getHealthConversationRecipients(
     @Args('locale', { type: () => LocaleEnum, nullable: true })
@@ -103,7 +103,7 @@ export class HealthConversationsResolver {
     nullable: true,
   })
   @Audit()
-  @Scopes(ApiScope.health)
+  @Scopes(ApiScope.internal, ApiScope.health)
   @FeatureFlag(Features.isServicePortalHealthMessagesPageEnabled)
   createHealthConversation(
     @Args('input') input: HealthDirectorateCreateConversationInput,
@@ -117,7 +117,7 @@ export class HealthConversationsResolver {
     nullable: true,
   })
   @Audit()
-  @Scopes(ApiScope.health)
+  @Scopes(ApiScope.internal, ApiScope.health)
   @FeatureFlag(Features.isServicePortalHealthMessagesPageEnabled)
   replyToHealthConversation(
     @Args('input') input: HealthDirectorateReplyToConversationInput,
@@ -130,7 +130,7 @@ export class HealthConversationsResolver {
     name: 'healthDirectorateMarkHealthConversationAsRead',
   })
   @Audit()
-  @Scopes(ApiScope.health)
+  @Scopes(ApiScope.internal, ApiScope.health)
   @FeatureFlag(Features.isServicePortalHealthMessagesPageEnabled)
   markHealthConversationAsRead(
     @Args('input') input: HealthDirectorateConversationIdInput,
@@ -143,7 +143,7 @@ export class HealthConversationsResolver {
     name: 'healthDirectorateArchiveHealthConversation',
   })
   @Audit()
-  @Scopes(ApiScope.health)
+  @Scopes(ApiScope.internal, ApiScope.health)
   @FeatureFlag(Features.isServicePortalHealthMessagesPageEnabled)
   archiveHealthConversation(
     @Args('input') input: HealthDirectorateConversationIdInput,
@@ -156,7 +156,7 @@ export class HealthConversationsResolver {
     name: 'healthDirectorateUnarchiveHealthConversation',
   })
   @Audit()
-  @Scopes(ApiScope.health)
+  @Scopes(ApiScope.internal, ApiScope.health)
   @FeatureFlag(Features.isServicePortalHealthMessagesPageEnabled)
   unarchiveHealthConversation(
     @Args('input') input: HealthDirectorateConversationIdInput,
@@ -169,7 +169,7 @@ export class HealthConversationsResolver {
     name: 'healthDirectorateStarHealthConversation',
   })
   @Audit()
-  @Scopes(ApiScope.health)
+  @Scopes(ApiScope.internal, ApiScope.health)
   @FeatureFlag(Features.isServicePortalHealthMessagesPageEnabled)
   starHealthConversation(
     @Args('input') input: HealthDirectorateConversationIdInput,
@@ -182,7 +182,7 @@ export class HealthConversationsResolver {
     name: 'healthDirectorateUnstarHealthConversation',
   })
   @Audit()
-  @Scopes(ApiScope.health)
+  @Scopes(ApiScope.internal, ApiScope.health)
   @FeatureFlag(Features.isServicePortalHealthMessagesPageEnabled)
   unstarHealthConversation(
     @Args('input') input: HealthDirectorateConversationIdInput,


### PR DESCRIPTION
## What

Add internal scope to health message endpoints so native app can call them.

## Why

Native app does not have the `@island.is/health` scope

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude code
