### PR TITLE
chore(j-s): Harden e2e assertions and deduplicate regression steps

### DIFF
--- a/apps/system-e2e/src/support/api-tools.ts
+++ b/apps/system-e2e/src/support/api-tools.ts
@@ -48,7 +48,15 @@ export async function verifyRequestCompletion(
     (resp) =>
       resp.url().includes(url) &&
       resp.request().postDataJSON().operationName === op,
+    { timeout: 15000 },
   )
 
-  return await response.json()
+  const body = await response.json()
+  if (body.errors?.length) {
+    throw new Error(
+      `GraphQL operation ${op} returned errors: ${body.errors[0].message}`,
+    )
+  }
+
+  return body
 }

--- a/apps/system-e2e/src/tests/judicial-system/regression/custody-tests.spec.ts
+++ b/apps/system-e2e/src/tests/judicial-system/regression/custody-tests.spec.ts
@@ -5,11 +5,11 @@ import { verifyRequestCompletion } from '../../../support/api-tools'
 import { test } from '../utils/judicialSystemTest'
 import {
   randomPoliceCaseNumber,
-  randomCourtCaseNumber,
   getDaysFromNow,
   chooseDocument,
   verifyUpload,
 } from '../utils/helpers'
+import { judgeSubmitsDecision } from './shared-steps/court-decision'
 import { judgeReceivesAppealTest } from './shared-steps/receive-appeal'
 import { prosecutorAppealsCaseTest } from './shared-steps/send-appeal'
 import { coaJudgesCompleteAppealCaseTest } from './shared-steps/complete-appeal'
