### PR TITLE
feat(j-s): Add e2e coverage for prison admin, defenders, appeals and rejections

### DIFF
--- a/apps/system-e2e/src/support/api-tools.ts
+++ b/apps/system-e2e/src/support/api-tools.ts
@@ -48,7 +48,15 @@ export async function verifyRequestCompletion(
     (resp) =>
       resp.url().includes(url) &&
       resp.request().postDataJSON().operationName === op,
+    { timeout: 15000 },
   )
 
-  return await response.json()
+  const body = await response.json()
+  if (body.errors?.length) {
+    throw new Error(
+      `GraphQL operation ${op} returned errors: ${body.errors[0].message}`,
+    )
+  }
+
+  return body
 }

--- a/apps/system-e2e/src/support/urls.ts
+++ b/apps/system-e2e/src/support/urls.ts
@@ -27,6 +27,8 @@ export const JUDICIAL_SYSTEM_PUBLIC_PROSECUTOR_OFFICE_HOME_URL =
   '/api/auth/login?nationalId=0000007777'
 export const JUDICIAL_SYSTEM_PUBLIC_PROSECUTOR_HOME_URL =
   '/api/auth/login?nationalId=0000998888'
+export const JUDICIAL_SYSTEM_PRISON_ADMIN_HOME_URL =
+  '/api/auth/login?nationalId=0000004449'
 
 export const shouldSkipNavigation = (url: string) => {
   return [
@@ -36,6 +38,7 @@ export const shouldSkipNavigation = (url: string) => {
     JUDICIAL_SYSTEM_JUDGE_HOME_URL,
     JUDICIAL_SYSTEM_PUBLIC_PROSECUTOR_OFFICE_HOME_URL,
     JUDICIAL_SYSTEM_PUBLIC_PROSECUTOR_HOME_URL,
+    JUDICIAL_SYSTEM_PRISON_ADMIN_HOME_URL,
   ].includes(url)
 }
 

--- a/apps/system-e2e/src/tests/judicial-system/regression/custody-rejected-tests.spec.ts
+++ b/apps/system-e2e/src/tests/judicial-system/regression/custody-rejected-tests.spec.ts
@@ -1,0 +1,97 @@
+import { expect } from '@playwright/test'
+import faker from 'faker'
+import { urls } from '../../../support/urls'
+import { verifyRequestCompletion } from '../../../support/api-tools'
+import { test } from '../utils/judicialSystemTest'
+import { getDaysFromNow } from '../utils/helpers'
+import { prosecutorCreatesCustodyRequest } from './shared-steps/create-restriction-case'
+import { judgeSubmitsDecision } from './shared-steps/court-decision'
+import { prosecutorAppealsCaseTest } from './shared-steps/send-appeal'
+
+test.use({ baseURL: urls.judicialSystemBaseUrl })
+
+test.describe.serial('Custody rejection tests', () => {
+  let caseId = ''
+  const accusedName = faker.name.findName()
+  const requestedCustodyEndDate = getDaysFromNow(3)
+
+  test('prosecutor should submit a custody request to court', async ({
+    prosecutorPage,
+  }) => {
+    caseId = await prosecutorCreatesCustodyRequest(
+      prosecutorPage,
+      accusedName,
+      requestedCustodyEndDate,
+    )
+  })
+
+  test('court should reject the custody request', async ({ judgePage }) => {
+    // Rejected cases have no restriction length, so no validToDate is set
+    await judgeSubmitsDecision(judgePage, caseId, {
+      decisionText: 'Kröfu um gæsluvarðhald hafnað',
+      dismissSignatureModal: true,
+    })
+  })
+
+  test('prosecutor should see the rejected case and open the request pdf', async ({
+    prosecutorPage,
+  }) => {
+    const page = prosecutorPage
+
+    await Promise.all([
+      page.goto(`/krafa/yfirlit/${caseId}`),
+      verifyRequestCompletion(page, '/api/graphql', 'Case'),
+    ])
+    await expect(page).toHaveURL(`/krafa/yfirlit/${caseId}`)
+    await expect(
+      page.getByRole('heading', { name: 'Kröfu hafnað' }),
+    ).toBeVisible()
+
+    // PdfButton opens the pdf in a new tab via window.open
+    const [popup] = await Promise.all([
+      page.waitForEvent('popup'),
+      page.getByTestId('requestPDFButton').click(),
+    ])
+    await popup.waitForURL(new RegExp(`/api/case/${caseId}/request`), {
+      waitUntil: 'commit',
+    })
+
+    // The endpoint actually serves a pdf
+    const response = await page.request.get(popup.url())
+    expect(response.status()).toBe(200)
+    expect(response.headers()['content-type']).toContain('application/pdf')
+    await popup.close()
+  })
+
+  test('prosecutor should appeal the rejected ruling', async ({
+    prosecutorPage,
+  }) => {
+    await prosecutorAppealsCaseTest(prosecutorPage, caseId)
+  })
+
+  test('prosecutor should withdraw the appeal', async ({ prosecutorPage }) => {
+    const page = prosecutorPage
+
+    // Withdrawal lives in the appealed-cases table row context menu
+    await page.goto('/malalistar/rannsoknarmal-i-kaeuferli')
+    await expect(page).toHaveURL('/malalistar/rannsoknarmal-i-kaeuferli')
+
+    const caseRow = page.getByRole('row').filter({ hasText: accusedName })
+    await caseRow
+      .getByRole('button', { name: /Frekari aðgerðir/ })
+      .first()
+      .click()
+    await page.getByText('Afturkalla kæru').click()
+    await Promise.all([
+      verifyRequestCompletion(page, '/api/graphql', 'TransitionAppealCase'),
+      page.getByTestId('modalPrimaryButton').click(),
+    ])
+
+    // The case overview shows the withdrawn appeal state
+    await Promise.all([
+      page.goto(`/krafa/yfirlit/${caseId}`),
+      verifyRequestCompletion(page, '/api/graphql', 'Case'),
+    ])
+    await expect(page.getByText('Afturkallað').first()).toBeVisible()
+  })
+})

--- a/apps/system-e2e/src/tests/judicial-system/regression/custody-tests.spec.ts
+++ b/apps/system-e2e/src/tests/judicial-system/regression/custody-tests.spec.ts
@@ -3,12 +3,8 @@ import faker from 'faker'
 import { urls } from '../../../support/urls'
 import { verifyRequestCompletion } from '../../../support/api-tools'
 import { test } from '../utils/judicialSystemTest'
-import {
-  randomPoliceCaseNumber,
-  getDaysFromNow,
-  chooseDocument,
-  verifyUpload,
-} from '../utils/helpers'
+import { getDaysFromNow, chooseDocument, verifyUpload } from '../utils/helpers'
+import { prosecutorCreatesCustodyRequest } from './shared-steps/create-restriction-case'
 import { judgeSubmitsDecision } from './shared-steps/court-decision'
 import { judgeReceivesAppealTest } from './shared-steps/receive-appeal'
 import { prosecutorAppealsCaseTest } from './shared-steps/send-appeal'
@@ -24,138 +20,21 @@ test.describe.serial('Custody tests', () => {
   const custodyEndDate = getDaysFromNow(2)
   const requestedCustodyEndDate = getDaysFromNow(3)
   const extendedCustodyEndDate = getDaysFromNow(4)
+  const accusedName = faker.name.findName()
 
   test('prosecutor should submit a custody request to court', async ({
     prosecutorPage,
   }) => {
-    const page = prosecutorPage
-
-    await page.route('**/api/graphql', (route, request) => {
-      const requestJSON = request.postDataJSON()
-
-      if (requestJSON.operationName === 'CreateCase') {
-        const modifiedData = requestJSON
-
-        modifiedData.variables.input = {
-          ...modifiedData.variables.input,
-          defenderNationalId: '0909090909',
-        }
-        route.continue({
-          method: 'POST',
-          postData: JSON.stringify(modifiedData),
-        })
-      } else {
-        route.continue()
-      }
-    })
-
-    // Case list groups
-    await page.goto('/malalistar')
-    await expect(page).toHaveURL('/malalistar')
-    await page.getByRole('button', { name: 'Nýtt mál' }).click()
-    await page.getByRole('menuitem', { name: 'Gæsluvarðhald' }).click()
-    await expect(page).toHaveURL('/krafa/ny/gaesluvardhald')
-
-    // New custody request
-    await expect(
-      page.getByRole('heading', { name: 'Gæsluvarðhald' }),
-    ).toBeVisible()
-    await page
-      .locator('input[name=policeCaseNumbers]')
-      .fill(randomPoliceCaseNumber())
-    await page.getByRole('button', { name: 'Skrá númer' }).click()
-    await page.getByRole('checkbox').first().check()
-    await page.locator('input[name=inputName]').fill(faker.name.findName())
-    await page.locator('input[name=accusedAddress]').fill('Einhversstaðar 1')
-    await page.locator('#defendantGender').click()
-    await page.locator('#react-select-defendantGender-option-0').click()
-    await page.locator('input[name=leadInvestigator]').fill('Stjórinn')
-    await expect(
-      page.getByRole('button', { name: 'Óskir um fyrirtöku' }),
-    ).toBeVisible()
-    await Promise.all([
-      page.getByRole('button', { name: 'Stofna mál' }).click(),
-      verifyRequestCompletion(page, '/api/graphql', 'CreateCase').then(
-        (res) => (caseId = res.data.createCase.id),
-      ),
-      verifyRequestCompletion(page, '/api/graphql', 'Case'),
-    ])
-
-    // Court date request
-    await expect(page).toHaveURL(`/krafa/fyrirtaka/${caseId}`)
-    await page.locator('input[id=arrestDate]').fill(today)
-    await page.keyboard.press('Escape')
-    await page.locator('input[id=arrestDate-time]').fill('00:00')
-    await page.locator('input[id=reqCourtDate]').fill(today)
-    await page.keyboard.press('Escape')
-    await page.locator('input[id=reqCourtDate-time]').fill('15:00')
-    await expect(
-      page.getByRole('button', { name: 'Dómkröfur og lagagrundvöllur' }),
-    ).toBeVisible()
-    await page.getByRole('button', { name: 'Halda áfram' }).click()
-    await Promise.all([
-      page.getByRole('button', { name: 'Halda áfram með kröfu' }).click(),
-      verifyRequestCompletion(page, '/api/graphql', 'Case'),
-    ])
-
-    // Prosecutor demands
-    await expect(page).toHaveURL(
-      `/krafa/domkrofur-og-lagagrundvollur/${caseId}`,
+    caseId = await prosecutorCreatesCustodyRequest(
+      prosecutorPage,
+      accusedName,
+      requestedCustodyEndDate,
     )
-    await page.locator('input[id=reqValidToDate]').fill(requestedCustodyEndDate)
-    await page.keyboard.press('Escape')
-    await page.locator('textarea[name=lawsBroken]').click()
-    await page.keyboard.type('Einhver lög voru brotin')
-    await page.getByTestId('checkbox').first().click()
-    await expect(
-      page.getByRole('button', { name: 'Greinargerð' }),
-    ).toBeVisible()
-    await Promise.all([
-      page.getByRole('button', { name: 'Halda áfram' }).click(),
-      verifyRequestCompletion(page, '/api/graphql', 'Case'),
-    ])
-
-    // Prosecutor statement
-    await expect(page).toHaveURL(`/krafa/greinargerd/${caseId}`)
-    await page.locator('textarea[name=caseFacts]').click()
-    await page.keyboard.type('Eitthvað gerðist')
-    await page.locator('textarea[name=legalArguments]').click()
-    await page.keyboard.type('Þetta er ekki löglegt')
-    await page.locator('textarea[name=comments]').click()
-    await page.keyboard.type('Sakborningur er hættulegur')
-    // Blur so debounced Case update runs; then wait for form to become valid (footer button enabled).
-    await page.keyboard.press('Tab')
-    await expect(page.getByRole('button', { name: 'Halda áfram' })).toBeEnabled(
-      { timeout: 15000 },
-    )
-    await Promise.all([
-      page.getByRole('button', { name: 'Halda áfram' }).click(),
-      verifyRequestCompletion(page, '/api/graphql', 'Case'),
-    ])
-
-    // Case files
-    await expect(page).toHaveURL(`/krafa/rannsoknargogn/${caseId}`)
-    await page.locator('textarea[name=caseFilesComments]').click()
-    await page.keyboard.type('Engin gögn fylgja')
-    await page.keyboard.press('Tab')
-    await expect(page.getByRole('button', { name: 'Halda áfram' })).toBeEnabled(
-      { timeout: 15000 },
-    )
-    await Promise.all([
-      page.getByRole('button', { name: 'Halda áfram' }).click(),
-      verifyRequestCompletion(page, '/api/graphql', 'Case'),
-    ])
-
-    // Submit to court
-    await expect(page).toHaveURL(`/krafa/stadfesta/${caseId}`)
-    await page.getByRole('button', { name: 'Senda kröfu á héraðsdóm' }).click()
-    await page.getByTestId('modalSecondaryButton').click()
-    await expect(page).toHaveURL('/malalistar')
   })
 
   test('court should submit decision in case', async ({ judgePage }) => {
     await judgeSubmitsDecision(judgePage, caseId, {
-      acceptRulingText: 'Krafa um gæsluvarðhald samþykkt',
+      decisionText: 'Krafa um gæsluvarðhald samþykkt',
       validToDate: custodyEndDate,
       dismissSignatureModal: true,
     })

--- a/apps/system-e2e/src/tests/judicial-system/regression/custody-tests.spec.ts
+++ b/apps/system-e2e/src/tests/judicial-system/regression/custody-tests.spec.ts
@@ -5,11 +5,11 @@ import { verifyRequestCompletion } from '../../../support/api-tools'
 import { test } from '../utils/judicialSystemTest'
 import {
   randomPoliceCaseNumber,
-  randomCourtCaseNumber,
   getDaysFromNow,
   chooseDocument,
   verifyUpload,
 } from '../utils/helpers'
+import { judgeSubmitsDecision } from './shared-steps/court-decision'
 import { judgeReceivesAppealTest } from './shared-steps/receive-appeal'
 import { prosecutorAppealsCaseTest } from './shared-steps/send-appeal'
 import { coaJudgesCompleteAppealCaseTest } from './shared-steps/complete-appeal'
@@ -154,79 +154,11 @@ test.describe.serial('Custody tests', () => {
   })
 
   test('court should submit decision in case', async ({ judgePage }) => {
-    const page = judgePage
-    await Promise.all([
-      page.goto(`/domur/mottaka/${caseId}`),
-      verifyRequestCompletion(page, '/api/graphql', 'Case'),
-    ])
-
-    // Reception and assignment
-    await expect(page).toHaveURL(`/domur/mottaka/${caseId}`)
-    await page.getByTestId('courtCaseNumber').fill(randomCourtCaseNumber())
-    await page.keyboard.press('Tab')
-    await page.getByText('Veldu dómara/aðstoðarmann').click()
-    await page
-      .getByTestId('select-judge')
-      .getByText('Test Dómari')
-      .last()
-      .click()
-    await Promise.all([
-      page.getByTestId('continueButton').click(),
-      verifyRequestCompletion(page, '/api/graphql', 'Case'),
-    ])
-
-    // Overview
-    await expect(page).toHaveURL(`/domur/krafa/${caseId}`)
-    await page.getByTestId('continueButton').isVisible()
-    await Promise.all([
-      page.getByTestId('continueButton').click(),
-      verifyRequestCompletion(page, '/api/graphql', 'Case'),
-    ])
-
-    // Hearing arrangements
-    await expect(page).toHaveURL(`/domur/fyrirtokutimi/${caseId}`)
-    await page.locator('input[id=courtDate]').fill(today)
-    await page.keyboard.press('Escape')
-    await page.locator('input[id=courtDate-time]').fill('09:00')
-    await page.keyboard.press('Tab')
-    await page.getByTestId('continueButton').click()
-    await Promise.all([
-      page.getByTestId('modalPrimaryButton').click(),
-      verifyRequestCompletion(page, '/api/graphql', 'Case'),
-    ])
-
-    // Ruling
-    await expect(page).toHaveURL(`/domur/urskurdur/${caseId}`)
-    await page.getByText('Krafa um gæsluvarðhald samþykkt').click()
-    await page.locator('input[id=validToDate]').fill(custodyEndDate)
-    await page.keyboard.press('Escape')
-    await page.locator('input[id=validToDate-time]').fill('16:00')
-    await page.keyboard.press('Tab')
-    await Promise.all([
-      page.getByTestId('continueButton').click(),
-      verifyRequestCompletion(page, '/api/graphql', 'Case'),
-    ])
-
-    // Court record
-    await expect(page).toHaveURL(`/domur/thingbok/${caseId}`)
-    await page.getByText('Varnaraðili tekur sér lögboðinn frest').click()
-    await page.getByText('Sækjandi tekur sér lögboðinn frest').click()
-    await page.locator('input[id=courtEndTime]').fill(today)
-    await page.keyboard.press('Escape')
-    await page.locator('input[id=courtEndTime-time]').fill('10:00')
-    await page.keyboard.press('Tab')
-    await Promise.all([
-      page.getByTestId('continueButton').click(),
-      verifyRequestCompletion(page, '/api/graphql', 'Case'),
-    ])
-
-    // Confirmation
-    await expect(page).toHaveURL(`/domur/stadfesta/${caseId}`)
-    await Promise.all([
-      page.getByTestId('continueButton').click(),
-      verifyRequestCompletion(page, '/api/graphql', 'TransitionCase'),
-    ])
-    await page.getByTestId('modalSecondaryButton').click()
+    await judgeSubmitsDecision(judgePage, caseId, {
+      acceptRulingText: 'Krafa um gæsluvarðhald samþykkt',
+      validToDate: custodyEndDate,
+      dismissSignatureModal: true,
+    })
   })
 
   test('judge should amend case', async ({ judgePage }) => {

--- a/apps/system-e2e/src/tests/judicial-system/regression/indictment-completing-for-some-tests.spec.ts
+++ b/apps/system-e2e/src/tests/judicial-system/regression/indictment-completing-for-some-tests.spec.ts
@@ -1,0 +1,82 @@
+import { expect } from '@playwright/test'
+import faker from 'faker'
+import { urls } from '../../../support/urls'
+import { verifyRequestCompletion } from '../../../support/api-tools'
+import { test } from '../utils/judicialSystemTest'
+import {
+  prosecutorCreatesIndictmentCase,
+  prosecutorSendsIndictmentToCourt,
+  judgeReceivesIndictmentThroughAdvocates,
+} from './shared-steps/indictment-to-court-record'
+
+test.use({ baseURL: urls.judicialSystemBaseUrl })
+
+test.describe.serial('Indictment completing for some tests', () => {
+  let caseId = ''
+  const accusedName = faker.name.findName()
+  const secondAccusedName = faker.name.findName()
+
+  test('prosecutor should create a new indictment case with two defendants', async ({
+    prosecutorPage,
+  }) => {
+    caseId = await prosecutorCreatesIndictmentCase(
+      prosecutorPage,
+      accusedName,
+      secondAccusedName,
+    )
+  })
+
+  test('prosecutor should accept and send indictment case to court', async ({
+    prosecutorPage,
+  }) => {
+    await prosecutorSendsIndictmentToCourt(prosecutorPage, caseId, accusedName)
+  })
+
+  test('judge should complete the case for one of two defendants', async ({
+    judgePage,
+  }) => {
+    const page = judgePage
+
+    // Case list through subpoena, advocates and on to the court record
+    await judgeReceivesIndictmentThroughAdvocates(page, caseId, accusedName)
+
+    // Conclusion - completing for some does not require a court record
+    await Promise.all([
+      page.goto(`/domur/akaera/stada-og-lyktir/${caseId}`),
+      verifyRequestCompletion(page, '/api/graphql', 'Case'),
+    ])
+
+    await page
+      .locator('label')
+      .filter({ hasText: 'Skrá lyktir á einstaka aðila án þess að ljúka máli' })
+      .click()
+
+    // A conclusion can be registered for all but one defendant -
+    // cancel the indictment against the first defendant
+    await page.getByText('Veldu lyktir ef á við').first().click()
+    await page.getByRole('option', { name: 'Niðurfelling máls' }).click()
+
+    await page.getByTestId('continueButton').click()
+
+    // Conclusion date modal - the date is prefilled with today
+    await expect(
+      page.getByText('Skrá lyktir á aðila án þess að ljúka máli'),
+    ).toBeVisible()
+    await page.getByTestId('modalPrimaryButton').click()
+
+    // Confirmation modal - wait for the first modal to unmount so only
+    // one modal button remains
+    await expect(page.getByText('Viltu staðfesta lyktir?')).toBeVisible()
+    await expect(
+      page.getByText('Lyktir verða skráðar á valda aðila.'),
+    ).toHaveCount(0)
+    await Promise.all([
+      page.getByTestId('modalPrimaryButton').click(),
+      verifyRequestCompletion(page, '/api/graphql', 'UpdateCase'),
+    ])
+
+    // The case is not completed - it remains active for the other defendant
+    await expect(page).toHaveURL(`domur/akaera/yfirlit/${caseId}`)
+    await expect(page.getByText('Niðurfellt').first()).toBeVisible()
+  })
+})

--- a/apps/system-e2e/src/tests/judicial-system/regression/indictment-defender-tests.spec.ts
+++ b/apps/system-e2e/src/tests/judicial-system/regression/indictment-defender-tests.spec.ts
@@ -1,0 +1,54 @@
+import { expect } from '@playwright/test'
+import faker from 'faker'
+import { urls } from '../../../support/urls'
+import { verifyRequestCompletion } from '../../../support/api-tools'
+import { test } from '../utils/judicialSystemTest'
+import {
+  prosecutorCreatesIndictmentCase,
+  prosecutorSendsIndictmentToCourt,
+  judgeReceivesIndictmentThroughAdvocates,
+} from './shared-steps/indictment-to-court-record'
+
+test.use({ baseURL: urls.judicialSystemBaseUrl })
+
+test.describe.serial('Indictment defender tests', () => {
+  let caseId = ''
+  const accusedName = faker.name.findName()
+
+  test('prosecutor should create a new indictment case', async ({
+    prosecutorPage,
+  }) => {
+    caseId = await prosecutorCreatesIndictmentCase(prosecutorPage, accusedName)
+  })
+
+  test('prosecutor should accept and send indictment case to court', async ({
+    prosecutorPage,
+  }) => {
+    await prosecutorSendsIndictmentToCourt(prosecutorPage, caseId, accusedName)
+  })
+
+  test('judge should assign a defender to the accused', async ({
+    judgePage,
+  }) => {
+    await judgeReceivesIndictmentThroughAdvocates(
+      judgePage,
+      caseId,
+      accusedName,
+      { assignDefender: true },
+    )
+  })
+
+  test('defender should see the indictment case', async ({ defenderPage }) => {
+    const page = defenderPage
+
+    await Promise.all([
+      page.goto(`/verjandi/akaera/${caseId}`),
+      verifyRequestCompletion(page, '/api/graphql', 'LimitedAccessCase'),
+    ])
+    await expect(page).toHaveURL(`/verjandi/akaera/${caseId}`)
+    await expect(
+      page.getByRole('heading', { name: 'Yfirlit ákæru' }),
+    ).toBeVisible()
+    await expect(page.getByText(accusedName).first()).toBeVisible()
+  })
+})

--- a/apps/system-e2e/src/tests/judicial-system/regression/indictment-fine-tests.spec.ts
+++ b/apps/system-e2e/src/tests/judicial-system/regression/indictment-fine-tests.spec.ts
@@ -1,0 +1,94 @@
+import { expect } from '@playwright/test'
+import faker from 'faker'
+import { urls } from '../../../support/urls'
+import { verifyRequestCompletion } from '../../../support/api-tools'
+import { test } from '../utils/judicialSystemTest'
+import {
+  prosecutorCreatesIndictmentCase,
+  prosecutorSendsIndictmentToCourt,
+  judgeReceivesIndictmentThroughAdvocates,
+} from './shared-steps/indictment-to-court-record'
+
+test.use({ baseURL: urls.judicialSystemBaseUrl })
+
+test.describe.serial('Indictment fine tests', () => {
+  let caseId = ''
+  const accusedName = faker.name.findName()
+
+  test('prosecutor should create a new indictment case', async ({
+    prosecutorPage,
+  }) => {
+    caseId = await prosecutorCreatesIndictmentCase(prosecutorPage, accusedName)
+  })
+
+  test('prosecutor should accept and send indictment case to court', async ({
+    prosecutorPage,
+  }) => {
+    await prosecutorSendsIndictmentToCourt(prosecutorPage, caseId, accusedName)
+  })
+
+  test('judge should complete indictment case with a fine', async ({
+    judgePage,
+  }) => {
+    const page = judgePage
+
+    // Case list through subpoena, advocates and on to the court record
+    await judgeReceivesIndictmentThroughAdvocates(page, caseId, accusedName)
+
+    // Indictment court record - a fine needs a confirmed court record
+    // but no judgement ruling
+    await Promise.all([
+      page.getByRole('button', { name: 'Bæta við þinghaldi' }).click(),
+      verifyRequestCompletion(page, '/api/graphql', 'CreateCourtSession'),
+    ])
+
+    // Session accordion expands and auto-initializes judge/location/dates.
+    await expect(page.getByTestId('entries')).toBeVisible({ timeout: 15000 })
+    await expect(page.getByTestId('confirm-court-record')).toBeVisible()
+
+    await page
+      .getByTestId('entries')
+      .frameLocator('iframe')
+      .locator('body')
+      .fill('Þinghald vegna viðurlagaákvörðunar')
+
+    // No judgement or order is pronounced in the session
+    await Promise.all([
+      verifyRequestCompletion(page, '/api/graphql', 'UpdateCourtSession'),
+      page.locator('input[id^="result_no-"]').check(),
+    ])
+
+    await expect(page.getByTestId('confirm-court-record')).toBeEnabled({
+      timeout: 15000,
+    })
+    await Promise.all([
+      verifyRequestCompletion(page, '/api/graphql', 'UpdateCourtSession'),
+      page.getByTestId('confirm-court-record').click(),
+    ])
+    await page.getByTestId('continueButton').click()
+
+    // Conclusion
+    await expect(page).toHaveURL(`domur/akaera/stada-og-lyktir/${caseId}`)
+
+    await page.locator('label').filter({ hasText: 'Lokið' }).click()
+    await page.locator('label').filter({ hasText: 'Viðurlagaákvörðun' }).click()
+
+    await Promise.all([
+      page.getByTestId('continueButton').click(),
+      verifyRequestCompletion(page, '/api/graphql', 'Case'),
+    ])
+
+    // Case overview
+    await expect(page).toHaveURL(`domur/akaera/samantekt/${caseId}`)
+    await page.getByTestId('continueButton').click()
+
+    await Promise.all([
+      page.getByTestId('modalPrimaryButton').click(),
+      verifyRequestCompletion(page, '/api/graphql', 'TransitionCase'),
+    ])
+
+    // Completed case overview
+    await expect(page).toHaveURL(`domur/akaera/lokid/${caseId}`)
+    await expect(page.getByText('Viðurlagaákvörðun').first()).toBeVisible()
+  })
+})

--- a/apps/system-e2e/src/tests/judicial-system/regression/indictment-merge-tests.spec.ts
+++ b/apps/system-e2e/src/tests/judicial-system/regression/indictment-merge-tests.spec.ts
@@ -1,0 +1,76 @@
+import { expect } from '@playwright/test'
+import faker from 'faker'
+import { urls } from '../../../support/urls'
+import { verifyRequestCompletion } from '../../../support/api-tools'
+import { test } from '../utils/judicialSystemTest'
+import { randomIndictmentCourtCaseNumber } from '../utils/helpers'
+import {
+  prosecutorCreatesIndictmentCase,
+  prosecutorSendsIndictmentToCourt,
+  judgeReceivesIndictmentThroughAdvocates,
+} from './shared-steps/indictment-to-court-record'
+
+test.use({ baseURL: urls.judicialSystemBaseUrl })
+
+test.describe.serial('Indictment merge tests', () => {
+  let caseId = ''
+  const accusedName = faker.name.findName()
+
+  test('prosecutor should create a new indictment case', async ({
+    prosecutorPage,
+  }) => {
+    caseId = await prosecutorCreatesIndictmentCase(prosecutorPage, accusedName)
+  })
+
+  test('prosecutor should accept and send indictment case to court', async ({
+    prosecutorPage,
+  }) => {
+    await prosecutorSendsIndictmentToCourt(prosecutorPage, caseId, accusedName)
+  })
+
+  test('judge should complete indictment case with a merge', async ({
+    judgePage,
+  }) => {
+    const page = judgePage
+
+    // Case list through subpoena, advocates and on to the court record
+    await judgeReceivesIndictmentThroughAdvocates(page, caseId, accusedName)
+
+    // Conclusion - a merge is allowed with an empty court record,
+    // so no court session is created
+    await Promise.all([
+      page.goto(`/domur/akaera/stada-og-lyktir/${caseId}`),
+      verifyRequestCompletion(page, '/api/graphql', 'Case'),
+    ])
+
+    await page.locator('label').filter({ hasText: 'Lokið' }).click()
+    await page
+      .locator('label')
+      .filter({ hasText: 'Sameinað öðru máli' })
+      .click()
+
+    // Merge into a case outside of the judicial system portal
+    await page
+      .getByRole('textbox', { name: 'Sameina við mál utan Réttarvörslugáttar' })
+      .fill(randomIndictmentCourtCaseNumber())
+    await page.keyboard.press('Tab')
+
+    await Promise.all([
+      page.getByTestId('continueButton').click(),
+      verifyRequestCompletion(page, '/api/graphql', 'Case'),
+    ])
+
+    // Case overview
+    await expect(page).toHaveURL(`domur/akaera/samantekt/${caseId}`)
+    await page.getByTestId('continueButton').click()
+
+    await Promise.all([
+      page.getByTestId('modalPrimaryButton').click(),
+      verifyRequestCompletion(page, '/api/graphql', 'TransitionCase'),
+    ])
+
+    // Completed case overview
+    await expect(page).toHaveURL(`domur/akaera/lokid/${caseId}`)
+    await expect(page.getByText('Sameinað').first()).toBeVisible()
+  })
+})

--- a/apps/system-e2e/src/tests/judicial-system/regression/indictment-tests.spec.ts
+++ b/apps/system-e2e/src/tests/judicial-system/regression/indictment-tests.spec.ts
@@ -186,4 +186,22 @@ test.describe.serial('Indictment tests', () => {
     await expect(page).toHaveURL('/malalistar/sakamal-i-fullnustu')
     await expect(page.getByText(accusedName)).toHaveCount(1)
   })
+
+  test('prison admin should receive indictment case', async ({
+    prisonAdminPage,
+  }) => {
+    const page = prisonAdminPage
+
+    // Case list for cases sent to the prison administration
+    await page.goto('/malalistar/sakamal-til-fullnustu')
+    await expect(page).toHaveURL('/malalistar/sakamal-til-fullnustu')
+    await page.getByText(accusedName).click()
+
+    // Prison admin indictment overview
+    await expect(page).toHaveURL(`fangelsi/akaera/yfirlit/${caseId}`)
+    await expect(
+      page.getByRole('heading', { name: 'Dómur til fullnustu' }),
+    ).toBeVisible()
+    await expect(page.getByText(accusedName).first()).toBeVisible()
+  })
 })

--- a/apps/system-e2e/src/tests/judicial-system/regression/indictment-tests.spec.ts
+++ b/apps/system-e2e/src/tests/judicial-system/regression/indictment-tests.spec.ts
@@ -3,12 +3,12 @@ import faker from 'faker'
 import { urls } from '../../../support/urls'
 import { verifyRequestCompletion } from '../../../support/api-tools'
 import { test } from '../utils/judicialSystemTest'
+import { getDaysFromNow, chooseDocument } from '../utils/helpers'
 import {
-  randomPoliceCaseNumber,
-  getDaysFromNow,
-  randomIndictmentCourtCaseNumber,
-  chooseDocument,
-} from '../utils/helpers'
+  prosecutorCreatesIndictmentCase,
+  prosecutorSendsIndictmentToCourt,
+  judgeReceivesIndictmentThroughAdvocates,
+} from './shared-steps/indictment-to-court-record'
 
 test.use({ baseURL: urls.judicialSystemBaseUrl })
 
@@ -19,226 +19,22 @@ test.describe.serial('Indictment tests', () => {
   test('prosecutor should create a new indictment case', async ({
     prosecutorPage,
   }) => {
-    const page = prosecutorPage
-    const today = getDaysFromNow()
-
-    const policeCaseNumber = randomPoliceCaseNumber()
-
-    // Case list groups
-    await page.goto('/malalistar')
-    await expect(page).toHaveURL('/malalistar')
-    await page.getByRole('button', { name: 'Nýtt mál' }).click()
-    await page.getByRole('menuitem', { name: 'Ákæra' }).click()
-    await expect(page).toHaveURL('/akaera/ny')
-
-    // New indictment case
-    await page.getByTestId('policeCaseNumber0').click()
-    await page.getByTestId('policeCaseNumber0').fill(policeCaseNumber)
-
-    await page.getByText('Sakarefni *Veldu sakarefni').click()
-    await page.getByRole('option', { name: 'Umferðarlagabrot' }).click()
-    await page.getByPlaceholder('Sláðu inn vettvang').click()
-    await page.getByPlaceholder('Sláðu inn vettvang').fill('Reykjavík')
-    await page
-      .locator(`input[id=crime-scene-date-${policeCaseNumber}]`)
-      .fill(today)
-    await page.keyboard.press('Escape')
-    const nationalIdInput = page.getByTestId('inputNationalId')
-    const nameInput = page.getByTestId('inputName')
-
-    await Promise.all([
-      page.waitForResponse(
-        (resp) =>
-          resp.url().includes('/api/nationalRegistry/getPersonByNationalId') &&
-          resp.request().method() === 'GET',
-      ),
-      nationalIdInput.fill('000000-0000'),
-    ])
-
-    await nameInput.fill(accusedName)
-    await nameInput.press('Tab')
-    await expect(nameInput).toHaveValue(accusedName)
-    await Promise.all([
-      page.getByRole('button', { name: 'Stofna mál' }).click(),
-      verifyRequestCompletion(page, '/api/graphql', 'CreateCase').then(
-        (res) => (caseId = res.data.createCase.id),
-      ),
-      verifyRequestCompletion(page, '/api/graphql', 'Case'),
-    ])
-
-    // Police case files (Málsgögn)
-    await expect(page).toHaveURL(`/akaera/malsgogn/${caseId}`)
-    await Promise.all([
-      page.getByTestId('continueButton').click(),
-      verifyRequestCompletion(page, '/api/graphql', 'Case'),
-    ])
-
-    // Case file
-    await expect(page).toHaveURL(`/akaera/skjalaskra/${caseId}`)
-    await Promise.all([
-      page.getByTestId('continueButton').click(),
-      verifyRequestCompletion(page, '/api/graphql', 'Case'),
-    ])
-
-    // Case files
-    await expect(page).toHaveURL(`/akaera/domskjol/${caseId}`)
-    await Promise.all([
-      page.getByTestId('continueButton').click(),
-      verifyRequestCompletion(page, '/api/graphql', 'Case'),
-      verifyRequestCompletion(page, '/api/graphql', 'UpdateCase'),
-    ])
-
-    // Processing
-    await expect(page).toHaveURL(`/akaera/malsmedferd/${caseId}`)
-
-    await Promise.all([
-      page.getByText('Játar sök').click(),
-      verifyRequestCompletion(page, '/api/graphql', 'UpdateDefendant'),
-    ])
-
-    await Promise.all([
-      page.getByText('Nei').last().click(),
-      verifyRequestCompletion(page, '/api/graphql', 'UpdateCase'),
-    ])
-
-    await Promise.all([
-      page.getByTestId('continueButton').click(),
-      verifyRequestCompletion(page, '/api/graphql', 'Case'),
-    ])
-
-    // Indictment
-    // The auto-created indictment count is expanded by default (open state is
-    // persisted in local storage), so no "Opna alla" toggle is needed.
-
-    await page.getByPlaceholder('AB123').fill('AB123')
-
-    await Promise.all([
-      page.keyboard.press('Tab'),
-      verifyRequestCompletion(page, '/api/graphql', 'UpdateIndictmentCount'),
-    ])
-
-    await Promise.all([
-      page.getByText('Brot *Veldu brot').click(),
-      page.getByRole('option', { name: 'Sviptingarakstur' }).click(),
-      verifyRequestCompletion(page, '/api/graphql', 'UpdateIndictmentCount'),
-    ])
-
-    await Promise.all([
-      page.getByLabel('Krefjast sviptingarKrefjast').check(),
-      verifyRequestCompletion(page, '/api/graphql', 'UpdateCase'),
-    ])
-
-    await Promise.all([
-      page.getByTestId('continueButton').click(),
-      verifyRequestCompletion(page, '/api/graphql', 'Case'),
-    ])
-
-    // Overview
-    await expect(page).toHaveURL(`/akaera/stadfesta/${caseId}`)
-
-    await Promise.all([
-      page.getByTestId('continueButton').click(),
-      verifyRequestCompletion(page, '/api/graphql', 'TransitionCase'),
-    ])
-    await page.getByTestId('modalPrimaryButton').click()
+    caseId = await prosecutorCreatesIndictmentCase(prosecutorPage, accusedName)
   })
 
   test('prosecutor should accept and send indictment case to court', async ({
     prosecutorPage,
   }) => {
-    const page = prosecutorPage
-
-    // Case list
-    await page.goto('/malalistar/sakamal-sem-bida-stadfestingar')
-    await expect(page).toHaveURL('/malalistar/sakamal-sem-bida-stadfestingar')
-    await page.getByText(accusedName).click()
-
-    // Indictment case
-    await expect(page).toHaveURL(`/akaera/stadfesta/${caseId}`)
-
-    await page.getByText('Staðfesta ákæru og senda á dómstól').click()
-    await page.getByTestId('continueButton').click()
-
-    await Promise.all([
-      page.getByTestId('modalPrimaryButton').click(),
-      verifyRequestCompletion(page, '/api/graphql', 'TransitionCase'),
-    ])
+    await prosecutorSendsIndictmentToCourt(prosecutorPage, caseId, accusedName)
   })
 
   test('judge should receive indictment case', async ({ judgePage }) => {
     const page = judgePage
-    const nextWeek = getDaysFromNow(7)
 
-    // Case list
-    await page.goto('/malalistar/sakamal-sem-bida-uthlutunar')
-    await expect(page).toHaveURL('/malalistar/sakamal-sem-bida-uthlutunar')
-    await page.getByText(accusedName).click()
-
-    // Indictment Overview
-    await expect(page).toHaveURL(`domur/akaera/yfirlit/${caseId}`)
-
-    await Promise.all([
-      page.getByTestId('continueButton').click(),
-      verifyRequestCompletion(page, '/api/graphql', 'Case'),
-    ])
-
-    // Reception and assignment
-    await expect(page).toHaveURL(`domur/akaera/mottaka/${caseId}`)
-
-    await page
-      .getByTestId('courtCaseNumber')
-      .fill(randomIndictmentCourtCaseNumber())
-    await page.keyboard.press('Tab')
-
-    await page.getByText('Veldu dómara/aðstoðarmann').click()
-    await page
-      .getByTestId('select-judge')
-      .getByText('Test Dómari')
-      .last()
-      .click()
-
-    await Promise.all([
-      page.getByTestId('continueButton').click(),
-      verifyRequestCompletion(page, '/api/graphql', 'Case'),
-    ])
-
-    // Subpoena
-    await expect(page).toHaveURL(`domur/akaera/fyrirkall/${caseId}`)
-
-    await page
-      .locator('label')
-      .filter({ hasText: 'Útivistarfyrirkall' })
-      .click()
-
-    await page.locator('input[id=courtDate]').fill(nextWeek)
-    await page.keyboard.press('Escape')
-
-    await page.getByTestId('courtDate-time').fill('11:00')
-    await page.getByTestId('courtroom').press('Tab')
-
-    await page.getByTestId('courtroom').fill('12')
-    await page.getByTestId('courtroom').press('Tab')
-
-    await page.getByTestId('continueButton').click()
-    await page.getByTestId('modalPrimaryButton').click()
-
-    // Advocates and civil claimants
-    await expect(page).toHaveURL(`domur/akaera/malflytjendur/${caseId}`)
-
-    await page
-      .locator('label')
-      .filter({ hasText: 'Ákærði óskar ekki eftir að sé' })
-      .click()
-    await page.getByRole('button', { name: 'Staðfesta val' }).click()
-    await page.getByTestId('modalPrimaryButton').click()
-
-    await Promise.all([
-      page.getByTestId('continueButton').click(),
-      verifyRequestCompletion(page, '/api/graphql', 'Case'),
-    ])
+    // Case list through subpoena, advocates and on to the court record
+    await judgeReceivesIndictmentThroughAdvocates(page, caseId, accusedName)
 
     // Indictment court record
-    await expect(page).toHaveURL(`domur/akaera/thingbok/${caseId}`)
     await Promise.all([
       page.getByRole('button', { name: 'Bæta við þinghaldi' }).click(),
       verifyRequestCompletion(page, '/api/graphql', 'CreateCourtSession'),

--- a/apps/system-e2e/src/tests/judicial-system/regression/restraining-order-tests.spec.ts
+++ b/apps/system-e2e/src/tests/judicial-system/regression/restraining-order-tests.spec.ts
@@ -1,0 +1,208 @@
+import { expect } from '@playwright/test'
+import faker from 'faker'
+import { urls } from '../../../support/urls'
+import { verifyRequestCompletion } from '../../../support/api-tools'
+import { test } from '../utils/judicialSystemTest'
+import {
+  getDaysFromNow,
+  randomCourtCaseNumber,
+  randomPoliceCaseNumber,
+} from '../utils/helpers'
+
+test.use({ baseURL: urls.judicialSystemBaseUrl })
+
+test.describe.serial('Restraining order tests', () => {
+  let caseId = ''
+  const today = getDaysFromNow()
+  const yesterday = getDaysFromNow(-1)
+  const accusedName = faker.name.findName()
+
+  test('prosecutor should submit a restraining order request to court', async ({
+    prosecutorPage,
+  }) => {
+    const page = prosecutorPage
+
+    // Case list
+    await page.goto('/malalistar')
+    await page.getByRole('button', { name: 'Nýtt mál' }).click()
+    await page.getByRole('menuitem', { name: 'Rannsóknarheimild' }).click()
+    await expect(page).toHaveURL('/krafa/ny/rannsoknarheimild')
+
+    // New restraining order request
+    await expect(
+      page.getByRole('heading', { name: 'Rannsóknarheimild' }).first(),
+    ).toBeVisible()
+    await page
+      .locator('input[name=policeCaseNumbers]')
+      .fill(randomPoliceCaseNumber())
+    await page.getByRole('button', { name: 'Skrá númer' }).click()
+    await page.locator('#type').click()
+    await page
+      .getByRole('option', { name: 'Nálgunarbann', exact: true })
+      .click()
+    await Promise.all([
+      page.getByRole('button', { name: 'Stofna mál' }).click(),
+      verifyRequestCompletion(page, '/api/graphql', 'CreateCase'),
+      verifyRequestCompletion(page, '/api/graphql', 'Case'),
+    ]).then((values) => {
+      const createCaseResult = values[1]
+      caseId = createCaseResult.data.createCase.id
+    })
+
+    // Defendant information
+    await expect(page).toHaveURL(
+      `/krafa/rannsoknarheimild/varnaradili/${caseId}`,
+    )
+    await page.getByRole('checkbox').first().check()
+    await page.locator('input[name=inputName]').fill(accusedName)
+    await page.locator('input[name=accusedAddress]').fill('Einhversstaðar 1')
+    await page.locator('#defendantGender').click()
+    await page.locator('#react-select-defendantGender-option-0').click()
+    await Promise.all([
+      page.getByRole('button', { name: 'Halda áfram' }).click(),
+      verifyRequestCompletion(page, '/api/graphql', 'Case'),
+    ])
+
+    // Court date request
+    await expect(page).toHaveURL(`/krafa/rannsoknarheimild/fyrirtaka/${caseId}`)
+    await page.locator('input[id=reqCourtDate]').fill(today)
+    await page.keyboard.press('Escape')
+    await page.locator('input[id=reqCourtDate-time]').fill('15:00')
+    await page.getByRole('button', { name: 'Halda áfram' }).click()
+    await Promise.all([
+      page.getByRole('button', { name: 'Halda áfram með kröfu' }).click(),
+      verifyRequestCompletion(page, '/api/graphql', 'Case'),
+    ])
+
+    // Prosecutor demands - restraining orders have no demands prefill
+    await expect(page).toHaveURL(
+      `/krafa/rannsoknarheimild/domkrofur-og-lagagrundvollur/${caseId}`,
+    )
+    await page.locator('textarea[name=demands]').click()
+    await page.keyboard.type(
+      'Þess er krafist að varnaraðila verði gert að sæta nálgunarbanni',
+    )
+    await page.keyboard.press('Tab')
+    await page.locator('textarea[name=lawsBroken]').click()
+    await page.keyboard.type('Einhver lög voru brotin')
+    await page.keyboard.press('Tab')
+    await page.locator('textarea[name=legalBasis]').click()
+    await page.keyboard.type('Krafan byggir á lagaákvæðum')
+    await page.keyboard.press('Tab')
+    await Promise.all([
+      page.getByRole('button', { name: 'Halda áfram' }).click(),
+      verifyRequestCompletion(page, '/api/graphql', 'Case'),
+    ])
+
+    // Prosecutor statement
+    await expect(page).toHaveURL(
+      `/krafa/rannsoknarheimild/greinargerd/${caseId}`,
+    )
+    await page.locator('textarea[name=caseFacts]').click()
+    await page.keyboard.type('Eitthvað gerðist')
+    await page.locator('textarea[name=legalArguments]').click()
+    await page.keyboard.type('Þetta er ekki löglegt')
+    await page.locator('textarea[name=comments]').click()
+    await page.keyboard.type('Varnaraðili er hættulegur')
+    await Promise.all([
+      page.getByRole('button', { name: 'Halda áfram' }).click(),
+      verifyRequestCompletion(page, '/api/graphql', 'Case'),
+    ])
+
+    // Case files
+    await expect(page).toHaveURL(
+      `/krafa/rannsoknarheimild/rannsoknargogn/${caseId}`,
+    )
+    await page.locator('textarea[name=caseFilesComments]').click()
+    await page.keyboard.type('Engin gögn fylgja')
+    await Promise.all([
+      page.getByRole('button', { name: 'Halda áfram' }).click(),
+      verifyRequestCompletion(page, '/api/graphql', 'Case'),
+    ])
+
+    // Submit to court
+    await expect(page).toHaveURL(`/krafa/rannsoknarheimild/stadfesta/${caseId}`)
+    await page.getByRole('button', { name: 'Senda kröfu á héraðsdóm' }).click()
+    await page.getByTestId('modalSecondaryButton').click()
+    await expect(page).toHaveURL('/malalistar')
+  })
+
+  test('court should receive restraining order request and make a ruling', async ({
+    judgePage,
+  }) => {
+    const page = judgePage
+
+    // Reception and assignment
+    await Promise.all([
+      page.goto(`domur/rannsoknarheimild/mottaka/${caseId}`),
+      verifyRequestCompletion(page, '/api/graphql', 'Case'),
+    ])
+    await page.getByTestId('courtCaseNumber').click()
+    await page.getByTestId('courtCaseNumber').fill(randomCourtCaseNumber())
+    await page
+      .getByText('Veldu dómara/aðstoðarmann *Veldu héraðsdómara')
+      .click()
+    await page.getByTestId('select-judge').getByText('Test Dómari').click()
+    await Promise.all([
+      page.getByTestId('continueButton').click(),
+      verifyRequestCompletion(page, '/api/graphql', 'Case'),
+    ])
+
+    // Overview
+    await expect(page).toHaveURL(`/domur/rannsoknarheimild/yfirlit/${caseId}`)
+    await Promise.all([
+      page.getByTestId('continueButton').click(),
+      verifyRequestCompletion(page, '/api/graphql', 'Case'),
+    ])
+
+    // Hearing arrangements
+    await expect(page).toHaveURL(`/domur/rannsoknarheimild/fyrirtaka/${caseId}`)
+    await page.getByText('Fulltrúar málsaðila boðaðir').click()
+    await page.getByTestId('continueButton').click()
+    await Promise.all([
+      page.getByTestId('modalSecondaryButton').click(),
+      verifyRequestCompletion(page, '/api/graphql', 'Case'),
+    ])
+
+    // Ruling
+    await expect(page).toHaveURL(`/domur/rannsoknarheimild/urskurdur/${caseId}`)
+    await page.getByText('Krafa samþykkt').click()
+    await Promise.all([
+      page.getByTestId('continueButton').click(),
+      verifyRequestCompletion(page, '/api/graphql', 'Case'),
+    ])
+
+    // Court Record - the session bookings autofill has a restraining-order
+    // specific branch
+    await expect(page).toHaveURL(`/domur/rannsoknarheimild/thingbok/${caseId}`)
+    await expect(page.getByTestId('sessionBookings')).toHaveValue(/nálgun/i)
+    await page.getByLabel('Dagsetning þingfestingar *').click()
+    await page.locator('input[id=courtStartDate]').fill(yesterday)
+    await page.keyboard.press('Escape')
+    await page.getByTestId('courtStartDate-time').fill('12:00')
+    await page.keyboard.press('Tab')
+    await page
+      .locator('label')
+      .filter({ hasText: 'Varnaraðili unir úrskurðinum' })
+      .click()
+    await page
+      .locator('label')
+      .filter({ hasText: 'Sækjandi tekur sér lögboðinn frest' })
+      .click()
+    await page.locator('input[id=courtEndTime]').fill(yesterday)
+    await page.keyboard.press('Escape')
+    await page.getByTestId('courtEndTime-time').fill('15:00')
+    await page.keyboard.press('Tab')
+    await Promise.all([
+      page.getByTestId('continueButton').click(),
+      verifyRequestCompletion(page, '/api/graphql', 'Case'),
+    ])
+
+    // Confirmation
+    await expect(page).toHaveURL(`/domur/rannsoknarheimild/stadfesta/${caseId}`)
+    await Promise.all([
+      page.getByTestId('continueButton').click(),
+      verifyRequestCompletion(page, '/api/graphql', 'TransitionCase'),
+    ])
+  })
+})

--- a/apps/system-e2e/src/tests/judicial-system/regression/shared-steps/complete-appeal.ts
+++ b/apps/system-e2e/src/tests/judicial-system/regression/shared-steps/complete-appeal.ts
@@ -75,5 +75,20 @@ export const coaJudgesCompleteAppealCaseTest = async (
   await expect(page).toHaveURL(
     new RegExp(`/landsrettur/samantekt/${caseId}(\\?.*)?$`),
   )
-  await page.getByTestId('continueButton').click()
+  await Promise.all([
+    verifyRequestCompletion(page, '/api/graphql', 'TransitionAppealCase'),
+    page.getByTestId('continueButton').click(),
+  ])
+
+  // Closing the completion modal lands on the result screen
+  await page.getByTestId('modalSecondaryButton').click()
+  await expect(page).toHaveURL(
+    new RegExp(`/landsrettur/nidurstada/${caseId}(\\?.*)?$`),
+  )
+  await expect(
+    page.getByRole('heading', { name: 'Úrskurðarorð Landsréttar' }),
+  ).toBeVisible()
+  await expect(
+    page.getByText('Test úrskurðarorð Landsréttar').first(),
+  ).toBeVisible()
 }

--- a/apps/system-e2e/src/tests/judicial-system/regression/shared-steps/court-decision.ts
+++ b/apps/system-e2e/src/tests/judicial-system/regression/shared-steps/court-decision.ts
@@ -1,0 +1,90 @@
+import { expect, Page } from '@playwright/test'
+import { verifyRequestCompletion } from '../../../../support/api-tools'
+import { getDaysFromNow, randomCourtCaseNumber } from '../../utils/helpers'
+
+export const judgeSubmitsDecision = async (
+  page: Page,
+  caseId: string,
+  options: {
+    acceptRulingText: string
+    validToDate: string
+    // The confirmation step may open the signing-method modal, which the
+    // custody flow dismisses without signing. E-signing is not exercised
+    // by these tests.
+    dismissSignatureModal?: boolean
+  },
+) => {
+  const today = getDaysFromNow()
+
+  await Promise.all([
+    page.goto(`/domur/mottaka/${caseId}`),
+    verifyRequestCompletion(page, '/api/graphql', 'Case'),
+  ])
+
+  // Reception and assignment
+  await expect(page).toHaveURL(`/domur/mottaka/${caseId}`)
+  await page.getByTestId('courtCaseNumber').fill(randomCourtCaseNumber())
+  await page.keyboard.press('Tab')
+  await page.getByText('Veldu dómara/aðstoðarmann').click()
+  await page.getByTestId('select-judge').getByText('Test Dómari').last().click()
+  await Promise.all([
+    page.getByTestId('continueButton').click(),
+    verifyRequestCompletion(page, '/api/graphql', 'Case'),
+  ])
+
+  // Overview
+  await expect(page).toHaveURL(`/domur/krafa/${caseId}`)
+  await expect(page.getByTestId('continueButton')).toBeVisible()
+  await Promise.all([
+    page.getByTestId('continueButton').click(),
+    verifyRequestCompletion(page, '/api/graphql', 'Case'),
+  ])
+
+  // Hearing arrangements
+  await expect(page).toHaveURL(`/domur/fyrirtokutimi/${caseId}`)
+  await page.locator('input[id=courtDate]').fill(today)
+  await page.keyboard.press('Escape')
+  await page.locator('input[id=courtDate-time]').fill('09:00')
+  await page.keyboard.press('Tab')
+  await page.getByTestId('continueButton').click()
+  await Promise.all([
+    page.getByTestId('modalPrimaryButton').click(),
+    verifyRequestCompletion(page, '/api/graphql', 'Case'),
+  ])
+
+  // Ruling
+  await expect(page).toHaveURL(`/domur/urskurdur/${caseId}`)
+  await page.getByText(options.acceptRulingText).click()
+  await page.locator('input[id=validToDate]').fill(options.validToDate)
+  await page.keyboard.press('Escape')
+  await page.locator('input[id=validToDate-time]').fill('16:00')
+  await page.keyboard.press('Tab')
+  await Promise.all([
+    page.getByTestId('continueButton').click(),
+    verifyRequestCompletion(page, '/api/graphql', 'Case'),
+  ])
+
+  // Court record
+  await expect(page).toHaveURL(`/domur/thingbok/${caseId}`)
+  await page.getByText('Varnaraðili tekur sér lögboðinn frest').click()
+  await page.getByText('Sækjandi tekur sér lögboðinn frest').click()
+  await page.locator('input[id=courtEndTime]').fill(today)
+  await page.keyboard.press('Escape')
+  await page.locator('input[id=courtEndTime-time]').fill('10:00')
+  await page.keyboard.press('Tab')
+  await Promise.all([
+    page.getByTestId('continueButton').click(),
+    verifyRequestCompletion(page, '/api/graphql', 'Case'),
+  ])
+
+  // Confirmation
+  await expect(page).toHaveURL(`/domur/stadfesta/${caseId}`)
+  await Promise.all([
+    page.getByTestId('continueButton').click(),
+    verifyRequestCompletion(page, '/api/graphql', 'TransitionCase'),
+  ])
+
+  if (options.dismissSignatureModal) {
+    await page.getByTestId('modalSecondaryButton').click()
+  }
+}

--- a/apps/system-e2e/src/tests/judicial-system/regression/shared-steps/court-decision.ts
+++ b/apps/system-e2e/src/tests/judicial-system/regression/shared-steps/court-decision.ts
@@ -6,8 +6,12 @@ export const judgeSubmitsDecision = async (
   page: Page,
   caseId: string,
   options: {
-    acceptRulingText: string
-    validToDate: string
+    // Label of the decision radio to pick, e.g. 'Krafa um gæsluvarðhald
+    // samþykkt' or 'Kröfu um gæsluvarðhald hafnað'.
+    decisionText: string
+    // Required when accepting; rejected/dismissed cases hide the
+    // restriction-length section entirely.
+    validToDate?: string
     // The confirmation step may open the signing-method modal, which the
     // custody flow dismisses without signing. E-signing is not exercised
     // by these tests.
@@ -54,11 +58,13 @@ export const judgeSubmitsDecision = async (
 
   // Ruling
   await expect(page).toHaveURL(`/domur/urskurdur/${caseId}`)
-  await page.getByText(options.acceptRulingText).click()
-  await page.locator('input[id=validToDate]').fill(options.validToDate)
-  await page.keyboard.press('Escape')
-  await page.locator('input[id=validToDate-time]').fill('16:00')
-  await page.keyboard.press('Tab')
+  await page.getByText(options.decisionText).click()
+  if (options.validToDate) {
+    await page.locator('input[id=validToDate]').fill(options.validToDate)
+    await page.keyboard.press('Escape')
+    await page.locator('input[id=validToDate-time]').fill('16:00')
+    await page.keyboard.press('Tab')
+  }
   await Promise.all([
     page.getByTestId('continueButton').click(),
     verifyRequestCompletion(page, '/api/graphql', 'Case'),

--- a/apps/system-e2e/src/tests/judicial-system/regression/shared-steps/court-decision.ts
+++ b/apps/system-e2e/src/tests/judicial-system/regression/shared-steps/court-decision.ts
@@ -58,7 +58,9 @@ export const judgeSubmitsDecision = async (
 
   // Ruling
   await expect(page).toHaveURL(`/domur/urskurdur/${caseId}`)
-  await page.getByText(options.decisionText).click()
+  // Exact match because some decision labels are prefixes of others, e.g.
+  // 'Kröfu um gæsluvarðhald hafnað( en úrskurðað í farbann)'
+  await page.getByText(options.decisionText, { exact: true }).click()
   if (options.validToDate) {
     await page.locator('input[id=validToDate]').fill(options.validToDate)
     await page.keyboard.press('Escape')

--- a/apps/system-e2e/src/tests/judicial-system/regression/shared-steps/create-restriction-case.ts
+++ b/apps/system-e2e/src/tests/judicial-system/regression/shared-steps/create-restriction-case.ts
@@ -1,0 +1,132 @@
+import { expect, Page } from '@playwright/test'
+import { verifyRequestCompletion } from '../../../../support/api-tools'
+import {
+  getDaysFromNow,
+  injectTestDefenderIntoLawyerRegistry,
+  randomPoliceCaseNumber,
+  selectTestDefender,
+} from '../../utils/helpers'
+
+/**
+ * Prosecutor creates a custody request and submits it to court. The test
+ * defender is registered through the lawyer-registry combobox so the
+ * defender fixture (0909090909) gets limited access to the case.
+ * Returns the created case id.
+ */
+export const prosecutorCreatesCustodyRequest = async (
+  page: Page,
+  accusedName: string,
+  requestedCustodyEndDate: string,
+): Promise<string> => {
+  let caseId = ''
+  const today = getDaysFromNow()
+
+  await injectTestDefenderIntoLawyerRegistry(page)
+
+  // Case list groups
+  await page.goto('/malalistar')
+  await expect(page).toHaveURL('/malalistar')
+  await page.getByRole('button', { name: 'Nýtt mál' }).click()
+  await page.getByRole('menuitem', { name: 'Gæsluvarðhald' }).click()
+  await expect(page).toHaveURL('/krafa/ny/gaesluvardhald')
+
+  // New custody request
+  await expect(
+    page.getByRole('heading', { name: 'Gæsluvarðhald' }),
+  ).toBeVisible()
+  await page
+    .locator('input[name=policeCaseNumbers]')
+    .fill(randomPoliceCaseNumber())
+  await page.getByRole('button', { name: 'Skrá númer' }).click()
+  await page.getByRole('checkbox').first().check()
+  await page.locator('input[name=inputName]').fill(accusedName)
+  await page.locator('input[name=accusedAddress]').fill('Einhversstaðar 1')
+  await page.locator('#defendantGender').click()
+  await page.locator('#react-select-defendantGender-option-0').click()
+
+  // Defender - selected from the (intercepted) lawyer registry so the
+  // CreateCase mutation carries the defender fields set by the real UI
+  await selectTestDefender(page)
+  await page.locator('label[for="defender-access-ready-for-court"]').click()
+
+  await page.locator('input[name=leadInvestigator]').fill('Stjórinn')
+  await expect(
+    page.getByRole('button', { name: 'Óskir um fyrirtöku' }),
+  ).toBeVisible()
+  await Promise.all([
+    page.getByRole('button', { name: 'Stofna mál' }).click(),
+    verifyRequestCompletion(page, '/api/graphql', 'CreateCase').then(
+      (res) => (caseId = res.data.createCase.id),
+    ),
+    verifyRequestCompletion(page, '/api/graphql', 'Case'),
+  ])
+
+  // Court date request
+  await expect(page).toHaveURL(`/krafa/fyrirtaka/${caseId}`)
+  await page.locator('input[id=arrestDate]').fill(today)
+  await page.keyboard.press('Escape')
+  await page.locator('input[id=arrestDate-time]').fill('00:00')
+  await page.locator('input[id=reqCourtDate]').fill(today)
+  await page.keyboard.press('Escape')
+  await page.locator('input[id=reqCourtDate-time]').fill('15:00')
+  await expect(
+    page.getByRole('button', { name: 'Dómkröfur og lagagrundvöllur' }),
+  ).toBeVisible()
+  await page.getByRole('button', { name: 'Halda áfram' }).click()
+  await Promise.all([
+    page.getByRole('button', { name: 'Halda áfram með kröfu' }).click(),
+    verifyRequestCompletion(page, '/api/graphql', 'Case'),
+  ])
+
+  // Prosecutor demands
+  await expect(page).toHaveURL(`/krafa/domkrofur-og-lagagrundvollur/${caseId}`)
+  await page.locator('input[id=reqValidToDate]').fill(requestedCustodyEndDate)
+  await page.keyboard.press('Escape')
+  await page.locator('textarea[name=lawsBroken]').click()
+  await page.keyboard.type('Einhver lög voru brotin')
+  await page.getByTestId('checkbox').first().click()
+  await expect(page.getByRole('button', { name: 'Greinargerð' })).toBeVisible()
+  await Promise.all([
+    page.getByRole('button', { name: 'Halda áfram' }).click(),
+    verifyRequestCompletion(page, '/api/graphql', 'Case'),
+  ])
+
+  // Prosecutor statement
+  await expect(page).toHaveURL(`/krafa/greinargerd/${caseId}`)
+  await page.locator('textarea[name=caseFacts]').click()
+  await page.keyboard.type('Eitthvað gerðist')
+  await page.locator('textarea[name=legalArguments]').click()
+  await page.keyboard.type('Þetta er ekki löglegt')
+  await page.locator('textarea[name=comments]').click()
+  await page.keyboard.type('Sakborningur er hættulegur')
+  // Blur so debounced Case update runs; then wait for form to become valid (footer button enabled).
+  await page.keyboard.press('Tab')
+  await expect(page.getByRole('button', { name: 'Halda áfram' })).toBeEnabled({
+    timeout: 15000,
+  })
+  await Promise.all([
+    page.getByRole('button', { name: 'Halda áfram' }).click(),
+    verifyRequestCompletion(page, '/api/graphql', 'Case'),
+  ])
+
+  // Case files
+  await expect(page).toHaveURL(`/krafa/rannsoknargogn/${caseId}`)
+  await page.locator('textarea[name=caseFilesComments]').click()
+  await page.keyboard.type('Engin gögn fylgja')
+  await page.keyboard.press('Tab')
+  await expect(page.getByRole('button', { name: 'Halda áfram' })).toBeEnabled({
+    timeout: 15000,
+  })
+  await Promise.all([
+    page.getByRole('button', { name: 'Halda áfram' }).click(),
+    verifyRequestCompletion(page, '/api/graphql', 'Case'),
+  ])
+
+  // Submit to court
+  await expect(page).toHaveURL(`/krafa/stadfesta/${caseId}`)
+  await page.getByRole('button', { name: 'Senda kröfu á héraðsdóm' }).click()
+  await page.getByTestId('modalSecondaryButton').click()
+  await expect(page).toHaveURL('/malalistar')
+
+  return caseId
+}

--- a/apps/system-e2e/src/tests/judicial-system/regression/shared-steps/indictment-to-court-record.ts
+++ b/apps/system-e2e/src/tests/judicial-system/regression/shared-steps/indictment-to-court-record.ts
@@ -91,6 +91,8 @@ export const prosecutorCreatesIndictmentCase = async (
     page.getByTestId('continueButton').click(),
   ])
 
+  // The auto-created indictment count is expanded by default (open state is
+  // persisted in local storage), so no "Opna alla" toggle is needed.
   await page.getByPlaceholder('AB123').fill('AB123')
 
   await Promise.all([

--- a/apps/system-e2e/src/tests/judicial-system/regression/shared-steps/indictment-to-court-record.ts
+++ b/apps/system-e2e/src/tests/judicial-system/regression/shared-steps/indictment-to-court-record.ts
@@ -9,6 +9,7 @@ import {
 export const prosecutorCreatesIndictmentCase = async (
   page: Page,
   accusedName: string,
+  secondAccusedName?: string,
 ): Promise<string> => {
   let caseId = ''
   const today = getDaysFromNow()
@@ -47,10 +48,34 @@ export const prosecutorCreatesIndictmentCase = async (
   await nameInput.fill(accusedName)
   await nameInput.press('Tab')
   await expect(nameInput).toHaveValue(accusedName)
+
+  if (secondAccusedName) {
+    // The case does not exist yet, so this only adds a defendant locally -
+    // it is persisted with a CreateDefendant mutation when the case is
+    // created below. The second defendant has no Icelandic national id to
+    // avoid a duplicate national registry lookup.
+    await page.getByTestId('addDefendantButton').click()
+    await page
+      .getByRole('checkbox', {
+        name: 'Varnaraðili er ekki með íslenska kennitölu',
+      })
+      .last()
+      .check()
+    await page.getByTestId('inputNationalId').last().fill('12.12.2000')
+    const secondNameInput = page.getByTestId('inputName').last()
+    await secondNameInput.fill(secondAccusedName)
+    await page.getByTestId('accusedAddress').last().fill('Einhversstaðar 2')
+    await secondNameInput.press('Tab')
+    await expect(secondNameInput).toHaveValue(secondAccusedName)
+  }
+
   await Promise.all([
     verifyRequestCompletion(page, '/api/graphql', 'CreateCase').then(
       (res) => (caseId = res.data.createCase.id),
     ),
+    ...(secondAccusedName
+      ? [verifyRequestCompletion(page, '/api/graphql', 'CreateDefendant')]
+      : []),
     verifyRequestCompletion(page, '/api/graphql', 'Case'),
     page.getByRole('button', { name: 'Stofna mál' }).click(),
   ])
@@ -76,10 +101,16 @@ export const prosecutorCreatesIndictmentCase = async (
 
   await expect(page).toHaveURL(`/akaera/malsmedferd/${caseId}`)
 
-  await Promise.all([
-    verifyRequestCompletion(page, '/api/graphql', 'UpdateDefendant'),
-    page.getByText('Játar sök').click(),
-  ])
+  // One plea per defendant
+  const pleaOptions = page.getByText('Játar sök')
+  await expect(pleaOptions.first()).toBeVisible()
+  const pleaCount = await pleaOptions.count()
+  for (let i = 0; i < pleaCount; i++) {
+    await Promise.all([
+      verifyRequestCompletion(page, '/api/graphql', 'UpdateDefendant'),
+      pleaOptions.nth(i).click(),
+    ])
+  }
 
   await Promise.all([
     verifyRequestCompletion(page, '/api/graphql', 'UpdateCase'),
@@ -182,7 +213,15 @@ export const judgeReceivesIndictmentThroughAdvocates = async (
 
   await expect(page).toHaveURL(`domur/akaera/fyrirkall/${caseId}`)
 
-  await page.locator('label').filter({ hasText: 'Útivistarfyrirkall' }).click()
+  // One subpoena type per defendant
+  const subpoenaTypeOptions = page
+    .locator('label')
+    .filter({ hasText: 'Útivistarfyrirkall' })
+  await expect(subpoenaTypeOptions.first()).toBeVisible()
+  const subpoenaTypeCount = await subpoenaTypeOptions.count()
+  for (let i = 0; i < subpoenaTypeCount; i++) {
+    await subpoenaTypeOptions.nth(i).click()
+  }
 
   await page.locator('input[id=courtDate]').fill(nextWeek)
   await page.keyboard.press('Escape')
@@ -198,10 +237,15 @@ export const judgeReceivesIndictmentThroughAdvocates = async (
 
   await expect(page).toHaveURL(`domur/akaera/malflytjendur/${caseId}`)
 
-  await page
+  // One defender choice per defendant
+  const defenderChoiceOptions = page
     .locator('label')
-    .filter({ hasText: 'Ákærði óskar ekki eftir að sé' })
-    .click()
+    .filter({ hasText: 'óskar ekki eftir að sé' })
+  await expect(defenderChoiceOptions.first()).toBeVisible()
+  const defenderChoiceCount = await defenderChoiceOptions.count()
+  for (let i = 0; i < defenderChoiceCount; i++) {
+    await defenderChoiceOptions.nth(i).click()
+  }
   await page.getByRole('button', { name: 'Staðfesta val' }).click()
   await page.getByTestId('modalPrimaryButton').click()
 

--- a/apps/system-e2e/src/tests/judicial-system/regression/shared-steps/indictment-to-court-record.ts
+++ b/apps/system-e2e/src/tests/judicial-system/regression/shared-steps/indictment-to-court-record.ts
@@ -3,7 +3,9 @@ import { verifyRequestCompletion } from '../../../../support/api-tools'
 import {
   randomPoliceCaseNumber,
   getDaysFromNow,
+  injectTestDefenderIntoLawyerRegistry,
   randomIndictmentCourtCaseNumber,
+  selectTestDefender,
 } from '../../utils/helpers'
 
 export const prosecutorCreatesIndictmentCase = async (
@@ -182,8 +184,17 @@ export const judgeReceivesIndictmentThroughAdvocates = async (
   page: Page,
   caseId: string,
   accusedName: string,
+  options?: {
+    // Assign the test defender on the advocates screen instead of the
+    // defendants waiving their right to counsel
+    assignDefender?: boolean
+  },
 ) => {
   const nextWeek = getDaysFromNow(7)
+
+  if (options?.assignDefender) {
+    await injectTestDefenderIntoLawyerRegistry(page)
+  }
 
   await page.goto('/malalistar/sakamal-sem-bida-uthlutunar')
   await expect(page).toHaveURL('/malalistar/sakamal-sem-bida-uthlutunar')
@@ -237,17 +248,29 @@ export const judgeReceivesIndictmentThroughAdvocates = async (
 
   await expect(page).toHaveURL(`domur/akaera/malflytjendur/${caseId}`)
 
-  // One defender choice per defendant
-  const defenderChoiceOptions = page
-    .locator('label')
-    .filter({ hasText: 'óskar ekki eftir að sé' })
-  await expect(defenderChoiceOptions.first()).toBeVisible()
-  const defenderChoiceCount = await defenderChoiceOptions.count()
-  for (let i = 0; i < defenderChoiceCount; i++) {
-    await defenderChoiceOptions.nth(i).click()
+  if (options?.assignDefender) {
+    // Assign the test defender from the lawyer registry; selecting fires an
+    // UpdateDefendant with the defender fields
+    await selectTestDefender(page)
+    await page.getByRole('button', { name: 'Staðfesta val' }).click()
+    await Promise.all([
+      verifyRequestCompletion(page, '/api/graphql', 'UpdateDefendant'),
+      page.getByTestId('modalPrimaryButton').click(),
+    ])
+    await expect(page.getByText('Verjandi staðfestur')).toBeVisible()
+  } else {
+    // One defender choice per defendant
+    const defenderChoiceOptions = page
+      .locator('label')
+      .filter({ hasText: 'óskar ekki eftir að sé' })
+    await expect(defenderChoiceOptions.first()).toBeVisible()
+    const defenderChoiceCount = await defenderChoiceOptions.count()
+    for (let i = 0; i < defenderChoiceCount; i++) {
+      await defenderChoiceOptions.nth(i).click()
+    }
+    await page.getByRole('button', { name: 'Staðfesta val' }).click()
+    await page.getByTestId('modalPrimaryButton').click()
   }
-  await page.getByRole('button', { name: 'Staðfesta val' }).click()
-  await page.getByTestId('modalPrimaryButton').click()
 
   await Promise.all([
     verifyRequestCompletion(page, '/api/graphql', 'Case'),

--- a/apps/system-e2e/src/tests/judicial-system/regression/shared-steps/receive-appeal.ts
+++ b/apps/system-e2e/src/tests/judicial-system/regression/shared-steps/receive-appeal.ts
@@ -1,4 +1,4 @@
-import { Page } from '@playwright/test'
+import { expect, Page } from '@playwright/test'
 import { verifyRequestCompletion } from '../../../../support/api-tools'
 
 export const judgeReceivesAppealTest = async (page: Page, caseId: string) => {
@@ -6,10 +6,11 @@ export const judgeReceivesAppealTest = async (page: Page, caseId: string) => {
     page.goto(`krafa/yfirlit/${caseId}`),
     verifyRequestCompletion(page, '/api/graphql', 'Case'),
   ])
-  await page
-    .getByRole('button', {
-      name: 'Senda tilkynningu um kæru til Landsréttar',
-    })
-    .click()
+  const sendNotificationButton = page.getByRole('button', {
+    name: 'Senda tilkynningu um kæru til Landsréttar',
+  })
+  await expect(sendNotificationButton).toBeVisible()
+  await sendNotificationButton.click()
   await page.getByTestId('modalPrimaryButton').click()
+  await expect(page.getByText('Tilkynning um móttöku send')).toBeVisible()
 }

--- a/apps/system-e2e/src/tests/judicial-system/regression/shared-steps/send-appeal.ts
+++ b/apps/system-e2e/src/tests/judicial-system/regression/shared-steps/send-appeal.ts
@@ -79,3 +79,45 @@ export const prosecutorAppealsCaseTest = async (page: Page, caseId: string) => {
   ])
   await page.getByTestId('modalSecondaryButton').click()
 }
+
+export const defenderAppealsCaseTest = async (page: Page, caseId: string) => {
+  await Promise.all([
+    page.goto(`/verjandi/krafa/${caseId}`),
+    verifyRequestCompletion(page, '/api/graphql', 'LimitedAccessCase'),
+  ])
+  await expect(page).toHaveURL(`/verjandi/krafa/${caseId}`)
+
+  // The appeal banner links to the limited-access appeal screen while the
+  // appeal deadline is open
+  await Promise.all([
+    page.getByRole('button', { name: 'Senda inn kæru' }).click(),
+    verifyRequestCompletion(page, '/api/graphql', 'LimitedAccessCase'),
+  ])
+
+  // Send appeal - only the appeal brief is required
+  await expect(page).toHaveURL(`/verjandi/kaera/${caseId}`)
+  await chooseDocument(
+    page,
+    async () => {
+      await page
+        .getByRole('button', { name: 'Velja skjöl til að hlaða upp' })
+        .nth(1)
+        .click()
+    },
+    'TestKaeraVerjanda.pdf',
+  )
+  await Promise.all([
+    page.getByTestId('continueButton').click(),
+    verifyUpload(page, true),
+    verifyRequestCompletion(
+      page,
+      '/api/graphql',
+      'LimitedAccessCreateAppealCase',
+    ),
+  ])
+  await page.getByTestId('modalSecondaryButton').click()
+
+  // Back on the overview the appeal state is visible to the defender
+  await expect(page).toHaveURL(`/verjandi/krafa/${caseId}`)
+  await expect(page.getByText('Úrskurður kærður')).toBeVisible()
+}

--- a/apps/system-e2e/src/tests/judicial-system/regression/travel-ban-tests.spec.ts
+++ b/apps/system-e2e/src/tests/judicial-system/regression/travel-ban-tests.spec.ts
@@ -2,9 +2,14 @@ import { expect } from '@playwright/test'
 import { urls } from '../../../support/urls'
 import { test } from '../utils/judicialSystemTest'
 import { verifyRequestCompletion } from '../../../support/api-tools'
-import { getDaysFromNow, randomPoliceCaseNumber } from '../utils/helpers'
+import {
+  getDaysFromNow,
+  injectTestDefenderIntoLawyerRegistry,
+  randomPoliceCaseNumber,
+  selectTestDefender,
+} from '../utils/helpers'
 import { judgeSubmitsDecision } from './shared-steps/court-decision'
-import { prosecutorAppealsCaseTest } from './shared-steps/send-appeal'
+import { defenderAppealsCaseTest } from './shared-steps/send-appeal'
 import { judgeReceivesAppealTest } from './shared-steps/receive-appeal'
 import { coaJudgesCompleteAppealCaseTest } from './shared-steps/complete-appeal'
 
@@ -20,6 +25,8 @@ test.describe.serial('Travel ban tests', () => {
     prosecutorPage,
   }) => {
     const page = prosecutorPage
+
+    await injectTestDefenderIntoLawyerRegistry(page)
 
     await page.goto('/malalistar')
     await page.getByRole('button', { name: 'Nýtt mál' }).click()
@@ -48,6 +55,12 @@ test.describe.serial('Travel ban tests', () => {
       .fill('Latibær')
     await page.locator('#defendantGender').click()
     await page.locator('#react-select-defendantGender-option-0').click()
+
+    // Defender - registered through the lawyer registry combobox so the
+    // defender fixture can appeal the ruling later
+    await selectTestDefender(page)
+    await page.locator('label[for="defender-access-ready-for-court"]').click()
+
     await Promise.all([
       page.getByRole('button', { name: 'Stofna mál' }).click(),
       verifyRequestCompletion(page, '/api/graphql', 'CreateCase'),
@@ -110,13 +123,13 @@ test.describe.serial('Travel ban tests', () => {
     judgePage,
   }) => {
     await judgeSubmitsDecision(judgePage, caseId, {
-      acceptRulingText: 'Krafa um farbann samþykkt',
+      decisionText: 'Krafa um farbann samþykkt',
       validToDate: travelBanEndDate,
     })
   })
 
-  test('prosecutor should appeal case', async ({ prosecutorPage }) => {
-    await prosecutorAppealsCaseTest(prosecutorPage, caseId)
+  test('defender should appeal case', async ({ defenderPage }) => {
+    await defenderAppealsCaseTest(defenderPage, caseId)
   })
 
   test('judge should receive appealed case', async ({ judgePage }) => {

--- a/apps/system-e2e/src/tests/judicial-system/regression/travel-ban-tests.spec.ts
+++ b/apps/system-e2e/src/tests/judicial-system/regression/travel-ban-tests.spec.ts
@@ -2,7 +2,8 @@ import { expect } from '@playwright/test'
 import { urls } from '../../../support/urls'
 import { test } from '../utils/judicialSystemTest'
 import { verifyRequestCompletion } from '../../../support/api-tools'
-import { getDaysFromNow, randomCourtCaseNumber } from '../utils/helpers'
+import { getDaysFromNow, randomPoliceCaseNumber } from '../utils/helpers'
+import { judgeSubmitsDecision } from './shared-steps/court-decision'
 import { prosecutorAppealsCaseTest } from './shared-steps/send-appeal'
 import { judgeReceivesAppealTest } from './shared-steps/receive-appeal'
 import { coaJudgesCompleteAppealCaseTest } from './shared-steps/complete-appeal'
@@ -29,7 +30,7 @@ test.describe.serial('Travel ban tests', () => {
       .getByRole('textbox', {
         name: 'Sláðu inn málsnúmer úr lögreglukerfi (LÖKE)',
       })
-      .fill('123-1231-23123')
+      .fill(randomPoliceCaseNumber())
     await page.getByRole('button', { name: 'Skrá númer' }).click()
     await page
       .getByRole('checkbox', {
@@ -108,78 +109,10 @@ test.describe.serial('Travel ban tests', () => {
   test('court should submit decision on travel ban case', async ({
     judgePage,
   }) => {
-    const page = judgePage
-    await Promise.all([
-      page.goto(`/domur/mottaka/${caseId}`),
-      verifyRequestCompletion(page, '/api/graphql', 'Case'),
-    ])
-
-    // Reception and assignment
-    await expect(page).toHaveURL(`/domur/mottaka/${caseId}`)
-    await page.getByTestId('courtCaseNumber').fill(randomCourtCaseNumber())
-    await page.keyboard.press('Tab')
-    await page.getByText('Veldu dómara/aðstoðarmann').click()
-    await page
-      .getByTestId('select-judge')
-      .getByText('Test Dómari')
-      .last()
-      .click()
-    await Promise.all([
-      page.getByTestId('continueButton').click(),
-      verifyRequestCompletion(page, '/api/graphql', 'Case'),
-    ])
-
-    // Overview
-    await expect(page).toHaveURL(`/domur/krafa/${caseId}`)
-    await page.getByTestId('continueButton').isVisible()
-    await Promise.all([
-      page.getByTestId('continueButton').click(),
-      verifyRequestCompletion(page, '/api/graphql', 'Case'),
-    ])
-
-    // Hearing arrangements
-    await expect(page).toHaveURL(`/domur/fyrirtokutimi/${caseId}`)
-    await page.locator('input[id=courtDate]').fill(today)
-    await page.keyboard.press('Escape')
-    await page.locator('input[id=courtDate-time]').fill('09:00')
-    await page.keyboard.press('Tab')
-    await page.getByTestId('continueButton').click()
-    await Promise.all([
-      page.getByTestId('modalPrimaryButton').click(),
-      verifyRequestCompletion(page, '/api/graphql', 'Case'),
-    ])
-
-    // Ruling
-    await expect(page).toHaveURL(`/domur/urskurdur/${caseId}`)
-    await page.getByText('Krafa um farbann samþykkt').click()
-    await page.locator('input[id=validToDate]').fill(travelBanEndDate)
-    await page.keyboard.press('Escape')
-    await page.locator('input[id=validToDate-time]').fill('16:00')
-    await page.keyboard.press('Tab')
-    await Promise.all([
-      page.getByTestId('continueButton').click(),
-      verifyRequestCompletion(page, '/api/graphql', 'Case'),
-    ])
-
-    // Court record
-    await expect(page).toHaveURL(`/domur/thingbok/${caseId}`)
-    await page.getByText('Varnaraðili tekur sér lögboðinn frest').click()
-    await page.getByText('Sækjandi tekur sér lögboðinn frest').click()
-    await page.locator('input[id=courtEndTime]').fill(today)
-    await page.keyboard.press('Escape')
-    await page.locator('input[id=courtEndTime-time]').fill('10:00')
-    await page.keyboard.press('Tab')
-    await Promise.all([
-      page.getByTestId('continueButton').click(),
-      verifyRequestCompletion(page, '/api/graphql', 'Case'),
-    ])
-
-    // Confirmation
-    await expect(page).toHaveURL(`/domur/stadfesta/${caseId}`)
-    await Promise.all([
-      page.getByTestId('continueButton').click(),
-      verifyRequestCompletion(page, '/api/graphql', 'TransitionCase'),
-    ])
+    await judgeSubmitsDecision(judgePage, caseId, {
+      acceptRulingText: 'Krafa um farbann samþykkt',
+      validToDate: travelBanEndDate,
+    })
   })
 
   test('prosecutor should appeal case', async ({ prosecutorPage }) => {

--- a/apps/system-e2e/src/tests/judicial-system/smoke/case-list.spec.ts
+++ b/apps/system-e2e/src/tests/judicial-system/smoke/case-list.spec.ts
@@ -19,6 +19,6 @@ test.describe('Case list test', () => {
     const page = await context.newPage()
     await page.goto('/malalistar')
     await expect(page).toHaveURL('/malalistar')
-    await page.getByRole('button', { name: 'Nýtt mál' }).isVisible()
+    await expect(page.getByRole('button', { name: 'Nýtt mál' })).toBeVisible()
   })
 })

--- a/apps/system-e2e/src/tests/judicial-system/utils/helpers.ts
+++ b/apps/system-e2e/src/tests/judicial-system/utils/helpers.ts
@@ -1,4 +1,4 @@
-import { Page } from '@playwright/test'
+import { expect, Page } from '@playwright/test'
 import { verifyRequestCompletion } from '../../../support/api-tools'
 
 export const randomPoliceCaseNumber = () => {
@@ -27,6 +27,54 @@ export const getDaysFromNow = (days = 0) => {
   const daysAdded = day * days
 
   return new Date(new Date().getTime() + daysAdded).toLocaleDateString('is-IS')
+}
+
+// The defender login fixture uses national id 0909090909, which does not
+// exist in the LMFÍ lawyer registry backing the defender comboboxes. The
+// registry response is intercepted and the test defender prepended so the
+// real selection UI (and its mutations) can be driven end to end.
+export const testDefender = {
+  name: 'Test Verjandi',
+  practice: 'Réttarvörslugátt',
+  email: 'verjandi@dummy.dd',
+  phoneNr: '1111111',
+  nationalId: '0909090909',
+  isLitigator: true,
+}
+
+export const injectTestDefenderIntoLawyerRegistry = async (page: Page) => {
+  await page.route('**/api/defender/lawyerRegistry*', async (route) => {
+    const response = await route.fetch()
+    let lawyers: unknown[] = []
+    if (response.ok()) {
+      try {
+        lawyers = await response.json()
+      } catch {
+        lawyers = []
+      }
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([testDefender, ...lawyers]),
+    })
+  })
+}
+
+// Selects the test defender in an InputAdvocate lawyer combobox. Assumes
+// injectTestDefenderIntoLawyerRegistry has been called on the page.
+export const selectTestDefender = async (page: Page) => {
+  await page.locator('#advocateName').click()
+  await page.keyboard.type(testDefender.name)
+  await page
+    .locator('[id^="react-select-advocateName-option"]')
+    .filter({ hasText: testDefender.name })
+    .first()
+    .click()
+  // Selecting a lawyer auto-fills email and phone from the registry entry.
+  await expect(page.getByTestId('defenderEmail')).toHaveValue(
+    testDefender.email,
+  )
 }
 
 const createFakePdf = (title: string) => {

--- a/apps/system-e2e/src/tests/judicial-system/utils/helpers.ts
+++ b/apps/system-e2e/src/tests/judicial-system/utils/helpers.ts
@@ -5,9 +5,12 @@ export const randomPoliceCaseNumber = () => {
   return `007-${new Date().getFullYear()}-${Math.floor(Math.random() * 100000)}`
 }
 
+// The app validates R-/S- case numbers as 1-5 digits and appeal case
+// numbers as 1-4 digits, so these draw from the full allowed space to
+// minimize collisions with cases left behind by previous runs.
 export const randomCourtCaseNumber = (prefix?: string) => {
   return `${prefix ?? 'R'}-${Math.floor(
-    Math.random() * 1000,
+    Math.random() * 100000,
   )}/${new Date().getFullYear()}`
 }
 
@@ -16,7 +19,7 @@ export const randomIndictmentCourtCaseNumber = () => {
 }
 
 export const randomAppealCaseNumber = () => {
-  return `${Math.floor(Math.random() * 1000)}/${new Date().getFullYear()}`
+  return `${Math.floor(Math.random() * 10000)}/${new Date().getFullYear()}`
 }
 
 export const getDaysFromNow = (days = 0) => {
@@ -45,7 +48,6 @@ export const chooseDocument = async (
   await clickButton()
 
   const fileChooser = await fileChooserPromise
-  await page.waitForTimeout(1000)
   await fileChooser.setFiles(createFakePdf(fileName))
 }
 

--- a/apps/system-e2e/src/tests/judicial-system/utils/judicialSystemTest.ts
+++ b/apps/system-e2e/src/tests/judicial-system/utils/judicialSystemTest.ts
@@ -4,6 +4,7 @@ import {
   JUDICIAL_SYSTEM_COA_JUDGE_HOME_URL,
   JUDICIAL_SYSTEM_DEFENDER_HOME_URL,
   JUDICIAL_SYSTEM_JUDGE_HOME_URL,
+  JUDICIAL_SYSTEM_PRISON_ADMIN_HOME_URL,
   JUDICIAL_SYSTEM_PUBLIC_PROSECUTOR_HOME_URL,
   JUDICIAL_SYSTEM_PUBLIC_PROSECUTOR_OFFICE_HOME_URL,
 } from '../../../support/urls'
@@ -17,6 +18,7 @@ export const test = base.extend<{
   defenderPage: Page
   publicProsecutorOfficePage: Page
   publicProsecutorPage: Page
+  prisonAdminPage: Page
 }>({
   prosecutorPage: async ({ browser }, use) => {
     const prosecutorContext = await judicialSystemSession({
@@ -77,5 +79,15 @@ export const test = base.extend<{
     await use(publicProsecutorPage)
     await publicProsecutorPage.close()
     await publicProsecutorContext.close()
+  },
+  prisonAdminPage: async ({ browser }, use) => {
+    const prisonAdminContext = await judicialSystemSession({
+      browser,
+      homeUrl: JUDICIAL_SYSTEM_PRISON_ADMIN_HOME_URL,
+    })
+    const prisonAdminPage = await prisonAdminContext.newPage()
+    await use(prisonAdminPage)
+    await prisonAdminPage.close()
+    await prisonAdminContext.close()
   },
 })


### PR DESCRIPTION
# Expand e2e coverage: prison admin, defenders, appeals, rejections and PDFs

## What

**Prison admin**
- Add a `prisonAdminPage` fixture (FMST user 0000004449) and extend the indictment regression chain: the prison admin opens the "Mál til fullnustu" case list, clicks the delivered case, and verifies the `/fangelsi/akaera/yfirlit/:id` overview.

**Defenders driven through the real UI**
- Remove the `CreateCase` GraphQL rewrite from the custody chain. The prosecutor now registers the defender through the lawyer-registry combobox; since the test defender (0909090909) is not in the LMFÍ registry, the `/api/defender/lawyerRegistry` response is intercepted and the test defender prepended — the combobox, auto-filled email/phone and the defender-access radios are all exercised for real.
- Custody request creation is extracted into a shared step (`create-restriction-case.ts`) and reused.
- The travel-ban chain now registers the defender at creation and the appeal is **defender-initiated** from `/verjandi/krafa/:id` through the limited-access appeal screen (`LimitedAccessCreateAppealCase`).
- New `indictment-defender-tests.spec.ts`: the judge assigns a defender on the Advocates screen (`Staðfesta val` + confirmation modal, `UpdateDefendant`), then the defender opens `/verjandi/akaera/:id`.

**Appeal completion + withdrawal**
- `complete-appeal.ts` now finishes the CoA flow: `Ljúka máli` → completion modal → asserts the Result screen (`/landsrettur/nidurstada/:id`, `Úrskurðarorð Landsréttar` and the conclusion text).
- New withdrawal test: the prosecutor withdraws an appeal from the case-table row context menu (`Afturkalla kæru` → `TransitionAppealCase`) and the overview shows `Afturkallað`.

**Rejected ruling + restraining order**
- New `custody-rejected-tests.spec.ts`: the judge rejects the custody request (`Kröfu um gæsluvarðhald hafnað`, no restriction length), the completed overview shows `Kröfu hafnað`, then prosecutor appeal + withdrawal.
- New `restraining-order-tests.spec.ts`: full investigation-case chain with type `Nálgunarbann`, asserting the restraining-order-specific session-bookings autofill branch in the district court court record.

**PDF smoke**
- In the rejected-custody chain the prosecutor clicks the `Krafa - PDF` PdfButton. `PdfButton` uses `window.open` (no download event), so the test asserts the popup URL and additionally fetches the endpoint directly, asserting a 200 with `application/pdf`.

## Why

The suite previously never touched the prison-admin side, defender selection, defender-initiated appeals, the CoA result screen, appeal withdrawal, rejected rulings, restraining orders, or PDF serving. This closes those gaps so regressions in those flows are caught automatically.

Stacked on #23475 (`j-s/e2e-conclusion-branches`).

## Screenshots / Gifs


## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code
