### PR TITLE
fix(ui): More generic cell box props naming

### DIFF
--- a/libs/application/templates/directorate-of-equality/salary-report/src/fields/SalaryAnalysisResults/OutlierEditor.tsx
+++ b/libs/application/templates/directorate-of-equality/salary-report/src/fields/SalaryAnalysisResults/OutlierEditor.tsx
@@ -62,7 +62,7 @@ export const OutlierEditor: FC<Props> = ({
   // group card owns it from then on. Removing a group frees its members
   // back into this list.
   const assignedOrdinals = new Set(
-    (fields as unknown as (OutlierGroupAnswer & { id: string })[]).flatMap(
+    ((fields as unknown) as (OutlierGroupAnswer & { id: string })[]).flatMap(
       (g) => g.employeeOrdinals,
     ),
   )
@@ -175,7 +175,7 @@ export const OutlierEditor: FC<Props> = ({
 
       <Box>
         {fields.map((field, index) => {
-          const group = field as unknown as OutlierGroupAnswer & {
+          const group = (field as unknown) as OutlierGroupAnswer & {
             id: string
           }
           return (

--- a/libs/application/templates/directorate-of-equality/salary-report/src/fields/SalaryAnalysisResults/OutlierEditor.tsx
+++ b/libs/application/templates/directorate-of-equality/salary-report/src/fields/SalaryAnalysisResults/OutlierEditor.tsx
@@ -62,7 +62,7 @@ export const OutlierEditor: FC<Props> = ({
   // group card owns it from then on. Removing a group frees its members
   // back into this list.
   const assignedOrdinals = new Set(
-    ((fields as unknown) as (OutlierGroupAnswer & { id: string })[]).flatMap(
+    (fields as unknown as (OutlierGroupAnswer & { id: string })[]).flatMap(
       (g) => g.employeeOrdinals,
     ),
   )
@@ -175,7 +175,7 @@ export const OutlierEditor: FC<Props> = ({
 
       <Box>
         {fields.map((field, index) => {
-          const group = (field as unknown) as OutlierGroupAnswer & {
+          const group = field as unknown as OutlierGroupAnswer & {
             id: string
           }
           return (

--- a/libs/application/templates/directorate-of-equality/salary-report/src/fields/SalaryAnalysisResults/OutlierEditor.tsx
+++ b/libs/application/templates/directorate-of-equality/salary-report/src/fields/SalaryAnalysisResults/OutlierEditor.tsx
@@ -127,7 +127,10 @@ export const OutlierEditor: FC<Props> = ({
             columns={columns}
             data={pageRows}
             mobileTitleKey="employee"
-            cellPaddingX={2}
+            cellBox={{
+              header: { paddingLeft: 2, paddingRight: 2 },
+              body: { paddingLeft: 2, paddingRight: 2 },
+            }}
           />
 
           <Box marginTop={2}>

--- a/libs/island-ui/core/src/lib/InteractiveTable/InteractiveTable.tsx
+++ b/libs/island-ui/core/src/lib/InteractiveTable/InteractiveTable.tsx
@@ -70,20 +70,14 @@ type BaseInteractiveTableProps<TData extends object> = {
   srCaption?: string
   sortHint?: string
   meta?: TableMeta<TData>
-  /**
-   * Style overrides merged into every header/body cell's `box` props (e.g. padding).
-   * `background` and `borderBottomWidth` on `body` are reserved for the row-expansion
-   * highlight and are always overridden internally — they cannot be set here.
-   */
   cellBox?: {
     header?: Omit<UseBoxStylesProps, 'component'>
     body?: Omit<UseBoxStylesProps, 'component'>
   }
 }
 
-export type InteractiveTableProps<
-  TData extends object
-> = BaseInteractiveTableProps<TData> & (WithExpander<TData> | WithoutExpander)
+export type InteractiveTableProps<TData extends object> =
+  BaseInteractiveTableProps<TData> & (WithExpander<TData> | WithoutExpander)
 
 export const InteractiveTable = <TData extends object>({
   columns: providedColumns,

--- a/libs/island-ui/core/src/lib/InteractiveTable/InteractiveTable.tsx
+++ b/libs/island-ui/core/src/lib/InteractiveTable/InteractiveTable.tsx
@@ -70,15 +70,20 @@ type BaseInteractiveTableProps<TData extends object> = {
   srCaption?: string
   sortHint?: string
   meta?: TableMeta<TData>
-  /** Style overrides merged into every header/body cell's `box` props (e.g. padding, background). */
+  /**
+   * Style overrides merged into every header/body cell's `box` props (e.g. padding).
+   * `background` and `borderBottomWidth` on `body` are reserved for the row-expansion
+   * highlight and are always overridden internally — they cannot be set here.
+   */
   cellBox?: {
     header?: Omit<UseBoxStylesProps, 'component'>
     body?: Omit<UseBoxStylesProps, 'component'>
   }
 }
 
-export type InteractiveTableProps<TData extends object> =
-  BaseInteractiveTableProps<TData> & (WithExpander<TData> | WithoutExpander)
+export type InteractiveTableProps<
+  TData extends object
+> = BaseInteractiveTableProps<TData> & (WithExpander<TData> | WithoutExpander)
 
 export const InteractiveTable = <TData extends object>({
   columns: providedColumns,

--- a/libs/island-ui/core/src/lib/InteractiveTable/InteractiveTable.tsx
+++ b/libs/island-ui/core/src/lib/InteractiveTable/InteractiveTable.tsx
@@ -20,7 +20,7 @@ import cn from 'classnames'
 import { helperStyles } from '@island.is/island-ui/theme'
 
 import { Box } from '../Box/Box'
-import type { ResponsiveSpace } from '../Box/useBoxStyles'
+import type { UseBoxStylesProps } from '../Box/useBoxStyles'
 import { Button } from '../Button/Button'
 import { FocusableBox } from '../FocusableBox/FocusableBox'
 import { Hidden } from '../Hidden/Hidden'
@@ -70,8 +70,11 @@ type BaseInteractiveTableProps<TData extends object> = {
   srCaption?: string
   sortHint?: string
   meta?: TableMeta<TData>
-  /** Override the default horizontal cell/header padding (defaults to the `Table` component's own default of `3`). */
-  cellPaddingX?: ResponsiveSpace
+  /** Style overrides merged into every header/body cell's `box` props (e.g. padding, background). */
+  cellBox?: {
+    header?: Omit<UseBoxStylesProps, 'component'>
+    body?: Omit<UseBoxStylesProps, 'component'>
+  }
 }
 
 export type InteractiveTableProps<TData extends object> =
@@ -95,7 +98,7 @@ export const InteractiveTable = <TData extends object>({
   srCaption = 'Table with sortable columns.',
   sortHint = 'Activate to sort.',
   meta,
-  cellPaddingX,
+  cellBox,
 }: InteractiveTableProps<TData>) => {
   const resolvedExpanderLabel = expanderLabel ?? ''
   const [internalSorting, setInternalSorting] = useState<SortingState>(
@@ -200,11 +203,7 @@ export const InteractiveTable = <TData extends object>({
                     textAlign: header.column.columnDef.meta.align,
                   }),
                 }}
-                box={
-                  cellPaddingX !== undefined
-                    ? { paddingLeft: cellPaddingX, paddingRight: cellPaddingX }
-                    : undefined
-                }
+                box={cellBox?.header}
               >
                 {header.column.getCanSort() ? (
                   <FocusableBox
@@ -277,12 +276,9 @@ export const InteractiveTable = <TData extends object>({
                     <T.Data
                       key={cell.id}
                       box={{
-                        position: 'relative',
                         paddingY: 2,
-                        ...(cellPaddingX !== undefined && {
-                          paddingLeft: cellPaddingX,
-                          paddingRight: cellPaddingX,
-                        }),
+                        ...cellBox?.body,
+                        position: 'relative',
                         background: rowBackground,
                         borderBottomWidth:
                           isExpanded || isCollapsing ? undefined : 'standard',
@@ -330,10 +326,7 @@ export const InteractiveTable = <TData extends object>({
                       key={cell.id}
                       box={{
                         paddingY: 2,
-                        ...(cellPaddingX !== undefined && {
-                          paddingLeft: cellPaddingX,
-                          paddingRight: cellPaddingX,
-                        }),
+                        ...cellBox?.body,
                         background: rowBackground,
                         borderBottomWidth:
                           isExpanded || isCollapsing ? undefined : 'standard',


### PR DESCRIPTION
## What

Replace `InteractiveTable`'s single-purpose `cellPaddingX` prop with a generic `cellBox: { header?, body? }` prop that accepts any `Box` style override (padding, etc.), matching the existing bare-`box` naming convention already used by `T.Data`/`T.HeadData` in `Table.tsx`. Updated `OutlierEditor.tsx`'s usage to the new shape.

## Why

`cellPaddingX` only covered horizontal padding; any other niche visual tweak to cells would have needed its own dedicated prop. `cellBox` generalizes to any `Box`-supported style so future one-off styling needs don't require new props each time.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: claude code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added separate styling controls for InteractiveTable header and body cells.
  - Supports more flexible cell layout and spacing customization.

- **Bug Fixes**
  - Updated the salary analysis table to apply consistent horizontal padding across headers and body cells.
  - Preserved row-expansion highlighting while allowing body-cell style customization.

- **Refactor**
  - Replaced the previous shared horizontal padding option with configurable header and body cell styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->