### PR TITLE
chore(j-s): Add e2e tests for fine, merge and completing-for-some conclusions

### DIFF
--- a/apps/system-e2e/src/support/api-tools.ts
+++ b/apps/system-e2e/src/support/api-tools.ts
@@ -48,7 +48,15 @@ export async function verifyRequestCompletion(
     (resp) =>
       resp.url().includes(url) &&
       resp.request().postDataJSON().operationName === op,
+    { timeout: 15000 },
   )
 
-  return await response.json()
+  const body = await response.json()
+  if (body.errors?.length) {
+    throw new Error(
+      `GraphQL operation ${op} returned errors: ${body.errors[0].message}`,
+    )
+  }
+
+  return body
 }

--- a/apps/system-e2e/src/tests/judicial-system/regression/custody-tests.spec.ts
+++ b/apps/system-e2e/src/tests/judicial-system/regression/custody-tests.spec.ts
@@ -5,11 +5,11 @@ import { verifyRequestCompletion } from '../../../support/api-tools'
 import { test } from '../utils/judicialSystemTest'
 import {
   randomPoliceCaseNumber,
-  randomCourtCaseNumber,
   getDaysFromNow,
   chooseDocument,
   verifyUpload,
 } from '../utils/helpers'
+import { judgeSubmitsDecision } from './shared-steps/court-decision'
 import { judgeReceivesAppealTest } from './shared-steps/receive-appeal'
 import { prosecutorAppealsCaseTest } from './shared-steps/send-appeal'
 import { coaJudgesCompleteAppealCaseTest } from './shared-steps/complete-appeal'
