### PR TITLE
fix(j-s): Justify rich text incident description in indictment PDF

### DIFF
--- a/apps/judicial-system/backend/src/app/formatters/generatedPdfs/indictmentPdf.ts
+++ b/apps/judicial-system/backend/src/app/formatters/generatedPdfs/indictmentPdf.ts
@@ -125,7 +125,7 @@ export const createIndictment = async (
       // Newer indictments store the incident description as rich text from
       // the TinyMCE editor, while older ones store plain text.
       if (containsHtml(incidentDescription)) {
-        addRichText(doc, incidentDescription, 0, basePlusFontSize)
+        addRichText(doc, incidentDescription, 0, basePlusFontSize, 'justify')
       } else {
         addNormalPlusJustifiedText(doc, incidentDescription)
       }

--- a/apps/judicial-system/backend/src/app/formatters/pdfHelpers/pdfHelpers.spec.ts
+++ b/apps/judicial-system/backend/src/app/formatters/pdfHelpers/pdfHelpers.spec.ts
@@ -655,6 +655,120 @@ describe('addRichText layout', () => {
     expect(inner.x - outer.x).toBe(30)
     doc.end()
   })
+
+  describe('justified alignment', () => {
+    // Where the trimmed text of the line's rightmost fragment ends.
+    const lineEnd = (doc: typeof PDFDocument.prototype, line: Frag[]) => {
+      const last = line.reduce((a, b) => (a.x > b.x ? a : b), line[0])
+      return last.x + doc.widthOfString(last.text.trimEnd())
+    }
+
+    const fragsByLine = (frags: Frag[]) => {
+      const ys = [...new Set(frags.map((f) => Math.round(f.y)))].sort(
+        (a, b) => a - b,
+      )
+      return ys.map((y) => frags.filter((f) => Math.round(f.y) === y))
+    }
+
+    it('stretches every wrapped line to the right margin, but not the last', () => {
+      const { doc, frags } = createInstrumentedDoc()
+
+      const filler = 'orðalengja stutt já langlokusamsetningarorð '
+        .repeat(12)
+        .trim()
+      addRichText(doc, `<p>${filler}</p>`, 2, 11, 'justify')
+
+      doc.font('Times-Roman').fontSize(11)
+      const edge = doc.page.width - doc.page.margins.right
+      const lines = fragsByLine(frags)
+      expect(lines.length).toBeGreaterThan(2)
+
+      for (const line of lines.slice(0, -1)) {
+        expect(Math.abs(lineEnd(doc, line) - edge)).toBeLessThanOrEqual(0.5)
+      }
+      // The block's last line keeps its natural width.
+      expect(lineEnd(doc, lines[lines.length - 1])).toBeLessThan(edge - 1)
+      doc.end()
+    })
+
+    it('does not stretch lines unless justify is requested', () => {
+      const { doc, frags } = createInstrumentedDoc()
+
+      const filler = 'orðalengja stutt já langlokusamsetningarorð '
+        .repeat(12)
+        .trim()
+      addRichText(doc, `<p>${filler}</p>`, 2)
+
+      // Every word on the first line sits at its natural cumulative position.
+      doc.font('Times-Roman').fontSize(11)
+      const [firstLine] = fragsByLine(frags)
+      const sorted = [...firstLine].sort((a, b) => a.x - b.x)
+      for (let i = 0; i < sorted.length - 1; i++) {
+        expect(
+          Math.abs(
+            sorted[i + 1].x - sorted[i].x - doc.widthOfString(sorted[i].text),
+          ),
+        ).toBeLessThanOrEqual(0.01)
+      }
+      doc.end()
+    })
+
+    it('does not stretch a line ended by a hard break', () => {
+      const { doc, frags } = createInstrumentedDoc()
+
+      addRichText(doc, '<p>stutt brot<br>framhald texta</p>', 2, 11, 'justify')
+
+      const first = findFragmentWith(frags, 'stutt')
+      const second = findFragmentWith(frags, 'brot')
+      doc.font('Times-Roman').fontSize(11)
+      expect(
+        Math.abs(second.x - first.x - doc.widthOfString(first.text)),
+      ).toBeLessThanOrEqual(0.01)
+      doc.end()
+    })
+
+    it('keeps the highlight rect glued to text across a widened gap', () => {
+      const { doc, rects, frags } = createInstrumentedDoc()
+
+      const filler = 'orðalengja '.repeat(30).trim()
+      addRichText(
+        doc,
+        `<p><span style="background-color: #FFF066;">MERKT ORÐ</span> ${filler}</p>`,
+        2,
+        11,
+        'justify',
+      )
+
+      const merkt = findFragmentWith(frags, 'MERKT')
+      const ord = findFragmentWith(frags, 'ORÐ')
+      doc.font('Times-Roman').fontSize(11)
+
+      // The gap inside the highlight was widened by justification...
+      expect(ord.x - merkt.x).toBeGreaterThan(doc.widthOfString(merkt.text))
+
+      // ...and the single rect still spans exactly from the first glyph to the
+      // last (1pt of horizontal padding on each side).
+      expect(rects.length).toBeGreaterThanOrEqual(1)
+      const rect = rects[0]
+      expect(Math.abs(rect.x - (merkt.x - 1))).toBeLessThanOrEqual(0.5)
+      expect(
+        Math.abs(rect.x + rect.w - (ord.x + doc.widthOfString('ORÐ') + 1)),
+      ).toBeLessThanOrEqual(0.5)
+      doc.end()
+    })
+
+    it('handles a chopped over-long token without gaps to stretch', () => {
+      const { doc, frags } = createInstrumentedDoc()
+
+      addRichText(doc, `<p>${'x'.repeat(300)} lok</p>`, 2, 11, 'justify')
+
+      expect(frags.length).toBeGreaterThan(1)
+      for (const frag of frags) {
+        expect(Number.isFinite(frag.x)).toBe(true)
+      }
+      doc.end()
+    })
+  })
 })
 
 describe('addNumberedList', () => {

--- a/apps/judicial-system/backend/src/app/formatters/pdfHelpers/pdfHelpers.ts
+++ b/apps/judicial-system/backend/src/app/formatters/pdfHelpers/pdfHelpers.ts
@@ -843,6 +843,7 @@ export const addRichText = (
   html: string,
   lineGap = 0,
   fontSize = baseFontSize,
+  alignment: 'left' | 'justify' = 'left',
 ): void => {
   const blocks = htmlToBlocks(html)
 
@@ -899,7 +900,42 @@ export const addRichText = (
       doc.text(block.marker, markerX, y, { lineBreak: false })
     }
 
-    const flushLine = () => {
+    // Stretch a wrapped line to the full block width by widening the gaps
+    // between words evenly. Fragment x/width values are adjusted in place
+    // before anything is drawn, so the highlight rects (computed from the same
+    // fragments) widen with the spaces they cover.
+    const justifyLineFragments = () => {
+      const last = lineFragments[lineFragments.length - 1]
+      doc.font(last.font).fontSize(fontSize)
+      const lineEnd = last.x + doc.widthOfString(last.text.trimEnd())
+      const slack = leftX + width - lineEnd
+      if (slack <= 0) return
+
+      // Words carry their single trailing space, and inter-run spaces are lone
+      // ' ' tokens, so every gap is a fragment ending in a space.
+      const gaps = lineFragments.filter(
+        (fragment, index) =>
+          index < lineFragments.length - 1 && fragment.text.endsWith(' '),
+      ).length
+      if (gaps === 0) return
+
+      const extra = slack / gaps
+      let offset = 0
+      for (let i = 0; i < lineFragments.length; i++) {
+        const fragment = lineFragments[i]
+        fragment.x += offset
+        if (i < lineFragments.length - 1 && fragment.text.endsWith(' ')) {
+          fragment.width += extra
+          offset += extra
+        }
+      }
+    }
+
+    const flushLine = (justifyLine = false) => {
+      if (alignment === 'justify' && justifyLine && lineFragments.length > 0) {
+        justifyLineFragments()
+      }
+
       // Draw one rect per contiguous same-colored group, then the text on top.
       let i = 0
       let drewRect = false
@@ -939,8 +975,8 @@ export const addRichText = (
       lineFragments = []
     }
 
-    const newline = () => {
-      flushLine()
+    const newline = (justifyLine = false) => {
+      flushLine(justifyLine)
       x = leftX
       y += lineAdvance
       ensureRoom()
@@ -968,7 +1004,9 @@ export const addRichText = (
           ? doc.widthOfString(token.trimEnd())
           : tokenWidth
         if (x + wordWidth > leftX + width && x > leftX) {
-          newline()
+          // Only wrap-induced breaks justify; hard breaks and the block's last
+          // line keep their natural width, as in any word processor.
+          newline(true)
         }
 
         // A single token wider than the whole line is chopped to fit.


### PR DESCRIPTION
## What

Justify HTML (TinyMCE) incident descriptions in the indictment PDF, matching the surrounding justified text blocks.

- `addRichText` now accepts an optional `alignment: 'left' | 'justify'` parameter (default `'left'`, so all other callers are unchanged). When justifying, leftover slack on wrap-induced lines is distributed evenly across the word gaps. Fragment positions and widths are adjusted in place before anything is drawn, so highlight rects widen with the gaps and stay glued to their words. The last line of a paragraph and lines ended by a break keep their natural width.
- The indictment PDF's rich-text incident description branch opts into `'justify'`. The court record PDF call site is unchanged (its surroundings were always left-aligned).
- Added tests covering flush right edges on wrapped lines, unstretched last/break lines, unchanged default alignment, highlight rect geometry across widened gaps, and over-long token chopping.

## Why

Since the TinyMCE rich text editor was introduced for the indictment count incident description, that field is rendered by `addRichText`, which laid out words manually with hard left alignment. Old plain-text descriptions are justified via PDFKit, so indictments rendered with mixed alignment — HTML descriptions ragged-right next to justified legal arguments and demands.

## Screenshots / Gifs
Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code
- [ ] No AI tools were used in preparing this pull request

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved PDF formatting for rich-text incident descriptions by applying justified alignment.
  - Ensured wrapped text aligns consistently with plain-text descriptions.

- **Tests**
  - Added coverage for justified text spacing, line breaks, highlights, and long words in generated PDFs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->