### PR TITLE
fix: post-release hotfixes (delegation notify, web 404 redirect, image cache)

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -214,6 +214,12 @@ const nextConfig = {
     return config
   },
 
+  // The prod container's .next/cache is read-only, so Next 16's on-disk image
+  // LRU throws EACCES on mkdir. Disable it; CloudFront caches optimized images.
+  images: {
+    maximumDiskCacheSize: 0,
+  },
+
   // Runtime configuration lives in environments/runtimeEnvironment.ts
   env: {
     API_MOCKS: process.env.API_MOCKS || '',

--- a/apps/web/utils/fetch404RedirectUrl.ts
+++ b/apps/web/utils/fetch404RedirectUrl.ts
@@ -18,34 +18,35 @@ export const fetch404RedirectUrl = async (
 ): Promise<string | null> => {
   path = path.trim().replace(/\/\/+/g, '/').replace(/\/+$/, '').toLowerCase()
 
-  const [redirectPropsWithQueryParams, redirectPropsWithoutQueryParams] =
-    await Promise.all([
+  const lookup = async (lang: Locale) => {
+    const [withQueryParams, withoutQueryParams] = await Promise.all([
       apolloClient.query<GetUrlQuery, GetUrlQueryVariables>({
         query: GET_URL_QUERY,
-        variables: {
-          input: {
-            slug: path,
-            lang: locale,
-          },
-        },
+        variables: { input: { slug: path, lang } },
       }),
       apolloClient.query<GetUrlQuery, GetUrlQueryVariables>({
         query: GET_URL_QUERY,
-        variables: {
-          input: {
-            slug: path.split('?')[0],
-            lang: locale,
-          },
-        },
+        variables: { input: { slug: path.split('?')[0], lang } },
       }),
     ])
 
-  let redirectProps: ApolloQueryResult<GetUrlQuery> | null = null
+    if (withQueryParams?.data?.getUrl) return withQueryParams
+    if (withoutQueryParams?.data?.getUrl) return withoutQueryParams
+    return null
+  }
 
-  if (redirectPropsWithQueryParams?.data?.getUrl) {
-    redirectProps = redirectPropsWithQueryParams
-  } else if (redirectPropsWithoutQueryParams?.data?.getUrl) {
-    redirectProps = redirectPropsWithoutQueryParams
+  // Url (redirect) entries are stored under the default locale, so a lookup in
+  // another language returns nothing — fall back to the default language.
+  let resolvedLocale = locale
+  let redirectProps: ApolloQueryResult<GetUrlQuery> | null = await lookup(
+    locale,
+  )
+  if (!redirectProps?.data?.getUrl && locale !== defaultLanguage) {
+    const fallback = await lookup(defaultLanguage)
+    if (fallback?.data?.getUrl) {
+      redirectProps = fallback
+      resolvedLocale = defaultLanguage
+    }
   }
 
   if (redirectProps?.data?.getUrl) {
@@ -54,7 +55,11 @@ export const fetch404RedirectUrl = async (
     if (!page && explicitRedirect) {
       return encodeURI(explicitRedirect)
     } else if (page) {
-      let url = linkResolver(page.type as LinkType, [page.slug], locale).href
+      let url = linkResolver(
+        page.type as LinkType,
+        [page.slug],
+        resolvedLocale,
+      ).href
 
       if (!url) {
         // Fallback to using default language if page isn't present in another language

--- a/libs/auth-api-lib/src/lib/delegations/delegations-outgoing.service.ts
+++ b/libs/auth-api-lib/src/lib/delegations/delegations-outgoing.service.ts
@@ -250,6 +250,13 @@ export class DelegationsOutgoingService {
       },
     })
 
+    // Whether the delegation already had scopes before this grant, so the
+    // recipient gets the "new delegation" vs "updated delegation" notification.
+    const hadExistingScopes = delegation
+      ? (await this.delegationScopeService.findByDelegationId(delegation.id))
+          .length > 0
+      : false
+
     if (!delegation) {
       const [fromDisplayName, toName] = await Promise.all([
         this.namesService.getUserName(user),
@@ -296,6 +303,8 @@ export class DelegationsOutgoingService {
       user,
     )
 
+    void this.notifyDelegationUpdate(user, newDelegation, hadExistingScopes)
+
     return newDelegation
   }
 
@@ -314,7 +323,7 @@ export class DelegationsOutgoingService {
 
       if (
         !allowDelegationNotification ||
-        !delegation.scopes ||
+        !delegation.scopes?.length ||
         !delegation.domainName
       ) {
         return


### PR DESCRIPTION
Cherry-pick of #23481, #23466, #23447 onto the release branch.

- #23481 — fix(auth): notify recipient when a new delegation is created
- #23466 — fix(web): resolve 404 redirects via default locale for client-side nav
- #23447 — fix(web): disable read-only image disk cache to stop EACCES

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code