### PR TITLE
fix(auth): notify recipient when a new delegation is created

### DIFF
--- a/libs/auth-api-lib/src/lib/delegations/delegations-outgoing.service.ts
+++ b/libs/auth-api-lib/src/lib/delegations/delegations-outgoing.service.ts
@@ -250,6 +250,13 @@ export class DelegationsOutgoingService {
       },
     })
 
+    // Whether the delegation already had scopes before this grant, so the
+    // recipient gets the "new delegation" vs "updated delegation" notification.
+    const hadExistingScopes = delegation
+      ? (await this.delegationScopeService.findByDelegationId(delegation.id))
+          .length > 0
+      : false
+
     if (!delegation) {
       const [fromDisplayName, toName] = await Promise.all([
         this.namesService.getUserName(user),
@@ -295,6 +302,8 @@ export class DelegationsOutgoingService {
       createDelegation.toNationalId,
       user,
     )
+
+    void this.notifyDelegationUpdate(user, newDelegation, hadExistingScopes)
 
     return newDelegation
   }

--- a/libs/auth-api-lib/src/lib/delegations/delegations-outgoing.service.ts
+++ b/libs/auth-api-lib/src/lib/delegations/delegations-outgoing.service.ts
@@ -323,7 +323,7 @@ export class DelegationsOutgoingService {
 
       if (
         !allowDelegationNotification ||
-        !delegation.scopes ||
+        !delegation.scopes?.length ||
         !delegation.domainName
       ) {
         return


### PR DESCRIPTION
# notify recipient when a new delegation is created

## What

- Fire the delegation notification from the `create` path (not only `patch`), using the new-delegation template for first-time grants.

## Why

- The `create` path never sent a notification, so granting a brand-new delegation produced no push or email for the recipient — only edits (via `patch`) notified.

## Screenshots / Gifs

N/A

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved delegation update notifications by distinguishing between newly created delegations and updates to existing delegations.
  - Preserved existing scopes when adding new scopes to an established delegation.
  - Notifications are now sent only when a delegation includes at least one scope.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->