### PR TITLE
fix(inheritance-report): validate spouse national id only when included in grantors

### DIFF
--- a/libs/application/template-api-modules/src/lib/modules/templates/inheritance-report/utils/mappers.spec.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/inheritance-report/utils/mappers.spec.ts
@@ -1,0 +1,88 @@
+import { YES } from '@island.is/application/core'
+import { expandAnswers } from './mappers'
+
+type SchemaInput = Parameters<typeof expandAnswers>[0]
+
+describe('expandAnswers', () => {
+  it('should map spouse fields when includeSpouse is YES', () => {
+    const answers = {
+      applicationFor: 'prepaidInheritance',
+      applicant: {
+        email: 'applicant@example.com',
+        phone: '+3548994207',
+        name: 'Applicant Name',
+        nationalId: '0101302209',
+        relation: 'grantor',
+      },
+      executors: {
+        includeSpouse: [YES],
+        executor: {
+          email: 'executor@example.com',
+          phone: '+3548994207',
+          name: 'Executor Name',
+          nationalId: '0101302209',
+        },
+        spouse: {
+          email: 'spouse@example.com',
+          phone: '+3548979957',
+          name: 'Spouse Name',
+          nationalId: '1803723509',
+        },
+      },
+      assets: {
+        assetsTotal: 1000000,
+      },
+      approveExternalData: true,
+    } as unknown as SchemaInput
+
+    const result = expandAnswers(answers)
+
+    expect(result.executors.spouse).toEqual({
+      email: 'spouse@example.com',
+      phone: '+3548979957',
+      name: 'Spouse Name',
+      nationalId: '1803723509',
+    })
+  })
+
+  it('should clear spouse fields when includeSpouse is not YES', () => {
+    const answers = {
+      applicationFor: 'prepaidInheritance',
+      applicant: {
+        email: 'applicant@example.com',
+        phone: '+3548994207',
+        name: 'Applicant Name',
+        nationalId: '0101302209',
+        relation: 'grantor',
+      },
+      executors: {
+        includeSpouse: [],
+        executor: {
+          email: 'executor@example.com',
+          phone: '+3548994207',
+          name: 'Executor Name',
+          nationalId: '0101302209',
+        },
+        spouse: {
+          email: 'stale_spouse@example.com',
+          phone: '+3548979957',
+          name: 'Stale Spouse Name',
+          nationalId: '1803723509',
+        },
+      },
+      assets: {
+        assetsTotal: 1000000,
+      },
+      approveExternalData: true,
+    } as unknown as SchemaInput
+
+    const result = expandAnswers(answers)
+
+    expect(result.executors.spouse).toEqual({
+      email: '',
+      phone: '',
+      name: '',
+      nationalId: '',
+    })
+  })
+})

--- a/libs/application/template-api-modules/src/lib/modules/templates/inheritance-report/utils/mappers.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/inheritance-report/utils/mappers.ts
@@ -1,4 +1,5 @@
 import { infer as zinfer } from 'zod'
+import { YES } from '@island.is/application/core'
 import { inheritanceReportSchema } from '@island.is/application/templates/inheritance-report'
 
 type InheritanceReportSchema = zinfer<typeof inheritanceReportSchema>
@@ -37,12 +38,19 @@ export const expandAnswers = (
         name: answers.executors?.executor.name ?? '',
         nationalId: answers.executors?.executor.nationalId ?? '',
       },
-      spouse: {
-        email: answers.executors?.spouse?.email ?? '',
-        phone: answers.executors?.spouse?.phone ?? '',
-        name: answers.executors?.spouse?.name ?? '',
-        nationalId: answers.executors?.spouse?.nationalId ?? '',
-      },
+      spouse: answers.executors?.includeSpouse?.includes(YES)
+        ? {
+            email: answers.executors?.spouse?.email ?? '',
+            phone: answers.executors?.spouse?.phone ?? '',
+            name: answers.executors?.spouse?.name ?? '',
+            nationalId: answers.executors?.spouse?.nationalId ?? '',
+          }
+        : {
+            email: '',
+            phone: '',
+            name: '',
+            nationalId: '',
+          },
       includeSpouse: undefined,
     },
     approveExternalData: answers.approveExternalData,

--- a/libs/application/templates/inheritance-report/src/fields/HeirsRepeater/index.tsx
+++ b/libs/application/templates/inheritance-report/src/fields/HeirsRepeater/index.tsx
@@ -32,6 +32,8 @@ import {
   formatPhoneNumber,
   getEstateDataFromApplication,
   getPrePaidTotalValueFromApplication,
+  includeSpouse,
+  nationalIdsMatch,
   valueToNumber,
 } from '../../lib/utils/helpers'
 import { HeirsRepeaterProps } from './types'
