### PR TITLE
fix(web): Show 404 if open data page is not found

### DIFF
--- a/apps/web/screens/OpenData/OpenData.tsx
+++ b/apps/web/screens/OpenData/OpenData.tsx
@@ -35,6 +35,7 @@ import {
 } from '@island.is/web/graphql/schema'
 import { withMainLayout } from '@island.is/web/layouts/main'
 import { Screen } from '@island.is/web/types'
+import { CustomNextError } from '@island.is/web/units/errors'
 
 import { buildHeaderNavData } from '../../components/Header/buildHeaderNavData'
 import type { HeaderNavData } from '../../components/Header/headerNavData'
@@ -45,7 +46,7 @@ import { GET_ORGANIZATION_LOGOS_QUERY } from '../queries/Organization'
 import * as styles from './OpenData.css'
 
 interface OpenDataProps {
-  page: GetOpenDataPageQuery['getOpenDataPage']
+  page: NonNullable<GetOpenDataPageQuery['getOpenDataPage']>
   headerNavData?: HeaderNavData | null
 }
 
@@ -129,7 +130,9 @@ const OpenDataPage: Screen<OpenDataProps> = ({ page, headerNavData }) => {
                 })}
               >
                 <Box className={styles.headerGraphParent}>
-                  <SimpleLineChart graphData={pageHeaderGraph} />
+                  {pageHeaderGraph && (
+                    <SimpleLineChart graphData={pageHeaderGraph} />
+                  )}
                 </Box>
               </Box>
             </GridColumn>
@@ -181,7 +184,7 @@ const OpenDataPage: Screen<OpenDataProps> = ({ page, headerNavData }) => {
           // @ts-ignore make web strict
           image={externalLinkSectionImage}
           description={externalLinkSectionDescription}
-          cards={externalLinkCardSelection.cards}
+          cards={externalLinkCardSelection?.cards ?? []}
         />
       </Section>
     </Box>
@@ -223,6 +226,10 @@ OpenDataPage.getProps = async ({ apolloClient, locale }) => {
       .then((res) => res.data.getOrganizations?.items ?? [])
       .catch(() => []),
   ])
+
+  if (!page) {
+    throw new CustomNextError(404, 'Open data page not found')
+  }
 
   return {
     page,

--- a/apps/web/screens/OpenDataSubPage/OpenDataSubPage.tsx
+++ b/apps/web/screens/OpenDataSubPage/OpenDataSubPage.tsx
@@ -22,12 +22,13 @@ import {
 } from '@island.is/web/graphql/schema'
 import { withMainLayout } from '@island.is/web/layouts/main'
 import { Screen } from '@island.is/web/types'
+import { CustomNextError } from '@island.is/web/units/errors'
 
 import { useLinkResolver } from '../../hooks/useLinkResolver'
 import { GET_OPEN_DATA_SUBPAGE_QUERY } from '../queries'
 
 interface OpenDataSubpageProps {
-  page: GetOpenDataSubpageQuery['getOpenDataSubpage']
+  page: NonNullable<GetOpenDataSubpageQuery['getOpenDataSubpage']>
 }
 
 const OpenDataSubPage: Screen<OpenDataSubpageProps> = ({ page }) => {
@@ -206,6 +207,10 @@ OpenDataSubPage.getProps = async ({ apolloClient, locale }) => {
       },
     }),
   ])
+
+  if (!page) {
+    throw new CustomNextError(404, 'Open data subpage not found')
+  }
 
   return {
     page,

--- a/libs/cms/src/lib/cms.contentful.service.ts
+++ b/libs/cms/src/lib/cms.contentful.service.ts
@@ -558,7 +558,7 @@ export class CmsContentfulService {
     return (result.items as types.IAuction[]).map(mapAuction)
   }
 
-  async getAuction(id: string, lang: string): Promise<Auction | null> {
+  async getAuction(id: string, lang: string): Promise<Auction> {
     const params = {
       ['content_type']: 'auction',
       'sys.id': id,
@@ -568,7 +568,7 @@ export class CmsContentfulService {
       .getLocalizedEntries<types.IAuctionFields>(lang, params)
       .catch(errorHandler('getAuction'))
 
-    return (result.items as types.IAuction[]).map(mapAuction)[0] ?? null
+    return (result.items as types.IAuction[]).map(mapAuction)[0]
   }
 
   async getProjectPage(

--- a/libs/cms/src/lib/cms.contentful.service.ts
+++ b/libs/cms/src/lib/cms.contentful.service.ts
@@ -558,7 +558,7 @@ export class CmsContentfulService {
     return (result.items as types.IAuction[]).map(mapAuction)
   }
 
-  async getAuction(id: string, lang: string): Promise<Auction> {
+  async getAuction(id: string, lang: string): Promise<Auction | null> {
     const params = {
       ['content_type']: 'auction',
       'sys.id': id,
@@ -568,7 +568,7 @@ export class CmsContentfulService {
       .getLocalizedEntries<types.IAuctionFields>(lang, params)
       .catch(errorHandler('getAuction'))
 
-    return (result.items as types.IAuction[]).map(mapAuction)[0]
+    return (result.items as types.IAuction[]).map(mapAuction)[0] ?? null
   }
 
   async getProjectPage(
@@ -1190,7 +1190,9 @@ export class CmsContentfulService {
       .filter((category) => category?.title && category?.slug)
   }
 
-  async getOpenDataPage({ lang }: GetOpenDataPageInput): Promise<OpenDataPage> {
+  async getOpenDataPage({
+    lang,
+  }: GetOpenDataPageInput): Promise<OpenDataPage | null> {
     const params = {
       ['content_type']: 'openDataPage',
       include: 10,
@@ -1208,7 +1210,7 @@ export class CmsContentfulService {
 
   async getOpenDataSubpage({
     lang,
-  }: GetOpenDataSubpageInput): Promise<OpenDataSubpage> {
+  }: GetOpenDataSubpageInput): Promise<OpenDataSubpage | null> {
     const params = {
       ['content_type']: 'openDataSubpage',
       include: 10,

--- a/libs/cms/src/lib/cms.resolver.ts
+++ b/libs/cms/src/lib/cms.resolver.ts
@@ -250,7 +250,7 @@ export class CmsResolver {
   }
 
   @CacheControl(defaultCache)
-  @Query(() => OpenDataPage)
+  @Query(() => OpenDataPage, { nullable: true })
   getOpenDataPage(
     @Args('input') input: GetOpenDataPageInput,
   ): Promise<OpenDataPage | null> {
@@ -258,7 +258,7 @@ export class CmsResolver {
   }
 
   @CacheControl(defaultCache)
-  @Query(() => OpenDataSubpage)
+  @Query(() => OpenDataSubpage, { nullable: true })
   getOpenDataSubpage(
     @Args('input') input: GetOpenDataSubpageInput,
   ): Promise<OpenDataSubpage | null> {


### PR DESCRIPTION
# Show 404 if open data page is not found

Today it's a 500 error since it's coded up like it will always be found.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- Missing Open Data pages and subpages now return a clear 404 error.
- Header charts appear only when data is available.
- Open Data pages gracefully handle unavailable external links.
- Content retrieval more accurately handles missing auction and Open Data entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->