### PR TITLE
fix(j-s): Hide the ruling order context menu at the district court until the ruling is confirmed

### DIFF
--- a/apps/judicial-system/web/src/components/IndictmentCaseFilesList/RulingOrderConfirmationStatus.tsx
+++ b/apps/judicial-system/web/src/components/IndictmentCaseFilesList/RulingOrderConfirmationStatus.tsx
@@ -17,6 +17,14 @@ interface Props {
 }
 
 /**
+ * A ruling order uploaded during the course of a case is confirmed when the
+ * registered judge signs it off, which the backend records as the file's
+ * submission date.
+ */
+export const isRulingOrderConfirmed = (file: CaseFile): boolean =>
+  Boolean(file.submissionDate)
+
+/**
  * Right-aligned confirmation state of a ruling order uploaded during the
  * course of a case:
  * - confirmed: nothing is rendered,
@@ -33,7 +41,7 @@ const RulingOrderConfirmationStatus: FC<Props> = ({ file }) => {
 
   const [confirmRulingOrder, { loading }] = useConfirmRulingOrderMutation()
 
-  const isConfirmed = Boolean(file.submissionDate)
+  const isConfirmed = isRulingOrderConfirmed(file)
   const isRegisteredJudge = Boolean(
     user?.id && user.id === workingCase.judge?.id,
   )

--- a/apps/judicial-system/web/src/components/IndictmentCaseFilesList/RulingOrderFileRow.spec.tsx
+++ b/apps/judicial-system/web/src/components/IndictmentCaseFilesList/RulingOrderFileRow.spec.tsx
@@ -69,9 +69,12 @@ describe('RulingOrderFileRow - send in-court appeal to Court of appeals', () => 
     category: CaseFileCategory.COURT_INDICTMENT_RULING_ORDER,
     hasBeenAppealed: true,
     isKeyAccessible: true,
+    // The judge has confirmed the ruling order, so the district court may act
+    // on the appeal.
+    submissionDate: '2026-06-05T10:00:00.000Z',
   } as CaseFile
 
-  const renderRow = (user: User) => {
+  const renderRow = (user: User, file: CaseFile = rulingOrderFile) => {
     const workingCase = {
       ...mockCase(CaseType.INDICTMENT),
       state: CaseState.RECEIVED,
@@ -105,7 +108,7 @@ describe('RulingOrderFileRow - send in-court appeal to Court of appeals', () => 
 
     return render(
       wrapInProviders(
-        <RulingOrderFileRow file={rulingOrderFile} onOpenFile={jest.fn()} />,
+        <RulingOrderFileRow file={file} onOpenFile={jest.fn()} />,
       ),
     )
   }
@@ -149,6 +152,39 @@ describe('RulingOrderFileRow - send in-court appeal to Court of appeals', () => 
 
     expect(await screen.findByText('Senda inn greinargerð')).toBeInTheDocument()
     expect(screen.queryByText('Senda til Landsréttar')).not.toBeInTheDocument()
+  })
+
+  // The ruling order still awaits the judge's confirmation ("Staðfesta"), so
+  // the district court gets no action menu at all - the appeal is not theirs to
+  // forward yet.
+  describe('before the ruling order has been confirmed', () => {
+    const unconfirmedRulingOrderFile = {
+      ...rulingOrderFile,
+      submissionDate: null,
+    } as CaseFile
+
+    it('hides the action menu from a district court user', () => {
+      renderRow(mockJudge, unconfirmedRulingOrderFile)
+
+      expect(
+        screen.queryByLabelText(`Valmynd fyrir ${fileName}`),
+      ).not.toBeInTheDocument()
+    })
+
+    it('still shows the in-court appeal status to the district court', async () => {
+      renderRow(mockJudge, unconfirmedRulingOrderFile)
+
+      expect(await screen.findByText(/Kært í þinghaldi/)).toBeInTheDocument()
+    })
+
+    it('keeps the prosecution actions available', async () => {
+      renderRow(mockProsecutor, unconfirmedRulingOrderFile)
+      openMenu()
+
+      expect(
+        await screen.findByText('Senda inn greinargerð'),
+      ).toBeInTheDocument()
+    })
   })
 })
 

--- a/apps/judicial-system/web/src/components/IndictmentCaseFilesList/RulingOrderFileRow.tsx
+++ b/apps/judicial-system/web/src/components/IndictmentCaseFilesList/RulingOrderFileRow.tsx
@@ -48,7 +48,9 @@ import {
   userHasActiveInCourtAppeal,
 } from '@island.is/judicial-system-web/src/utils/utils'
 
-import RulingOrderConfirmationStatus from './RulingOrderConfirmationStatus'
+import RulingOrderConfirmationStatus, {
+  isRulingOrderConfirmed,
+} from './RulingOrderConfirmationStatus'
 
 interface Props {
   file: CaseFile
@@ -194,6 +196,12 @@ const RulingOrderFileRow: FC<Props> = ({ file, onOpenFile }) => {
   }
   // COMPLETED / WITHDRAWN: read-only, no menu items.
 
+  // The district court has nothing to act on before the registered judge has
+  // confirmed the ruling order - until then the row only offers the
+  // "Staðfesta" button, so its action menu stays hidden.
+  const menuItems =
+    isDistrictCourt && !isRulingOrderConfirmed(file) ? [] : items
+
   // Status text below the file row. Visible to working prosecution, defence,
   // and district-court users. Other roles (e.g. PUBLIC_PROSECUTOR_STAFF) see
   // the row without status text or actions.
@@ -291,10 +299,10 @@ const RulingOrderFileRow: FC<Props> = ({ file, onOpenFile }) => {
               />
             </Box>
           )}
-          {items.length > 0 && (
+          {menuItems.length > 0 && (
             <Box marginLeft={1}>
               <ContextMenu
-                items={items}
+                items={menuItems}
                 placement="left-start"
                 shift={-12}
                 render={


### PR DESCRIPTION
# Hide the ruling order context menu at the district court until the ruling is confirmed

[ÚURM - fela context menu hjá héraðsdómi þar til úrsk. hefur verið staðfestur af dómara](https://app.asana.com/1/203394141643832/project/1199153462262248/task/1217659579862244)

When a ruling order was uploaded but not yet confirmed by the registered judge, and the ruling was pronounced and appealed in a court session, the district court still saw the ruling-order action menu on the file row — offering "Senda til Landsréttar" for a ruling that is not a valid ruling to act on yet.

The action menu is now hidden from district-court users until the ruling order has been confirmed. Until then the row only offers the judge's "Staðfesta" button (or "Bíður staðfestingar" for other court staff). The in-court appeal status text ("Kært í þinghaldi") is unchanged, and prosecution/defence actions are untouched — the ticket scopes the hiding to héraðsdómur.

- `RulingOrderConfirmationStatus.tsx`: extracted the confirmation predicate as an exported `isRulingOrderConfirmed(file)` so the row and the confirmation UI share one definition of "confirmed".
- `RulingOrderFileRow.tsx`: district-court users get no menu items while the ruling order is unconfirmed; the ⋮ trigger is already dropped when there are no items.
- `RulingOrderFileRow.spec.tsx`: existing district-court tests now use a confirmed ruling file, plus new cases covering the unconfirmed ruling — menu hidden for the judge, appeal status still shown, prosecution actions unaffected.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * District court actions are now hidden until a ruling order is confirmed.
  * In-court appeal status remains visible for unconfirmed ruling orders.
  * Prosecution actions continue to be available as expected.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->