@@ -389,22 +391,29 @@ export const HeirsRepeater: FC<
   }, [])
 
   useEffect(() => {
-    const executorNationalId = getValueViaPath(
+    if (!isPrePaidApplication) {
+      setHasHeirWithNationalIdSameAsExecutor(false)
+      return
+    }
+
+    const executorNationalId = getValueViaPath<string>(
       answers,
       'executors.executor.nationalId',
     )
-    const spouseNationalId = getValueViaPath(
-      answers,
-      'executors.spouse.nationalId',
-    )
+    const isSpouseIncluded = includeSpouse(answers)
+    const spouseNationalId = isSpouseIncluded
+      ? getValueViaPath<string>(answers, 'executors.spouse.nationalId')
+      : undefined
 
     const match = (heirsData ?? []).some(
-      (field: any) =>
-        field.nationalId === executorNationalId ||
-        field.nationalId === spouseNationalId,
+      (field: EstateMember) =>
+        field?.enabled !== false &&
+        (nationalIdsMatch(field?.nationalId, executorNationalId) ||
+          (isSpouseIncluded &&
+            nationalIdsMatch(field?.nationalId, spouseNationalId))),
     )
     setHasHeirWithNationalIdSameAsExecutor(match)
-  }, [answers, heirsData])
+  }, [answers, heirsData, isPrePaidApplication])
 
   return (
     <Box>

--- a/libs/application/templates/inheritance-report/src/lib/utils/helpers.spec.ts
+++ b/libs/application/templates/inheritance-report/src/lib/utils/helpers.spec.ts
@@ -1,4 +1,9 @@
-import { isValidEmail, valueToNumber, nationalIdsMatch } from './helpers'
+import {
+  isValidEmail,
+  valueToNumber,
+  nationalIdsMatch,
+  includeSpouse,
+} from './helpers'
 
 describe('isValidEmail', () => {
   it('should return false if email is malformed', () => {
@@ -75,5 +80,20 @@ describe('nationalIdsMatch', () => {
     expect(nationalIdsMatch('', '0101302209')).toBe(false)
     expect(nationalIdsMatch('0101302209', '')).toBe(false)
     expect(nationalIdsMatch('', '')).toBe(false)
+  })
+})
+
+describe('includeSpouse', () => {
+  it('should return true when includeSpouse contains YES', () => {
+    expect(includeSpouse({ executors: { includeSpouse: ['yes'] } })).toBe(true)
+  })
+
+  it('should return false when includeSpouse is empty array', () => {
+    expect(includeSpouse({ executors: { includeSpouse: [] } })).toBe(false)
+  })
+
+  it('should return false when includeSpouse is undefined or missing', () => {
+    expect(includeSpouse({ executors: {} })).toBe(false)
+    expect(includeSpouse({})).toBe(false)
   })
 })


### PR DESCRIPTION
# fix(inheritance-report): validate spouse national id only when included in grantors

## What

In the Inheritance Report template (`inheritance-report` / prepaid inheritance):
- In `HeirsRepeater/index.tsx`, only check `executors.spouse.nationalId` when `includeSpouse(answers)` is true (`executors.includeSpouse` contains `YES`).
- Use `nationalIdsMatch` helper for robust national ID comparison, sanitizing hyphens and safely handling null/undefined/empty string values.
- Guard the validation check with `if (!isPrePaidApplication)` and ignore disabled heirs.
- In `mappers.ts` (`expandAnswers`), default spouse fields to empty strings unless `answers.executors?.includeSpouse?.includes(YES)`.
- Added unit tests for `includeSpouse` in `helpers.spec.ts` and `expandAnswers` in `mappers.spec.ts`.

## Why

In prepaid inheritance applications, if an applicant checks "Ráðstafa úr sameign hjúskaps", enters a national ID under spouse, and later unchecks the box, the spouse form inputs are hidden on the UI and `includeSpouse` becomes `[]`. However, the previously typed national ID remained in draft answers.

When proceeding to the Heirs step, `HeirsRepeater` was comparing heirs against both `executors.executor.nationalId` and `executors.spouse.nationalId` unconditionally. If the person entered as a spouse was then added as an heir, it caused a false-positive validation error:
`"Ekki er hægt að halda áfram með umsókn þar sem erfingi má ekki vera sá sami og arfleifandi"` ("Cannot proceed with application because an heir cannot be the same as the grantor").

## Screenshots / Gifs

N/A

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude (Oh My Pi harness)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved inheritance report handling of executor spouse details based on spouse inclusion answers.
  - Prevented stale spouse information from appearing when a spouse is not included.
  - Refined duplicate national ID warnings to apply only in relevant prepaid applications and enabled heir records.

- **Tests**
  - Added coverage for spouse inclusion scenarios and national ID matching behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->