### PR TITLE
chore(j-s): Finish the CaseDefendantPoliceCaseNumber migration

### DIFF
--- a/apps/judicial-system/backend/src/app/modules/defendant/civilClaimant.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/defendant/civilClaimant.service.ts
@@ -23,7 +23,7 @@ import {
 import { CourtService } from '../court'
 import {
   Case,
-  CaseDefendantPoliceCaseNumber,
+  CaseDefendantPoliceCaseNumberRepositoryService,
   CivilClaimant,
 } from '../repository'
 import { UpdateCivilClaimantDto } from './dto/updateCivilClaimant.dto'
@@ -34,8 +34,7 @@ export class CivilClaimantService {
   constructor(
     @InjectModel(CivilClaimant)
     private readonly civilClaimantModel: typeof CivilClaimant,
-    @InjectModel(CaseDefendantPoliceCaseNumber)
-    private readonly caseDefendantPoliceCaseNumberModel: typeof CaseDefendantPoliceCaseNumber,
+    private readonly caseDefendantPoliceCaseNumberRepositoryService: CaseDefendantPoliceCaseNumberRepositoryService,
     private readonly courtService: CourtService,
     @Inject(LOGGER_PROVIDER) private readonly logger: Logger,
   ) {}
@@ -97,18 +96,12 @@ export class CivilClaimantService {
       return []
     }
 
-    const validLinks = await this.caseDefendantPoliceCaseNumberModel.findAll({
-      where: {
-        caseId,
-        policeCaseNumber: policeCaseNumbers,
-        defendantId: currentDefendantIds,
-      },
-    })
-
     const validDefendantIds = new Set(
-      validLinks
-        .map((link) => link.defendantId)
-        .filter((id): id is string => !!id),
+      await this.caseDefendantPoliceCaseNumberRepositoryService.findAssignedDefendantIds(
+        caseId,
+        policeCaseNumbers,
+        currentDefendantIds,
+      ),
     )
 
     return currentDefendantIds.filter((id) => validDefendantIds.has(id))

--- a/apps/judicial-system/backend/src/app/modules/defendant/defendant.module.ts
+++ b/apps/judicial-system/backend/src/app/modules/defendant/defendant.module.ts
@@ -1,7 +1,7 @@
 import { forwardRef, Module } from '@nestjs/common'
 import { SequelizeModule } from '@nestjs/sequelize'
 
-import { CaseDefendantPoliceCaseNumber, CivilClaimant } from '../repository'
+import { CivilClaimant } from '../repository'
 import { CaseModule, CourtModule, RepositoryModule } from '..'
 import { CivilClaimantController } from './civilClaimant.controller'
 import { CivilClaimantService } from './civilClaimant.service'
@@ -16,7 +16,7 @@ import { LimitedAccessDefendantController } from './limitedAccessDefendant.contr
     forwardRef(() => CourtModule),
     forwardRef(() => CaseModule),
     forwardRef(() => RepositoryModule),
-    SequelizeModule.forFeature([CaseDefendantPoliceCaseNumber, CivilClaimant]),
+    SequelizeModule.forFeature([CivilClaimant]),
   ],
   controllers: [
     DefendantController,

--- a/apps/judicial-system/backend/src/app/modules/defendant/test/civilClaimantController/update.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/defendant/test/civilClaimantController/update.spec.ts
@@ -8,7 +8,11 @@ import {
 
 import { createTestingDefendantModule } from '../createTestingDefendantModule'
 
-import { Case, CivilClaimant } from '../../../repository'
+import {
+  Case,
+  CaseDefendantPoliceCaseNumberRepositoryService,
+  CivilClaimant,
+} from '../../../repository'
 import { UpdateCivilClaimantDto } from '../../dto/updateCivilClaimant.dto'
 
 interface Then {
@@ -32,14 +36,21 @@ describe('CivilClaimantController - Update', () => {
 
   let mockQueuedMessages: Message[]
   let mockCivilClaimantModel: typeof CivilClaimant
+  let mockCaseDefendantPoliceCaseNumberRepositoryService: CaseDefendantPoliceCaseNumberRepositoryService
   let givenWhenThen: GivenWhenThen
 
   beforeEach(async () => {
-    const { queuedMessages, civilClaimantModel, civilClaimantController } =
-      await createTestingDefendantModule()
+    const {
+      queuedMessages,
+      civilClaimantModel,
+      caseDefendantPoliceCaseNumberRepositoryService,
+      civilClaimantController,
+    } = await createTestingDefendantModule()
 
     mockQueuedMessages = queuedMessages
     mockCivilClaimantModel = civilClaimantModel
+    mockCaseDefendantPoliceCaseNumberRepositoryService =
+      caseDefendantPoliceCaseNumberRepositoryService
 
     givenWhenThen = async (
       theCase: Case,
@@ -94,6 +105,39 @@ describe('CivilClaimantController - Update', () => {
 
     it('should return the updated civil claimant', () => {
       expect(then.result).toBe(updatedCivilClaimant)
+    })
+  })
+
+  describe('civil claimant defendants narrowed by police case numbers', () => {
+    const civilClaimantUpdate = {
+      policeCaseNumbers: ['007-1', '007-2'],
+      defendantIds: ['def-a', 'def-b'],
+    }
+    const updatedCivilClaimant = {
+      id: civilClaimantId,
+      caseId,
+      ...civilClaimantUpdate,
+    }
+
+    beforeEach(async () => {
+      const mockFindAssignedDefendantIds =
+        mockCaseDefendantPoliceCaseNumberRepositoryService.findAssignedDefendantIds as jest.Mock
+      mockFindAssignedDefendantIds.mockResolvedValueOnce(['def-b'])
+
+      const mockUpdate = mockCivilClaimantModel.update as jest.Mock
+      mockUpdate.mockResolvedValueOnce([1, [updatedCivilClaimant]])
+
+      await givenWhenThen(theCase, civilClaimantId, civilClaimantUpdate)
+    })
+
+    it('should only keep the defendants still linked to the police case numbers', () => {
+      expect(
+        mockCaseDefendantPoliceCaseNumberRepositoryService.findAssignedDefendantIds,
+      ).toHaveBeenCalledWith(caseId, ['007-1', '007-2'], ['def-a', 'def-b'])
+      expect(mockCivilClaimantModel.update).toHaveBeenCalledWith(
+        { policeCaseNumbers: ['007-1', '007-2'], defendantIds: ['def-b'] },
+        { where: { id: civilClaimantId, caseId }, returning: true },
+      )
     })
   })
 

--- a/apps/judicial-system/backend/src/app/modules/defendant/test/createTestingDefendantModule.ts
+++ b/apps/judicial-system/backend/src/app/modules/defendant/test/createTestingDefendantModule.ts
@@ -20,7 +20,7 @@ import { CaseService } from '../../case'
 import { CourtService } from '../../court'
 import { EventLogService } from '../../event-log'
 import {
-  CaseDefendantPoliceCaseNumber,
+  CaseDefendantPoliceCaseNumberRepositoryService,
   CivilClaimant,
   DefendantEventLogRepositoryService,
   DefendantRepositoryService,
@@ -40,6 +40,9 @@ jest.mock('../../court/court.service')
 jest.mock('../../case/case.service')
 jest.mock('../../repository/services/defendantRepository.service')
 jest.mock('../../repository/services/defendantEventLogRepository.service')
+jest.mock(
+  '../../repository/services/caseDefendantPoliceCaseNumber.repository.service',
+)
 jest.mock('../../event-log/eventLog.service')
 
 export const createTestingDefendantModule = async () => {
@@ -60,6 +63,7 @@ export const createTestingDefendantModule = async () => {
       CaseService,
       DefendantRepositoryService,
       DefendantEventLogRepositoryService,
+      CaseDefendantPoliceCaseNumberRepositoryService,
       EventLogService,
       {
         provide: LOGGER_PROVIDER,
@@ -81,12 +85,6 @@ export const createTestingDefendantModule = async () => {
           findByPk: jest.fn(),
         },
       },
-      {
-        provide: getModelToken(CaseDefendantPoliceCaseNumber),
-        useValue: {
-          findAll: jest.fn(),
-        },
-      },
       DefendantService,
       CivilClaimantService,
     ],
@@ -106,6 +104,11 @@ export const createTestingDefendantModule = async () => {
   const defendantEventLogRepositoryService =
     defendantModule.get<DefendantEventLogRepositoryService>(
       DefendantEventLogRepositoryService,
+    )
+
+  const caseDefendantPoliceCaseNumberRepositoryService =
+    defendantModule.get<CaseDefendantPoliceCaseNumberRepositoryService>(
+      CaseDefendantPoliceCaseNumberRepositoryService,
     )
 
   const defendantService =
@@ -156,6 +159,7 @@ export const createTestingDefendantModule = async () => {
     sequelize,
     defendantRepositoryService,
     defendantEventLogRepositoryService,
+    caseDefendantPoliceCaseNumberRepositoryService,
     defendantService,
     defendantController,
     internalDefendantController,

--- a/apps/judicial-system/backend/src/app/modules/repository/services/caseDefendantPoliceCaseNumber.repository.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/repository/services/caseDefendantPoliceCaseNumber.repository.service.ts
@@ -131,6 +131,52 @@ export class CaseDefendantPoliceCaseNumberRepositoryService {
     }))
   }
 
+  /**
+   * Returns the distinct ids of the given defendants that are linked to at
+   * least one of the given police case numbers on the case. Used when a civil
+   * claimant's police case numbers change and its defendant selection must be
+   * narrowed to the defendants still reachable through those numbers.
+   */
+  async findAssignedDefendantIds(
+    caseId: string,
+    policeCaseNumbers: string[],
+    defendantIds: string[],
+  ): Promise<string[]> {
+    if (policeCaseNumbers.length === 0 || defendantIds.length === 0) {
+      return []
+    }
+
+    try {
+      this.logger.debug(
+        `Finding assigned defendant ids for case ${caseId} among ${defendantIds.length} defendant(s) and ${policeCaseNumbers.length} police case number(s)`,
+      )
+
+      const rows = await this.model.findAll({
+        where: {
+          caseId,
+          policeCaseNumber: policeCaseNumbers,
+          defendantId: defendantIds,
+        },
+        attributes: ['defendantId'],
+      })
+
+      return [
+        ...new Set(
+          rows
+            .map((row) => row.defendantId)
+            .filter((defendantId): defendantId is string => !!defendantId),
+        ),
+      ]
+    } catch (error) {
+      this.logger.error(
+        `Error finding assigned defendant ids for case ${caseId}`,
+        { error },
+      )
+
+      throw error
+    }
+  }
+
   async findDistinctPoliceCaseNumbersByCaseIds(
     caseIds: string[],
     options?: { transaction?: Transaction },

--- a/apps/judicial-system/backend/src/app/modules/repository/test/caseDefendantPoliceCaseNumber.repository.service.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/repository/test/caseDefendantPoliceCaseNumber.repository.service.spec.ts
@@ -185,6 +185,59 @@ describe('CaseDefendantPoliceCaseNumberRepositoryService', () => {
     })
   })
 
+  describe('findAssignedDefendantIds', () => {
+    it('filters on case, police case numbers and defendants, and de-duplicates', async () => {
+      mockModel.findAll.mockResolvedValue([
+        { defendantId: 'def-a' },
+        { defendantId: 'def-b' },
+        { defendantId: 'def-a' },
+      ])
+
+      const res = await service.findAssignedDefendantIds(
+        'case-1',
+        ['007-1', '007-2'],
+        ['def-a', 'def-b', 'def-c'],
+      )
+
+      expect(mockModel.findAll).toHaveBeenCalledWith({
+        where: {
+          caseId: 'case-1',
+          policeCaseNumber: ['007-1', '007-2'],
+          defendantId: ['def-a', 'def-b', 'def-c'],
+        },
+        attributes: ['defendantId'],
+      })
+      expect(res).toEqual(['def-a', 'def-b'])
+    })
+
+    it('drops rows without a defendant id', async () => {
+      mockModel.findAll.mockResolvedValue([
+        { defendantId: null },
+        { defendantId: undefined },
+        { defendantId: 'def-a' },
+      ])
+
+      const res = await service.findAssignedDefendantIds(
+        'case-1',
+        ['007-1'],
+        ['def-a'],
+      )
+
+      expect(res).toEqual(['def-a'])
+    })
+
+    it('does not query when there are no police case numbers or no defendants', async () => {
+      expect(
+        await service.findAssignedDefendantIds('case-1', [], ['def-a']),
+      ).toEqual([])
+      expect(
+        await service.findAssignedDefendantIds('case-1', ['007-1'], []),
+      ).toEqual([])
+
+      expect(mockModel.findAll).not.toHaveBeenCalled()
+    })
+  })
+
   describe('findDistinctPoliceCaseNumbersByCaseIds', () => {
     it('returns distinct numbers per case id in created order', async () => {
       mockModel.findAll.mockResolvedValue([


### PR DESCRIPTION
# Finish the CaseDefendantPoliceCaseNumber migration

[Klára CaseDefendantPoliceCaseNumber færsluna](https://app.asana.com/1/203394141643832/project/1199153462262248/task/1217656364811025)

`CaseDefendantPoliceCaseNumber` was the last half-migrated model: it has had a repository service with seven methods since the repository module was introduced, but was *also* injected directly into `CivilClaimantService`. This closes that — the model is now injected and registered in exactly one place, `RepositoryModule`.

## What changed

- **`CaseDefendantPoliceCaseNumberRepositoryService`** gains one method, `findAssignedDefendantIds(caseId, policeCaseNumbers, defendantIds)`, which returns the **deduplicated defendant ids** rather than the link rows. Returning ids instead of rows means the model disappears from `CivilClaimantService` entirely — not even as a declared type — so the leak closes completely rather than trading `@InjectModel` for a type import.
- **`CivilClaimantService`** injects the repository service instead of the model. `filterDefendantIdsByPoliceCaseNumbers` keeps its own ordering logic (`currentDefendantIds.filter(...)`), which is a domain rule about preserving caller order, not a query.
- **`DefendantModule`** drops `CaseDefendantPoliceCaseNumber` from `SequelizeModule.forFeature`. `CivilClaimant` stays — it is still injected in `CivilClaimantService` and is a slice of its own.
- **`createTestingDefendantModule`** provides a mocked repository service in place of the model token.

`repository.module.ts` and `index.ts` needed no change: the service was already a provider and already exported.

The query is narrowed to `attributes: ['defendantId']` since that is the only column the caller ever used.

## Out of scope

- `CivilClaimant` itself (6 raw calls in `CivilClaimantService`) — its own slice.
- `case/limitedAccessCase.service.ts` still imports the model, but only as an entry in a raw Sequelize `include` array. That is query composition in a business service, a separate concern from this migration, and it is not an `@InjectModel` or `forFeature` registration.

## Verification

- `tsc --noEmit` clean.
- `yarn nx test judicial-system-backend --testPathPatterns='app/modules/(defendant|repository)/'` — 55 suites, 239 tests, all passing.
- `yarn nx run judicial-system-backend:codegen/backend-schema` boots the real Nest module graph (which unit tests never do, since they hand-wire testing modules) and `openapi.yaml` comes back byte-identical.
- `yarn nx lint judicial-system-backend` — 0 errors; the 2 warnings are pre-existing in `case.model.ts`.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved civil claimant updates by ensuring only defendants assigned to the specified police case numbers are retained.
  * Prevented duplicate or invalid defendant assignments from being included.

* **Tests**
  * Added coverage for filtering, duplicate removal, invalid records, and empty-input handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->