@@ -154,79 +154,11 @@ test.describe.serial('Custody tests', () => {
   })
 
   test('court should submit decision in case', async ({ judgePage }) => {
-    const page = judgePage
-    await Promise.all([
-      page.goto(`/domur/mottaka/${caseId}`),
-      verifyRequestCompletion(page, '/api/graphql', 'Case'),
-    ])
-
-    // Reception and assignment
-    await expect(page).toHaveURL(`/domur/mottaka/${caseId}`)
-    await page.getByTestId('courtCaseNumber').fill(randomCourtCaseNumber())
-    await page.keyboard.press('Tab')
-    await page.getByText('Veldu dómara/aðstoðarmann').click()
-    await page
-      .getByTestId('select-judge')
-      .getByText('Test Dómari')
-      .last()
-      .click()
-    await Promise.all([
-      page.getByTestId('continueButton').click(),
-      verifyRequestCompletion(page, '/api/graphql', 'Case'),
-    ])
-
-    // Overview
-    await expect(page).toHaveURL(`/domur/krafa/${caseId}`)
-    await page.getByTestId('continueButton').isVisible()
-    await Promise.all([
-      page.getByTestId('continueButton').click(),
-      verifyRequestCompletion(page, '/api/graphql', 'Case'),
-    ])
-
-    // Hearing arrangements
-    await expect(page).toHaveURL(`/domur/fyrirtokutimi/${caseId}`)
-    await page.locator('input[id=courtDate]').fill(today)
-    await page.keyboard.press('Escape')
-    await page.locator('input[id=courtDate-time]').fill('09:00')
-    await page.keyboard.press('Tab')
-    await page.getByTestId('continueButton').click()
-    await Promise.all([
-      page.getByTestId('modalPrimaryButton').click(),
-      verifyRequestCompletion(page, '/api/graphql', 'Case'),
-    ])
-
-    // Ruling
-    await expect(page).toHaveURL(`/domur/urskurdur/${caseId}`)
-    await page.getByText('Krafa um gæsluvarðhald samþykkt').click()
-    await page.locator('input[id=validToDate]').fill(custodyEndDate)
-    await page.keyboard.press('Escape')
-    await page.locator('input[id=validToDate-time]').fill('16:00')
-    await page.keyboard.press('Tab')
-    await Promise.all([
-      page.getByTestId('continueButton').click(),
-      verifyRequestCompletion(page, '/api/graphql', 'Case'),
-    ])
-
-    // Court record
-    await expect(page).toHaveURL(`/domur/thingbok/${caseId}`)
-    await page.getByText('Varnaraðili tekur sér lögboðinn frest').click()
-    await page.getByText('Sækjandi tekur sér lögboðinn frest').click()
-    await page.locator('input[id=courtEndTime]').fill(today)
-    await page.keyboard.press('Escape')
-    await page.locator('input[id=courtEndTime-time]').fill('10:00')
-    await page.keyboard.press('Tab')
-    await Promise.all([
-      page.getByTestId('continueButton').click(),
-      verifyRequestCompletion(page, '/api/graphql', 'Case'),
-    ])
-
-    // Confirmation
-    await expect(page).toHaveURL(`/domur/stadfesta/${caseId}`)
-    await Promise.all([
-      page.getByTestId('continueButton').click(),
-      verifyRequestCompletion(page, '/api/graphql', 'TransitionCase'),
-    ])
-    await page.getByTestId('modalSecondaryButton').click()
+    await judgeSubmitsDecision(judgePage, caseId, {
+      acceptRulingText: 'Krafa um gæsluvarðhald samþykkt',
+      validToDate: custodyEndDate,
+      dismissSignatureModal: true,
+    })
   })
 
   test('judge should amend case', async ({ judgePage }) => {

--- a/apps/system-e2e/src/tests/judicial-system/regression/indictment-completing-for-some-tests.spec.ts
+++ b/apps/system-e2e/src/tests/judicial-system/regression/indictment-completing-for-some-tests.spec.ts
@@ -1,0 +1,82 @@
+import { expect } from '@playwright/test'
+import faker from 'faker'
+import { urls } from '../../../support/urls'
+import { verifyRequestCompletion } from '../../../support/api-tools'
+import { test } from '../utils/judicialSystemTest'
+import {
+  prosecutorCreatesIndictmentCase,
+  prosecutorSendsIndictmentToCourt,
+  judgeReceivesIndictmentThroughAdvocates,
+} from './shared-steps/indictment-to-court-record'
+
+test.use({ baseURL: urls.judicialSystemBaseUrl })
+
+test.describe.serial('Indictment completing for some tests', () => {
+  let caseId = ''
+  const accusedName = faker.name.findName()
+  const secondAccusedName = faker.name.findName()
+
+  test('prosecutor should create a new indictment case with two defendants', async ({
+    prosecutorPage,
+  }) => {
+    caseId = await prosecutorCreatesIndictmentCase(
+      prosecutorPage,
+      accusedName,
+      secondAccusedName,
+    )
+  })
+
+  test('prosecutor should accept and send indictment case to court', async ({
+    prosecutorPage,
+  }) => {
+    await prosecutorSendsIndictmentToCourt(prosecutorPage, caseId, accusedName)
+  })
+
+  test('judge should complete the case for one of two defendants', async ({
+    judgePage,
+  }) => {
+    const page = judgePage
+
+    // Case list through subpoena, advocates and on to the court record
+    await judgeReceivesIndictmentThroughAdvocates(page, caseId, accusedName)
+
+    // Conclusion - completing for some does not require a court record
+    await Promise.all([
+      page.goto(`/domur/akaera/stada-og-lyktir/${caseId}`),
+      verifyRequestCompletion(page, '/api/graphql', 'Case'),
+    ])
+
+    await page
+      .locator('label')
+      .filter({ hasText: 'Skrá lyktir á einstaka aðila án þess að ljúka máli' })
+      .click()
+
+    // A conclusion can be registered for all but one defendant -
+    // cancel the indictment against the first defendant
+    await page.getByText('Veldu lyktir ef á við').first().click()
+    await page.getByRole('option', { name: 'Niðurfelling máls' }).click()
+
+    await page.getByTestId('continueButton').click()
+
+    // Conclusion date modal - the date is prefilled with today
+    await expect(
+      page.getByText('Skrá lyktir á aðila án þess að ljúka máli'),
+    ).toBeVisible()
+    await page.getByTestId('modalPrimaryButton').click()
+
+    // Confirmation modal - wait for the first modal to unmount so only
+    // one modal button remains
+    await expect(page.getByText('Viltu staðfesta lyktir?')).toBeVisible()
+    await expect(
+      page.getByText('Lyktir verða skráðar á valda aðila.'),
+    ).toHaveCount(0)
+    await Promise.all([
+      page.getByTestId('modalPrimaryButton').click(),
+      verifyRequestCompletion(page, '/api/graphql', 'UpdateCase'),
+    ])
+
+    // The case is not completed - it remains active for the other defendant
+    await expect(page).toHaveURL(`domur/akaera/yfirlit/${caseId}`)
+    await expect(page.getByText('Niðurfellt').first()).toBeVisible()
+  })
+})

--- a/apps/system-e2e/src/tests/judicial-system/regression/indictment-fine-tests.spec.ts
+++ b/apps/system-e2e/src/tests/judicial-system/regression/indictment-fine-tests.spec.ts
@@ -1,0 +1,94 @@
+import { expect } from '@playwright/test'
+import faker from 'faker'
+import { urls } from '../../../support/urls'
+import { verifyRequestCompletion } from '../../../support/api-tools'
+import { test } from '../utils/judicialSystemTest'
+import {
+  prosecutorCreatesIndictmentCase,
+  prosecutorSendsIndictmentToCourt,
+  judgeReceivesIndictmentThroughAdvocates,
+} from './shared-steps/indictment-to-court-record'
+
+test.use({ baseURL: urls.judicialSystemBaseUrl })
+
+test.describe.serial('Indictment fine tests', () => {
+  let caseId = ''
+  const accusedName = faker.name.findName()
+
+  test('prosecutor should create a new indictment case', async ({
+    prosecutorPage,
+  }) => {
+    caseId = await prosecutorCreatesIndictmentCase(prosecutorPage, accusedName)
+  })
+
+  test('prosecutor should accept and send indictment case to court', async ({
+    prosecutorPage,
+  }) => {
+    await prosecutorSendsIndictmentToCourt(prosecutorPage, caseId, accusedName)
+  })
+
+  test('judge should complete indictment case with a fine', async ({
+    judgePage,
+  }) => {
+    const page = judgePage
+
+    // Case list through subpoena, advocates and on to the court record
+    await judgeReceivesIndictmentThroughAdvocates(page, caseId, accusedName)
+
+    // Indictment court record - a fine needs a confirmed court record
+    // but no judgement ruling
+    await Promise.all([
+      page.getByRole('button', { name: 'Bæta við þinghaldi' }).click(),
+      verifyRequestCompletion(page, '/api/graphql', 'CreateCourtSession'),
+    ])
+
+    // Session accordion expands and auto-initializes judge/location/dates.
+    await expect(page.getByTestId('entries')).toBeVisible({ timeout: 15000 })
+    await expect(page.getByTestId('confirm-court-record')).toBeVisible()
+
+    await page
+      .getByTestId('entries')
+      .frameLocator('iframe')
+      .locator('body')
+      .fill('Þinghald vegna viðurlagaákvörðunar')
+
+    // No judgement or order is pronounced in the session
+    await Promise.all([
+      verifyRequestCompletion(page, '/api/graphql', 'UpdateCourtSession'),
+      page.locator('input[id^="result_no-"]').check(),
+    ])
+
+    await expect(page.getByTestId('confirm-court-record')).toBeEnabled({
+      timeout: 15000,
+    })
+    await Promise.all([
+      verifyRequestCompletion(page, '/api/graphql', 'UpdateCourtSession'),
+      page.getByTestId('confirm-court-record').click(),
+    ])
+    await page.getByTestId('continueButton').click()
+
+    // Conclusion
+    await expect(page).toHaveURL(`domur/akaera/stada-og-lyktir/${caseId}`)
+
+    await page.locator('label').filter({ hasText: 'Lokið' }).click()
+    await page.locator('label').filter({ hasText: 'Viðurlagaákvörðun' }).click()
+
+    await Promise.all([
+      page.getByTestId('continueButton').click(),
+      verifyRequestCompletion(page, '/api/graphql', 'Case'),
+    ])
+
+    // Case overview
+    await expect(page).toHaveURL(`domur/akaera/samantekt/${caseId}`)
+    await page.getByTestId('continueButton').click()
+
+    await Promise.all([
+      page.getByTestId('modalPrimaryButton').click(),
+      verifyRequestCompletion(page, '/api/graphql', 'TransitionCase'),
+    ])
+
+    // Completed case overview
+    await expect(page).toHaveURL(`domur/akaera/lokid/${caseId}`)
+    await expect(page.getByText('Viðurlagaákvörðun').first()).toBeVisible()
+  })
+})

--- a/apps/system-e2e/src/tests/judicial-system/regression/indictment-merge-tests.spec.ts
+++ b/apps/system-e2e/src/tests/judicial-system/regression/indictment-merge-tests.spec.ts
@@ -1,0 +1,76 @@
+import { expect } from '@playwright/test'
+import faker from 'faker'
+import { urls } from '../../../support/urls'
+import { verifyRequestCompletion } from '../../../support/api-tools'
+import { test } from '../utils/judicialSystemTest'
+import { randomIndictmentCourtCaseNumber } from '../utils/helpers'
+import {
+  prosecutorCreatesIndictmentCase,
+  prosecutorSendsIndictmentToCourt,
+  judgeReceivesIndictmentThroughAdvocates,
+} from './shared-steps/indictment-to-court-record'
+
+test.use({ baseURL: urls.judicialSystemBaseUrl })
+
+test.describe.serial('Indictment merge tests', () => {
+  let caseId = ''
+  const accusedName = faker.name.findName()
+
+  test('prosecutor should create a new indictment case', async ({
+    prosecutorPage,
+  }) => {
+    caseId = await prosecutorCreatesIndictmentCase(prosecutorPage, accusedName)
+  })
+
+  test('prosecutor should accept and send indictment case to court', async ({
+    prosecutorPage,
+  }) => {
+    await prosecutorSendsIndictmentToCourt(prosecutorPage, caseId, accusedName)
+  })
+
+  test('judge should complete indictment case with a merge', async ({
+    judgePage,
+  }) => {
+    const page = judgePage
+
+    // Case list through subpoena, advocates and on to the court record
+    await judgeReceivesIndictmentThroughAdvocates(page, caseId, accusedName)
+
+    // Conclusion - a merge is allowed with an empty court record,
+    // so no court session is created
+    await Promise.all([
+      page.goto(`/domur/akaera/stada-og-lyktir/${caseId}`),
+      verifyRequestCompletion(page, '/api/graphql', 'Case'),
+    ])
+
+    await page.locator('label').filter({ hasText: 'Lokið' }).click()
+    await page
+      .locator('label')
+      .filter({ hasText: 'Sameinað öðru máli' })
+      .click()
+
+    // Merge into a case outside of the judicial system portal
+    await page
+      .getByRole('textbox', { name: 'Sameina við mál utan Réttarvörslugáttar' })
+      .fill(randomIndictmentCourtCaseNumber())
+    await page.keyboard.press('Tab')
+
+    await Promise.all([
+      page.getByTestId('continueButton').click(),
+      verifyRequestCompletion(page, '/api/graphql', 'Case'),
+    ])
+
+    // Case overview
+    await expect(page).toHaveURL(`domur/akaera/samantekt/${caseId}`)
+    await page.getByTestId('continueButton').click()
+
+    await Promise.all([
+      page.getByTestId('modalPrimaryButton').click(),
+      verifyRequestCompletion(page, '/api/graphql', 'TransitionCase'),
+    ])
+
+    // Completed case overview
+    await expect(page).toHaveURL(`domur/akaera/lokid/${caseId}`)
+    await expect(page.getByText('Sameinað').first()).toBeVisible()
+  })
+})

--- a/apps/system-e2e/src/tests/judicial-system/regression/indictment-tests.spec.ts
+++ b/apps/system-e2e/src/tests/judicial-system/regression/indictment-tests.spec.ts
@@ -3,12 +3,12 @@ import faker from 'faker'
 import { urls } from '../../../support/urls'
 import { verifyRequestCompletion } from '../../../support/api-tools'
 import { test } from '../utils/judicialSystemTest'
+import { getDaysFromNow, chooseDocument } from '../utils/helpers'
 import {
-  randomPoliceCaseNumber,
-  getDaysFromNow,
-  randomIndictmentCourtCaseNumber,
-  chooseDocument,
-} from '../utils/helpers'
+  prosecutorCreatesIndictmentCase,
+  prosecutorSendsIndictmentToCourt,
+  judgeReceivesIndictmentThroughAdvocates,
+} from './shared-steps/indictment-to-court-record'
 
 test.use({ baseURL: urls.judicialSystemBaseUrl })
 
@@ -19,226 +19,22 @@ test.describe.serial('Indictment tests', () => {
   test('prosecutor should create a new indictment case', async ({
     prosecutorPage,
   }) => {
-    const page = prosecutorPage
-    const today = getDaysFromNow()
-
-    const policeCaseNumber = randomPoliceCaseNumber()
-
-    // Case list groups
-    await page.goto('/malalistar')
-    await expect(page).toHaveURL('/malalistar')
-    await page.getByRole('button', { name: 'Nýtt mál' }).click()
-    await page.getByRole('menuitem', { name: 'Ákæra' }).click()
-    await expect(page).toHaveURL('/akaera/ny')
-
-    // New indictment case
-    await page.getByTestId('policeCaseNumber0').click()
-    await page.getByTestId('policeCaseNumber0').fill(policeCaseNumber)
-
-    await page.getByText('Sakarefni *Veldu sakarefni').click()
-    await page.getByRole('option', { name: 'Umferðarlagabrot' }).click()
-    await page.getByPlaceholder('Sláðu inn vettvang').click()
-    await page.getByPlaceholder('Sláðu inn vettvang').fill('Reykjavík')
-    await page
-      .locator(`input[id=crime-scene-date-${policeCaseNumber}]`)
-      .fill(today)
-    await page.keyboard.press('Escape')
-    const nationalIdInput = page.getByTestId('inputNationalId')
-    const nameInput = page.getByTestId('inputName')
-
-    await Promise.all([
-      page.waitForResponse(
-        (resp) =>
-          resp.url().includes('/api/nationalRegistry/getPersonByNationalId') &&
-          resp.request().method() === 'GET',
-      ),
-      nationalIdInput.fill('000000-0000'),
-    ])
-
-    await nameInput.fill(accusedName)
-    await nameInput.press('Tab')
-    await expect(nameInput).toHaveValue(accusedName)
-    await Promise.all([
-      page.getByRole('button', { name: 'Stofna mál' }).click(),
-      verifyRequestCompletion(page, '/api/graphql', 'CreateCase').then(
-        (res) => (caseId = res.data.createCase.id),
-      ),
-      verifyRequestCompletion(page, '/api/graphql', 'Case'),
-    ])
-
-    // Police case files (Málsgögn)
-    await expect(page).toHaveURL(`/akaera/malsgogn/${caseId}`)
-    await Promise.all([
-      page.getByTestId('continueButton').click(),
-      verifyRequestCompletion(page, '/api/graphql', 'Case'),
-    ])
-
-    // Case file
-    await expect(page).toHaveURL(`/akaera/skjalaskra/${caseId}`)
-    await Promise.all([
-      page.getByTestId('continueButton').click(),
-      verifyRequestCompletion(page, '/api/graphql', 'Case'),
-    ])
-
-    // Case files
-    await expect(page).toHaveURL(`/akaera/domskjol/${caseId}`)
-    await Promise.all([
-      page.getByTestId('continueButton').click(),
-      verifyRequestCompletion(page, '/api/graphql', 'Case'),
-      verifyRequestCompletion(page, '/api/graphql', 'UpdateCase'),
-    ])
-
-    // Processing
-    await expect(page).toHaveURL(`/akaera/malsmedferd/${caseId}`)
-
-    await Promise.all([
-      page.getByText('Játar sök').click(),
-      verifyRequestCompletion(page, '/api/graphql', 'UpdateDefendant'),
-    ])
-
-    await Promise.all([
-      page.getByText('Nei').last().click(),
-      verifyRequestCompletion(page, '/api/graphql', 'UpdateCase'),
-    ])
-
-    await Promise.all([
-      page.getByTestId('continueButton').click(),
-      verifyRequestCompletion(page, '/api/graphql', 'Case'),
-    ])
-
-    // Indictment
-    // The auto-created indictment count is expanded by default (open state is
-    // persisted in local storage), so no "Opna alla" toggle is needed.
-
-    await page.getByPlaceholder('AB123').fill('AB123')
-
-    await Promise.all([
-      page.keyboard.press('Tab'),
-      verifyRequestCompletion(page, '/api/graphql', 'UpdateIndictmentCount'),
-    ])
-
-    await Promise.all([
-      page.getByText('Brot *Veldu brot').click(),
-      page.getByRole('option', { name: 'Sviptingarakstur' }).click(),
-      verifyRequestCompletion(page, '/api/graphql', 'UpdateIndictmentCount'),
-    ])
-
-    await Promise.all([
-      page.getByLabel('Krefjast sviptingarKrefjast').check(),
-      verifyRequestCompletion(page, '/api/graphql', 'UpdateCase'),
-    ])
-
-    await Promise.all([
-      page.getByTestId('continueButton').click(),
-      verifyRequestCompletion(page, '/api/graphql', 'Case'),
-    ])
-
-    // Overview
-    await expect(page).toHaveURL(`/akaera/stadfesta/${caseId}`)
-
-    await Promise.all([
-      page.getByTestId('continueButton').click(),
-      verifyRequestCompletion(page, '/api/graphql', 'TransitionCase'),
-    ])
-    await page.getByTestId('modalPrimaryButton').click()
+    caseId = await prosecutorCreatesIndictmentCase(prosecutorPage, accusedName)
   })
 
   test('prosecutor should accept and send indictment case to court', async ({
     prosecutorPage,
   }) => {
-    const page = prosecutorPage
-
-    // Case list
-    await page.goto('/malalistar/sakamal-sem-bida-stadfestingar')
-    await expect(page).toHaveURL('/malalistar/sakamal-sem-bida-stadfestingar')
-    await page.getByText(accusedName).click()
-
-    // Indictment case
-    await expect(page).toHaveURL(`/akaera/stadfesta/${caseId}`)
-
-    await page.getByText('Staðfesta ákæru og senda á dómstól').click()
-    await page.getByTestId('continueButton').click()
-
-    await Promise.all([
-      page.getByTestId('modalPrimaryButton').click(),
-      verifyRequestCompletion(page, '/api/graphql', 'TransitionCase'),
-    ])
+    await prosecutorSendsIndictmentToCourt(prosecutorPage, caseId, accusedName)
   })
 
   test('judge should receive indictment case', async ({ judgePage }) => {
     const page = judgePage
-    const nextWeek = getDaysFromNow(7)
 
-    // Case list
-    await page.goto('/malalistar/sakamal-sem-bida-uthlutunar')
-    await expect(page).toHaveURL('/malalistar/sakamal-sem-bida-uthlutunar')
-    await page.getByText(accusedName).click()
-
-    // Indictment Overview
-    await expect(page).toHaveURL(`domur/akaera/yfirlit/${caseId}`)
-
-    await Promise.all([
-      page.getByTestId('continueButton').click(),
-      verifyRequestCompletion(page, '/api/graphql', 'Case'),
-    ])
-
-    // Reception and assignment
-    await expect(page).toHaveURL(`domur/akaera/mottaka/${caseId}`)
-
-    await page
-      .getByTestId('courtCaseNumber')
-      .fill(randomIndictmentCourtCaseNumber())
-    await page.keyboard.press('Tab')
-
-    await page.getByText('Veldu dómara/aðstoðarmann').click()
-    await page
-      .getByTestId('select-judge')
-      .getByText('Test Dómari')
-      .last()
-      .click()
-
-    await Promise.all([
-      page.getByTestId('continueButton').click(),
-      verifyRequestCompletion(page, '/api/graphql', 'Case'),
-    ])
-
-    // Subpoena
-    await expect(page).toHaveURL(`domur/akaera/fyrirkall/${caseId}`)
-
-    await page
-      .locator('label')
-      .filter({ hasText: 'Útivistarfyrirkall' })
-      .click()
-
-    await page.locator('input[id=courtDate]').fill(nextWeek)
-    await page.keyboard.press('Escape')
-
-    await page.getByTestId('courtDate-time').fill('11:00')
-    await page.getByTestId('courtroom').press('Tab')
-
-    await page.getByTestId('courtroom').fill('12')
-    await page.getByTestId('courtroom').press('Tab')
-
-    await page.getByTestId('continueButton').click()
-    await page.getByTestId('modalPrimaryButton').click()
-
-    // Advocates and civil claimants
-    await expect(page).toHaveURL(`domur/akaera/malflytjendur/${caseId}`)
-
-    await page
-      .locator('label')
-      .filter({ hasText: 'Ákærði óskar ekki eftir að sé' })
-      .click()
-    await page.getByRole('button', { name: 'Staðfesta val' }).click()
-    await page.getByTestId('modalPrimaryButton').click()
-
-    await Promise.all([
-      page.getByTestId('continueButton').click(),
-      verifyRequestCompletion(page, '/api/graphql', 'Case'),
-    ])
+    // Case list through subpoena, advocates and on to the court record
+    await judgeReceivesIndictmentThroughAdvocates(page, caseId, accusedName)
 
     // Indictment court record
-    await expect(page).toHaveURL(`domur/akaera/thingbok/${caseId}`)
     await Promise.all([
       page.getByRole('button', { name: 'Bæta við þinghaldi' }).click(),
       verifyRequestCompletion(page, '/api/graphql', 'CreateCourtSession'),

--- a/apps/system-e2e/src/tests/judicial-system/regression/shared-steps/court-decision.ts
+++ b/apps/system-e2e/src/tests/judicial-system/regression/shared-steps/court-decision.ts
@@ -1,0 +1,90 @@
+import { expect, Page } from '@playwright/test'
+import { verifyRequestCompletion } from '../../../../support/api-tools'
+import { getDaysFromNow, randomCourtCaseNumber } from '../../utils/helpers'
+
+export const judgeSubmitsDecision = async (
+  page: Page,
+  caseId: string,
+  options: {
+    acceptRulingText: string
+    validToDate: string
+    // The confirmation step may open the signing-method modal, which the
+    // custody flow dismisses without signing. E-signing is not exercised
+    // by these tests.
+    dismissSignatureModal?: boolean
+  },
+) => {
+  const today = getDaysFromNow()
+
+  await Promise.all([
+    page.goto(`/domur/mottaka/${caseId}`),
+    verifyRequestCompletion(page, '/api/graphql', 'Case'),
+  ])
+
+  // Reception and assignment
+  await expect(page).toHaveURL(`/domur/mottaka/${caseId}`)
+  await page.getByTestId('courtCaseNumber').fill(randomCourtCaseNumber())
+  await page.keyboard.press('Tab')
+  await page.getByText('Veldu dómara/aðstoðarmann').click()
+  await page.getByTestId('select-judge').getByText('Test Dómari').last().click()
+  await Promise.all([
+    page.getByTestId('continueButton').click(),
+    verifyRequestCompletion(page, '/api/graphql', 'Case'),
+  ])
+
+  // Overview
+  await expect(page).toHaveURL(`/domur/krafa/${caseId}`)
+  await expect(page.getByTestId('continueButton')).toBeVisible()
+  await Promise.all([
+    page.getByTestId('continueButton').click(),
+    verifyRequestCompletion(page, '/api/graphql', 'Case'),
+  ])
+
+  // Hearing arrangements
+  await expect(page).toHaveURL(`/domur/fyrirtokutimi/${caseId}`)
+  await page.locator('input[id=courtDate]').fill(today)
+  await page.keyboard.press('Escape')
+  await page.locator('input[id=courtDate-time]').fill('09:00')
+  await page.keyboard.press('Tab')
+  await page.getByTestId('continueButton').click()
+  await Promise.all([
+    page.getByTestId('modalPrimaryButton').click(),
+    verifyRequestCompletion(page, '/api/graphql', 'Case'),
+  ])
+
+  // Ruling
+  await expect(page).toHaveURL(`/domur/urskurdur/${caseId}`)
+  await page.getByText(options.acceptRulingText).click()
+  await page.locator('input[id=validToDate]').fill(options.validToDate)
+  await page.keyboard.press('Escape')
+  await page.locator('input[id=validToDate-time]').fill('16:00')
+  await page.keyboard.press('Tab')
+  await Promise.all([
+    page.getByTestId('continueButton').click(),
+    verifyRequestCompletion(page, '/api/graphql', 'Case'),
+  ])
+
+  // Court record
+  await expect(page).toHaveURL(`/domur/thingbok/${caseId}`)
+  await page.getByText('Varnaraðili tekur sér lögboðinn frest').click()
+  await page.getByText('Sækjandi tekur sér lögboðinn frest').click()
+  await page.locator('input[id=courtEndTime]').fill(today)
+  await page.keyboard.press('Escape')
+  await page.locator('input[id=courtEndTime-time]').fill('10:00')
+  await page.keyboard.press('Tab')
+  await Promise.all([
+    page.getByTestId('continueButton').click(),
+    verifyRequestCompletion(page, '/api/graphql', 'Case'),
+  ])
+
+  // Confirmation
+  await expect(page).toHaveURL(`/domur/stadfesta/${caseId}`)
+  await Promise.all([
+    page.getByTestId('continueButton').click(),
+    verifyRequestCompletion(page, '/api/graphql', 'TransitionCase'),
+  ])
+
+  if (options.dismissSignatureModal) {
+    await page.getByTestId('modalSecondaryButton').click()
+  }
+}

--- a/apps/system-e2e/src/tests/judicial-system/regression/shared-steps/indictment-to-court-record.ts
+++ b/apps/system-e2e/src/tests/judicial-system/regression/shared-steps/indictment-to-court-record.ts
@@ -91,6 +91,8 @@ export const prosecutorCreatesIndictmentCase = async (
     page.getByTestId('continueButton').click(),
   ])
 
+  // The auto-created indictment count is expanded by default (open state is
+  // persisted in local storage), so no "Opna alla" toggle is needed.
   await page.getByPlaceholder('AB123').fill('AB123')
 
   await Promise.all([

--- a/apps/system-e2e/src/tests/judicial-system/regression/shared-steps/indictment-to-court-record.ts
+++ b/apps/system-e2e/src/tests/judicial-system/regression/shared-steps/indictment-to-court-record.ts
@@ -9,6 +9,7 @@ import {
 export const prosecutorCreatesIndictmentCase = async (
   page: Page,
   accusedName: string,
+  secondAccusedName?: string,
 ): Promise<string> => {
   let caseId = ''
   const today = getDaysFromNow()
@@ -47,10 +48,34 @@ export const prosecutorCreatesIndictmentCase = async (
   await nameInput.fill(accusedName)
   await nameInput.press('Tab')
   await expect(nameInput).toHaveValue(accusedName)
+
+  if (secondAccusedName) {
+    // The case does not exist yet, so this only adds a defendant locally -
+    // it is persisted with a CreateDefendant mutation when the case is
+    // created below. The second defendant has no Icelandic national id to
+    // avoid a duplicate national registry lookup.
+    await page.getByTestId('addDefendantButton').click()
+    await page
+      .getByRole('checkbox', {
+        name: 'Varnaraðili er ekki með íslenska kennitölu',
+      })
+      .last()
+      .check()
+    await page.getByTestId('inputNationalId').last().fill('12.12.2000')
+    const secondNameInput = page.getByTestId('inputName').last()
+    await secondNameInput.fill(secondAccusedName)
+    await page.getByTestId('accusedAddress').last().fill('Einhversstaðar 2')
+    await secondNameInput.press('Tab')
+    await expect(secondNameInput).toHaveValue(secondAccusedName)
+  }
+
   await Promise.all([
     verifyRequestCompletion(page, '/api/graphql', 'CreateCase').then(
       (res) => (caseId = res.data.createCase.id),
     ),
+    ...(secondAccusedName
+      ? [verifyRequestCompletion(page, '/api/graphql', 'CreateDefendant')]
+      : []),
     verifyRequestCompletion(page, '/api/graphql', 'Case'),
     page.getByRole('button', { name: 'Stofna mál' }).click(),
   ])
@@ -76,10 +101,16 @@ export const prosecutorCreatesIndictmentCase = async (
 
   await expect(page).toHaveURL(`/akaera/malsmedferd/${caseId}`)
 
-  await Promise.all([
-    verifyRequestCompletion(page, '/api/graphql', 'UpdateDefendant'),
-    page.getByText('Játar sök').click(),
-  ])
+  // One plea per defendant
+  const pleaOptions = page.getByText('Játar sök')
+  await expect(pleaOptions.first()).toBeVisible()
+  const pleaCount = await pleaOptions.count()
+  for (let i = 0; i < pleaCount; i++) {
+    await Promise.all([
+      verifyRequestCompletion(page, '/api/graphql', 'UpdateDefendant'),
+      pleaOptions.nth(i).click(),
+    ])
+  }
 
   await Promise.all([
     verifyRequestCompletion(page, '/api/graphql', 'UpdateCase'),
@@ -182,7 +213,15 @@ export const judgeReceivesIndictmentThroughAdvocates = async (
 
   await expect(page).toHaveURL(`domur/akaera/fyrirkall/${caseId}`)
 
-  await page.locator('label').filter({ hasText: 'Útivistarfyrirkall' }).click()
+  // One subpoena type per defendant
+  const subpoenaTypeOptions = page
+    .locator('label')
+    .filter({ hasText: 'Útivistarfyrirkall' })
+  await expect(subpoenaTypeOptions.first()).toBeVisible()
+  const subpoenaTypeCount = await subpoenaTypeOptions.count()
+  for (let i = 0; i < subpoenaTypeCount; i++) {
+    await subpoenaTypeOptions.nth(i).click()
+  }
 
   await page.locator('input[id=courtDate]').fill(nextWeek)
   await page.keyboard.press('Escape')
@@ -198,10 +237,15 @@ export const judgeReceivesIndictmentThroughAdvocates = async (
 
   await expect(page).toHaveURL(`domur/akaera/malflytjendur/${caseId}`)
 
-  await page
+  // One defender choice per defendant
+  const defenderChoiceOptions = page
     .locator('label')
-    .filter({ hasText: 'Ákærði óskar ekki eftir að sé' })
-    .click()
+    .filter({ hasText: 'óskar ekki eftir að sé' })
+  await expect(defenderChoiceOptions.first()).toBeVisible()
+  const defenderChoiceCount = await defenderChoiceOptions.count()
+  for (let i = 0; i < defenderChoiceCount; i++) {
+    await defenderChoiceOptions.nth(i).click()
+  }
   await page.getByRole('button', { name: 'Staðfesta val' }).click()
   await page.getByTestId('modalPrimaryButton').click()
 

--- a/apps/system-e2e/src/tests/judicial-system/regression/shared-steps/receive-appeal.ts
+++ b/apps/system-e2e/src/tests/judicial-system/regression/shared-steps/receive-appeal.ts
@@ -1,4 +1,4 @@
-import { Page } from '@playwright/test'
+import { expect, Page } from '@playwright/test'
 import { verifyRequestCompletion } from '../../../../support/api-tools'
 
 export const judgeReceivesAppealTest = async (page: Page, caseId: string) => {
@@ -6,10 +6,11 @@ export const judgeReceivesAppealTest = async (page: Page, caseId: string) => {
     page.goto(`krafa/yfirlit/${caseId}`),
     verifyRequestCompletion(page, '/api/graphql', 'Case'),
   ])
-  await page
-    .getByRole('button', {
-      name: 'Senda tilkynningu um kæru til Landsréttar',
-    })
-    .click()
+  const sendNotificationButton = page.getByRole('button', {
+    name: 'Senda tilkynningu um kæru til Landsréttar',
+  })
+  await expect(sendNotificationButton).toBeVisible()
+  await sendNotificationButton.click()
   await page.getByTestId('modalPrimaryButton').click()
+  await expect(page.getByText('Tilkynning um móttöku send')).toBeVisible()
 }

--- a/apps/system-e2e/src/tests/judicial-system/regression/travel-ban-tests.spec.ts
+++ b/apps/system-e2e/src/tests/judicial-system/regression/travel-ban-tests.spec.ts
@@ -2,7 +2,8 @@ import { expect } from '@playwright/test'
 import { urls } from '../../../support/urls'
 import { test } from '../utils/judicialSystemTest'
 import { verifyRequestCompletion } from '../../../support/api-tools'
-import { getDaysFromNow, randomCourtCaseNumber } from '../utils/helpers'
+import { getDaysFromNow, randomPoliceCaseNumber } from '../utils/helpers'
+import { judgeSubmitsDecision } from './shared-steps/court-decision'
 import { prosecutorAppealsCaseTest } from './shared-steps/send-appeal'
 import { judgeReceivesAppealTest } from './shared-steps/receive-appeal'
 import { coaJudgesCompleteAppealCaseTest } from './shared-steps/complete-appeal'
@@ -29,7 +30,7 @@ test.describe.serial('Travel ban tests', () => {
       .getByRole('textbox', {
         name: 'Sláðu inn málsnúmer úr lögreglukerfi (LÖKE)',
       })
-      .fill('123-1231-23123')
+      .fill(randomPoliceCaseNumber())
     await page.getByRole('button', { name: 'Skrá númer' }).click()
     await page
       .getByRole('checkbox', {
@@ -108,78 +109,10 @@ test.describe.serial('Travel ban tests', () => {
   test('court should submit decision on travel ban case', async ({
     judgePage,
   }) => {
-    const page = judgePage
-    await Promise.all([
-      page.goto(`/domur/mottaka/${caseId}`),
-      verifyRequestCompletion(page, '/api/graphql', 'Case'),
-    ])
-
-    // Reception and assignment
-    await expect(page).toHaveURL(`/domur/mottaka/${caseId}`)
-    await page.getByTestId('courtCaseNumber').fill(randomCourtCaseNumber())
-    await page.keyboard.press('Tab')
-    await page.getByText('Veldu dómara/aðstoðarmann').click()
-    await page
-      .getByTestId('select-judge')
-      .getByText('Test Dómari')
-      .last()
-      .click()
-    await Promise.all([
-      page.getByTestId('continueButton').click(),
-      verifyRequestCompletion(page, '/api/graphql', 'Case'),
-    ])
-
-    // Overview
-    await expect(page).toHaveURL(`/domur/krafa/${caseId}`)
-    await page.getByTestId('continueButton').isVisible()
-    await Promise.all([
-      page.getByTestId('continueButton').click(),
-      verifyRequestCompletion(page, '/api/graphql', 'Case'),
-    ])
-
-    // Hearing arrangements
-    await expect(page).toHaveURL(`/domur/fyrirtokutimi/${caseId}`)
-    await page.locator('input[id=courtDate]').fill(today)
-    await page.keyboard.press('Escape')
-    await page.locator('input[id=courtDate-time]').fill('09:00')
-    await page.keyboard.press('Tab')
-    await page.getByTestId('continueButton').click()
-    await Promise.all([
-      page.getByTestId('modalPrimaryButton').click(),
-      verifyRequestCompletion(page, '/api/graphql', 'Case'),
-    ])
-
-    // Ruling
-    await expect(page).toHaveURL(`/domur/urskurdur/${caseId}`)
-    await page.getByText('Krafa um farbann samþykkt').click()
-    await page.locator('input[id=validToDate]').fill(travelBanEndDate)
-    await page.keyboard.press('Escape')
-    await page.locator('input[id=validToDate-time]').fill('16:00')
-    await page.keyboard.press('Tab')
-    await Promise.all([
-      page.getByTestId('continueButton').click(),
-      verifyRequestCompletion(page, '/api/graphql', 'Case'),
-    ])
-
-    // Court record
-    await expect(page).toHaveURL(`/domur/thingbok/${caseId}`)
-    await page.getByText('Varnaraðili tekur sér lögboðinn frest').click()
-    await page.getByText('Sækjandi tekur sér lögboðinn frest').click()
-    await page.locator('input[id=courtEndTime]').fill(today)
-    await page.keyboard.press('Escape')
-    await page.locator('input[id=courtEndTime-time]').fill('10:00')
-    await page.keyboard.press('Tab')
-    await Promise.all([
-      page.getByTestId('continueButton').click(),
-      verifyRequestCompletion(page, '/api/graphql', 'Case'),
-    ])
-
-    // Confirmation
-    await expect(page).toHaveURL(`/domur/stadfesta/${caseId}`)
-    await Promise.all([
-      page.getByTestId('continueButton').click(),
-      verifyRequestCompletion(page, '/api/graphql', 'TransitionCase'),
-    ])
+    await judgeSubmitsDecision(judgePage, caseId, {
+      acceptRulingText: 'Krafa um farbann samþykkt',
+      validToDate: travelBanEndDate,
+    })
   })
 
   test('prosecutor should appeal case', async ({ prosecutorPage }) => {

--- a/apps/system-e2e/src/tests/judicial-system/smoke/case-list.spec.ts
+++ b/apps/system-e2e/src/tests/judicial-system/smoke/case-list.spec.ts
@@ -19,6 +19,6 @@ test.describe('Case list test', () => {
     const page = await context.newPage()
     await page.goto('/malalistar')
     await expect(page).toHaveURL('/malalistar')
-    await page.getByRole('button', { name: 'Nýtt mál' }).isVisible()
+    await expect(page.getByRole('button', { name: 'Nýtt mál' })).toBeVisible()
   })
 })

--- a/apps/system-e2e/src/tests/judicial-system/utils/helpers.ts
+++ b/apps/system-e2e/src/tests/judicial-system/utils/helpers.ts
@@ -5,9 +5,12 @@ export const randomPoliceCaseNumber = () => {
   return `007-${new Date().getFullYear()}-${Math.floor(Math.random() * 100000)}`
 }
 
+// The app validates R-/S- case numbers as 1-5 digits and appeal case
+// numbers as 1-4 digits, so these draw from the full allowed space to
+// minimize collisions with cases left behind by previous runs.
 export const randomCourtCaseNumber = (prefix?: string) => {
   return `${prefix ?? 'R'}-${Math.floor(
-    Math.random() * 1000,
+    Math.random() * 100000,
   )}/${new Date().getFullYear()}`
 }
 
@@ -16,7 +19,7 @@ export const randomIndictmentCourtCaseNumber = () => {
 }
 
 export const randomAppealCaseNumber = () => {
-  return `${Math.floor(Math.random() * 1000)}/${new Date().getFullYear()}`
+  return `${Math.floor(Math.random() * 10000)}/${new Date().getFullYear()}`
 }
 
 export const getDaysFromNow = (days = 0) => {
@@ -45,7 +48,6 @@ export const chooseDocument = async (
   await clickButton()
 
   const fileChooser = await fileChooserPromise
-  await page.waitForTimeout(1000)
   await fileChooser.setFiles(createFakePdf(fileName))
 }
 


### PR DESCRIPTION
## What

Three new Playwright regression specs in `apps/system-e2e` covering previously untested indictment Conclusion decision branches:

- **`indictment-fine-tests.spec.ts`** — completes an indictment with a fine (Viðurlagaákvörðun): the judge creates a court session, fills the entries, answers "Nei" to the ruling question, confirms the court record, then picks Lokið → Viðurlagaákvörðun and completes via the Summary confirm modal. Asserts the case lands on the completed screen showing the fine decision.
- **`indictment-merge-tests.spec.ts`** — completes an indictment with a merge (Sameinað öðru máli) into a case outside RVG by typing an S-case-number, exercising the empty-court-record merge path. Asserts "Sameinað" on the completed case.
- **`indictment-completing-for-some-tests.spec.ts`** — creates an indictment with **two defendants** and registers "Niðurfelling máls" for one of them via the per-defendant Lyktir select and the two-modal confirmation flow. Asserts the case is *not* completed and the defendant shows the "Niðurfellt" state on the active-case overview.

Supporting changes to `shared-steps/indictment-to-court-record.ts` (backwards-compatible with existing specs):

- `prosecutorCreatesIndictmentCase` takes an optional second accused name — the second defendant uses the "no Icelandic national ID" path and the step waits for the `CreateDefendant` mutation fired on case creation.
- The plea, subpoena-type, and defender-choice interactions now loop over all matching per-defendant radios instead of assuming exactly one, which would throw strict-mode violations with multiple defendants.

## Why

The Conclusion screen's decision branches were the largest untested surface in the judicial-system e2e suite — only `COMPLETING` + `RULING` had coverage. `FINE`, `MERGE`, and `COMPLETING_FOR_SOME` (including its per-defendant event-log flow) had no e2e or component tests at all, and multi-defendant indictments could not be exercised by the shared steps.

Stacked on #23473 (`j-s/e2e-hardening-and-dedup`).

## Screenshots / Gifs
Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code
- [ ] No AI tools were used in preparing this pull request