### PR TITLE
fix(my-pages): Health attachments file name

### DIFF
--- a/apps/download-service/src/app/modules/health/conversations-attachment.controller.ts
+++ b/apps/download-service/src/app/modules/health/conversations-attachment.controller.ts
@@ -20,6 +20,13 @@ import {
 import { ApiOkResponse } from '@nestjs/swagger'
 import { Response } from 'express'
 
+const mimeTypeToExtension: Record<string, string> = {
+  'application/pdf': '.pdf',
+  'image/jpeg': '.jpg',
+  'image/png': '.png',
+  'image/heic': '.heic',
+}
+
 @UseGuards(IdsUserGuard, ScopesGuard)
 @Scopes(ApiScope.internal, ApiScope.health)
 @Controller('health/conversations')
@@ -71,6 +78,11 @@ export class HealthConversationsAttachmentController {
     const buffer = Buffer.from(attachment.data)
     res.header('Content-Length', buffer.length.toString())
     res.header('Content-Type', attachment.contentType)
+    const ext = mimeTypeToExtension[attachment.contentType] ?? ''
+    res.header(
+      'Content-Disposition',
+      `attachment; filename=fylgiskjal-${messageId}-${attachmentId}${ext}`,
+    )
     res.header('Pragma', 'no-cache')
     res.header('Cache-Control', 'no-store, private, max-age=0')
     return res.status(200).end(buffer)

--- a/apps/download-service/src/app/modules/health/conversations-attachment.controller.ts
+++ b/apps/download-service/src/app/modules/health/conversations-attachment.controller.ts
@@ -81,7 +81,7 @@ export class HealthConversationsAttachmentController {
     const ext = mimeTypeToExtension[attachment.contentType] ?? ''
     res.header(
       'Content-Disposition',
-      `attachment; filename=fylgiskjal-${messageId}-${attachmentId}${ext}`,
+      `attachment; filename=fylgiskjal-${attachmentId}${ext}`,
     )
     res.header('Pragma', 'no-cache')
     res.header('Cache-Control', 'no-store, private, max-age=0')

--- a/apps/download-service/src/app/modules/health/conversations-attachment.controller.ts
+++ b/apps/download-service/src/app/modules/health/conversations-attachment.controller.ts
@@ -20,13 +20,6 @@ import {
 import { ApiOkResponse } from '@nestjs/swagger'
 import { Response } from 'express'
 
-const mimeTypeToExtension: Record<string, string> = {
-  'application/pdf': '.pdf',
-  'image/jpeg': '.jpg',
-  'image/png': '.png',
-  'image/heic': '.heic',
-}
-
 @UseGuards(IdsUserGuard, ScopesGuard)
 @Scopes(ApiScope.internal, ApiScope.health)
 @Controller('health/conversations')
@@ -78,10 +71,9 @@ export class HealthConversationsAttachmentController {
     const buffer = Buffer.from(attachment.data)
     res.header('Content-Length', buffer.length.toString())
     res.header('Content-Type', attachment.contentType)
-    const ext = mimeTypeToExtension[attachment.contentType] ?? ''
     res.header(
       'Content-Disposition',
-      `attachment; filename=fylgiskjal-${attachmentId}${ext}`,
+      `attachment; filename=fylgiskjal-${attachmentId}.pdf`,
     )
     res.header('Pragma', 'no-cache')
     res.header('Cache-Control', 'no-store, private, max-age=0')

--- a/libs/clients/health-directorate/src/lib/clients/health/health.service.ts
+++ b/libs/clients/health-directorate/src/lib/clients/health/health.service.ts
@@ -704,7 +704,7 @@ export class HealthDirectorateHealthService {
     return {
       data: result.data as ArrayBuffer,
       contentType:
-        result.response.headers.get('content-type') ??
+        result.response.headers.get('content-type') ||
         'application/octet-stream',
     }
   }


### PR DESCRIPTION
## What

Add filenames to health attachments

## Why

So they get more unique names when downloaded

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude code 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Downloaded attachments now consistently use the `.pdf` filename extension.
  - Attachment downloads now use `application/octet-stream` when the server provides no content type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->