### PR TITLE
refactor(application): DOE - ER - upload & use draft endpoints

### DIFF
--- a/libs/api/domains/directorate-of-equality-application/src/lib/directorate-of-equality-application.resolver.ts
+++ b/libs/api/domains/directorate-of-equality-application/src/lib/directorate-of-equality-application.resolver.ts
@@ -21,7 +21,9 @@ import {
   DraftEmployeesResponseModel,
   DraftEmployeesWithStepsResponseModel,
 } from './dto/draftEmployeesResponse.model'
+import { EditEqualityContentInput } from './dto/editEqualityContent.input'
 import { SyncSalaryReportDraftInput } from './dto/syncSalaryReportDraft.input'
+import { UpdateEqualityDraftContentInput } from './dto/updateEqualityDraftContent.input'
 import { DirectorateOfEqualityApplicationService } from './directorate-of-equality-application.service'
 
 // Sync carries an arbitrary per-screen payload, and the employee list queries
@@ -74,6 +76,34 @@ export class DirectorateOfEqualityApplicationResolver {
     @CurrentUser() user: User,
   ) {
     return this.directorateOfEqualityApplicationService.listDraftEmployeesWithSteps(
+      input,
+      user,
+    )
+  }
+
+  @Mutation(() => Boolean, {
+    name: 'directorateOfEqualityUpdateEqualityDraftContent',
+  })
+  @Audit()
+  updateEqualityDraftContent(
+    @Args('input') input: UpdateEqualityDraftContentInput,
+    @CurrentUser() user: User,
+  ) {
+    return this.directorateOfEqualityApplicationService.updateEqualityDraftContent(
+      input,
+      user,
+    )
+  }
+
+  @Mutation(() => Boolean, {
+    name: 'directorateOfEqualityEditEqualityContent',
+  })
+  @Audit()
+  editEqualityContent(
+    @Args('input') input: EditEqualityContentInput,
+    @CurrentUser() user: User,
+  ) {
+    return this.directorateOfEqualityApplicationService.editEqualityContent(
       input,
       user,
     )

--- a/libs/api/domains/directorate-of-equality-application/src/lib/directorate-of-equality-application.service.ts
+++ b/libs/api/domains/directorate-of-equality-application/src/lib/directorate-of-equality-application.service.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable } from '@nestjs/common'
+import { BadRequestException, Inject, Injectable } from '@nestjs/common'
 
 import type { Auth, User } from '@island.is/auth-nest-tools'
 import { AuthMiddleware } from '@island.is/auth-nest-tools'
@@ -32,13 +32,20 @@ export class DirectorateOfEqualityApplicationService {
   }
 
   // Duplicates apps/application-system's ownership check since this resolver sits outside that REST layer and nothing else verifies the caller owns applicationId.
