### PR TITLE
fix(driving-license): explain the extended-licence 65+ block and log RLS error codes

### DIFF
--- a/libs/api/domains/driving-license/src/lib/drivingLicense.service.ts
+++ b/libs/api/domains/driving-license/src/lib/drivingLicense.service.ts
@@ -365,7 +365,12 @@ export class DrivingLicenseService {
       case 'PERSON_NOT_REGISTERED_IN_ICELAND':
         return RequirementKey.localResidency
       default:
-        this.logger.warn(`${LOGTAG} unhandled can apply error code`, errorCode)
+        // Must be an object: a bare string second arg is treated as winston
+        // splat and silently dropped, which is why ~265 of these warnings a
+        // month never recorded which code was unhandled.
+        this.logger.warn(`${LOGTAG} unhandled can apply error code`, {
+          errorCode,
+        })
 
         return RequirementKey.deniedByService
     }
@@ -386,6 +391,12 @@ export class DrivingLicenseService {
         await this.drivingLicenseApi.getErrorCodeDescriptions()
       const match = descriptions.find((d) => d.code === code)
       if (!match) {
+        // RLS has no description for this code either, so the UI falls back to
+        // generic copy. Worth knowing about: it means neither we nor RLS
+        // document the code, and it is a candidate to ask RLS to catalogue.
+        this.logger.warn(`${LOGTAG} no RLS description for error code`, {
+          code,
+        })
         return null
       }
       return {

--- a/libs/application/templates/driving-license/src/lib/messages.ts
+++ b/libs/application/templates/driving-license/src/lib/messages.ts
@@ -1098,8 +1098,13 @@ export const requirementsMessages = defineMessages({
     description: 'requirement unmet 65 plus renewal',
   },
   noExtendedDrivingLicenseDescription: {
-    id: 'dl.application:requirementunmet.noExtendedDrivingLicenseDescription#markdown',
-    defaultMessage: 'Ekki hægt að sækja um endurnýjun á 65+ ökuskírteini.',
+    // V2: the previous copy repeated the title verbatim, so the card never
+    // explained why the applicant was blocked. Id bumped so the new text is
+    // picked up rather than overridden by the old Contentful entry (same
+    // approach as beLicenseQualityPhotoDescriptionV2 above).
+    id: 'dl.application:requirementunmet.noExtendedDrivingLicenseDescriptionV2#markdown',
+    defaultMessage:
+      'Þú ert með aukin ökuréttindi (t.d. C, CE, D1 eða D1E) sem voru gefin út á öðrum tíma en almennu ökuréttindin þín. Endurnýjun á slíkum réttindum fer ekki fram hér. Vinsamlega hafðu samband við næsta sýslumannsembætti til að fá frekari upplýsingar.',
     description: 'requirement unmet 65 plus renewal',
   },
 })


### PR DESCRIPTION
## What

A 65+ renewal applicant was shown two red "Krefst aðgerða" cards, neither of which explained anything. Investigation showed the **rule was correct** — the applicant holds extended privileges — but nothing in the UI or our logs said so.

**1. The 65+ card now explains itself.** `noExtendedDrivingLicenseTitle` and `noExtendedDrivingLicenseDescription` were the *identical string*, so the card rendered "Ekki hægt að sækja um endurnýjun á 65+ ökuskírteini." as both title and description. The new description names the cause (aukin ökuréttindi: C/CE/D1/D1E) and the next step (sýslumaður).

The message id is bumped to `…noExtendedDrivingLicenseDescriptionV2#markdown` so the new text actually renders instead of being overridden by the existing Contentful entry — same approach as `beLicenseQualityPhotoDescriptionV2` a few lines above.

**2. `unhandled can apply error code` now records the code.** It was passed as a bare string second argument, which winston treats as splat and drops. In prod that warning fired **265 times in 30 days** (steady 5–32/day, all licence types) without ever recording *which* code was unhandled. Now passed as `{ errorCode }`, matching every other logger call in the file.

**3. A code missing from RLS's catalogue is now logged.** `describeErrorCode` returned `null` silently when RLS had no description, so there was no signal that the generic fallback copy was in use. That path is the interesting one — it means neither we nor RLS document the code, and it is a candidate to ask RLS to catalogue.

## Why

Real case, prod, 2026-08-26. The applicant holds B/BE issued 1969-11-19 plus **C/CE issued 1980-01-31** and D1/D1E. `hasExtendedDrivingLicense` blocks the self-service 65+ flow when any extended category was issued on a different date than B — correct, since extended privileges renew via sýslumaður. RLS independently refused with an error code we could not identify, because of (2).

So the applicant was correctly ineligible, but the screen gave them no reason and no route forward, and we had no way to see RLS's reason. Nothing here changes eligibility — it only makes the existing outcome legible.

## Required follow-up — Contentful

The bumped id has no Contentful entry yet, so until one is added React Intl falls back to `defaultMessage`. That is correct Icelandic, but **English-locale users will see Icelandic text**. Please add both locales for:

`dl.application:requirementunmet.noExtendedDrivingLicenseDescriptionV2#markdown`

- **is** — Þú ert með aukin ökuréttindi (t.d. C, CE, D1 eða D1E) sem voru gefin út á öðrum tíma en almennu ökuréttindin þín. Endurnýjun á slíkum réttindum fer ekki fram hér. Vinsamlega hafðu samband við næsta sýslumannsembætti til að fá frekari upplýsingar.
- **en** — You hold extended driving privileges (e.g. C, CE, D1 or D1E) that were issued on a different date than your ordinary driving privileges. Renewal of those privileges is not handled here. Please contact your nearest district commissioner for further information.

The title id (`noExtendedDrivingLicenseTitle`) is unchanged and keeps its existing entries.

## Screenshots / Gifs

n/a — copy and logging only. Before: title and description were the same sentence.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code (Claude Opus)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Content Updates**
  - Updated the 65+ driving licence renewal denial message with clearer information about unsupported extended driving rights.
  - Added guidance directing applicants to contact their district commissioner for assistance.
  - Improved message compatibility for consistent display across supported content platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
