### PR TITLE
feat(my-pages): Show main operator in vehicle detail

### DIFF
--- a/libs/portals/my-pages/assets/src/lib/messages.ts
+++ b/libs/portals/my-pages/assets/src/lib/messages.ts
@@ -518,6 +518,10 @@ export const vehicleMessage = defineMessages({
     id: 'sp.vehicles:operator',
     defaultMessage: 'Umráðamaður',
   },
+  mainOperator: {
+    id: 'sp.vehicles:main-operator',
+    defaultMessage: 'Aðalumráðamaður',
+  },
   name: {
     id: 'sp.vehicles:name',
     defaultMessage: 'Nafn',

--- a/libs/portals/my-pages/assets/src/screens/VehicleDetail/VehicleDetail.graphql
+++ b/libs/portals/my-pages/assets/src/screens/VehicleDetail/VehicleDetail.graphql
@@ -112,6 +112,7 @@ query GetUsersVehiclesDetail($input: GetVehicleDetailInput!) {
       city
       startDate
       endDate
+      mainOperator
     }
     downloadServiceURL
     latestMileageRegistration

--- a/libs/portals/my-pages/assets/src/utils/createVehicleUnits.ts
+++ b/libs/portals/my-pages/assets/src/utils/createVehicleUnits.ts
@@ -189,7 +189,9 @@ const operatorInfoArray = (
 ) => {
   return {
     header: {
-      title: formatMessage(messages.operator),
+      title: formatMessage(
+        data.mainOperator ? messages.mainOperator : messages.operator,
+      ),
     },
     rows: chunk(
       [


### PR DESCRIPTION
Reported via Zendesk by Samgöngustofa (#616975).

## What

In the vehicle detail view on Mínar síður (Ökutæki → Ökutækin mín → vehicle), every operator was rendered under the same **Umráðamaður** heading, with nothing indicating which one is the main operator (*aðalumráðamaður*).

This requests `mainOperator` in the vehicle detail query and uses it to label that operator's card **Aðalumráðamaður**. Other operators are unchanged.

- `VehicleDetail.graphql` — add `mainOperator` to the `operators` selection
- `messages.ts` — new message `sp.vehicles:main-operator`
- `createVehicleUnits.ts` — pick the heading based on the flag

## Why

Samgöngustofa pointed out that the registry distinguishes the main operator but Mínar síður does not, so the page shows two seemingly equivalent operators with no way to tell them apart.

The data was already available end to end — `VehiclesOperator.mainOperator` exists in the schema and is mapped in `basicVehicleInformationMapper`. The query simply never asked for it, so the frontend could not show it.

Operators are already filtered to `current: true` in `basicVehicleInformationMapper.ts:43`, so a historical operator carrying the flag cannot be mislabelled.

## Screenshots / Gifs

<img width="500" height="auto" alt="image" src="https://github.com/user-attachments/assets/d534dbb8-80f7-4f77-a741-39b6ba0a3f99" />

Verified locally against the vehicle from the report (GOR07), signed in as the test user who is its main operator:

```
Aðalumráðamaður   Gervimaður Noregur    010130-2129   18.12.2025
Umráðamaður       Gervimaður Færeyjar   010130-2399   18.12.2025
```

Before the change both cards read "Umráðamaður".

## Follow-up

The English translation for `sp.vehicles:main-operator` needs a Contentful entry. Until then the English page falls back to the Icelandic `defaultMessage`.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code

### Notes on the unticked boxes

- **Documentation** — no user-facing docs cover this heading.
- **Tests** — no existing test covers `operatorInfoArray`; happy to add one if reviewers would like.
- **Lint** — `yarn lint portals-my-pages-assets` could not run locally: `eslint-plugin-storybook` is ESM while `@eslint/eslintrc` `require()`s it, which fails while loading the root `.eslintrc.json` and therefore affects every project, not this change. Prettier (2.6.2) and `tsc --noEmit` both pass.