+  // expectedState additionally rejects calls made outside the state the mutation is meant for (e.g. a
+  // content edit fired at IN_REVIEW/APPROVED/DENIED instead of DRAFT_RETRY) — callers that are valid across
+  // every state (draft sync, draft employee listing) simply omit it.
   private async assertOwnsApplication(
     applicationId: string,
     user: User,
     locale: Locale,
+    expectedState?: string,
   ): Promise<void> {
+    let application
     try {
-      await this.applicationApiWithAuth(user).applicationControllerFindOne({
+      application = await this.applicationApiWithAuth(
+        user,
+      ).applicationControllerFindOne({
         id: applicationId,
         locale,
       })
@@ -48,6 +55,21 @@ export class DirectorateOfEqualityApplicationService {
         context: LOGGING_CONTEXT,
       })
       throw error
+    }
+
+    if (expectedState && application.state !== expectedState) {
+      this.logger.warn(
+        'Rejected draft sync: application is not in the expected state',
+        {
+          applicationId,
+          expectedState,
+          actualState: application.state,
+          context: LOGGING_CONTEXT,
+        },
+      )
+      throw new BadRequestException(
+        `Application ${applicationId} is not in the expected state`,
+      )
     }
   }
 
@@ -111,7 +133,8 @@ export class DirectorateOfEqualityApplicationService {
     input: UpdateEqualityDraftContentInput,
     user: User,
   ): Promise<boolean> {
-    await this.assertOwnsApplication(input.applicationId, user, 'is')
+    // 'draft' matches equality-report's States.DRAFT — the only state this content push is valid in.
+    await this.assertOwnsApplication(input.applicationId, user, 'is', 'draft')
     await this.directorateOfEqualityService.updateDraft(
       user,
       input.applicationId,
@@ -126,7 +149,13 @@ export class DirectorateOfEqualityApplicationService {
     input: EditEqualityContentInput,
     user: User,
   ): Promise<boolean> {
-    await this.assertOwnsApplication(input.applicationId, user, 'is')
+    // 'draftRetry' matches equality-report's States.DRAFT_RETRY — the only state this edit is valid in.
+    await this.assertOwnsApplication(
+      input.applicationId,
+      user,
+      'is',
+      'draftRetry',
+    )
     await this.directorateOfEqualityService.editEqualityContent(
       user,
       input.applicationId,

--- a/libs/api/domains/directorate-of-equality-application/src/lib/directorate-of-equality-application.service.ts
+++ b/libs/api/domains/directorate-of-equality-application/src/lib/directorate-of-equality-application.service.ts
@@ -1,4 +1,5 @@
 import { BadRequestException, Inject, Injectable } from '@nestjs/common'
+import sanitizeHtml from 'sanitize-html'
 
 import type { Auth, User } from '@island.is/auth-nest-tools'
 import { AuthMiddleware } from '@island.is/auth-nest-tools'
@@ -125,6 +126,17 @@ export class DirectorateOfEqualityApplicationService {
     )
   }
 
+  // Content is browser-side HTML converted from an applicant-uploaded DOCX
+  // (mammoth doesn't sanitize its output — a document can carry a
+  // javascript: href straight through), base64-encoded for transport. Strip
+  // it down to sanitize-html's default allowlist (which already excludes the
+  // javascript: scheme) before it reaches DMR, since this resolver — not the
+  // browser — is the actual trust boundary for this payload.
+  private sanitizeEqualityReportContent(base64Content: string): string {
+    const html = Buffer.from(base64Content, 'base64').toString('utf-8')
+    return Buffer.from(sanitizeHtml(html)).toString('base64')
+  }
+
   // Custom resolver, not the standard updateApplicationExternalData provider
   // mechanism — that only takes {actionId, order}, with no channel for an
   // arbitrary content payload. Content goes straight to DMR, never through
@@ -138,7 +150,11 @@ export class DirectorateOfEqualityApplicationService {
     await this.directorateOfEqualityService.updateDraft(
       user,
       input.applicationId,
-      { equalityReportContent: input.equalityReportContent },
+      {
+        equalityReportContent: this.sanitizeEqualityReportContent(
+          input.equalityReportContent,
+        ),
+      },
     )
     return true
   }
@@ -159,7 +175,11 @@ export class DirectorateOfEqualityApplicationService {
     await this.directorateOfEqualityService.editEqualityContent(
       user,
       input.applicationId,
-      { equalityReportContent: input.equalityReportContent },
+      {
+        equalityReportContent: this.sanitizeEqualityReportContent(
+          input.equalityReportContent,
+        ),
+      },
     )
     return true
   }

--- a/libs/api/domains/directorate-of-equality-application/src/lib/directorate-of-equality-application.service.ts
+++ b/libs/api/domains/directorate-of-equality-application/src/lib/directorate-of-equality-application.service.ts
@@ -13,7 +13,9 @@ import { type Logger, LOGGER_PROVIDER } from '@island.is/logging'
 import type { Locale } from '@island.is/shared/types'
 
 import { DraftEmployeesInput } from './dto/draftEmployees.input'
+import { EditEqualityContentInput } from './dto/editEqualityContent.input'
 import { SyncSalaryReportDraftInput } from './dto/syncSalaryReportDraft.input'
+import { UpdateEqualityDraftContentInput } from './dto/updateEqualityDraftContent.input'
 
 const LOGGING_CONTEXT = 'DirectorateOfEqualityApplicationService'
 
@@ -99,5 +101,37 @@ export class DirectorateOfEqualityApplicationService {
       input.page,
       input.pageSize,
     )
+  }
+
+  // Custom resolver, not the standard updateApplicationExternalData provider
+  // mechanism — that only takes {actionId, order}, with no channel for an
+  // arbitrary content payload. Content goes straight to DMR, never through
+  // application.answers.
+  async updateEqualityDraftContent(
+    input: UpdateEqualityDraftContentInput,
+    user: User,
+  ): Promise<boolean> {
+    await this.assertOwnsApplication(input.applicationId, user, 'is')
+    await this.directorateOfEqualityService.updateDraft(
+      user,
+      input.applicationId,
+      { equalityReportContent: input.equalityReportContent },
+    )
+    return true
+  }
+
+  // Same rationale as updateEqualityDraftContent, but for an already-submitted
+  // (IN_REVIEW) report during a case-worker-requested revision, not a DRAFT.
+  async editEqualityContent(
+    input: EditEqualityContentInput,
+    user: User,
+  ): Promise<boolean> {
+    await this.assertOwnsApplication(input.applicationId, user, 'is')
+    await this.directorateOfEqualityService.editEqualityContent(
+      user,
+      input.applicationId,
+      { equalityReportContent: input.equalityReportContent },
+    )
+    return true
   }
 }

--- a/libs/api/domains/directorate-of-equality-application/src/lib/dto/editEqualityContent.input.ts
+++ b/libs/api/domains/directorate-of-equality-application/src/lib/dto/editEqualityContent.input.ts
@@ -1,0 +1,10 @@
+import { Field, InputType } from '@nestjs/graphql'
+
+@InputType('DirectorateOfEqualityEditEqualityContentInput')
+export class EditEqualityContentInput {
+  @Field(() => String)
+  applicationId!: string
+
+  @Field(() => String)
+  equalityReportContent!: string
+}

--- a/libs/api/domains/directorate-of-equality-application/src/lib/dto/updateEqualityDraftContent.input.ts
+++ b/libs/api/domains/directorate-of-equality-application/src/lib/dto/updateEqualityDraftContent.input.ts
@@ -1,0 +1,10 @@
+import { Field, InputType } from '@nestjs/graphql'
+
+@InputType('DirectorateOfEqualityUpdateEqualityDraftContentInput')
+export class UpdateEqualityDraftContentInput {
+  @Field(() => String)
+  applicationId!: string
+
+  @Field(() => String)
+  equalityReportContent!: string
+}

--- a/libs/application/template-api-modules/src/lib/modules/templates/directorate-of-equality/directorate-of-equality.service.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/directorate-of-equality/directorate-of-equality.service.ts
@@ -208,29 +208,28 @@ export class DirectorateOfEqualityService extends BaseTemplateApiService {
     auth,
     application,
   }: TemplateApiModuleActionProps) {
-    const activeReport =
-      await this.directorateOfEqualityService.getActiveEqualityReport(auth)
+    try {
+      const activeReport =
+        await this.directorateOfEqualityService.getActiveEqualityReport(auth)
 
-    if (activeReport && activeReport.identifier) {
-      try {
-        const report = await this.directorateOfEqualityService.getReport(
-          auth,
-          activeReport.identifier,
-        )
-        return { equalityReportContent: report.equalityReportContent ?? '' }
-      } catch (error) {
-        this.logger.error(
-          'Failed to get previous equality report content, falling back',
-          {
-            applicationId: application.id,
-            context: LOGGING_CONTEXT,
-            ...this.extractFetchErrorDetails(error),
-          },
-        )
-        return null
-      }
+      if (!activeReport || !activeReport.identifier) return null
+
+      const report = await this.directorateOfEqualityService.getReport(
+        auth,
+        activeReport.identifier,
+      )
+      return { equalityReportContent: report.equalityReportContent ?? '' }
+    } catch (error) {
+      this.logger.error(
+        'Failed to get previous equality report content, falling back',
+        {
+          applicationId: application.id,
+          context: LOGGING_CONTEXT,
+          ...this.extractFetchErrorDetails(error),
+        },
+      )
+      return null
     }
-    return null
   }
 
   async getBlankExcelTemplate({

--- a/libs/application/template-api-modules/src/lib/modules/templates/directorate-of-equality/directorate-of-equality.service.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/directorate-of-equality/directorate-of-equality.service.ts
@@ -12,10 +12,7 @@ import {
   getValueViaPath,
   YES,
 } from '@island.is/application/core'
-import {
-  Gender,
-  dataSchema as equalityReportDataSchema,
-} from '@island.is/application/templates/directorate-of-equality/equality-report'
+import { dataSchema as equalityReportDataSchema } from '@island.is/application/templates/directorate-of-equality/equality-report'
 import {
   dataSchema as salaryReportDataSchema,
   PERIOD_ONE_MONTH,
@@ -186,24 +183,6 @@ export class DirectorateOfEqualityService extends BaseTemplateApiService {
     }
   }
 
-  async getEqualityReportTemplateHtml({
-    auth,
-    application,
-  }: TemplateApiModuleActionProps) {
-    try {
-      return await this.directorateOfEqualityService.getEqualityReportTemplateHtml(
-        auth,
-      )
-    } catch (error) {
-      this.logger.error('Failed to get equality report template html', {
-        applicationId: application.id,
-        context: LOGGING_CONTEXT,
-        ...this.extractFetchErrorDetails(error),
-      })
-      throw error
-    }
-  }
-
   async getEqualityReportTemplateDocx({
     auth,
     application,
@@ -229,38 +208,29 @@ export class DirectorateOfEqualityService extends BaseTemplateApiService {
     auth,
     application,
   }: TemplateApiModuleActionProps) {
-    const hasActiveReport = getValueViaPath<boolean>(
-      application.externalData,
-      'activeEqualityReport.data.hasActiveEqualityReport',
-    )
-    if (!hasActiveReport) return null
+    const activeReport =
+      await this.directorateOfEqualityService.getActiveEqualityReport(auth)
 
-    // `identifier` is set to the submitting application's id at submit time
-    // (see submitEqualityReport below), the same value stored as `providerId`
-    // — which is what getReport() looks up by.
-    const providerId = getValueViaPath<string>(
-      application.externalData,
-      'activeEqualityReport.data.identifier',
-    )
-    if (!providerId) return null
-    try {
-      // TODO: PROVIDER ID VS COMPANY ID.
-      const report = await this.directorateOfEqualityService.getReport(
-        auth,
-        providerId,
-      )
-      return { equalityReportContent: report.equalityReportContent ?? '' }
-    } catch (error) {
-      this.logger.error(
-        'Failed to get previous equality report content, falling back',
-        {
-          applicationId: application.id,
-          context: LOGGING_CONTEXT,
-          ...this.extractFetchErrorDetails(error),
-        },
-      )
-      return null
+    if (activeReport && activeReport.identifier) {
+      try {
+        const report = await this.directorateOfEqualityService.getReport(
+          auth,
+          activeReport.id,
+        )
+        return { equalityReportContent: report.equalityReportContent ?? '' }
+      } catch (error) {
+        this.logger.error(
+          'Failed to get previous equality report content, falling back',
+          {
+            applicationId: application.id,
+            context: LOGGING_CONTEXT,
+            ...this.extractFetchErrorDetails(error),
+          },
+        )
+        return null
+      }
     }
+    return null
   }
 
   async getBlankExcelTemplate({
@@ -301,6 +271,22 @@ export class DirectorateOfEqualityService extends BaseTemplateApiService {
       () =>
         this.directorateOfEqualityService.createDraft(auth, {
           type: ReportTypeEnum.SALARY,
+          providerId: application.id,
+        }),
+    )
+  }
+
+  // Idempotent on providerId — reopening this step returns the same draft.
+  async createEqualityDraft({
+    auth,
+    application,
+  }: TemplateApiModuleActionProps) {
+    return this.withTemplateApiError(
+      application.id,
+      'Failed to create equality report draft',
+      () =>
+        this.directorateOfEqualityService.createDraft(auth, {
+          type: ReportTypeEnum.EQUALITY,
           providerId: application.id,
         }),
     )
@@ -574,7 +560,12 @@ export class DirectorateOfEqualityService extends BaseTemplateApiService {
     )
   }
 
-  async submitEqualityReport({
+  // Finalises the draft; only the pre-dataEntry answers need patching onto
+  // it first — the report's narrative content was already pushed live via
+  // the directorate-of-equality-application GraphQL resolver's
+  // updateEqualityDraftContent mutation as the applicant uploaded it, not
+  // read from application.answers here.
+  async submitEqualityDraft({
     auth,
     application,
   }: TemplateApiModuleActionProps) {
@@ -583,43 +574,21 @@ export class DirectorateOfEqualityService extends BaseTemplateApiService {
       application.answers,
       application.id,
     )
-
-    const genderMap: Record<Gender, 'MALE' | 'FEMALE' | 'NEUTRAL'> = {
-      [Gender.MALE]: 'MALE',
-      [Gender.FEMALE]: 'FEMALE',
-      [Gender.NON_BINARY]: 'NEUTRAL',
-    }
-    const equalityReportContent = getValueViaPath(
-      answers,
-      'goalsAndActions.customField',
-      '',
-    )
-
+    const providerId = application.id
     const subsidiaryList = answers.subsidiaries?.list ?? []
 
     return this.withTemplateApiError(
       application.id,
       'Failed to submit equality report',
-      () =>
-        this.directorateOfEqualityService.submitEqualityReport(auth, {
-          providerId: application.id,
+      async () => {
+        await this.directorateOfEqualityService.updateDraft(auth, providerId, {
           companyAdminName: answers.chiefExecutive?.name ?? '',
+          companyAdminTitle: answers.chiefExecutive?.jobTitle ?? '',
           companyAdminEmail: answers.chiefExecutive?.email ?? '',
-          companyAdminGender: answers.chiefExecutive?.gender
-            ? genderMap[answers.chiefExecutive.gender]
-            : 'NEUTRAL',
+          companyAdminGender: mapGender(answers.chiefExecutive?.gender),
           contactName: answers.contactPerson?.name ?? '',
           contactEmail: answers.contactPerson?.email ?? '',
           contactPhone: answers.contactPerson?.phone ?? '',
-          equalityReportContent: equalityReportContent ?? '',
-          company: {
-            name: answers.generalInformation?.companyName ?? '',
-            nationalId: answers.generalInformation?.nationalId ?? '',
-            address: answers.generalInformation?.address ?? '',
-            city: answers.generalInformation?.municipality ?? '',
-            postcode: answers.generalInformation?.postalCode ?? '',
-            isatCategory: answers.generalInformation?.isatClassification ?? '',
-          },
           averageEmployeeFemaleCount: toNumberOrZero(
             answers.employeeCount?.women,
           ),
@@ -627,47 +596,28 @@ export class DirectorateOfEqualityService extends BaseTemplateApiService {
           averageEmployeeNeutralCount: toNumberOrZero(
             answers.employeeCount?.nonBinary,
           ),
+        })
 
-          subsidiaries:
-            answers.subsidiaries?.includesSubsidiaries === 'yes'
-              ? subsidiaryList.map((s) => ({
-                  name: s.nationalIdWithName.name,
-                  nationalId: s.nationalIdWithName.nationalId,
-                }))
-              : [],
-        }),
-    )
-  }
-
-  // Narrow in-place edit — PUTs just the report's narrative content, unlike
-  // submitEqualityReport's full create call. This is what DRAFT_RETRY's
-  // onExit uses: submitEqualityReport is a one-shot create (POST .../reports/
-  // equality), not something a revision can safely re-invoke.
-  async editEqualityContent({
-    auth,
-    application,
-  }: TemplateApiModuleActionProps) {
-    return this.withTemplateApiError(
-      application.id,
-      'Failed to edit equality content',
-      async () => {
-        const answers = this.parseAnswers(
-          equalityReportDataSchema,
-          application.answers,
-          application.id,
-        )
-
-        const equalityReportContent = getValueViaPath<string>(
-          answers,
-          'goalsAndActions.customField',
-          '',
-        )
-
-        await this.directorateOfEqualityService.editEqualityContent(
+        return await this.directorateOfEqualityService.submitDraft(
           auth,
-          application.id,
+          providerId,
           {
-            equalityReportContent: equalityReportContent ?? '',
+            company: {
+              name: answers.generalInformation?.companyName ?? '',
+              nationalId: answers.generalInformation?.nationalId ?? '',
+              address: answers.generalInformation?.address ?? '',
+              city: answers.generalInformation?.municipality ?? '',
+              postcode: answers.generalInformation?.postalCode ?? '',
+              isatCategory:
+                answers.generalInformation?.isatClassification ?? '',
+            },
+            subsidiaries:
+              answers.subsidiaries?.includesSubsidiaries === 'yes'
+                ? subsidiaryList.map((s) => ({
+                    name: s.nationalIdWithName.name,
+                    nationalId: s.nationalIdWithName.nationalId,
+                  }))
+                : [],
           },
         )
       },

--- a/libs/application/template-api-modules/src/lib/modules/templates/directorate-of-equality/directorate-of-equality.service.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/directorate-of-equality/directorate-of-equality.service.ts
@@ -215,7 +215,7 @@ export class DirectorateOfEqualityService extends BaseTemplateApiService {
       try {
         const report = await this.directorateOfEqualityService.getReport(
           auth,
-          activeReport.id,
+          activeReport.identifier,
         )
         return { equalityReportContent: report.equalityReportContent ?? '' }
       } catch (error) {

--- a/libs/application/templates/directorate-of-equality/equality-report/src/dataProviders/index.ts
+++ b/libs/application/templates/directorate-of-equality/equality-report/src/dataProviders/index.ts
@@ -36,13 +36,6 @@ export const PreviousEqualityReportContentApi = defineTemplateApi({
   order: 0,
 })
 
-export const EqualityReportTemplateHtmlApi = defineTemplateApi({
-  action: ApiActions.getEqualityReportTemplateHtml,
-  externalDataId: 'equalityReportTemplateHtml',
-  namespace: 'DirectorateOfEquality',
-  order: 0,
-})
-
 export const EqualityReportTemplateDocxApi = defineTemplateApi({
   action: ApiActions.getEqualityReportTemplateDocx,
   externalDataId: 'equalityReportTemplateDocx',
@@ -69,18 +62,18 @@ export const SubmitReportCommentApi = defineTemplateApi({
   throwOnError: false,
 })
 
-export const SubmitEqualityReportApi = defineTemplateApi({
-  action: ApiActions.submitEqualityReport,
+// Idempotent on providerId — reopening this step returns the same draft.
+export const CreateEqualityDraftApi = defineTemplateApi({
+  action: ApiActions.createEqualityDraft,
+  externalDataId: 'equalityDraft',
   namespace: 'DirectorateOfEquality',
-  shouldPersistToExternalData: true,
+  shouldPersistToExternalData: false,
   throwOnError: true,
 })
 
-// PUTs just the report's narrative content in place — used as DRAFT_RETRY's
-// onExit, since submitEqualityReport is a one-shot create call that a
-// revision can't safely re-invoke.
-export const EditEqualityContentApi = defineTemplateApi({
-  action: ApiActions.editEqualityContent,
+export const SubmitEqualityDraftApi = defineTemplateApi({
+  action: ApiActions.submitEqualityDraft,
+  externalDataId: 'submitEqualityDraft',
   namespace: 'DirectorateOfEquality',
   shouldPersistToExternalData: true,
   throwOnError: true,

--- a/libs/application/templates/directorate-of-equality/equality-report/src/fields/Editor.tsx
+++ b/libs/application/templates/directorate-of-equality/equality-report/src/fields/Editor.tsx
@@ -60,9 +60,7 @@ export const Editor = ({ application, errors, field }: Props) => {
   // from `rejectionMessage` below, which feeds InputFileUpload's own
   // `errorMessage` slot instead of a standalone alert.
   const [actionError, setActionError] = useState<string | undefined>()
-  const [rejectionMessage, setRejectionMessage] = useState<
-    string | undefined
-  >()
+  const [rejectionMessage, setRejectionMessage] = useState<string | undefined>()
   const [loadingDocx, setLoadingDocx] = useState(false)
 
   const [updateApplicationExternalData] = useMutation(

--- a/libs/application/templates/directorate-of-equality/equality-report/src/fields/Editor.tsx
+++ b/libs/application/templates/directorate-of-equality/equality-report/src/fields/Editor.tsx
@@ -1,48 +1,78 @@
-import { HTMLEditor } from '../components/html-editor/HTMLEditor'
-import { HTMLText } from '@dmr.is/regulations-tools/types'
 import { useFormContext } from 'react-hook-form'
 import { getErrorViaPath, getValueViaPath } from '@island.is/application/core'
-import { FieldBaseProps } from '@island.is/application/types'
-import { Button, DropdownMenu, toast } from '@island.is/island-ui/core'
+import { CustomField, FieldBaseProps } from '@island.is/application/types'
+import {
+  AlertMessage,
+  Box,
+  Button,
+  FileUploadStatus,
+  InputFileUpload,
+  UploadFile,
+} from '@island.is/island-ui/core'
 import { messages } from '../lib/messages'
 import { useIntl } from 'react-intl'
-import { useRef, useState } from 'react'
+import { useState } from 'react'
 import mammoth from 'mammoth'
+import { FileRejection } from 'react-dropzone'
 import { useMutation } from '@apollo/client'
 import { UPDATE_APPLICATION_EXTERNAL_DATA } from '@island.is/application/graphql'
 import { useLocale } from '@island.is/localization'
 import { ApiActions } from '../utils/constants'
 import { escapeHtml } from '../utils/htmlHelpers'
+import {
+  useEnsureEqualityDraft,
+  useEqualityContentPush,
+} from '../utils/useEqualityDraft'
 
-export const Editor = ({ application, errors }: FieldBaseProps) => {
+interface Props extends FieldBaseProps {
+  field: CustomField
+}
+
+export const Editor = ({ application, errors, field }: Props) => {
   const { formatMessage } = useIntl()
   const { locale } = useLocale()
-  const { setValue, clearErrors } = useFormContext()
-  const fileInputRef = useRef<HTMLInputElement>(null)
-  const [loadingTemplate, setLoadingTemplate] = useState(false)
+  const { setValue } = useFormContext()
+  const m = messages.equalityReport.information
+
+  const mode =
+    field?.props && typeof field.props['mode'] === 'string'
+      ? (field.props['mode'] as 'draft' | 'retry')
+      : 'draft'
+
+  const ensureDraft = useEnsureEqualityDraft(application)
+  const { pushDraftContent, pushRetryContent } = useEqualityContentPush()
+
+  const initialFilename = getValueViaPath<string>(
+    application.answers,
+    'goalsAndActions.filename',
+  )
+
+  // No content lives in application.answers anymore, so the only signal a
+  // resumed screen has is `filename` — a synthetic entry (status: done) is
+  // enough for InputFileUpload to render the already-uploaded state.
+  const [selectedFile, setSelectedFile] = useState<UploadFile | null>(() =>
+    initialFilename
+      ? { name: initialFilename, status: FileUploadStatus.done }
+      : null,
+  )
+  const [uploadSuccess, setUploadSuccess] = useState(!!initialFilename)
+  // Conversion/read failures and the download-template failure — distinct
+  // from `rejectionMessage` below, which feeds InputFileUpload's own
+  // `errorMessage` slot instead of a standalone alert.
+  const [actionError, setActionError] = useState<string | undefined>()
+  const [rejectionMessage, setRejectionMessage] = useState<
+    string | undefined
+  >()
   const [loadingDocx, setLoadingDocx] = useState(false)
-  const [editorKey, setEditorKey] = useState(0)
-  const [editorHtml, setEditorHtml] = useState<HTMLText | null>(null)
 
   const [updateApplicationExternalData] = useMutation(
     UPDATE_APPLICATION_EXTERNAL_DATA,
   )
 
-  const handleChange = (val: HTMLText) => {
-    const base64 = Buffer.from(val).toString('base64')
-    setValue('goalsAndActions.customField', base64)
-  }
-
-  const handleBlur = (val: HTMLText) => {
-    const base64 = Buffer.from(val).toString('base64')
-    setValue('goalsAndActions.customField', base64, { shouldValidate: true })
-  }
-
-  const handleFileUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0]
-    if (!file) return
-
-    e.target.value = ''
+  const handleFile = async (file: File) => {
+    setActionError(undefined)
+    setRejectionMessage(undefined)
+    setUploadSuccess(false)
 
     try {
       let html = ''
@@ -58,70 +88,66 @@ export const Editor = ({ application, errors }: FieldBaseProps) => {
           .map((p) => `<p>${escapeHtml(p).replace(/\n/g, '<br />')}</p>`)
           .join('')
       } else {
-        toast.error(
-          formatMessage(
-            messages.equalityReport.information.editorUnsupportedFile,
-          ),
-        )
+        setSelectedFile(null)
+        setRejectionMessage(formatMessage(m.editorUnsupportedFile))
+        return
+      }
+
+      // A .docx/.txt that converts to blank/whitespace-only content is
+      // treated the same as an unsupported file — there's nothing to send.
+      const plainTextLength = html.replace(/<[^>]*>/g, '').trim().length
+      if (plainTextLength === 0) {
+        setSelectedFile(null)
+        setRejectionMessage(formatMessage(m.editorUnsupportedFile))
         return
       }
 
       const base64 = Buffer.from(html).toString('base64')
-      setValue('goalsAndActions.customField', base64)
-      clearErrors('goalsAndActions.customField')
-      setEditorHtml(html as HTMLText)
-      setEditorKey((k) => k + 1)
+
+      if (mode === 'draft') {
+        await ensureDraft()
+        await pushDraftContent(application.id, base64)
+      } else {
+        await pushRetryContent(application.id, base64)
+      }
+
+      setValue('goalsAndActions.filename', file.name, { shouldValidate: true })
+      setSelectedFile({ name: file.name, status: FileUploadStatus.done })
+      setUploadSuccess(true)
     } catch {
-      toast.error(
-        formatMessage(messages.equalityReport.information.editorUploadError),
-      )
+      setSelectedFile(null)
+      setActionError(formatMessage(m.editorUploadError))
     }
   }
 
-  const handleFetchTemplateHtml = async () => {
-    setLoadingTemplate(true)
-    try {
-      const res = await updateApplicationExternalData({
-        variables: {
-          input: {
-            id: application.id,
-            dataProviders: [
-              {
-                actionId: `DirectorateOfEquality.${ApiActions.getEqualityReportTemplateHtml}`,
-                order: 0,
-              },
-            ],
-          },
-          locale,
-        },
-      })
+  const handleFilesChanged = (files: File[]) => {
+    const file = files[0]
+    if (!file) return
+    void handleFile(file)
+  }
 
-      const html =
-        res.data?.updateApplicationExternalData?.externalData
-          ?.equalityReportTemplateHtml?.data
+  const handleUploadRejection = (rejections: FileRejection[]) => {
+    setActionError(undefined)
+    setUploadSuccess(false)
+    setSelectedFile(null)
+    setRejectionMessage(
+      rejections[0]?.errors[0]?.code === 'file-invalid-type'
+        ? formatMessage(m.editorUnsupportedFile)
+        : formatMessage(m.editorUploadError),
+    )
+  }
 
-      if (typeof html === 'string') {
-        const base64 = Buffer.from(html).toString('base64')
-        setValue('goalsAndActions.customField', base64)
-        clearErrors('goalsAndActions.customField')
-        setEditorHtml(html as HTMLText)
-        setEditorKey((k) => k + 1)
-      } else {
-        toast.error(
-          formatMessage(messages.equalityReport.information.editorUploadError),
-        )
-      }
-    } catch {
-      toast.error(
-        formatMessage(messages.equalityReport.information.editorUploadError),
-      )
-    } finally {
-      setLoadingTemplate(false)
-    }
+  const handleRemove = () => {
+    setValue('goalsAndActions.filename', '', { shouldValidate: true })
+    setSelectedFile(null)
+    setUploadSuccess(false)
+    setActionError(undefined)
+    setRejectionMessage(undefined)
   }
 
   const handleDownloadTemplateDocx = async () => {
     setLoadingDocx(true)
+    setActionError(undefined)
     try {
       const res = await updateApplicationExternalData({
         variables: {
@@ -160,89 +186,62 @@ export const Editor = ({ application, errors }: FieldBaseProps) => {
         document.body.removeChild(a)
         setTimeout(() => URL.revokeObjectURL(url), 100)
       } else {
-        toast.error(
-          formatMessage(messages.equalityReport.information.editorUploadError),
-        )
+        setActionError(formatMessage(m.editorUploadError))
       }
     } catch {
-      toast.error(
-        formatMessage(messages.equalityReport.information.editorUploadError),
-      )
+      setActionError(formatMessage(m.editorUploadError))
     } finally {
       setLoadingDocx(false)
     }
   }
 
-  const base64 =
-    getValueViaPath<string>(
-      application.answers,
-      'goalsAndActions.customField',
-    ) ?? ''
-
-  const defaultHtml =
-    editorHtml ?? (Buffer.from(base64, 'base64').toString('utf-8') as HTMLText)
+  const fieldError =
+    errors && getErrorViaPath(errors, 'goalsAndActions.filename')
 
   return (
-    <>
-      <input
-        ref={fileInputRef}
-        type="file"
-        accept=".txt,.docx"
-        style={{ display: 'none' }}
-        onChange={handleFileUpload}
+    <Box>
+      <Box display="flex" justifyContent="flexEnd" marginBottom={3}>
+        <Button
+          variant="utility"
+          size="small"
+          icon="download"
+          iconType="outline"
+          loading={loadingDocx}
+          disabled={loadingDocx}
+          onClick={() => void handleDownloadTemplateDocx()}
+        >
+          {formatMessage(m.editorFetchTemplateDoc)}
+        </Button>
+      </Box>
+
+      {actionError && (
+        <Box marginBottom={3}>
+          <AlertMessage type="error" message={actionError} />
+        </Box>
+      )}
+
+      <InputFileUpload
+        name="equalityReportUpload"
+        files={selectedFile ? [selectedFile] : []}
+        description={formatMessage(m.editorSupportedFileTypes)}
+        buttonLabel={formatMessage(m.editorUploadFile)}
+        accept={['.txt', '.docx']}
+        multiple={false}
+        onChange={handleFilesChanged}
+        onRemove={handleRemove}
+        onUploadRejection={handleUploadRejection}
+        errorMessage={rejectionMessage ?? fieldError}
       />
-      <HTMLEditor
-        key={editorKey}
-        title={formatMessage(messages.equalityReport.information.editorTitle)}
-        error={errors && getErrorViaPath(errors, 'goalsAndActions.customField')}
-        value={defaultHtml}
-        onChange={handleChange}
-        onBlur={handleBlur}
-        fileUploader={() => Promise.resolve({} as unknown)}
-        buttonGroup={[
-          <Button
-            variant="utility"
-            size="small"
-            icon="download"
-            iconType="outline"
-            onClick={() => fileInputRef.current?.click()}
-          >
-            {formatMessage(
-              messages.equalityReport.information.editorUploadFile,
-            )}
-          </Button>,
-          <DropdownMenu
-            icon="attach"
-            iconType="outline"
-            title={formatMessage(
-              messages.equalityReport.information.editorFetchTemplate,
-            )}
-            disabled={loadingTemplate || loadingDocx}
-            loading={loadingTemplate || loadingDocx}
-            items={[
-              {
-                title: formatMessage(
-                  messages.equalityReport.information.editorFetchTemplateDoc,
-                ),
-                onClick: (e) => {
-                  e.preventDefault()
-                  handleDownloadTemplateDocx()
-                },
-              },
-              {
-                title: formatMessage(
-                  messages.equalityReport.information.editorFetchTemplateFill,
-                ),
-                onClick: (e) => {
-                  e.preventDefault()
-                  handleFetchTemplateHtml()
-                },
-              },
-            ]}
-          />,
-        ]}
-      />
-    </>
+
+      {uploadSuccess && (
+        <Box marginTop={3}>
+          <AlertMessage
+            type="success"
+            message={formatMessage(m.editorUploadSuccess)}
+          />
+        </Box>
+      )}
+    </Box>
   )
 }
 

--- a/libs/application/templates/directorate-of-equality/equality-report/src/fields/Editor.tsx
+++ b/libs/application/templates/directorate-of-equality/equality-report/src/fields/Editor.tsx
@@ -11,7 +11,7 @@ import {
 } from '@island.is/island-ui/core'
 import { messages } from '../lib/messages'
 import { useIntl } from 'react-intl'
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import mammoth from 'mammoth'
 import { FileRejection } from 'react-dropzone'
 import { useMutation } from '@apollo/client'
@@ -62,6 +62,11 @@ export const Editor = ({ application, errors, field }: Props) => {
   const [actionError, setActionError] = useState<string | undefined>()
   const [rejectionMessage, setRejectionMessage] = useState<string | undefined>()
   const [loadingDocx, setLoadingDocx] = useState(false)
+  const [isUploading, setIsUploading] = useState(false)
+  // The filename last known to actually match DMR's stored content — restored
+  // on a failed replacement so a bad re-upload attempt can't strand the user
+  // on an invalid, unrecoverable field.
+  const lastGoodFilenameRef = useRef(initialFilename ?? '')
 
   const [updateApplicationExternalData] = useMutation(
     UPDATE_APPLICATION_EXTERNAL_DATA,
@@ -71,6 +76,25 @@ export const Editor = ({ application, errors, field }: Props) => {
     setActionError(undefined)
     setRejectionMessage(undefined)
     setUploadSuccess(false)
+    setIsUploading(true)
+    // Clear the (possibly still-valid, previously pushed) filename for the
+    // duration of this attempt so the required-field check fails and
+    // Continue is blocked — otherwise a replacement upload could still be
+    // in flight to DMR while the stale-but-valid old filename lets the user
+    // navigate straight to Submit.
+    setValue('goalsAndActions.filename', '', { shouldValidate: true })
+    setSelectedFile({ name: file.name, status: FileUploadStatus.uploading })
+
+    const restoreLastGood = () => {
+      setValue('goalsAndActions.filename', lastGoodFilenameRef.current, {
+        shouldValidate: true,
+      })
+      setSelectedFile(
+        lastGoodFilenameRef.current
+          ? { name: lastGoodFilenameRef.current, status: FileUploadStatus.done }
+          : null,
+      )
+    }
 
     try {
       let html = ''
@@ -86,7 +110,7 @@ export const Editor = ({ application, errors, field }: Props) => {
           .map((p) => `<p>${escapeHtml(p).replace(/\n/g, '<br />')}</p>`)
           .join('')
       } else {
-        setSelectedFile(null)
+        restoreLastGood()
         setRejectionMessage(formatMessage(m.editorUnsupportedFile))
         return
       }
@@ -95,7 +119,7 @@ export const Editor = ({ application, errors, field }: Props) => {
       // treated the same as an unsupported file — there's nothing to send.
       const plainTextLength = html.replace(/<[^>]*>/g, '').trim().length
       if (plainTextLength === 0) {
-        setSelectedFile(null)
+        restoreLastGood()
         setRejectionMessage(formatMessage(m.editorUnsupportedFile))
         return
       }
@@ -109,12 +133,15 @@ export const Editor = ({ application, errors, field }: Props) => {
         await pushRetryContent(application.id, base64)
       }
 
+      lastGoodFilenameRef.current = file.name
       setValue('goalsAndActions.filename', file.name, { shouldValidate: true })
       setSelectedFile({ name: file.name, status: FileUploadStatus.done })
       setUploadSuccess(true)
     } catch {
-      setSelectedFile(null)
+      restoreLastGood()
       setActionError(formatMessage(m.editorUploadError))
+    } finally {
+      setIsUploading(false)
     }
   }
 
@@ -127,7 +154,11 @@ export const Editor = ({ application, errors, field }: Props) => {
   const handleUploadRejection = (rejections: FileRejection[]) => {
     setActionError(undefined)
     setUploadSuccess(false)
-    setSelectedFile(null)
+    setSelectedFile(
+      lastGoodFilenameRef.current
+        ? { name: lastGoodFilenameRef.current, status: FileUploadStatus.done }
+        : null,
+    )
     setRejectionMessage(
       rejections[0]?.errors[0]?.code === 'file-invalid-type'
         ? formatMessage(m.editorUnsupportedFile)
@@ -136,6 +167,7 @@ export const Editor = ({ application, errors, field }: Props) => {
   }
 
   const handleRemove = () => {
+    lastGoodFilenameRef.current = ''
     setValue('goalsAndActions.filename', '', { shouldValidate: true })
     setSelectedFile(null)
     setUploadSuccess(false)
@@ -221,6 +253,7 @@ export const Editor = ({ application, errors, field }: Props) => {
       <InputFileUpload
         name="equalityReportUpload"
         files={selectedFile ? [selectedFile] : []}
+        disabled={isUploading}
         description={formatMessage(m.editorSupportedFileTypes)}
         buttonLabel={formatMessage(m.editorUploadFile)}
         accept={['.txt', '.docx']}

--- a/libs/application/templates/directorate-of-equality/equality-report/src/fields/Overview.tsx
+++ b/libs/application/templates/directorate-of-equality/equality-report/src/fields/Overview.tsx
@@ -1,8 +1,6 @@
 import { FieldBaseProps } from '@island.is/application/types'
 import { getValueViaPath } from '@island.is/application/core'
 import { ReviewGroup } from '@island.is/application/ui-components'
-import { HTMLEditor } from '../components/html-editor/HTMLEditor'
-import { HTMLText } from '@dmr.is/regulations-tools/types'
 import { Box, GridColumn, GridRow, Text } from '@island.is/island-ui/core'
 import { useLocale } from '@island.is/localization'
 import { messages } from '../lib/messages'
@@ -26,18 +24,10 @@ export const Overview = ({ application, goToScreen }: FieldBaseProps) => {
   const subsidiaryList = answers.subsidiaries?.list ?? []
   const hasSubsidiaries = answers.subsidiaries?.includesSubsidiaries === 'yes'
 
-  const equalityPlanHtml = (() => {
-    const base64 =
-      getValueViaPath<string>(
-        application.answers,
-        'goalsAndActions.customField',
-      ) ?? ''
-    try {
-      return Buffer.from(base64, 'base64').toString('utf-8') as HTMLText
-    } catch {
-      return '' as HTMLText
-    }
-  })()
+  const equalityPlanFilename = getValueViaPath<string>(
+    application.answers,
+    'goalsAndActions.filename',
+  )
 
   return (
     <Box>
@@ -74,10 +64,9 @@ export const Overview = ({ application, goToScreen }: FieldBaseProps) => {
         <Text variant="h3" marginBottom={3}>
           {formatMessage(messages.overview.equalityPlan)}
         </Text>
-        <HTMLEditor
-          value={equalityPlanHtml}
-          readOnly
-          fileUploader={() => Promise.resolve({} as unknown)}
+        <Row
+          label={formatMessage(messages.overview.equalityPlanFile)}
+          value={equalityPlanFilename}
         />
       </ReviewGroup>
     </Box>

--- a/libs/application/templates/directorate-of-equality/equality-report/src/forms/draftRetryForm/goalsAndActionsSection.ts
+++ b/libs/application/templates/directorate-of-equality/equality-report/src/forms/draftRetryForm/goalsAndActionsSection.ts
@@ -9,7 +9,7 @@ import { DefaultEvents } from '@island.is/application/types'
 import { messages } from '../../lib/messages'
 
 // Reuses the same field id as mainForm's equalityReportSection
-// (goalsAndActions.customField) so this edits the same underlying answer
+// (goalsAndActions.filename) so this edits the same underlying answer
 // rather than a shadow copy. No inline CommentThread here — draftRetryForm
 // already has its own standalone comments screen as the landing page.
 export const draftRetryGoalsAndActionsSection = buildSection({
@@ -27,10 +27,13 @@ export const draftRetryGoalsAndActionsSection = buildSection({
           link: messages.equalityReport.information.detailLink,
           variant: 'text',
         }),
-        buildCustomField({
-          id: 'goalsAndActions.customField',
-          component: 'Editor',
-        }),
+        buildCustomField(
+          {
+            id: 'goalsAndActions.filename',
+            component: 'Editor',
+          },
+          { mode: 'retry' },
+        ),
         buildSubmitField({
           id: 'draftRetrySubmit',
           title: messages.draftRetry.submitButton,

--- a/libs/application/templates/directorate-of-equality/equality-report/src/forms/mainForm/aboutTheCompanySection.ts
+++ b/libs/application/templates/directorate-of-equality/equality-report/src/forms/mainForm/aboutTheCompanySection.ts
@@ -267,7 +267,6 @@ export const aboutTheCompanySection = buildSection({
               title: messages.aboutTheCompany.employeeCount.nonBinary,
               width: 'half',
               variant: 'number',
-              required: true,
             }),
           ],
         }),

--- a/libs/application/templates/directorate-of-equality/equality-report/src/forms/mainForm/equalityReportSection.ts
+++ b/libs/application/templates/directorate-of-equality/equality-report/src/forms/mainForm/equalityReportSection.ts
@@ -90,10 +90,13 @@ export const equalityReportSection = buildSection({
               link: messages.equalityReport.information.detailLink,
               variant: 'text',
             }),
-            buildCustomField({
-              id: 'goalsAndActions.customField',
-              component: 'Editor',
-            }),
+            buildCustomField(
+              {
+                id: 'goalsAndActions.filename',
+                component: 'Editor',
+              },
+              { mode: 'draft' },
+            ),
           ],
         }),
       ],

--- a/libs/application/templates/directorate-of-equality/equality-report/src/lib/dataSchema.ts
+++ b/libs/application/templates/directorate-of-equality/equality-report/src/lib/dataSchema.ts
@@ -53,14 +53,16 @@ const employeeCount = z.object({
     params: messages.errors.invalidNonNegativeNumber,
   }),
   // Optional — unlike women/men, companies aren't required to report this.
-  nonBinary: z.string().refine(
-    (v) =>
-      v === '' ||
-      (v.trim() !== '' && Number.isFinite(Number(v)) && Number(v) >= 0),
-    {
-      params: messages.errors.invalidNonNegativeNumber,
-    },
-  ),
+  nonBinary: z
+    .string()
+    .refine(
+      (v) =>
+        v === '' ||
+        (v.trim() !== '' && Number.isFinite(Number(v)) && Number(v) >= 0),
+      {
+        params: messages.errors.invalidNonNegativeNumber,
+      },
+    ),
 })
 
 const subsidiaries = z.object({

--- a/libs/application/templates/directorate-of-equality/equality-report/src/lib/dataSchema.ts
+++ b/libs/application/templates/directorate-of-equality/equality-report/src/lib/dataSchema.ts
@@ -53,9 +53,14 @@ const employeeCount = z.object({
     params: messages.errors.invalidNonNegativeNumber,
   }),
   // Optional — unlike women/men, companies aren't required to report this.
-  nonBinary: z.string().refine((v) => v === '' || Number(v) >= 0, {
-    params: messages.errors.invalidNonNegativeNumber,
-  }),
+  nonBinary: z.string().refine(
+    (v) =>
+      v === '' ||
+      (v.trim() !== '' && Number.isFinite(Number(v)) && Number(v) >= 0),
+    {
+      params: messages.errors.invalidNonNegativeNumber,
+    },
+  ),
 })
 
 const subsidiaries = z.object({

--- a/libs/application/templates/directorate-of-equality/equality-report/src/lib/dataSchema.ts
+++ b/libs/application/templates/directorate-of-equality/equality-report/src/lib/dataSchema.ts
@@ -3,7 +3,6 @@ import * as kennitala from 'kennitala'
 import { messages } from './messages'
 import { EMAIL_REGEX } from '@island.is/application/core'
 import { Gender } from '../utils/constants'
-import { decodeEditorHtml } from '../utils/htmlHelpers'
 
 const generalInformation = z.object({
   companyName: z.string().optional(),
@@ -53,7 +52,8 @@ const employeeCount = z.object({
   men: z.string().refine((v) => v !== '' && Number(v) >= 0, {
     params: messages.errors.invalidNonNegativeNumber,
   }),
-  nonBinary: z.string().refine((v) => v !== '' && Number(v) >= 0, {
+  // Optional — unlike women/men, companies aren't required to report this.
+  nonBinary: z.string().refine((v) => v === '' || Number(v) >= 0, {
     params: messages.errors.invalidNonNegativeNumber,
   }),
 })
@@ -95,7 +95,7 @@ const subsidiaries = z.object({
 })
 
 const goalsAndActions = z.object({
-  customField: z.string().refine((v) => decodeEditorHtml(v).length > 0, {
+  filename: z.string().refine((v) => v.length > 0, {
     params: messages.errors.required,
   }),
 })

--- a/libs/application/templates/directorate-of-equality/equality-report/src/lib/messages.ts
+++ b/libs/application/templates/directorate-of-equality/equality-report/src/lib/messages.ts
@@ -441,25 +441,17 @@ export const messages = {
         defaultMessage:
           '* Markmiðin eru skýr\n\n* Framkvæmdaáætlun er í samræmi við sett markmið\n\n* Aðgerðir hafa tímaramma\n\n* Áætlunin inniheldur árangursmat\n\n* Ábyrgð er skýr\n\n* Gildistími tilgreindur',
       },
-      editorTitle: {
-        id: 'doe.er.application:equalityReport.information.editorTitle',
-        defaultMessage: 'Innihald efnis',
-      },
-      editorFetchTemplate: {
-        id: 'doe.er.application:equalityReport.information.editorFetchTemplate',
-        defaultMessage: 'Sækja sniðmát',
-      },
       editorFetchTemplateDoc: {
         id: 'doe.er.application:equalityReport.information.editorFetchTemplateDoc',
         defaultMessage: 'Hlaða niður sniðmáti (.docx)',
       },
-      editorFetchTemplateFill: {
-        id: 'doe.er.application:equalityReport.information.editorFetchTemplateFill',
-        defaultMessage: 'Fá sniðmát í ritil',
-      },
       editorUploadFile: {
         id: 'doe.er.application:equalityReport.information.editorUploadFile',
         defaultMessage: 'Hlaða upp skjali',
+      },
+      editorSupportedFileTypes: {
+        id: 'doe.er.application:equalityReport.information.editorSupportedFileTypes',
+        defaultMessage: 'Samþykktar skráartegundir eru: .docx, .txt',
       },
       editorUnsupportedFile: {
         id: 'doe.er.application:equalityReport.information.editorUnsupportedFile',
@@ -470,6 +462,10 @@ export const messages = {
         id: 'doe.er.application:equalityReport.information.editorUploadError',
         defaultMessage:
           'Villa kom upp við lestur skráar. Vinsamlegast reynið aftur.',
+      },
+      editorUploadSuccess: {
+        id: 'doe.er.application:equalityReport.information.editorUploadSuccess',
+        defaultMessage: 'Jafnréttisáætlun var hlaðið upp.',
       },
     }),
     previousEqualityPlan: defineMessages({
@@ -564,6 +560,10 @@ export const messages = {
     equalityPlan: {
       id: 'doe.er.application:overview.equalityPlan',
       defaultMessage: 'Jafnréttisáætlun',
+    },
+    equalityPlanFile: {
+      id: 'doe.er.application:overview.equalityPlanFile',
+      defaultMessage: 'Skjal',
     },
     women: {
       id: 'doe.er.application:overview.women',

--- a/libs/application/templates/directorate-of-equality/equality-report/src/lib/template.ts
+++ b/libs/application/templates/directorate-of-equality/equality-report/src/lib/template.ts
@@ -14,14 +14,13 @@ import { Features } from '@island.is/feature-flags'
 import {
   ActiveEqualityReportApi,
   CompanyRegistryApi,
+  CreateEqualityDraftApi,
   DoeCompanyApi,
-  EditEqualityContentApi,
   EqualityReportTemplateDocxApi,
-  EqualityReportTemplateHtmlApi,
   GetReportCommentsApi,
   PreviousEqualityReportContentApi,
   SubmitReportCommentApi,
-  SubmitEqualityReportApi,
+  SubmitEqualityDraftApi,
 } from '../dataProviders'
 import { Events, Roles, States } from '../utils/constants'
 import { mapUserToRole } from '../utils/mapUserToRole'
@@ -143,7 +142,7 @@ const template: ApplicationTemplate<
           // onExit (not onEntry on IN_REVIEW) so a failed submission blocks
           // the transition instead of silently landing the applicant on a
           // fake "in review" screen with a stale backend record.
-          onExit: SubmitEqualityReportApi,
+          onExit: SubmitEqualityDraftApi,
           roles: [
             {
               id: Roles.APPLICANT,
@@ -161,7 +160,7 @@ const template: ApplicationTemplate<
               write: 'all',
               read: 'all',
               api: [
-                EqualityReportTemplateHtmlApi,
+                CreateEqualityDraftApi,
                 EqualityReportTemplateDocxApi,
                 PreviousEqualityReportContentApi,
               ],
@@ -262,11 +261,11 @@ const template: ApplicationTemplate<
           // So the comment thread's non-empty check has fresh externalData —
           // see the identical comment on States.DRAFT.
           onEntry: GetReportCommentsApi,
-          // PUTs just the report's narrative content in place — NOT
-          // SubmitEqualityReportApi, which is a one-shot create call
-          // (POST .../reports/equality) that a revision can't safely
-          // re-invoke. Mirrors salary-report's EditOutliersApi/onExit here.
-          onExit: EditEqualityContentApi,
+          // No onExit for content — Editor.tsx pushes the revised content
+          // straight to DMR's already-submitted (IN_REVIEW) report via the
+          // directorateOfEqualityEditEqualityContent GraphQL mutation the
+          // moment a file is uploaded, so there's nothing left to commit at
+          // transition time.
           actionCard: {
             tag: {
               label: messages.draftRetry.tagLabel,
@@ -302,9 +301,17 @@ const template: ApplicationTemplate<
               read: 'all',
               write: {
                 answers: ['comment', 'goalsAndActions'],
-                externalData: ['getReportComments', 'submitReportComment'],
+                externalData: [
+                  'getReportComments',
+                  'submitReportComment',
+                  'equalityReportTemplateDocx',
+                ],
               },
-              api: [GetReportCommentsApi, SubmitReportCommentApi],
+              api: [
+                GetReportCommentsApi,
+                SubmitReportCommentApi,
+                EqualityReportTemplateDocxApi,
+              ],
               delete: false,
             },
             {

--- a/libs/application/templates/directorate-of-equality/equality-report/src/utils/constants.ts
+++ b/libs/application/templates/directorate-of-equality/equality-report/src/utils/constants.ts
@@ -40,11 +40,10 @@ export enum ApiActions {
   getCompanyData = 'getCompanyData',
   getDoeCompany = 'getDoeCompany',
   getActiveEqualityReport = 'getActiveEqualityReport',
-  getEqualityReportTemplateHtml = 'getEqualityReportTemplateHtml',
   getEqualityReportTemplateDocx = 'getEqualityReportTemplateDocx',
   getPreviousEqualityReportContent = 'getPreviousEqualityReportContent',
-  submitEqualityReport = 'submitEqualityReport',
-  editEqualityContent = 'editEqualityContent',
+  createEqualityDraft = 'createEqualityDraft',
+  submitEqualityDraft = 'submitEqualityDraft',
   getReportComments = 'getReportComments',
   submitReportComment = 'submitReportComment',
 }

--- a/libs/application/templates/directorate-of-equality/equality-report/src/utils/htmlHelpers.ts
+++ b/libs/application/templates/directorate-of-equality/equality-report/src/utils/htmlHelpers.ts
@@ -30,12 +30,3 @@ export const decodeHtmlEntities = (value: string) =>
     return HTML_NAMED_ENTITIES[entity.toLowerCase()] ?? match
   })
 
-export const decodeEditorHtml = (base64: string) => {
-  try {
-    return atob(base64)
-      .replace(/<[^>]*>/g, '')
-      .trim()
-  } catch {
-    return ''
-  }
-}

--- a/libs/application/templates/directorate-of-equality/equality-report/src/utils/htmlHelpers.ts
+++ b/libs/application/templates/directorate-of-equality/equality-report/src/utils/htmlHelpers.ts
@@ -29,4 +29,3 @@ export const decodeHtmlEntities = (value: string) =>
     }
     return HTML_NAMED_ENTITIES[entity.toLowerCase()] ?? match
   })
-

--- a/libs/application/templates/directorate-of-equality/equality-report/src/utils/useEqualityDraft.ts
+++ b/libs/application/templates/directorate-of-equality/equality-report/src/utils/useEqualityDraft.ts
@@ -1,0 +1,87 @@
+import { useCallback, useRef } from 'react'
+import { gql, useMutation } from '@apollo/client'
+import type { Application } from '@island.is/application/types'
+import { UPDATE_APPLICATION_EXTERNAL_DATA } from '@island.is/application/graphql'
+import { useLocale } from '@island.is/localization'
+import { ApiActions } from './constants'
+
+// Custom resolvers, not the standard updateApplicationExternalData provider
+// mechanism — that only takes {actionId, order}, with no channel for an
+// arbitrary content payload. Content goes straight to DMR, never through
+// application.answers.
+const UPDATE_EQUALITY_DRAFT_CONTENT = gql`
+  mutation DirectorateOfEqualityUpdateEqualityDraftContent(
+    $input: DirectorateOfEqualityUpdateEqualityDraftContentInput!
+  ) {
+    directorateOfEqualityUpdateEqualityDraftContent(input: $input)
+  }
+`
+
+const EDIT_EQUALITY_CONTENT = gql`
+  mutation DirectorateOfEqualityEditEqualityContent(
+    $input: DirectorateOfEqualityEditEqualityContentInput!
+  ) {
+    directorateOfEqualityEditEqualityContent(input: $input)
+  }
+`
+
+// Idempotent + awaitable: memoizes the in-flight/completed ensure-draft call
+// so concurrent or repeat callers share one request instead of re-POSTing;
+// clears on failure so a later retry can actually retry.
+export const useEnsureEqualityDraft = (application: Application) => {
+  const { locale } = useLocale()
+  const [updateApplicationExternalData] = useMutation(
+    UPDATE_APPLICATION_EXTERNAL_DATA,
+  )
+  const draftPromiseRef = useRef<Promise<void> | null>(null)
+
+  return useCallback((): Promise<void> => {
+    if (!draftPromiseRef.current) {
+      draftPromiseRef.current = updateApplicationExternalData({
+        variables: {
+          input: {
+            id: application.id,
+            dataProviders: [
+              {
+                actionId: `DirectorateOfEquality.${ApiActions.createEqualityDraft}`,
+                order: 0,
+              },
+            ],
+          },
+          locale,
+        },
+      })
+        .then(() => undefined)
+        .catch((error) => {
+          draftPromiseRef.current = null
+          throw error
+        })
+    }
+    return draftPromiseRef.current
+  }, [application.id, locale, updateApplicationExternalData])
+}
+
+export const useEqualityContentPush = () => {
+  const [updateDraftContent] = useMutation(UPDATE_EQUALITY_DRAFT_CONTENT)
+  const [editContent] = useMutation(EDIT_EQUALITY_CONTENT)
+
+  const pushDraftContent = useCallback(
+    async (applicationId: string, equalityReportContent: string) => {
+      await updateDraftContent({
+        variables: { input: { applicationId, equalityReportContent } },
+      })
+    },
+    [updateDraftContent],
+  )
+
+  const pushRetryContent = useCallback(
+    async (applicationId: string, equalityReportContent: string) => {
+      await editContent({
+        variables: { input: { applicationId, equalityReportContent } },
+      })
+    },
+    [editContent],
+  )
+
+  return { pushDraftContent, pushRetryContent }
+}

--- a/libs/clients/directorate-of-equality/src/lib/directorate-of-equality.service.ts
+++ b/libs/clients/directorate-of-equality/src/lib/directorate-of-equality.service.ts
@@ -13,7 +13,6 @@ import {
   getApplicationDraftAnalysis,
   getApplicationDraftCriteriaTree,
   getApplicationEqualityReportTemplateDocx,
-  getApplicationEqualityReportTemplateHtml,
   getApplicationReport,
   getApplicationReportDraft,
   getApplicationReportOutliers,
@@ -28,7 +27,6 @@ import {
   listApplicationDraftRoles,
   listApplicationDraftRolesWithSteps,
   presignApplicationImportUpload,
-  submitApplicationEqualityReport,
   submitApplicationReportComment,
   submitApplicationReportDraft,
   submitApplicationSalaryReport,
@@ -61,7 +59,6 @@ import type {
   SalaryAnalysisResponseDto,
   SubmitApplicationReportCommentDto,
   SubmitDraftDto,
-  SubmitEqualityReportDto,
   SubmitSalaryReportDto,
   SyncDraftDto,
   UpdateDraftDto,
@@ -104,30 +101,11 @@ export class DirectorateOfEqualityClientService {
     )
   }
 
-  async getEqualityReportTemplateHtml(user: User): Promise<string> {
-    return this.unwrap(
-      user,
-      () => getApplicationEqualityReportTemplateHtml(),
-      'Failed to get equality report template HTML',
-    )
-  }
-
   async getEqualityReportTemplateDocx(user: User): Promise<Blob> {
     return this.unwrap(
       user,
       () => getApplicationEqualityReportTemplateDocx(),
       'Failed to get equality report template DOCX',
-    )
-  }
-
-  async submitEqualityReport(
-    user: User,
-    body: SubmitEqualityReportDto,
-  ): Promise<CreateReportResponseDto> {
-    return this.unwrap(
-      user,
-      () => submitApplicationEqualityReport({ body }),
-      'Failed to submit equality report',
     )
   }
 


### PR DESCRIPTION
## Summary

- Equality-report's document upload now uses the platform's drag-and-drop `InputFileUpload` component instead of a hidden file input, matching salary-report's pattern
- Removed the in-browser rich-text editor entirely — applicants upload a `.docx`/`.txt` document and never type or edit content in the browser, in both the initial draft and the case-worker-requested-revision (`draftRetry`) flow
- Moved the report's narrative content off `application.answers` entirely and onto the same DMR "draft" lifecycle salary-report already uses (`createDraft`/`updateDraft`/`submitDraft`), sent straight to DMR via two new purpose-built GraphQL mutations — avoids the request-body size limit that inline base64 content in the answers payload could hit, and stops that content from being re-sent on every later screen navigation
- Overview screen now shows just the uploaded filename, not the rendered document content
- `employeeCount.nonBinary` ("Kynsegin") is no longer a required field
- Added a "supported file types" hint inside the upload widget

## Details

### Frontend (`equality-report` template)
- `Editor.tsx` — full rework: drag-and-drop upload, unchanged client-side `.docx`/`.txt`→HTML conversion (mammoth), pushes content straight to DMR via the new GraphQL mutations instead of `application.answers`; only the filename is persisted as an answer
- `dataSchema.ts` — `goalsAndActions.customField` removed; `goalsAndActions.filename` is now the required field; `employeeCount.nonBinary` is now optional
- `Overview.tsx` — displays filename instead of rendered content
- `template.ts` — `DRAFT` creates the DMR draft on demand and finalizes via `submitDraft` on exit; `DRAFT_RETRY` no longer has an `onExit` action for content, since the revision is committed the moment the applicant re-uploads
- Dead code removed: the old "fetch template into editor" action, `decodeEditorHtml`, and the one-shot `submitEqualityReport`/`editEqualityContent` template actions

### Backend
- `template-api-modules` — added `createEqualityDraft`/`submitEqualityDraft` (mirroring salary-report's draft methods); removed the old one-shot `submitEqualityReport`/`editEqualityContent`; also fixes a pre-existing gap where `companyAdminTitle` was never sent to DMR
- `libs/api/domains/directorate-of-equality-application` — two new GraphQL mutations (`directorateOfEqualityUpdateEqualityDraftContent`, `directorateOfEqualityEditEqualityContent`) so the browser can send document content straight to DMR, bypassing `application.answers` entirely — mirrors the existing `syncSalaryReportDraft` pattern, since the generic `updateApplicationExternalData` mechanism has no channel for arbitrary payloads
- `libs/clients/directorate-of-equality` — removed the now-unused `submitEqualityReport`/`getEqualityReportTemplateHtml` client methods

## Test plan

- [ ] Upload a `.docx`/`.txt` file on a fresh application — drag-and-drop works, content reaches DMR, filename shows on the overview screen
- [ ] Resume a draft after navigating away and back — previously uploaded filename still shows correctly
- [ ] Trigger a case-worker revision (`DRAFT_RETRY`) and re-upload a corrected document — commits without an extra submit step
- [ ] Leave "Kynsegin" employee count blank — form still proceeds
- [ ] Download the report template (`.docx`) button still works in both draft and retry states


## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added draft-based equality report creation and submission.
  * Added support for uploading `.txt` and `.docx` equality plan files.
  * Added direct saving of report content while drafting or retrying a submission.
  * Added clear upload success, error, and supported-file guidance.
* **Bug Fixes**
  * Employee count for non-binary employees is now optional.
  * Improved handling of uploaded equality plan filenames in the overview.
  * Added validation to ensure content updates occur in the correct application state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->