### PR TITLE
fix(j-s): Health conversations attachments file name

### DIFF
--- a/apps/download-service/src/app/modules/documents/document.controller.ts
+++ b/apps/download-service/src/app/modules/documents/document.controller.ts
@@ -1,5 +1,4 @@
 import type { User } from '@island.is/auth-nest-tools'
-import slugify from '@sindresorhus/slugify'
 import {
   CurrentUser,
   IdsUserGuard,
@@ -20,6 +19,7 @@ import {
 } from '@nestjs/common'
 import { ApiOkResponse, ApiTags } from '@nestjs/swagger'
 import { Response } from 'express'
+import { slugifyFileName } from '../../utils/fileName'
 
 @UseGuards(IdsUserGuard, ScopesGuard)
 @Scopes(DocumentsScope.main)
@@ -61,12 +61,10 @@ export class DocumentController {
 
     const buffer = Buffer.from(rawDocumentDTO.content, 'base64')
 
-    const slugFileName = slugify(rawDocumentDTO.fileName ?? 'postholf-skjal', {
-      customReplacements: [
-        ['Þ', 'th'],
-        ['ö', 'o'],
-      ],
-    })
+    const slugFileName = slugifyFileName(
+      rawDocumentDTO.fileName ?? '',
+      'postholf-skjal',
+    )
     res.header(
       'Content-Disposition',
       `${

--- a/apps/download-service/src/app/modules/health/conversations-attachment.controller.ts
+++ b/apps/download-service/src/app/modules/health/conversations-attachment.controller.ts
@@ -14,11 +14,13 @@ import {
   Param,
   ParseIntPipe,
   Post,
+  Query,
   Res,
   UseGuards,
 } from '@nestjs/common'
 import { ApiOkResponse } from '@nestjs/swagger'
 import { Response } from 'express'
+import { toSafeFileName } from '../../utils/fileName'
 
 @UseGuards(IdsUserGuard, ScopesGuard)
 @Scopes(ApiScope.internal, ApiScope.health)
@@ -38,6 +40,7 @@ export class HealthConversationsAttachmentController {
     @Param('conversationId') conversationId: string,
     @Param('messageId') messageId: string,
     @Param('attachmentId', ParseIntPipe) attachmentId: number,
+    @Query('fileName') fileName: string,
     @CurrentUser() user: User,
     @Res() res: Response,
   ) {
@@ -71,6 +74,10 @@ export class HealthConversationsAttachmentController {
     const buffer = Buffer.from(attachment.data)
     res.header('Content-Length', buffer.length.toString())
     res.header('Content-Type', attachment.contentType)
+    res.header(
+      'Content-Disposition',
+      `attachment; filename=${toSafeFileName(fileName, 'fylgiskjal')}`,
+    )
     res.header('Pragma', 'no-cache')
     res.header('Cache-Control', 'no-store, private, max-age=0')
     return res.status(200).end(buffer)

--- a/apps/download-service/src/app/utils/fileName.spec.ts
+++ b/apps/download-service/src/app/utils/fileName.spec.ts
@@ -1,0 +1,49 @@
+import { slugifyFileName, toSafeFileName } from './fileName'
+
+describe('slugifyFileName', () => {
+  it('slugifies Icelandic text to plain ASCII', () => {
+    expect(slugifyFileName('Ónæmisfræðideild', 'fallback')).toBe(
+      'onaemisfraedideild',
+    )
+  })
+
+  it('falls back when the name is empty', () => {
+    expect(slugifyFileName('', 'fylgiskjal')).toBe('fylgiskjal')
+  })
+
+  it('does not let a leading Þ get split by decamelization (TH != TH-)', () => {
+    expect(slugifyFileName('Þjóðskrá vottorð', 'fallback')).toBe(
+      'thjodskra-vottord',
+    )
+  })
+
+  it('maps ö to a single "o", not the German-style "oe" digraph', () => {
+    expect(slugifyFileName('Blóðprufa svör', 'fallback')).toBe('blodprufa-svor')
+  })
+})
+
+describe('toSafeFileName', () => {
+  it('preserves the original extension while slugifying the base name', () => {
+    expect(toSafeFileName('Þjóðskrárvottorð.pdf', 'fylgiskjal')).toBe(
+      'thjodskrarvottord.pdf',
+    )
+  })
+
+  it('preserves non-pdf extensions untouched', () => {
+    expect(toSafeFileName('mynd.jpg', 'fylgiskjal')).toBe('mynd.jpg')
+  })
+
+  it('falls back to the given default when fileName is undefined', () => {
+    expect(toSafeFileName(undefined, 'fylgiskjal')).toBe('fylgiskjal')
+  })
+
+  it('falls back to the given default when fileName is an empty string', () => {
+    expect(toSafeFileName('', 'fylgiskjal')).toBe('fylgiskjal')
+  })
+
+  it('does not mistake a dot in the middle of the base name for a missing extension', () => {
+    expect(toSafeFileName('v1.2 samantekt.pdf', 'fylgiskjal')).toBe(
+      'v1-2-samantekt.pdf',
+    )
+  })
+})

--- a/apps/download-service/src/app/utils/fileName.ts
+++ b/apps/download-service/src/app/utils/fileName.ts
@@ -1,0 +1,19 @@
+import slugify from '@sindresorhus/slugify'
+import { basename, extname } from 'path'
+
+const customReplacements: Array<[string, string]> = [
+  ['Þ', 'th'],
+  ['ö', 'o'],
+]
+
+export const slugifyFileName = (fileName: string, fallback: string) =>
+  slugify(fileName || fallback, { customReplacements })
+
+export const toSafeFileName = (
+  fileName: string | undefined,
+  fallback: string,
+) => {
+  const ext = fileName ? extname(fileName) : ''
+  const base = fileName ? basename(fileName, ext) : ''
+  return `${slugifyFileName(base, fallback)}${ext}`
+}

--- a/libs/api/domains/health-directorate/src/lib/health-directorate.service.ts
+++ b/libs/api/domains/health-directorate/src/lib/health-directorate.service.ts
@@ -752,7 +752,9 @@ export class HealthDirectorateService {
       id: String(a.id),
       fileName: a.fileName,
       description: a.description,
-      downloadServiceURL: `${this.downloadServiceConfig.baseUrl}/download/v1/health/conversations/${conversationId}/${messageId}/${a.id}`,
+      downloadServiceURL: `${this.downloadServiceConfig.baseUrl}/download/v1/health/conversations/${conversationId}/${messageId}/${a.id}?fileName=${encodeURIComponent(
+        a.fileName,
+      )}`,
     }
   }
 

--- a/libs/api/domains/health-directorate/src/lib/health-directorate.service.ts
+++ b/libs/api/domains/health-directorate/src/lib/health-directorate.service.ts
@@ -752,9 +752,11 @@ export class HealthDirectorateService {
       id: String(a.id),
       fileName: a.fileName,
       description: a.description,
-      downloadServiceURL: `${this.downloadServiceConfig.baseUrl}/download/v1/health/conversations/${conversationId}/${messageId}/${a.id}?fileName=${encodeURIComponent(
-        a.fileName,
-      )}`,
+      downloadServiceURL: `${
+        this.downloadServiceConfig.baseUrl
+      }/download/v1/health/conversations/${conversationId}/${messageId}/${
+        a.id
+      }?fileName=${encodeURIComponent(a.fileName)}`,
     }
   }
 


### PR DESCRIPTION
## What

Set the file name specifically so it doesn't default to api

## Why

Better for users so they save files with more specific file names

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Conversation attachment downloads now preserve the requested filename.
  * Downloaded document and attachment filenames are sanitized for safer, more consistent naming.
  * File extensions are preserved while filenames are normalized.

* **Bug Fixes**
  * Improved handling of Icelandic characters and fallback filenames.
  * Prevented malformed filename transformations involving dots and special characters.

* **Tests**
  * Added coverage for filename sanitization, slugification, extensions, fallbacks, and Icelandic text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->