### PR TITLE
fix(judicial-administration): remove hardcoded fallback credentials

### DIFF
--- a/libs/clients/judicial-administration/src/lib/judicialAdministration.config.spec.ts
+++ b/libs/clients/judicial-administration/src/lib/judicialAdministration.config.spec.ts
@@ -1,0 +1,40 @@
+import { JudicialAdministrationClientConfig } from './judicialAdministration.config'
+
+describe('JudicialAdministrationClientConfig', () => {
+  const OLD_ENV = process.env
+
+  beforeEach(() => {
+    jest.resetModules()
+    process.env = { ...OLD_ENV }
+  })
+
+  afterAll(() => {
+    process.env = OLD_ENV
+  })
+
+  it('should load configuration with empty fallback credentials when env vars are unset', () => {
+    delete process.env.DOMSYSLA_USERNAME
+    delete process.env.DOMSYSLA_PASSWORD
+    delete process.env.XROAD_COURT_BANKRUPTCY_CERT_PATH
+
+    const config = JudicialAdministrationClientConfig()
+
+    expect(config.username).toBe('')
+    expect(config.password).toBe('')
+    expect(config.xRoadServicePath).toBe(
+      'IS-DEV/GOV/10019/Domstolasyslan/JusticePortal-v1',
+    )
+  })
+
+  it('should load configured environment variables', () => {
+    process.env.DOMSYSLA_USERNAME = 'test-user'
+    process.env.DOMSYSLA_PASSWORD = 'test-password'
+    process.env.XROAD_COURT_BANKRUPTCY_CERT_PATH = 'custom-path'
+
+    const config = JudicialAdministrationClientConfig()
+
+    expect(config.username).toBe('test-user')
+    expect(config.password).toBe('test-password')
+    expect(config.xRoadServicePath).toBe('custom-path')
+  })
+})

--- a/libs/clients/judicial-administration/src/lib/judicialAdministration.config.ts
+++ b/libs/clients/judicial-administration/src/lib/judicialAdministration.config.ts
@@ -25,7 +25,7 @@ export const JudicialAdministrationClientConfig = defineConfig<
       timeout: 30000,
       scope: ['@island.is/internal'],
     },
-    username: env.required('DOMSYSLA_USERNAME', 'syslumennprofun'),
-    password: env.required('DOMSYSLA_PASSWORD', 'GottFramvegis_824'),
+    username: env.required('DOMSYSLA_USERNAME', ''),
+    password: env.required('DOMSYSLA_PASSWORD', ''),
   }),
 })


### PR DESCRIPTION
# fix(judicial-administration): remove hardcoded fallback credentials

Ticket: #615609

## What

- Removes hardcoded plaintext fallback credentials (`syslumennprofun` and `GottFramvegis_824`) from `JudicialAdministrationClientConfig`.
- Replaces them with standard empty string fallbacks `''` for development/mocking purposes.
- Adds unit tests in `judicialAdministration.config.spec.ts` covering config loading and fallback defaults.

## Why

- Prevents exposure of test environment credentials in the public GitHub repository.
- Aligns with monorepo client configuration standards where credentials are strictly injected via AWS Secrets Manager / Kubernetes secrets.

## Screenshots / Gifs

N/A

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude (Oh My Pi harness)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Removed hardcoded fallback credentials from the judicial administration client configuration.
  * Credentials now default to empty values when environment variables are unavailable.

* **Tests**
  * Added coverage for default configuration values and loading credentials from environment variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->