@@ -154,79 +154,11 @@ test.describe.serial('Custody tests', () => {
   })
 
   test('court should submit decision in case', async ({ judgePage }) => {
-    const page = judgePage
-    await Promise.all([
-      page.goto(`/domur/mottaka/${caseId}`),
-      verifyRequestCompletion(page, '/api/graphql', 'Case'),
-    ])
-
-    // Reception and assignment
-    await expect(page).toHaveURL(`/domur/mottaka/${caseId}`)
-    await page.getByTestId('courtCaseNumber').fill(randomCourtCaseNumber())
-    await page.keyboard.press('Tab')
-    await page.getByText('Veldu dómara/aðstoðarmann').click()
-    await page
-      .getByTestId('select-judge')
-      .getByText('Test Dómari')
-      .last()
-      .click()
-    await Promise.all([
-      page.getByTestId('continueButton').click(),
-      verifyRequestCompletion(page, '/api/graphql', 'Case'),
-    ])
-
-    // Overview
-    await expect(page).toHaveURL(`/domur/krafa/${caseId}`)
-    await page.getByTestId('continueButton').isVisible()
-    await Promise.all([
-      page.getByTestId('continueButton').click(),
-      verifyRequestCompletion(page, '/api/graphql', 'Case'),
-    ])
-
-    // Hearing arrangements
-    await expect(page).toHaveURL(`/domur/fyrirtokutimi/${caseId}`)
-    await page.locator('input[id=courtDate]').fill(today)
-    await page.keyboard.press('Escape')
-    await page.locator('input[id=courtDate-time]').fill('09:00')
-    await page.keyboard.press('Tab')
-    await page.getByTestId('continueButton').click()
-    await Promise.all([
-      page.getByTestId('modalPrimaryButton').click(),
-      verifyRequestCompletion(page, '/api/graphql', 'Case'),
-    ])
-
-    // Ruling
-    await expect(page).toHaveURL(`/domur/urskurdur/${caseId}`)
-    await page.getByText('Krafa um gæsluvarðhald samþykkt').click()
-    await page.locator('input[id=validToDate]').fill(custodyEndDate)
-    await page.keyboard.press('Escape')
-    await page.locator('input[id=validToDate-time]').fill('16:00')
-    await page.keyboard.press('Tab')
-    await Promise.all([
-      page.getByTestId('continueButton').click(),
-      verifyRequestCompletion(page, '/api/graphql', 'Case'),
-    ])
-
-    // Court record
-    await expect(page).toHaveURL(`/domur/thingbok/${caseId}`)
-    await page.getByText('Varnaraðili tekur sér lögboðinn frest').click()
-    await page.getByText('Sækjandi tekur sér lögboðinn frest').click()
-    await page.locator('input[id=courtEndTime]').fill(today)
-    await page.keyboard.press('Escape')
-    await page.locator('input[id=courtEndTime-time]').fill('10:00')
-    await page.keyboard.press('Tab')
-    await Promise.all([
-      page.getByTestId('continueButton').click(),
-      verifyRequestCompletion(page, '/api/graphql', 'Case'),
-    ])
-
-    // Confirmation
-    await expect(page).toHaveURL(`/domur/stadfesta/${caseId}`)
-    await Promise.all([
-      page.getByTestId('continueButton').click(),
-      verifyRequestCompletion(page, '/api/graphql', 'TransitionCase'),
-    ])
-    await page.getByTestId('modalSecondaryButton').click()
+    await judgeSubmitsDecision(judgePage, caseId, {
+      acceptRulingText: 'Krafa um gæsluvarðhald samþykkt',
+      validToDate: custodyEndDate,
+      dismissSignatureModal: true,
+    })
   })
 
   test('judge should amend case', async ({ judgePage }) => {

--- a/apps/system-e2e/src/tests/judicial-system/regression/indictment-tests.spec.ts
+++ b/apps/system-e2e/src/tests/judicial-system/regression/indictment-tests.spec.ts
@@ -3,12 +3,12 @@ import faker from 'faker'
 import { urls } from '../../../support/urls'
 import { verifyRequestCompletion } from '../../../support/api-tools'
 import { test } from '../utils/judicialSystemTest'
+import { getDaysFromNow, chooseDocument } from '../utils/helpers'
 import {
-  randomPoliceCaseNumber,
-  getDaysFromNow,
-  randomIndictmentCourtCaseNumber,
-  chooseDocument,
-} from '../utils/helpers'
+  prosecutorCreatesIndictmentCase,
+  prosecutorSendsIndictmentToCourt,
+  judgeReceivesIndictmentThroughAdvocates,
+} from './shared-steps/indictment-to-court-record'
 
 test.use({ baseURL: urls.judicialSystemBaseUrl })
 
@@ -19,226 +19,22 @@ test.describe.serial('Indictment tests', () => {
   test('prosecutor should create a new indictment case', async ({
     prosecutorPage,
   }) => {
-    const page = prosecutorPage
-    const today = getDaysFromNow()
-
-    const policeCaseNumber = randomPoliceCaseNumber()
-
-    // Case list groups
-    await page.goto('/malalistar')
-    await expect(page).toHaveURL('/malalistar')
-    await page.getByRole('button', { name: 'Nýtt mál' }).click()
-    await page.getByRole('menuitem', { name: 'Ákæra' }).click()
-    await expect(page).toHaveURL('/akaera/ny')
-
-    // New indictment case
-    await page.getByTestId('policeCaseNumber0').click()
-    await page.getByTestId('policeCaseNumber0').fill(policeCaseNumber)
-
-    await page.getByText('Sakarefni *Veldu sakarefni').click()
-    await page.getByRole('option', { name: 'Umferðarlagabrot' }).click()
-    await page.getByPlaceholder('Sláðu inn vettvang').click()
-    await page.getByPlaceholder('Sláðu inn vettvang').fill('Reykjavík')
-    await page
-      .locator(`input[id=crime-scene-date-${policeCaseNumber}]`)
-      .fill(today)
-    await page.keyboard.press('Escape')
-    const nationalIdInput = page.getByTestId('inputNationalId')
-    const nameInput = page.getByTestId('inputName')
-
-    await Promise.all([
-      page.waitForResponse(
-        (resp) =>
-          resp.url().includes('/api/nationalRegistry/getPersonByNationalId') &&
-          resp.request().method() === 'GET',
-      ),
-      nationalIdInput.fill('000000-0000'),
-    ])
-
-    await nameInput.fill(accusedName)
-    await nameInput.press('Tab')
-    await expect(nameInput).toHaveValue(accusedName)
-    await Promise.all([
-      page.getByRole('button', { name: 'Stofna mál' }).click(),
-      verifyRequestCompletion(page, '/api/graphql', 'CreateCase').then(
-        (res) => (caseId = res.data.createCase.id),
-      ),
-      verifyRequestCompletion(page, '/api/graphql', 'Case'),
-    ])
-
-    // Police case files (Málsgögn)
-    await expect(page).toHaveURL(`/akaera/malsgogn/${caseId}`)
-    await Promise.all([
-      page.getByTestId('continueButton').click(),
-      verifyRequestCompletion(page, '/api/graphql', 'Case'),
-    ])
-
-    // Case file
-    await expect(page).toHaveURL(`/akaera/skjalaskra/${caseId}`)
-    await Promise.all([
-      page.getByTestId('continueButton').click(),
-      verifyRequestCompletion(page, '/api/graphql', 'Case'),
-    ])
-
-    // Case files
-    await expect(page).toHaveURL(`/akaera/domskjol/${caseId}`)
-    await Promise.all([
-      page.getByTestId('continueButton').click(),
-      verifyRequestCompletion(page, '/api/graphql', 'Case'),
-      verifyRequestCompletion(page, '/api/graphql', 'UpdateCase'),
-    ])
-
-    // Processing
-    await expect(page).toHaveURL(`/akaera/malsmedferd/${caseId}`)
-
-    await Promise.all([
-      page.getByText('Játar sök').click(),
-      verifyRequestCompletion(page, '/api/graphql', 'UpdateDefendant'),
-    ])
-
-    await Promise.all([
-      page.getByText('Nei').last().click(),
-      verifyRequestCompletion(page, '/api/graphql', 'UpdateCase'),
-    ])
-
-    await Promise.all([
-      page.getByTestId('continueButton').click(),
-      verifyRequestCompletion(page, '/api/graphql', 'Case'),
-    ])
-
-    // Indictment
-    // The auto-created indictment count is expanded by default (open state is
-    // persisted in local storage), so no "Opna alla" toggle is needed.
-
-    await page.getByPlaceholder('AB123').fill('AB123')
-
-    await Promise.all([
-      page.keyboard.press('Tab'),
-      verifyRequestCompletion(page, '/api/graphql', 'UpdateIndictmentCount'),
-    ])
-
-    await Promise.all([
-      page.getByText('Brot *Veldu brot').click(),
-      page.getByRole('option', { name: 'Sviptingarakstur' }).click(),
-      verifyRequestCompletion(page, '/api/graphql', 'UpdateIndictmentCount'),
-    ])
-
-    await Promise.all([
-      page.getByLabel('Krefjast sviptingarKrefjast').check(),
-      verifyRequestCompletion(page, '/api/graphql', 'UpdateCase'),
-    ])
-
-    await Promise.all([
-      page.getByTestId('continueButton').click(),
-      verifyRequestCompletion(page, '/api/graphql', 'Case'),
-    ])
-
-    // Overview
-    await expect(page).toHaveURL(`/akaera/stadfesta/${caseId}`)
-
-    await Promise.all([
-      page.getByTestId('continueButton').click(),
-      verifyRequestCompletion(page, '/api/graphql', 'TransitionCase'),
-    ])
-    await page.getByTestId('modalPrimaryButton').click()
+    caseId = await prosecutorCreatesIndictmentCase(prosecutorPage, accusedName)
   })
 
   test('prosecutor should accept and send indictment case to court', async ({
     prosecutorPage,
   }) => {
-    const page = prosecutorPage
-
-    // Case list
-    await page.goto('/malalistar/sakamal-sem-bida-stadfestingar')
-    await expect(page).toHaveURL('/malalistar/sakamal-sem-bida-stadfestingar')
-    await page.getByText(accusedName).click()
-
-    // Indictment case
-    await expect(page).toHaveURL(`/akaera/stadfesta/${caseId}`)
-
-    await page.getByText('Staðfesta ákæru og senda á dómstól').click()
-    await page.getByTestId('continueButton').click()
-
-    await Promise.all([
-      page.getByTestId('modalPrimaryButton').click(),
-      verifyRequestCompletion(page, '/api/graphql', 'TransitionCase'),
-    ])
+    await prosecutorSendsIndictmentToCourt(prosecutorPage, caseId, accusedName)
   })
 
   test('judge should receive indictment case', async ({ judgePage }) => {
     const page = judgePage
-    const nextWeek = getDaysFromNow(7)
 
-    // Case list
-    await page.goto('/malalistar/sakamal-sem-bida-uthlutunar')
-    await expect(page).toHaveURL('/malalistar/sakamal-sem-bida-uthlutunar')
-    await page.getByText(accusedName).click()
-
-    // Indictment Overview
-    await expect(page).toHaveURL(`domur/akaera/yfirlit/${caseId}`)
-
-    await Promise.all([
-      page.getByTestId('continueButton').click(),
-      verifyRequestCompletion(page, '/api/graphql', 'Case'),
-    ])
-
-    // Reception and assignment
-    await expect(page).toHaveURL(`domur/akaera/mottaka/${caseId}`)
-
-    await page
-      .getByTestId('courtCaseNumber')
-      .fill(randomIndictmentCourtCaseNumber())
-    await page.keyboard.press('Tab')
-
-    await page.getByText('Veldu dómara/aðstoðarmann').click()
-    await page
-      .getByTestId('select-judge')
-      .getByText('Test Dómari')
-      .last()
-      .click()
-
-    await Promise.all([
-      page.getByTestId('continueButton').click(),
-      verifyRequestCompletion(page, '/api/graphql', 'Case'),
-    ])
-
-    // Subpoena
-    await expect(page).toHaveURL(`domur/akaera/fyrirkall/${caseId}`)
-
-    await page
-      .locator('label')
-      .filter({ hasText: 'Útivistarfyrirkall' })
-      .click()
-
-    await page.locator('input[id=courtDate]').fill(nextWeek)
-    await page.keyboard.press('Escape')
-
-    await page.getByTestId('courtDate-time').fill('11:00')
-    await page.getByTestId('courtroom').press('Tab')
-
-    await page.getByTestId('courtroom').fill('12')
-    await page.getByTestId('courtroom').press('Tab')
-
-    await page.getByTestId('continueButton').click()
-    await page.getByTestId('modalPrimaryButton').click()
-
-    // Advocates and civil claimants
-    await expect(page).toHaveURL(`domur/akaera/malflytjendur/${caseId}`)
-
-    await page
-      .locator('label')
-      .filter({ hasText: 'Ákærði óskar ekki eftir að sé' })
-      .click()
-    await page.getByRole('button', { name: 'Staðfesta val' }).click()
-    await page.getByTestId('modalPrimaryButton').click()
-
-    await Promise.all([
-      page.getByTestId('continueButton').click(),
-      verifyRequestCompletion(page, '/api/graphql', 'Case'),
-    ])
+    // Case list through subpoena, advocates and on to the court record
+    await judgeReceivesIndictmentThroughAdvocates(page, caseId, accusedName)
 
     // Indictment court record
-    await expect(page).toHaveURL(`domur/akaera/thingbok/${caseId}`)
     await Promise.all([
       page.getByRole('button', { name: 'Bæta við þinghaldi' }).click(),
       verifyRequestCompletion(page, '/api/graphql', 'CreateCourtSession'),

--- a/apps/system-e2e/src/tests/judicial-system/regression/shared-steps/court-decision.ts
+++ b/apps/system-e2e/src/tests/judicial-system/regression/shared-steps/court-decision.ts
@@ -1,0 +1,90 @@
+import { expect, Page } from '@playwright/test'
+import { verifyRequestCompletion } from '../../../../support/api-tools'
+import { getDaysFromNow, randomCourtCaseNumber } from '../../utils/helpers'
+
+export const judgeSubmitsDecision = async (
+  page: Page,
+  caseId: string,
+  options: {
+    acceptRulingText: string
+    validToDate: string
+    // The confirmation step may open the signing-method modal, which the
+    // custody flow dismisses without signing. E-signing is not exercised
+    // by these tests.
+    dismissSignatureModal?: boolean
+  },
+) => {
+  const today = getDaysFromNow()
+
+  await Promise.all([
+    page.goto(`/domur/mottaka/${caseId}`),
+    verifyRequestCompletion(page, '/api/graphql', 'Case'),
+  ])
+
+  // Reception and assignment
+  await expect(page).toHaveURL(`/domur/mottaka/${caseId}`)
+  await page.getByTestId('courtCaseNumber').fill(randomCourtCaseNumber())
+  await page.keyboard.press('Tab')
+  await page.getByText('Veldu dómara/aðstoðarmann').click()
+  await page.getByTestId('select-judge').getByText('Test Dómari').last().click()
+  await Promise.all([
+    page.getByTestId('continueButton').click(),
+    verifyRequestCompletion(page, '/api/graphql', 'Case'),
+  ])
+
+  // Overview
+  await expect(page).toHaveURL(`/domur/krafa/${caseId}`)
+  await expect(page.getByTestId('continueButton')).toBeVisible()
+  await Promise.all([
+    page.getByTestId('continueButton').click(),
+    verifyRequestCompletion(page, '/api/graphql', 'Case'),
+  ])
+
+  // Hearing arrangements
+  await expect(page).toHaveURL(`/domur/fyrirtokutimi/${caseId}`)
+  await page.locator('input[id=courtDate]').fill(today)
+  await page.keyboard.press('Escape')
+  await page.locator('input[id=courtDate-time]').fill('09:00')
+  await page.keyboard.press('Tab')
+  await page.getByTestId('continueButton').click()
+  await Promise.all([
+    page.getByTestId('modalPrimaryButton').click(),
+    verifyRequestCompletion(page, '/api/graphql', 'Case'),
+  ])
+
+  // Ruling
+  await expect(page).toHaveURL(`/domur/urskurdur/${caseId}`)
+  await page.getByText(options.acceptRulingText).click()
+  await page.locator('input[id=validToDate]').fill(options.validToDate)
+  await page.keyboard.press('Escape')
+  await page.locator('input[id=validToDate-time]').fill('16:00')
+  await page.keyboard.press('Tab')
+  await Promise.all([
+    page.getByTestId('continueButton').click(),
+    verifyRequestCompletion(page, '/api/graphql', 'Case'),
+  ])
+
+  // Court record
+  await expect(page).toHaveURL(`/domur/thingbok/${caseId}`)
+  await page.getByText('Varnaraðili tekur sér lögboðinn frest').click()
+  await page.getByText('Sækjandi tekur sér lögboðinn frest').click()
+  await page.locator('input[id=courtEndTime]').fill(today)
+  await page.keyboard.press('Escape')
+  await page.locator('input[id=courtEndTime-time]').fill('10:00')
+  await page.keyboard.press('Tab')
+  await Promise.all([
+    page.getByTestId('continueButton').click(),
+    verifyRequestCompletion(page, '/api/graphql', 'Case'),
+  ])
+
+  // Confirmation
+  await expect(page).toHaveURL(`/domur/stadfesta/${caseId}`)
+  await Promise.all([
+    page.getByTestId('continueButton').click(),
+    verifyRequestCompletion(page, '/api/graphql', 'TransitionCase'),
+  ])
+
+  if (options.dismissSignatureModal) {
+    await page.getByTestId('modalSecondaryButton').click()
+  }
+}

--- a/apps/system-e2e/src/tests/judicial-system/regression/shared-steps/indictment-to-court-record.ts
+++ b/apps/system-e2e/src/tests/judicial-system/regression/shared-steps/indictment-to-court-record.ts
@@ -91,6 +91,8 @@ export const prosecutorCreatesIndictmentCase = async (
     page.getByTestId('continueButton').click(),
   ])
 
+  // The auto-created indictment count is expanded by default (open state is
+  // persisted in local storage), so no "Opna alla" toggle is needed.
   await page.getByPlaceholder('AB123').fill('AB123')
 
   await Promise.all([

--- a/apps/system-e2e/src/tests/judicial-system/regression/shared-steps/receive-appeal.ts
+++ b/apps/system-e2e/src/tests/judicial-system/regression/shared-steps/receive-appeal.ts
@@ -1,4 +1,4 @@
-import { Page } from '@playwright/test'
+import { expect, Page } from '@playwright/test'
 import { verifyRequestCompletion } from '../../../../support/api-tools'
 
 export const judgeReceivesAppealTest = async (page: Page, caseId: string) => {
@@ -6,10 +6,11 @@ export const judgeReceivesAppealTest = async (page: Page, caseId: string) => {
     page.goto(`krafa/yfirlit/${caseId}`),
     verifyRequestCompletion(page, '/api/graphql', 'Case'),
   ])
-  await page
-    .getByRole('button', {
-      name: 'Senda tilkynningu um kæru til Landsréttar',
-    })
-    .click()
+  const sendNotificationButton = page.getByRole('button', {
+    name: 'Senda tilkynningu um kæru til Landsréttar',
+  })
+  await expect(sendNotificationButton).toBeVisible()
+  await sendNotificationButton.click()
   await page.getByTestId('modalPrimaryButton').click()
+  await expect(page.getByText('Tilkynning um móttöku send')).toBeVisible()
 }

--- a/apps/system-e2e/src/tests/judicial-system/regression/travel-ban-tests.spec.ts
+++ b/apps/system-e2e/src/tests/judicial-system/regression/travel-ban-tests.spec.ts
@@ -2,7 +2,8 @@ import { expect } from '@playwright/test'
 import { urls } from '../../../support/urls'
 import { test } from '../utils/judicialSystemTest'
 import { verifyRequestCompletion } from '../../../support/api-tools'
-import { getDaysFromNow, randomCourtCaseNumber } from '../utils/helpers'
+import { getDaysFromNow, randomPoliceCaseNumber } from '../utils/helpers'
+import { judgeSubmitsDecision } from './shared-steps/court-decision'
 import { prosecutorAppealsCaseTest } from './shared-steps/send-appeal'
 import { judgeReceivesAppealTest } from './shared-steps/receive-appeal'
 import { coaJudgesCompleteAppealCaseTest } from './shared-steps/complete-appeal'
@@ -29,7 +30,7 @@ test.describe.serial('Travel ban tests', () => {
       .getByRole('textbox', {
         name: 'Sláðu inn málsnúmer úr lögreglukerfi (LÖKE)',
       })
-      .fill('123-1231-23123')
+      .fill(randomPoliceCaseNumber())
     await page.getByRole('button', { name: 'Skrá númer' }).click()
     await page
       .getByRole('checkbox', {
@@ -108,78 +109,10 @@ test.describe.serial('Travel ban tests', () => {
   test('court should submit decision on travel ban case', async ({
     judgePage,
   }) => {
-    const page = judgePage
-    await Promise.all([
-      page.goto(`/domur/mottaka/${caseId}`),
-      verifyRequestCompletion(page, '/api/graphql', 'Case'),
-    ])
-
-    // Reception and assignment
-    await expect(page).toHaveURL(`/domur/mottaka/${caseId}`)
-    await page.getByTestId('courtCaseNumber').fill(randomCourtCaseNumber())
-    await page.keyboard.press('Tab')
-    await page.getByText('Veldu dómara/aðstoðarmann').click()
-    await page
-      .getByTestId('select-judge')
-      .getByText('Test Dómari')
-      .last()
-      .click()
-    await Promise.all([
-      page.getByTestId('continueButton').click(),
-      verifyRequestCompletion(page, '/api/graphql', 'Case'),
-    ])
-
-    // Overview
-    await expect(page).toHaveURL(`/domur/krafa/${caseId}`)
-    await page.getByTestId('continueButton').isVisible()
-    await Promise.all([
-      page.getByTestId('continueButton').click(),
-      verifyRequestCompletion(page, '/api/graphql', 'Case'),
-    ])
-
-    // Hearing arrangements
-    await expect(page).toHaveURL(`/domur/fyrirtokutimi/${caseId}`)
-    await page.locator('input[id=courtDate]').fill(today)
-    await page.keyboard.press('Escape')
-    await page.locator('input[id=courtDate-time]').fill('09:00')
-    await page.keyboard.press('Tab')
-    await page.getByTestId('continueButton').click()
-    await Promise.all([
-      page.getByTestId('modalPrimaryButton').click(),
-      verifyRequestCompletion(page, '/api/graphql', 'Case'),
-    ])
-
-    // Ruling
-    await expect(page).toHaveURL(`/domur/urskurdur/${caseId}`)
-    await page.getByText('Krafa um farbann samþykkt').click()
-    await page.locator('input[id=validToDate]').fill(travelBanEndDate)
-    await page.keyboard.press('Escape')
-    await page.locator('input[id=validToDate-time]').fill('16:00')
-    await page.keyboard.press('Tab')
-    await Promise.all([
-      page.getByTestId('continueButton').click(),
-      verifyRequestCompletion(page, '/api/graphql', 'Case'),
-    ])
-
-    // Court record
-    await expect(page).toHaveURL(`/domur/thingbok/${caseId}`)
-    await page.getByText('Varnaraðili tekur sér lögboðinn frest').click()
-    await page.getByText('Sækjandi tekur sér lögboðinn frest').click()
-    await page.locator('input[id=courtEndTime]').fill(today)
-    await page.keyboard.press('Escape')
-    await page.locator('input[id=courtEndTime-time]').fill('10:00')
-    await page.keyboard.press('Tab')
-    await Promise.all([
-      page.getByTestId('continueButton').click(),
-      verifyRequestCompletion(page, '/api/graphql', 'Case'),
-    ])
-
-    // Confirmation
-    await expect(page).toHaveURL(`/domur/stadfesta/${caseId}`)
-    await Promise.all([
-      page.getByTestId('continueButton').click(),
-      verifyRequestCompletion(page, '/api/graphql', 'TransitionCase'),
-    ])
+    await judgeSubmitsDecision(judgePage, caseId, {
+      acceptRulingText: 'Krafa um farbann samþykkt',
+      validToDate: travelBanEndDate,
+    })
   })
 
   test('prosecutor should appeal case', async ({ prosecutorPage }) => {

--- a/apps/system-e2e/src/tests/judicial-system/smoke/case-list.spec.ts
+++ b/apps/system-e2e/src/tests/judicial-system/smoke/case-list.spec.ts
@@ -19,6 +19,6 @@ test.describe('Case list test', () => {
     const page = await context.newPage()
     await page.goto('/malalistar')
     await expect(page).toHaveURL('/malalistar')
-    await page.getByRole('button', { name: 'Nýtt mál' }).isVisible()
+    await expect(page.getByRole('button', { name: 'Nýtt mál' })).toBeVisible()
   })
 })

--- a/apps/system-e2e/src/tests/judicial-system/utils/helpers.ts
+++ b/apps/system-e2e/src/tests/judicial-system/utils/helpers.ts
@@ -5,9 +5,12 @@ export const randomPoliceCaseNumber = () => {
   return `007-${new Date().getFullYear()}-${Math.floor(Math.random() * 100000)}`
 }
 
+// The app validates R-/S- case numbers as 1-5 digits and appeal case
+// numbers as 1-4 digits, so these draw from the full allowed space to
+// minimize collisions with cases left behind by previous runs.
 export const randomCourtCaseNumber = (prefix?: string) => {
   return `${prefix ?? 'R'}-${Math.floor(
-    Math.random() * 1000,
+    Math.random() * 100000,
   )}/${new Date().getFullYear()}`
 }
 
@@ -16,7 +19,7 @@ export const randomIndictmentCourtCaseNumber = () => {
 }
 
 export const randomAppealCaseNumber = () => {
-  return `${Math.floor(Math.random() * 1000)}/${new Date().getFullYear()}`
+  return `${Math.floor(Math.random() * 10000)}/${new Date().getFullYear()}`
 }
 
 export const getDaysFromNow = (days = 0) => {
@@ -45,7 +48,6 @@ export const chooseDocument = async (
   await clickButton()
 
   const fileChooser = await fileChooserPromise
-  await page.waitForTimeout(1000)
   await fileChooser.setFiles(createFakePdf(fileName))
 }
 


### PR DESCRIPTION
## What

Cleanup pass over the judicial-system Playwright suite in `apps/system-e2e`:

- **Fixed dead assertions**: bare `.isVisible()` calls (whose return value was discarded) in the smoke case-list spec and the custody/travel-ban court-decision tests are now real `expect(...).toBeVisible()` assertions, and the `judgeReceivesAppealTest` shared step (previously zero assertions) now verifies the notification button is visible and that the banner shows "Tilkynning um móttöku send" after the transition.
- **Hardened `verifyRequestCompletion`**: added a 15s timeout (aligned with the suite's action timeout) so a missing GraphQL operation fails fast instead of eating the 90s test timeout, and it now throws a descriptive error when the response body contains GraphQL `errors` instead of silently passing them through. All call sites only consume `.data`, so no call-site changes were needed.
- **Deduplicated regression steps**:
  - `indictment-tests.spec.ts` tests 1–3 were near-verbatim copies of the functions in `shared-steps/indictment-to-court-record.ts` (already used by the ruling-order-appeal specs) — the spec now consumes those shared steps directly.
  - The custody and travel-ban "court submits decision" tests were ~90% identical; extracted into a new `shared-steps/court-decision.ts` (`judgeSubmitsDecision`), parameterized by ruling text, valid-to date, and signature-modal dismissal.
- **Reduced collision risk in generated test data**: `randomCourtCaseNumber` now draws from the full 5-digit space the app's validation allows (100,000 values instead of 1,000) and `randomAppealCaseNumber` from the full 4-digit space; the travel-ban spec no longer reuses a hardcoded police case number on every run.
- **Removed the unconditional `waitForTimeout(1000)`** in `chooseDocument` that ran on every file upload — the file chooser event has already fired at that point, and callers still verify uploads via the GraphQL assertions in `verifyUpload`.

Net: −236 lines, no behavior changes to what the tests exercise.

## Why

These tests silently passed on failures they were meant to catch (discarded visibility checks, GraphQL error responses treated as success), duplicated steps had already drifted between the indictment and ruling-order-appeal suites, and the small case-number spaces caused avoidable collisions against environments that accumulate cases across runs.

## Screenshots / Gifs
Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code
- [ ] No AI tools were used in preparing this pull request

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation of GraphQL responses, with clearer errors when requests fail.
  - Strengthened appeal receipt checks by confirming notifications appear at each step.
  - Improved smoke-test validation for creating new cases.

- **Test Improvements**
  - Streamlined judicial case, indictment, custody, travel-ban, and court-decision workflows using shared test steps.
  - Increased test reliability with randomized case numbers and faster document selection.
  - Added coverage for complete judge decision submission and confirmation flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->