### PR TITLE
fix(j-s): don't update non loke case in loke

### DIFF
--- a/apps/judicial-system/backend/src/app/modules/case/internalCase.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/case/internalCase.service.ts
@@ -822,6 +822,8 @@ export class InternalCaseService {
         state: completedIndictmentCaseStates,
         type: CaseType.INDICTMENT,
         indictmentRulingDecision: CaseIndictmentRulingDecision.RULING,
+        // Only LOKE cases have a corresponding police case to update
+        origin: CaseOrigin.LOKE,
       },
     })
 
@@ -1452,6 +1454,11 @@ export class InternalCaseService {
     user: TUser,
     courtDocuments: PoliceDocument[],
   ): Promise<boolean> {
+    // Never call UpdateRVCase for cases that did not originate in LOKE
+    if (theCase.origin !== CaseOrigin.LOKE) {
+      return true
+    }
+
     const policeCaseId =
       await this.caseRepositoryService.findOriginalAncestorId(theCase)
 

--- a/apps/judicial-system/backend/src/app/modules/case/test/internalCaseController/deliverCaseFilesRecordToPolice.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/case/test/internalCaseController/deliverCaseFilesRecordToPolice.spec.ts
@@ -3,7 +3,12 @@ import { v4 as uuid } from 'uuid'
 
 import { BadRequestException } from '@nestjs/common'
 
-import { CaseState, CaseType, User } from '@island.is/judicial-system/types'
+import {
+  CaseOrigin,
+  CaseState,
+  CaseType,
+  User,
+} from '@island.is/judicial-system/types'
 
 import { createTestingCaseModule } from '../createTestingCaseModule'
 
@@ -43,6 +48,7 @@ describe('InternalCaseController - Deliver case files record to police', () => {
     id: caseId,
     type: caseType,
     state: caseState,
+    origin: CaseOrigin.LOKE,
     policeCaseNumbers: [policeCaseNumber],
     defendants: [{ nationalId: uuid() }],
     courtId,


### PR DESCRIPTION
[Asana](https://app.asana.com/1/203394141643832/project/1212657017130395/task/1217443525398727?focus=true)

## What

Don't try to  update a non LOKE case in LOKE. Found that we were not filtering based on origin in the daily batch job that delivers verdict service certificates

## Why

They don't exist in LOKE so they cannot be updated.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Cursor


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved case processing so only cases originating from LOKE are included in relevant appeal-deadline checks.
  * Prevented non-LOKE cases from being sent to the police system during case delivery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->