### PR TITLE
fix(web): disable read-only image disk cache to stop EACCES

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -214,6 +214,12 @@ const nextConfig = {
     return config
   },
 
+  // The prod container's .next/cache is read-only, so Next 16's on-disk image
+  // LRU throws EACCES on mkdir. Disable it; CloudFront caches optimized images.
+  images: {
+    maximumDiskCacheSize: 0,
+  },
+
   // Runtime configuration lives in environments/runtimeEnvironment.ts
   env: {
     API_MOCKS: process.env.API_MOCKS || '',


### PR DESCRIPTION
# disable read-only image disk cache to stop EACCES

## What

- Set `images.maximumDiskCacheSize: 0` in the web app's `next.config.js`.

## Why

- Next 16's on-disk image LRU does an unguarded `mkdir '/webapp/.next/cache/images'`, which is read-only in the prod container, throwing an `EACCES` unhandledRejection; CloudFront already caches optimized images.

## Screenshots / Gifs

N/A

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code