### PR TITLE
feat(driving-license): health-certificate upload for B-temp/B-full via the v6 withhealthdeclaration endpoints

### DIFF
--- a/libs/api/domains/driving-license/src/lib/drivingLicense.service.ts
+++ b/libs/api/domains/driving-license/src/lib/drivingLicense.service.ts
@@ -674,7 +674,7 @@ export class DrivingLicenseService {
     auth: Auth,
     input: NewDrivingLicenseWithHealthDeclarationInput,
   ): Promise<NewDrivingLicenseResult> {
-    const success =
+    const applicationGuid =
       await this.drivingLicenseApi.postFullLicenseWithHealthDeclarationV6({
         auth,
         category: input.licenseCategory,
@@ -690,8 +690,17 @@ export class DrivingLicenseService {
         },
       })
 
+    // Record the RLS application guid returned on creation. It is the only handle
+    // for reconciling or denying the application afterwards (RLS-side id, not our
+    // application id), and its absence is what made a failed create impossible to
+    // clean up during development.
+    this.logger.info(`${LOGTAG} created full driving-license application`, {
+      applicationGuid,
+      category: input.licenseCategory,
+    })
+
     return {
-      success,
+      success: true,
       errorMessage: null,
     }
   }
@@ -708,7 +717,7 @@ export class DrivingLicenseService {
     auth: Auth,
     input: NewTemporaryDrivingLicenseWithHealthDeclarationInput,
   ): Promise<NewDrivingLicenseResult> {
-    const response =
+    const applicationGuid =
       await this.drivingLicenseApi.postTemporaryLicenseWithHealthDeclarationV6({
         auth,
         model: {
@@ -732,8 +741,13 @@ export class DrivingLicenseService {
     // surfaced to the applicant as a failed submission *after they had paid*.
     // The client's `postTemporaryLicenseWithHealthDeclarationV6` already maps the
     // one benign 400 (a lost-response retry) to a resolved value, so a throw here
-    // is a genuine failure and must propagate to `submitApplication`.
-    void response
+    // is a genuine failure and must propagate to `submitApplication`. The value
+    // is the RLS application guid (or null on the lost-response path); log it, as
+    // it is the only handle for reconciling or denying the application later.
+    this.logger.info(`${LOGTAG} created temporary driving-license application`, {
+      applicationGuid,
+    })
+
     return {
       success: true,
       errorMessage: null,

--- a/libs/api/domains/driving-license/src/lib/drivingLicense.service.ts
+++ b/libs/api/domains/driving-license/src/lib/drivingLicense.service.ts
@@ -1,5 +1,5 @@
 import { Inject, Injectable } from '@nestjs/common'
-import type { User } from '@island.is/auth-nest-tools'
+import type { Auth, User } from '@island.is/auth-nest-tools'
 import {
   TeachingRightsStatus,
   StudentInformation,
@@ -14,6 +14,8 @@ import {
   ApplicationEligibilityRequirement,
   QualitySignatureResult,
   NewBEDrivingLicenseInput,
+  NewDrivingLicenseWithHealthDeclarationInput,
+  NewTemporaryDrivingLicenseWithHealthDeclarationInput,
   DrivinglicenseDuplicateValidityStatus,
   NewRenewal65DrivingLicenseInput,
 } from './drivingLicense.type'
@@ -655,6 +657,76 @@ export class DrivingLicenseService {
     return {
       success: response,
       errorMessage: null,
+    }
+  }
+
+  /**
+   * B-full via the v6 `withhealthdeclaration` endpoint. Takes the whole `Auth`
+   * object, not `auth.authorization` — the v6 client wraps the call in
+   * `withAuthContext`, which needs the object to put the token on the `jwttoken`
+   * header. Passing the string would leave that header unset and every request
+   * would come back 400, while unit tests carried on passing.
+   *
+   * The neighbouring methods take a bare string; that is deliberate and stays.
+   * Unifying them is PR #23064's job.
+   */
+  async newDrivingLicenseWithHealthDeclaration(
+    auth: Auth,
+    input: NewDrivingLicenseWithHealthDeclarationInput,
+  ): Promise<NewDrivingLicenseResult> {
+    const success =
+      await this.drivingLicenseApi.postFullLicenseWithHealthDeclarationV6({
+        auth,
+        category: input.licenseCategory,
+        model: {
+          districtId: input.districtId,
+          sendPlasticToPerson: input.sendPlasticToPerson,
+          email: input.email,
+          primaryPhoneNumber: input.primaryPhoneNumber,
+          healthDeclaration: input.healthDeclaration,
+          contentList: input.contentList,
+          photoBiometricsId: input.photoBiometricsId,
+          signatureBiometricsId: input.signatureBiometricsId,
+        },
+      })
+
+    return {
+      success,
+      errorMessage: null,
+    }
+  }
+
+  /**
+   * B-temp counterpart. Unlike the full-licence endpoint this one returns a DTO
+   * rather than a boolean, so the result MUST be mapped: this single call now
+   * decides success on its own, where previously the legacy submit that followed
+   * did. Leaving the DTO unread would make `submitApplication` never see
+   * `success: false`, and every RLS business rejection would reach the applicant
+   * as "submitted".
+   */
+  async newTemporaryDrivingLicenseWithHealthDeclaration(
+    auth: Auth,
+    input: NewTemporaryDrivingLicenseWithHealthDeclarationInput,
+  ): Promise<NewDrivingLicenseResult> {
+    const response =
+      await this.drivingLicenseApi.postTemporaryLicenseWithHealthDeclarationV6({
+        auth,
+        model: {
+          districtId: input.districtId,
+          instructorSSN: input.instructorSSN,
+          sendPlasticToPerson: input.sendPlasticToPerson,
+          email: input.email,
+          primaryPhoneNumber: input.primaryPhoneNumber,
+          healthDeclaration: input.healthDeclaration,
+          contentList: input.contentList,
+          photoBiometricsId: input.photoBiometricsId,
+          signatureBiometricsId: input.signatureBiometricsId,
+        },
+      })
+
+    return {
+      success: response.result ?? false,
+      errorMessage: response.errorCode ?? null,
     }
   }
 

--- a/libs/api/domains/driving-license/src/lib/drivingLicense.service.ts
+++ b/libs/api/domains/driving-license/src/lib/drivingLicense.service.ts
@@ -724,9 +724,19 @@ export class DrivingLicenseService {
         },
       })
 
+    // Reaching here means RLS returned 2xx — enhanced fetch throws on 4xx, which
+    // is how this endpoint signals a business rejection (e.g. 400
+    // APPLICATION_ALREADY_EXISTS). Do NOT gate on the DTO `result` field: RLS
+    // returns the new application's guid in the body on success, and dev showed a
+    // successfully-created application come back with `result` falsy, which then
+    // surfaced to the applicant as a failed submission *after they had paid*.
+    // The client's `postTemporaryLicenseWithHealthDeclarationV6` already maps the
+    // one benign 400 (a lost-response retry) to a resolved value, so a throw here
+    // is a genuine failure and must propagate to `submitApplication`.
+    void response
     return {
-      success: response.result ?? false,
-      errorMessage: response.errorCode ?? null,
+      success: true,
+      errorMessage: null,
     }
   }
 

--- a/libs/api/domains/driving-license/src/lib/drivingLicense.service.ts
+++ b/libs/api/domains/driving-license/src/lib/drivingLicense.service.ts
@@ -690,18 +690,12 @@ export class DrivingLicenseService {
         },
       })
 
-    // Record the RLS application guid returned on creation. It is the only handle
-    // for reconciling or denying the application afterwards (RLS-side id, not our
-    // application id), and its absence is what made a failed create impossible to
-    // clean up during development.
-    this.logger.info(`${LOGTAG} created full driving-license application`, {
-      applicationGuid,
-      category: input.licenseCategory,
-    })
-
+    // Return the RLS application guid so the submission service can log it next
+    // to our own application id — together they are the reconciliation record.
     return {
       success: true,
       errorMessage: null,
+      applicationGuid,
     }
   }
 
@@ -742,18 +736,12 @@ export class DrivingLicenseService {
     // The client's `postTemporaryLicenseWithHealthDeclarationV6` already maps the
     // one benign 400 (a lost-response retry) to a resolved value, so a throw here
     // is a genuine failure and must propagate to `submitApplication`. The value
-    // is the RLS application guid (or null on the lost-response path); log it, as
-    // it is the only handle for reconciling or denying the application later.
-    this.logger.info(
-      `${LOGTAG} created temporary driving-license application`,
-      {
-        applicationGuid,
-      },
-    )
-
+    // is the RLS application guid (or null on the lost-response path); return it
+    // so the submission service can log it next to our own application id.
     return {
       success: true,
       errorMessage: null,
+      applicationGuid,
     }
   }
 

--- a/libs/api/domains/driving-license/src/lib/drivingLicense.service.ts
+++ b/libs/api/domains/driving-license/src/lib/drivingLicense.service.ts
@@ -744,9 +744,12 @@ export class DrivingLicenseService {
     // is a genuine failure and must propagate to `submitApplication`. The value
     // is the RLS application guid (or null on the lost-response path); log it, as
     // it is the only handle for reconciling or denying the application later.
-    this.logger.info(`${LOGTAG} created temporary driving-license application`, {
-      applicationGuid,
-    })
+    this.logger.info(
+      `${LOGTAG} created temporary driving-license application`,
+      {
+        applicationGuid,
+      },
+    )
 
     return {
       success: true,

--- a/libs/api/domains/driving-license/src/lib/drivingLicense.spec.ts
+++ b/libs/api/domains/driving-license/src/lib/drivingLicense.spec.ts
@@ -557,4 +557,95 @@ describe('DrivingLicenseService', () => {
         .catch((e) => expect(e).toBeTruthy())
     })
   })
+
+  describe('withHealthDeclaration (v6)', () => {
+    const auth = { authorization: 'Bearer token' } as never
+    const allNo = {
+      isDisabled: false,
+      hasDiabetes: false,
+      hasEpilepsy: false,
+      isAlcoholic: false,
+      hasHeartDisease: false,
+      hasMentalIllness: false,
+      hasOtherDiseases: false,
+      usesMedicalDrugs: false,
+      usesContactGlasses: false,
+      hasReducedPeripheralVision: false,
+    }
+    const baseInput = {
+      districtId: 37,
+      sendPlasticToPerson: false,
+      healthDeclaration: allNo,
+    }
+
+    afterEach(() => {
+      jest.restoreAllMocks()
+    })
+
+    // The temporary endpoint returns a DTO, not a boolean. If `result` is not
+    // mapped, `submitApplication` never sees `success: false` and every RLS
+    // business rejection reaches the applicant as "submitted".
+    it('maps a rejected temporary submission to success: false and keeps the code', async () => {
+      jest
+        .spyOn(drivingLicenseApi, 'postTemporaryLicenseWithHealthDeclarationV6')
+        .mockResolvedValue({ result: false, errorCode: 'HAS_B_CATEGORY' })
+
+      await expect(
+        service.newTemporaryDrivingLicenseWithHealthDeclaration(auth, {
+          ...baseInput,
+          instructorSSN: MOCK_NATIONAL_ID_TEACHER,
+        }),
+      ).resolves.toStrictEqual({
+        success: false,
+        errorMessage: 'HAS_B_CATEGORY',
+      })
+    })
+
+    it('maps an accepted temporary submission to success: true', async () => {
+      jest
+        .spyOn(drivingLicenseApi, 'postTemporaryLicenseWithHealthDeclarationV6')
+        .mockResolvedValue({ result: true, driverLicenseId: 1 })
+
+      await expect(
+        service.newTemporaryDrivingLicenseWithHealthDeclaration(auth, {
+          ...baseInput,
+          instructorSSN: MOCK_NATIONAL_ID_TEACHER,
+        }),
+      ).resolves.toStrictEqual({ success: true, errorMessage: null })
+    })
+
+    // An empty DTO is what a 201 with no body deserialises to; it must not read
+    // as success.
+    it('treats an absent result as a failure rather than a success', async () => {
+      jest
+        .spyOn(drivingLicenseApi, 'postTemporaryLicenseWithHealthDeclarationV6')
+        .mockResolvedValue({})
+
+      await expect(
+        service.newTemporaryDrivingLicenseWithHealthDeclaration(auth, {
+          ...baseInput,
+          instructorSSN: MOCK_NATIONAL_ID_TEACHER,
+        }),
+      ).resolves.toStrictEqual({ success: false, errorMessage: null })
+    })
+
+    it('forwards the category as a path param for the full licence', async () => {
+      const spy = jest
+        .spyOn(drivingLicenseApi, 'postFullLicenseWithHealthDeclarationV6')
+        .mockResolvedValue(true)
+
+      await expect(
+        service.newDrivingLicenseWithHealthDeclaration(auth, {
+          ...baseInput,
+          licenseCategory: DrivingLicenseCategory.B,
+        }),
+      ).resolves.toStrictEqual({ success: true, errorMessage: null })
+
+      expect(spy).toHaveBeenCalledWith(
+        expect.objectContaining({ auth, category: DrivingLicenseCategory.B }),
+      )
+      // `licenseCategory` travels in the path, so it must not also be in the body.
+      expect('licenseCategory' in spy.mock.calls[0][0].model).toBe(false)
+    })
+  })
 })

--- a/libs/api/domains/driving-license/src/lib/drivingLicense.spec.ts
+++ b/libs/api/domains/driving-license/src/lib/drivingLicense.spec.ts
@@ -53,6 +53,8 @@ describe('DrivingLicenseService', () => {
           provide: LOGGER_PROVIDER,
           useValue: {
             warn: () => undefined,
+            info: () => undefined,
+            error: () => undefined,
           },
         },
         {
@@ -589,27 +591,17 @@ describe('DrivingLicenseService', () => {
     // retry then hit 400 APPLICATION_ALREADY_EXISTS. Any resolved response is a
     // success, whatever the DTO body looks like.
     it.each([
-      ['the documented shape', { result: true, driverLicenseId: 1 }],
-      [
-        'a created app with result falsy (the dev regression)',
-        { result: false },
-      ],
-      ['an empty body', {}],
-      [
-        'a body carrying only the guid RLS actually returns',
-        {
-          guid: '3630b0bc-ec51-442e-976d-13a3c21c5e5b',
-        },
-      ],
+      ['a guid', '3630b0bc-ec51-442e-976d-13a3c21c5e5b'],
+      ['null (guid unreadable / lost-response retry)', null],
     ])(
       'treats a resolved temporary submission (%s) as success',
-      async (_l, dto) => {
+      async (_l, guid) => {
         jest
           .spyOn(
             drivingLicenseApi,
             'postTemporaryLicenseWithHealthDeclarationV6',
           )
-          .mockResolvedValue(dto as never)
+          .mockResolvedValue(guid as never)
 
         await expect(
           service.newTemporaryDrivingLicenseWithHealthDeclaration(auth, {
@@ -640,7 +632,7 @@ describe('DrivingLicenseService', () => {
     it('forwards the category as a path param for the full licence', async () => {
       const spy = jest
         .spyOn(drivingLicenseApi, 'postFullLicenseWithHealthDeclarationV6')
-        .mockResolvedValue(true)
+        .mockResolvedValue('3630b0bc-ec51-442e-976d-13a3c21c5e5b')
 
       await expect(
         service.newDrivingLicenseWithHealthDeclaration(auth, {

--- a/libs/api/domains/driving-license/src/lib/drivingLicense.spec.ts
+++ b/libs/api/domains/driving-license/src/lib/drivingLicense.spec.ts
@@ -582,51 +582,59 @@ describe('DrivingLicenseService', () => {
       jest.restoreAllMocks()
     })
 
-    // The temporary endpoint returns a DTO, not a boolean. If `result` is not
-    // mapped, `submitApplication` never sees `success: false` and every RLS
-    // business rejection reaches the applicant as "submitted".
-    it('maps a rejected temporary submission to success: false and keeps the code', async () => {
-      jest
-        .spyOn(drivingLicenseApi, 'postTemporaryLicenseWithHealthDeclarationV6')
-        .mockResolvedValue({ result: false, errorCode: 'HAS_B_CATEGORY' })
+    // RLS signals success with 2xx (enhanced fetch throws on 4xx), and returns
+    // the new application's guid — NOT reliably a `result: true`. A created
+    // application was observed on dev coming back with `result` falsy, so gating
+    // on it reported failure to an applicant who had already paid, and their
+    // retry then hit 400 APPLICATION_ALREADY_EXISTS. Any resolved response is a
+    // success, whatever the DTO body looks like.
+    it.each([
+      ['the documented shape', { result: true, driverLicenseId: 1 }],
+      [
+        'a created app with result falsy (the dev regression)',
+        { result: false },
+      ],
+      ['an empty body', {}],
+      [
+        'a body carrying only the guid RLS actually returns',
+        {
+          guid: '3630b0bc-ec51-442e-976d-13a3c21c5e5b',
+        },
+      ],
+    ])(
+      'treats a resolved temporary submission (%s) as success',
+      async (_l, dto) => {
+        jest
+          .spyOn(
+            drivingLicenseApi,
+            'postTemporaryLicenseWithHealthDeclarationV6',
+          )
+          .mockResolvedValue(dto as never)
 
-      await expect(
-        service.newTemporaryDrivingLicenseWithHealthDeclaration(auth, {
-          ...baseInput,
-          instructorSSN: MOCK_NATIONAL_ID_TEACHER,
-        }),
-      ).resolves.toStrictEqual({
-        success: false,
-        errorMessage: 'HAS_B_CATEGORY',
+        await expect(
+          service.newTemporaryDrivingLicenseWithHealthDeclaration(auth, {
+            ...baseInput,
+            instructorSSN: MOCK_NATIONAL_ID_TEACHER,
+          }),
+        ).resolves.toStrictEqual({ success: true, errorMessage: null })
+      },
+    )
+
+    it('propagates a rejection so submitApplication surfaces the RLS error', async () => {
+      const problem = Object.assign(new Error('already exists'), {
+        name: 'FetchError',
+        status: 400,
       })
-    })
-
-    it('maps an accepted temporary submission to success: true', async () => {
       jest
         .spyOn(drivingLicenseApi, 'postTemporaryLicenseWithHealthDeclarationV6')
-        .mockResolvedValue({ result: true, driverLicenseId: 1 })
+        .mockRejectedValue(problem)
 
       await expect(
         service.newTemporaryDrivingLicenseWithHealthDeclaration(auth, {
           ...baseInput,
           instructorSSN: MOCK_NATIONAL_ID_TEACHER,
         }),
-      ).resolves.toStrictEqual({ success: true, errorMessage: null })
-    })
-
-    // An empty DTO is what a 201 with no body deserialises to; it must not read
-    // as success.
-    it('treats an absent result as a failure rather than a success', async () => {
-      jest
-        .spyOn(drivingLicenseApi, 'postTemporaryLicenseWithHealthDeclarationV6')
-        .mockResolvedValue({})
-
-      await expect(
-        service.newTemporaryDrivingLicenseWithHealthDeclaration(auth, {
-          ...baseInput,
-          instructorSSN: MOCK_NATIONAL_ID_TEACHER,
-        }),
-      ).resolves.toStrictEqual({ success: false, errorMessage: null })
+      ).rejects.toBe(problem)
     })
 
     it('forwards the category as a path param for the full licence', async () => {

--- a/libs/api/domains/driving-license/src/lib/drivingLicense.spec.ts
+++ b/libs/api/domains/driving-license/src/lib/drivingLicense.spec.ts
@@ -608,7 +608,11 @@ describe('DrivingLicenseService', () => {
             ...baseInput,
             instructorSSN: MOCK_NATIONAL_ID_TEACHER,
           }),
-        ).resolves.toStrictEqual({ success: true, errorMessage: null })
+        ).resolves.toStrictEqual({
+          success: true,
+          errorMessage: null,
+          applicationGuid: guid,
+        })
       },
     )
 
@@ -639,7 +643,11 @@ describe('DrivingLicenseService', () => {
           ...baseInput,
           licenseCategory: DrivingLicenseCategory.B,
         }),
-      ).resolves.toStrictEqual({ success: true, errorMessage: null })
+      ).resolves.toStrictEqual({
+        success: true,
+        errorMessage: null,
+        applicationGuid: '3630b0bc-ec51-442e-976d-13a3c21c5e5b',
+      })
 
       expect(spy).toHaveBeenCalledWith(
         expect.objectContaining({ auth, category: DrivingLicenseCategory.B }),

--- a/libs/api/domains/driving-license/src/lib/drivingLicense.type.ts
+++ b/libs/api/domains/driving-license/src/lib/drivingLicense.type.ts
@@ -83,6 +83,36 @@ export interface NewBEDrivingLicenseInput {
   healthDeclarationModel: NewBEHealthDeclaration
 }
 
+/**
+ * Input for the v6 `withhealthdeclaration` endpoints, which carry the health
+ * declaration AND the certificate in one call. Reuses the `NewBE*` types rather
+ * than renaming them: they are already product-neutral in practice — see
+ * `NewRenewal65DrivingLicenseInput.contentList` — and renaming would churn the
+ * live BE path for no behavioural gain.
+ *
+ * Note what the v6 models drop relative to the legacy inputs:
+ * `sendLicenseInMail` (0/1) and `sendToAddress` become the single boolean
+ * `sendPlasticToPerson`; `needsToPresentHealthCertificate` and
+ * `needsToPresentQualityPhoto` are gone, because the certificate travels as
+ * `contentList` and the photo as `photoBiometricsId`.
+ */
+export interface NewDrivingLicenseWithHealthDeclarationInput {
+  licenseCategory: string
+  districtId: number
+  sendPlasticToPerson: boolean
+  email?: string
+  primaryPhoneNumber?: string
+  healthDeclaration: NewBEHealthDeclaration
+  contentList?: NewBEDrivingLicenseContentItem[]
+  photoBiometricsId?: string | null
+  signatureBiometricsId?: string | null
+}
+
+export interface NewTemporaryDrivingLicenseWithHealthDeclarationInput
+  extends Omit<NewDrivingLicenseWithHealthDeclarationInput, 'licenseCategory'> {
+  instructorSSN: string
+}
+
 export interface NewDrivingLicenseResult {
   success: boolean
   errorMessage: string | null

--- a/libs/api/domains/driving-license/src/lib/drivingLicense.type.ts
+++ b/libs/api/domains/driving-license/src/lib/drivingLicense.type.ts
@@ -116,6 +116,10 @@ export interface NewTemporaryDrivingLicenseWithHealthDeclarationInput
 export interface NewDrivingLicenseResult {
   success: boolean
   errorMessage: string | null
+  // The RLS-side application guid returned on a v6 create (null on the
+  // lost-response duplicate path). Distinct from our own application id; the two
+  // together are the reconciliation record for an RLS application.
+  applicationGuid?: string | null
 }
 
 export interface NewDrivingAssessmentResult {

--- a/libs/application/template-api-modules/src/lib/modules/templates/transport-authority/driving-license-submission/driving-license-submission.service.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/transport-authority/driving-license-submission/driving-license-submission.service.ts
@@ -31,7 +31,10 @@ import { FetchError } from '@island.is/clients/middlewares'
 import { TemplateApiError } from '@island.is/nest/problem'
 import { User } from '@island.is/auth-nest-tools'
 import type { Locale } from '@island.is/shared/types'
-import { DriverLicenseWithoutImages } from '@island.is/clients/driving-license'
+import {
+  DriverLicenseWithoutImages,
+  isApplicationAlreadyExists,
+} from '@island.is/clients/driving-license'
 import { messages as drivingLicenseMessages } from '@island.is/application/templates/driving-license'
 import {
   PostTemporaryLicenseWithHealthDeclarationMapper,
@@ -420,6 +423,48 @@ export class DrivingLicenseSubmissionService extends BaseTemplateApiService {
     return contentList
   }
 
+  // A v6 create returns 400 APPLICATION_ALREADY_EXISTS when RLS already holds an
+  // application for this person+category. Treat that as success ONLY when THIS
+  // application already has a `submitApplication` entry — i.e. a lost-response
+  // retry re-running submit on the same application (the framework records that
+  // entry even when the first attempt failed, so it is present on the retry).
+  //
+  // A fresh application with no such entry means a *different* application created
+  // the RLS one; the v6 endpoint is a create, not an upsert, so this submission's
+  // (possibly changed) payload was discarded. Rethrow so the applicant sees RLS's
+  // own error via `toSubmissionError` — the truthful outcome, matching BE — rather
+  // than a false "Umsókn móttekin" that hides the lost edits and the payment.
+  private async createToleratingLostResponse(
+    application: ApplicationWithAttachments,
+    create: () => Promise<NewDrivingLicenseResult>,
+  ): Promise<NewDrivingLicenseResult> {
+    try {
+      return await create()
+    } catch (e) {
+      if (
+        isApplicationAlreadyExists(e) &&
+        getValueViaPath(application.externalData, 'submitApplication') !==
+          undefined
+      ) {
+        this.log(
+          'info',
+          'RLS application already exists on submit retry; treating as success',
+          { applicationId: application.id },
+        )
+        return {
+          success: true,
+          errorMessage: null,
+          applicationGuid:
+            getValueViaPath<string>(
+              application.externalData,
+              'submitApplication.data.applicationGuid',
+            ) ?? null,
+        }
+      }
+      throw e
+    }
+  }
+
   private async createLicense(
     nationalId: string,
     answers: FormValue,
@@ -613,27 +658,30 @@ export class DrivingLicenseSubmissionService extends BaseTemplateApiService {
           application,
         )
 
-        const fullResult =
-          await this.drivingLicenseService.newDrivingLicenseWithHealthDeclaration(
-            auth,
-            {
-              licenseCategory: DrivingLicenseCategory.B,
-              districtId: jurisdictionId
-                ? jurisdictionId
-                : setJurisdictionToKopavogur,
-              sendPlasticToPerson: deliveryMethod === Pickup.POST,
-              email,
-              primaryPhoneNumber: phone,
-              healthDeclaration: toHealthDeclarationModel(
-                healthDeclarationAnswers,
-              ),
-              contentList: needsHealthCertificate
-                ? await this.readHealthCertificateContentList(application)
-                : undefined,
-              photoBiometricsId: resolved?.photoBiometricsId,
-              signatureBiometricsId: resolved?.signatureBiometricsId,
-            },
-          )
+        const fullResult = await this.createToleratingLostResponse(
+          application,
+          async () =>
+            this.drivingLicenseService.newDrivingLicenseWithHealthDeclaration(
+              auth,
+              {
+                licenseCategory: DrivingLicenseCategory.B,
+                districtId: jurisdictionId
+                  ? jurisdictionId
+                  : setJurisdictionToKopavogur,
+                sendPlasticToPerson: deliveryMethod === Pickup.POST,
+                email,
+                primaryPhoneNumber: phone,
+                healthDeclaration: toHealthDeclarationModel(
+                  healthDeclarationAnswers,
+                ),
+                contentList: needsHealthCertificate
+                  ? await this.readHealthCertificateContentList(application)
+                  : undefined,
+                photoBiometricsId: resolved?.photoBiometricsId,
+                signatureBiometricsId: resolved?.signatureBiometricsId,
+              },
+            ),
+        )
 
         // Reconciliation record: our application id paired with the RLS-side
         // application guid (null on the lost-response duplicate path).
@@ -676,27 +724,30 @@ export class DrivingLicenseSubmissionService extends BaseTemplateApiService {
           application,
         )
 
-        const tempResult =
-          await this.drivingLicenseService.newTemporaryDrivingLicenseWithHealthDeclaration(
-            auth,
-            {
-              districtId: jurisdictionId
-                ? jurisdictionId
-                : setJurisdictionToKopavogur,
-              instructorSSN: teacher,
-              sendPlasticToPerson: deliveryMethod === Pickup.POST,
-              email,
-              primaryPhoneNumber: phone,
-              healthDeclaration: toHealthDeclarationModel(
-                healthDeclarationAnswers,
-              ),
-              contentList: needsHealthCertificate
-                ? await this.readHealthCertificateContentList(application)
-                : undefined,
-              photoBiometricsId: resolved?.photoBiometricsId,
-              signatureBiometricsId: resolved?.signatureBiometricsId,
-            },
-          )
+        const tempResult = await this.createToleratingLostResponse(
+          application,
+          async () =>
+            this.drivingLicenseService.newTemporaryDrivingLicenseWithHealthDeclaration(
+              auth,
+              {
+                districtId: jurisdictionId
+                  ? jurisdictionId
+                  : setJurisdictionToKopavogur,
+                instructorSSN: teacher,
+                sendPlasticToPerson: deliveryMethod === Pickup.POST,
+                email,
+                primaryPhoneNumber: phone,
+                healthDeclaration: toHealthDeclarationModel(
+                  healthDeclarationAnswers,
+                ),
+                contentList: needsHealthCertificate
+                  ? await this.readHealthCertificateContentList(application)
+                  : undefined,
+                photoBiometricsId: resolved?.photoBiometricsId,
+                signatureBiometricsId: resolved?.signatureBiometricsId,
+              },
+            ),
+        )
 
         // Reconciliation record: our application id paired with the RLS-side
         // application guid (null on the lost-response duplicate path).

--- a/libs/application/template-api-modules/src/lib/modules/templates/transport-authority/driving-license-submission/driving-license-submission.service.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/transport-authority/driving-license-submission/driving-license-submission.service.ts
@@ -681,10 +681,14 @@ export class DrivingLicenseSubmissionService extends BaseTemplateApiService {
 
         // Reconciliation record: our application id paired with the RLS-side
         // application guid (null on the lost-response duplicate path).
-        this.log('info', 'Created temporary driving-license application in RLS', {
-          applicationId: application.id,
-          applicationGuid: tempResult.applicationGuid,
-        })
+        this.log(
+          'info',
+          'Created temporary driving-license application in RLS',
+          {
+            applicationId: application.id,
+            applicationGuid: tempResult.applicationGuid,
+          },
+        )
 
         return tempResult
       }

--- a/libs/application/template-api-modules/src/lib/modules/templates/transport-authority/driving-license-submission/driving-license-submission.service.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/transport-authority/driving-license-submission/driving-license-submission.service.ts
@@ -456,7 +456,10 @@ export class DrivingLicenseSubmissionService extends BaseTemplateApiService {
     const healthDeclarationAnswers =
       getValueViaPath<Record<string, string>>(answers, 'healthDeclaration') ??
       {}
-    const glassesMismatch =
+    // `glassesCheck.data === true` means the applicant's current licence carries
+    // a glasses code — not that their answers contradict it. (The contradiction
+    // is `healthDeclaration.contactGlassesMismatch`, a different answer.)
+    const licenseRequiresGlasses =
       getValueViaPath<boolean>(
         application.externalData,
         'glassesCheck.data',
@@ -465,7 +468,8 @@ export class DrivingLicenseSubmissionService extends BaseTemplateApiService {
     // merged into `needsHealthCert` above: that one feeds the legacy v5
     // `needsToPresentHealthCertificate` flags, which must keep their exact
     // current values for flag-off drafts.
-    const needsHealthCertificate = needsHealthCert || remarks || glassesMismatch
+    const needsHealthCertificate =
+      needsHealthCert || remarks || licenseRequiresGlasses
     const needsQualityPhoto = answers.willBringQualityPhoto === 'yes'
     const jurisdictionId = Number(
       getValueViaPath(answers, 'delivery.jurisdiction'),
@@ -710,24 +714,17 @@ export class DrivingLicenseSubmissionService extends BaseTemplateApiService {
         signatureBiometricsId = resolvedBeBiometrics.signatureBiometricsId
       }
 
-      // Health certificate handling
-      const healthDeclaration =
-        getValueViaPath<Record<string, string>>(answers, 'healthDeclaration') ??
-        {}
-      const beNeedsHealthCert =
-        calculateNeedsHealthCert(healthDeclaration) ||
-        remarks ||
-        getValueViaPath<boolean>(
-          application.externalData,
-          'glassesCheck.data',
-        ) === true
-
-      const contentList = beNeedsHealthCert
+      // BE uses the shared predicate above — it recomputed an identical one from
+      // the same inputs until the redesigned B-temp/B-full flows needed the same
+      // rule and it was hoisted.
+      const contentList = needsHealthCertificate
         ? await this.readHealthCertificateContentList(application)
         : undefined
 
       // Health declaration model — always sent for BE
-      const healthDeclarationModel = toHealthDeclarationModel(healthDeclaration)
+      const healthDeclarationModel = toHealthDeclarationModel(
+        healthDeclarationAnswers,
+      )
 
       return this.drivingLicenseService.applyForBELicense(
         nationalId,

--- a/libs/application/template-api-modules/src/lib/modules/templates/transport-authority/driving-license-submission/driving-license-submission.service.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/transport-authority/driving-license-submission/driving-license-submission.service.ts
@@ -453,6 +453,19 @@ export class DrivingLicenseSubmissionService extends BaseTemplateApiService {
 
     const needsHealthCert = calculateNeedsHealthCert(answers.healthDeclaration)
     const remarks = answers.hasHealthRemarks === 'yes'
+    const healthDeclarationAnswers =
+      getValueViaPath<Record<string, string>>(answers, 'healthDeclaration') ??
+      {}
+    const glassesMismatch =
+      getValueViaPath<boolean>(
+        application.externalData,
+        'glassesCheck.data',
+      ) === true
+    // Certificate-required predicate, matching BE's rule. Deliberately NOT
+    // merged into `needsHealthCert` above: that one feeds the legacy v5
+    // `needsToPresentHealthCertificate` flags, which must keep their exact
+    // current values for flag-off drafts.
+    const needsHealthCertificate = needsHealthCert || remarks || glassesMismatch
     const needsQualityPhoto = answers.willBringQualityPhoto === 'yes'
     const jurisdictionId = Number(
       getValueViaPath(answers, 'delivery.jurisdiction'),
@@ -463,23 +476,20 @@ export class DrivingLicenseSubmissionService extends BaseTemplateApiService {
     const phone = formatPhoneNumber(answers.phone as string)
     const setJurisdictionToKopavogur = 37
 
+    // Legacy B-temp only: the v5 two-call path. It carried optional biometric-ID
+    // params, but the only flow that ever passed them (flag-on B-temp) now
+    // returns early through the v6 endpoint, so they are gone.
     const postHealthDeclaration = async (
       nationalId: string,
       answers: FormValue,
       auth: User,
-      photoBiometricsId?: string | null,
-      signatureBiometricsId?: string | null,
     ) => {
       await this.drivingLicenseService
         .postHealthDeclaration(
           nationalId,
-          {
-            ...PostTemporaryLicenseWithHealthDeclarationMapper(
-              answers as DrivingLicenseSchema,
-            ),
-            photoBiometricsId,
-            signatureBiometricsId,
-          },
+          PostTemporaryLicenseWithHealthDeclarationMapper(
+            answers as DrivingLicenseSchema,
+          ),
           auth.authorization.split(' ')[1] ?? '',
         )
         .catch((e) => {
@@ -562,32 +572,48 @@ export class DrivingLicenseSubmissionService extends BaseTemplateApiService {
       // branches on the flag value *frozen into answers* at prerequisites.
       // This is intentionally sticky: a draft keeps the flow it started with
       // even if the flag is flipped mid-lifecycle. A draft begun while the flag
-      // was ON therefore keeps sending biometric IDs even after a global
-      // rollback; only a NEW draft begun after rollback freezes the flag OFF.
-      // Flag frozen OFF → both IDs stay `undefined`, so the keys are omitted
-      // from the RLS request and the call is byte-identical to the pre-redesign
-      // flow.
-      // NOTE: the health-certificate upload is intentionally not wired here yet
-      // — the full-license RLS endpoint has no `contentList`, so only the photo
-      // is redesigned for now (same as B-temp).
+      // was ON therefore keeps the redesigned flow even after a global
+      // rollback; only a NEW draft begun after rollback freezes the flag OFF
+      // and takes the legacy path below unchanged.
       const isBFullRedesignEnabled =
         getValueViaPath<boolean>(answers, 'isBFullRedesignEnabled') === true
 
-      let photoBiometricsId: string | null | undefined
-      let signatureBiometricsId: string | null | undefined
-
       if (isBFullRedesignEnabled) {
+        // Redesigned B-full posts the health declaration and, when required, the
+        // certificate itself, through the v6 `withhealthdeclaration` endpoint.
+        // The declaration is always sent (as BE does) so there is one payload
+        // shape per product rather than one per flag/certificate combination;
+        // previously B-full sent only a derived boolean and dropped the ten
+        // answers entirely.
         const resolved = this.resolveSelectedPhotoBiometrics(
           answers,
           application,
         )
 
-        if (resolved) {
-          photoBiometricsId = resolved.photoBiometricsId
-          signatureBiometricsId = resolved.signatureBiometricsId
-        }
+        return this.drivingLicenseService.newDrivingLicenseWithHealthDeclaration(
+          auth,
+          {
+            licenseCategory: DrivingLicenseCategory.B,
+            districtId: jurisdictionId
+              ? jurisdictionId
+              : setJurisdictionToKopavogur,
+            sendPlasticToPerson: deliveryMethod === Pickup.POST,
+            email,
+            primaryPhoneNumber: phone,
+            healthDeclaration: toHealthDeclarationModel(
+              healthDeclarationAnswers,
+            ),
+            contentList: needsHealthCertificate
+              ? await this.readHealthCertificateContentList(application)
+              : undefined,
+            photoBiometricsId: resolved?.photoBiometricsId,
+            signatureBiometricsId: resolved?.signatureBiometricsId,
+          },
+        )
       }
 
+      // Legacy B-full — flag frozen OFF, so there is no photo step and no
+      // biometric IDs to send. Byte-identical to the pre-redesign request.
       return this.drivingLicenseService.newDrivingLicense(nationalId, {
         jurisdictionId: jurisdictionId
           ? jurisdictionId
@@ -596,43 +622,53 @@ export class DrivingLicenseSubmissionService extends BaseTemplateApiService {
         needsToPresentHealthCertificate: needsHealthCert || remarks,
         needsToPresentQualityPhoto: needsQualityPhoto,
         licenseCategory: DrivingLicenseCategory.B,
-        photoBiometricsId,
-        signatureBiometricsId,
       })
     } else if (applicationFor === 'B-temp') {
-      // Photo selection only applies to the redesigned B-temp flow. Gate on
-      // the *persisted* flag (captured into answers by a hidden input during
-      // prerequisites) — not on the mere presence of `selectLicensePhoto` —
-      // so a draft created while the flag was on does not keep sending
-      // biometric IDs after the flag is turned off. Flag off → both IDs stay
-      // `undefined`, so the keys are omitted from the RLS request bodies
-      // entirely and the calls are byte-identical to the pre-redesign flow.
+      // The redesigned B-temp flow (photo selection plus the health-certificate
+      // upload) is gated on the *persisted* flag — captured into answers by a
+      // hidden input during prerequisites — not on the mere presence of
+      // `selectLicensePhoto`, so a draft created while the flag was on keeps
+      // that flow and a draft created after a rollback takes the legacy path
+      // below unchanged.
       const isBTempRedesignEnabled =
         getValueViaPath<boolean>(answers, 'isBTempRedesignEnabled') === true
 
-      let photoBiometricsId: string | null | undefined
-      let signatureBiometricsId: string | null | undefined
-
       if (isBTempRedesignEnabled) {
+        // Redesigned B-temp: one call instead of two. The legacy path below
+        // posts the declaration and then submits, both of which RLS documents as
+        // "Apply for…" and both of which return NewTemporaryLicsenseDto; the v6
+        // endpoint does both jobs.
         const resolved = this.resolveSelectedPhotoBiometrics(
           answers,
           application,
         )
 
-        if (resolved) {
-          photoBiometricsId = resolved.photoBiometricsId
-          signatureBiometricsId = resolved.signatureBiometricsId
-        }
+        return this.drivingLicenseService.newTemporaryDrivingLicenseWithHealthDeclaration(
+          auth,
+          {
+            districtId: jurisdictionId
+              ? jurisdictionId
+              : setJurisdictionToKopavogur,
+            instructorSSN: teacher,
+            sendPlasticToPerson: deliveryMethod === Pickup.POST,
+            email,
+            primaryPhoneNumber: phone,
+            healthDeclaration: toHealthDeclarationModel(
+              healthDeclarationAnswers,
+            ),
+            contentList: needsHealthCertificate
+              ? await this.readHealthCertificateContentList(application)
+              : undefined,
+            photoBiometricsId: resolved?.photoBiometricsId,
+            signatureBiometricsId: resolved?.signatureBiometricsId,
+          },
+        )
       }
 
+      // Legacy B-temp — flag frozen OFF, so no photo step and no biometric IDs.
+      // Two calls: the declaration first, then the application itself.
       if (needsHealthCert) {
-        await postHealthDeclaration(
-          nationalId,
-          answers,
-          auth,
-          photoBiometricsId,
-          signatureBiometricsId,
-        )
+        await postHealthDeclaration(nationalId, answers, auth)
       }
       return this.drivingLicenseService.newTemporaryDrivingLicense(
         nationalId,
@@ -647,8 +683,6 @@ export class DrivingLicenseSubmissionService extends BaseTemplateApiService {
           teacherNationalId: teacher,
           email: email,
           phone: phone,
-          photoBiometricsId,
-          signatureBiometricsId,
         },
       )
     } else if (applicationFor === 'BE') {

--- a/libs/application/template-api-modules/src/lib/modules/templates/transport-authority/driving-license-submission/driving-license-submission.service.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/transport-authority/driving-license-submission/driving-license-submission.service.ts
@@ -130,7 +130,14 @@ export class DrivingLicenseSubmissionService extends BaseTemplateApiService {
     application,
     auth,
     currentUserLocale,
-  }: TemplateApiModuleActionProps): Promise<{ success: boolean }> {
+  }: TemplateApiModuleActionProps): Promise<{
+    success: boolean
+    // Persisted by the framework at `externalData.submitApplication.data`, so the
+    // RLS application guid is retrievable from the application record for support/
+    // reconciliation — not only from the api logs. Present for the redesigned
+    // B-temp/B-full v6 flows; null for the paths that don't return one.
+    applicationGuid?: string | null
+  }> {
     const { answers } = application
     const nationalId = application.applicant
 
@@ -183,6 +190,7 @@ export class DrivingLicenseSubmissionService extends BaseTemplateApiService {
 
     return {
       success: true,
+      applicationGuid: result.applicationGuid ?? null,
     }
   }
 

--- a/libs/application/template-api-modules/src/lib/modules/templates/transport-authority/driving-license-submission/driving-license-submission.service.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/transport-authority/driving-license-submission/driving-license-submission.service.ts
@@ -190,7 +190,18 @@ export class DrivingLicenseSubmissionService extends BaseTemplateApiService {
 
     return {
       success: true,
-      applicationGuid: result.applicationGuid ?? null,
+      // Preserve a guid already stored on a prior run: if submitApplication
+      // re-enters (state re-entry, admin re-trigger, retry), the v6 call returns
+      // APPLICATION_ALREADY_EXISTS and the client guard resolves with a null
+      // guid — which would otherwise overwrite the good guid the framework stored
+      // at externalData.submitApplication.data on the first pass.
+      applicationGuid:
+        result.applicationGuid ??
+        getValueViaPath<string>(
+          application.externalData,
+          'submitApplication.data.applicationGuid',
+        ) ??
+        null,
     }
   }
 

--- a/libs/application/template-api-modules/src/lib/modules/templates/transport-authority/driving-license-submission/driving-license-submission.service.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/transport-authority/driving-license-submission/driving-license-submission.service.ts
@@ -225,7 +225,14 @@ export class DrivingLicenseSubmissionService extends BaseTemplateApiService {
     err: FetchError,
     locale: Locale,
   ): Promise<TemplateApiError> {
-    const code = err.problem?.title
+    // RLS's error code is in `problem.title` for problem+json responses (the full
+    // endpoint), but the temporary endpoint returns a plain-JSON body carrying it
+    // as `body.errorCode` instead — fall back to that so both go through
+    // describeErrorCode and the applicant gets the localised text, not the
+    // generic "submission failed".
+    const code =
+      err.problem?.title ??
+      (err.body as { errorCode?: string } | undefined)?.errorCode
     if (code) {
       try {
         const described = await this.drivingLicenseService.describeErrorCode(

--- a/libs/application/template-api-modules/src/lib/modules/templates/transport-authority/driving-license-submission/driving-license-submission.service.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/transport-authority/driving-license-submission/driving-license-submission.service.ts
@@ -43,6 +43,31 @@ const calculateNeedsHealthCert = (healthDeclaration = {}) => {
   return !!Object.values(healthDeclaration).find((val) => val === 'yes')
 }
 
+/**
+ * Maps the form's yes/no health answers to the booleans RLS expects. Shared by
+ * BE and — behind their redesign flags — B-temp and B-full.
+ *
+ * The ten keys are listed explicitly rather than derived from the answers, so an
+ * unanswered question becomes `false` rather than being omitted. The older mapper
+ * in `utils/healthDeclarationMapper.ts` maps over the answer object instead, which
+ * silently drops unanswered keys — RLS then reads those as null, not false.
+ */
+const toHealthDeclarationModel = (
+  healthDeclaration: Record<string, string> = {},
+) => ({
+  isDisabled: healthDeclaration?.isDisabled === YES,
+  hasDiabetes: healthDeclaration?.hasDiabetes === YES,
+  hasEpilepsy: healthDeclaration?.hasEpilepsy === YES,
+  isAlcoholic: healthDeclaration?.isAlcoholic === YES,
+  hasHeartDisease: healthDeclaration?.hasHeartDisease === YES,
+  hasMentalIllness: healthDeclaration?.hasMentalIllness === YES,
+  hasOtherDiseases: healthDeclaration?.hasOtherDiseases === YES,
+  usesMedicalDrugs: healthDeclaration?.usesMedicalDrugs === YES,
+  usesContactGlasses: healthDeclaration?.usesContactGlasses === YES,
+  hasReducedPeripheralVision:
+    healthDeclaration?.hasReducedPeripheralVision === YES,
+})
+
 const getContentType = (fileName: string): string => {
   const ext = fileName.split('.').pop()?.toLowerCase() ?? ''
   switch (ext) {
@@ -314,6 +339,68 @@ export class DrivingLicenseSubmissionService extends BaseTemplateApiService {
     }
   }
 
+  /**
+   * Reads the applicant's uploaded health certificate from S3 and maps it to the
+   * contentList shape RLS expects. Shared by every branch that can send one:
+   * 65+, BE, and — behind their redesign flags — B-temp and B-full. This was
+   * copy-pasted per product, so a fix had to land in every copy.
+   *
+   * Throws the applicant-facing "certificate required" error on an empty result:
+   * every caller reaches this only when a certificate IS required, so nothing
+   * attached is always a hard stop rather than an omitted key. Deciding *whether*
+   * a certificate is required stays with the caller — 65+ always needs one, the
+   * other three only when a health answer, a remark or the glasses check fires.
+   */
+  private async readHealthCertificateContentList(
+    application: ApplicationWithAttachments,
+  ): Promise<
+    Array<{
+      fileName: string
+      fileExtension: string
+      contentType: string
+      content: string
+      description: string
+    }>
+  > {
+    let contentList
+    try {
+      const files = await this.attachmentS3Service.getFiles(application, [
+        'healthCertificate',
+      ])
+
+      contentList = files
+        .filter((f) => f.fileContent)
+        .map((f) => {
+          const rawExt = f.fileName.split('.').pop()?.toLowerCase() ?? ''
+          const ext = rawExt === 'jpg' ? 'jpeg' : rawExt
+          return {
+            fileName: f.fileName,
+            fileExtension: ext,
+            contentType: getContentType(f.fileName),
+            content: f.fileContent,
+            description: 'Laeknisvottord',
+          }
+        })
+    } catch (e) {
+      this.log('error', 'Failed to read health certificate files from S3', {
+        e,
+      })
+      throw e
+    }
+
+    if (!contentList || contentList.length === 0) {
+      throw new TemplateApiError(
+        {
+          title: coreErrorMessages.failedDataProviderSubmit,
+          summary: drivingLicenseMessages.healthCertificateRequired,
+        },
+        400,
+      )
+    }
+
+    return contentList
+  }
+
   private async createLicense(
     nationalId: string,
     answers: FormValue,
@@ -448,50 +535,10 @@ export class DrivingLicenseSubmissionService extends BaseTemplateApiService {
           resolvedRenewalBiometrics.signatureBiometricsId
       }
 
-      let renewalContentList:
-        | Array<{
-            fileName: string
-            fileExtension: string
-            contentType: string
-            content: string
-            description: string
-          }>
-        | undefined
-
-      try {
-        const files = await this.attachmentS3Service.getFiles(application, [
-          'healthCertificate',
-        ])
-
-        renewalContentList = files
-          .filter((f) => f.fileContent)
-          .map((f) => {
-            const rawExt = f.fileName.split('.').pop()?.toLowerCase() ?? ''
-            const ext = rawExt === 'jpg' ? 'jpeg' : rawExt
-            return {
-              fileName: f.fileName,
-              fileExtension: ext,
-              contentType: getContentType(f.fileName),
-              content: f.fileContent,
-              description: 'Laeknisvottord',
-            }
-          })
-      } catch (e) {
-        this.log('error', 'Failed to read health certificate files from S3', {
-          e,
-        })
-        throw e
-      }
-
-      if (!renewalContentList || renewalContentList.length === 0) {
-        throw new TemplateApiError(
-          {
-            title: coreErrorMessages.failedDataProviderSubmit,
-            summary: drivingLicenseMessages.healthCertificateRequired,
-          },
-          400,
-        )
-      }
+      // 65+ always requires a certificate, so this is ungated.
+      const renewalContentList = await this.readHealthCertificateContentList(
+        application,
+      )
 
       return this.drivingLicenseService.applyForRenewal65(auth.authorization, {
         jurisdiction: jurisdictionId
@@ -641,67 +688,12 @@ export class DrivingLicenseSubmissionService extends BaseTemplateApiService {
           'glassesCheck.data',
         ) === true
 
-      let contentList:
-        | Array<{
-            fileName: string
-            fileExtension: string
-            contentType: string
-            content: string
-            description: string
-          }>
-        | undefined
-
-      if (beNeedsHealthCert) {
-        try {
-          const files = await this.attachmentS3Service.getFiles(application, [
-            'healthCertificate',
-          ])
-
-          contentList = files
-            .filter((f) => f.fileContent)
-            .map((f) => {
-              const rawExt = f.fileName.split('.').pop()?.toLowerCase() ?? ''
-              const ext = rawExt === 'jpg' ? 'jpeg' : rawExt
-              return {
-                fileName: f.fileName,
-                fileExtension: ext,
-                contentType: getContentType(f.fileName),
-                content: f.fileContent,
-                description: 'Laeknisvottord',
-              }
-            })
-        } catch (e) {
-          this.log('error', 'Failed to read health certificate files from S3', {
-            e,
-          })
-          throw e
-        }
-
-        if (!contentList || contentList.length === 0) {
-          throw new TemplateApiError(
-            {
-              title: coreErrorMessages.failedDataProviderSubmit,
-              summary: drivingLicenseMessages.healthCertificateRequired,
-            },
-            400,
-          )
-        }
-      }
+      const contentList = beNeedsHealthCert
+        ? await this.readHealthCertificateContentList(application)
+        : undefined
 
       // Health declaration model — always sent for BE
-      const healthDeclarationModel = {
-        isDisabled: healthDeclaration?.isDisabled === 'yes',
-        hasDiabetes: healthDeclaration?.hasDiabetes === 'yes',
-        hasEpilepsy: healthDeclaration?.hasEpilepsy === 'yes',
-        isAlcoholic: healthDeclaration?.isAlcoholic === 'yes',
-        hasHeartDisease: healthDeclaration?.hasHeartDisease === 'yes',
-        hasMentalIllness: healthDeclaration?.hasMentalIllness === 'yes',
-        hasOtherDiseases: healthDeclaration?.hasOtherDiseases === 'yes',
-        usesMedicalDrugs: healthDeclaration?.usesMedicalDrugs === 'yes',
-        usesContactGlasses: healthDeclaration?.usesContactGlasses === 'yes',
-        hasReducedPeripheralVision:
-          healthDeclaration?.hasReducedPeripheralVision === 'yes',
-      }
+      const healthDeclarationModel = toHealthDeclarationModel(healthDeclaration)
 
       return this.drivingLicenseService.applyForBELicense(
         nationalId,

--- a/libs/application/template-api-modules/src/lib/modules/templates/transport-authority/driving-license-submission/driving-license-submission.service.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/transport-authority/driving-license-submission/driving-license-submission.service.ts
@@ -594,26 +594,36 @@ export class DrivingLicenseSubmissionService extends BaseTemplateApiService {
           application,
         )
 
-        return this.drivingLicenseService.newDrivingLicenseWithHealthDeclaration(
-          auth,
-          {
-            licenseCategory: DrivingLicenseCategory.B,
-            districtId: jurisdictionId
-              ? jurisdictionId
-              : setJurisdictionToKopavogur,
-            sendPlasticToPerson: deliveryMethod === Pickup.POST,
-            email,
-            primaryPhoneNumber: phone,
-            healthDeclaration: toHealthDeclarationModel(
-              healthDeclarationAnswers,
-            ),
-            contentList: needsHealthCertificate
-              ? await this.readHealthCertificateContentList(application)
-              : undefined,
-            photoBiometricsId: resolved?.photoBiometricsId,
-            signatureBiometricsId: resolved?.signatureBiometricsId,
-          },
-        )
+        const fullResult =
+          await this.drivingLicenseService.newDrivingLicenseWithHealthDeclaration(
+            auth,
+            {
+              licenseCategory: DrivingLicenseCategory.B,
+              districtId: jurisdictionId
+                ? jurisdictionId
+                : setJurisdictionToKopavogur,
+              sendPlasticToPerson: deliveryMethod === Pickup.POST,
+              email,
+              primaryPhoneNumber: phone,
+              healthDeclaration: toHealthDeclarationModel(
+                healthDeclarationAnswers,
+              ),
+              contentList: needsHealthCertificate
+                ? await this.readHealthCertificateContentList(application)
+                : undefined,
+              photoBiometricsId: resolved?.photoBiometricsId,
+              signatureBiometricsId: resolved?.signatureBiometricsId,
+            },
+          )
+
+        // Reconciliation record: our application id paired with the RLS-side
+        // application guid (null on the lost-response duplicate path).
+        this.log('info', 'Created full driving-license application in RLS', {
+          applicationId: application.id,
+          applicationGuid: fullResult.applicationGuid,
+        })
+
+        return fullResult
       }
 
       // Legacy B-full — flag frozen OFF, so there is no photo step and no
@@ -647,26 +657,36 @@ export class DrivingLicenseSubmissionService extends BaseTemplateApiService {
           application,
         )
 
-        return this.drivingLicenseService.newTemporaryDrivingLicenseWithHealthDeclaration(
-          auth,
-          {
-            districtId: jurisdictionId
-              ? jurisdictionId
-              : setJurisdictionToKopavogur,
-            instructorSSN: teacher,
-            sendPlasticToPerson: deliveryMethod === Pickup.POST,
-            email,
-            primaryPhoneNumber: phone,
-            healthDeclaration: toHealthDeclarationModel(
-              healthDeclarationAnswers,
-            ),
-            contentList: needsHealthCertificate
-              ? await this.readHealthCertificateContentList(application)
-              : undefined,
-            photoBiometricsId: resolved?.photoBiometricsId,
-            signatureBiometricsId: resolved?.signatureBiometricsId,
-          },
-        )
+        const tempResult =
+          await this.drivingLicenseService.newTemporaryDrivingLicenseWithHealthDeclaration(
+            auth,
+            {
+              districtId: jurisdictionId
+                ? jurisdictionId
+                : setJurisdictionToKopavogur,
+              instructorSSN: teacher,
+              sendPlasticToPerson: deliveryMethod === Pickup.POST,
+              email,
+              primaryPhoneNumber: phone,
+              healthDeclaration: toHealthDeclarationModel(
+                healthDeclarationAnswers,
+              ),
+              contentList: needsHealthCertificate
+                ? await this.readHealthCertificateContentList(application)
+                : undefined,
+              photoBiometricsId: resolved?.photoBiometricsId,
+              signatureBiometricsId: resolved?.signatureBiometricsId,
+            },
+          )
+
+        // Reconciliation record: our application id paired with the RLS-side
+        // application guid (null on the lost-response duplicate path).
+        this.log('info', 'Created temporary driving-license application in RLS', {
+          applicationId: application.id,
+          applicationGuid: tempResult.applicationGuid,
+        })
+
+        return tempResult
       }
 
       // Legacy B-temp — flag frozen OFF, so no photo step and no biometric IDs.

--- a/libs/application/template-api-modules/src/lib/modules/templates/transport-authority/driving-license-submission/driving-license-submission.spec.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/transport-authority/driving-license-submission/driving-license-submission.spec.ts
@@ -111,7 +111,7 @@ describe('DrivingLicenseSubmissionService', () => {
         currentUserLocale: 'is',
       })
 
-      expect(res).toEqual({
+      expect(res).toMatchObject({
         success: true,
       })
     })
@@ -203,7 +203,7 @@ describe('DrivingLicenseSubmissionService', () => {
         currentUserLocale: 'is',
       })
 
-      expect(result).toEqual({ success: true })
+      expect(result).toMatchObject({ success: true })
       expect(renewDrivingLicense65AndOver).toHaveBeenCalledTimes(1)
       expect(applyForRenewal65).not.toHaveBeenCalled()
 
@@ -280,7 +280,7 @@ describe('DrivingLicenseSubmissionService', () => {
         currentUserLocale: 'is',
       })
 
-      expect(res).toEqual({ success: true })
+      expect(res).toMatchObject({ success: true })
       expect(applyForRenewal65).toHaveBeenCalledTimes(1)
 
       const [auth, input] = applyForRenewal65.mock.calls[0]
@@ -320,7 +320,7 @@ describe('DrivingLicenseSubmissionService', () => {
         currentUserLocale: 'is',
       })
 
-      expect(res).toEqual({ success: true })
+      expect(res).toMatchObject({ success: true })
       expect(applyForRenewal65).not.toHaveBeenCalled()
     })
 
@@ -342,7 +342,7 @@ describe('DrivingLicenseSubmissionService', () => {
         currentUserLocale: 'is',
       })
 
-      expect(res).toEqual({ success: true })
+      expect(res).toMatchObject({ success: true })
       expect(applyForRenewal65).not.toHaveBeenCalled()
     })
 
@@ -376,7 +376,7 @@ describe('DrivingLicenseSubmissionService', () => {
         currentUserLocale: 'is',
       })
 
-      expect(res).toEqual({ success: true })
+      expect(res).toMatchObject({ success: true })
       expect(applyForRenewal65).toHaveBeenCalledTimes(1)
     })
 
@@ -410,7 +410,7 @@ describe('DrivingLicenseSubmissionService', () => {
         currentUserLocale: 'is',
       })
 
-      expect(res).toEqual({ success: true })
+      expect(res).toMatchObject({ success: true })
       expect(applyForRenewal65).toHaveBeenCalledTimes(1)
     })
   })
@@ -454,6 +454,7 @@ describe('DrivingLicenseSubmissionService', () => {
       newTemporaryDrivingLicenseWithHealthDeclaration = jest.fn(async () => ({
         success: true,
         errorMessage: null,
+        applicationGuid: '2e23bf24-d8bd-4353-9faf-3fc5ce04090d',
       }))
       getFiles = jest.fn(async () => [])
 
@@ -524,7 +525,7 @@ describe('DrivingLicenseSubmissionService', () => {
         currentUserLocale: 'is',
       })
 
-      expect(res).toEqual({ success: true })
+      expect(res).toMatchObject({ success: true })
       expect(newTemporaryDrivingLicense).toHaveBeenCalledTimes(1)
 
       // Flag off → biometric IDs are omitted entirely (not sent as null),
@@ -554,7 +555,13 @@ describe('DrivingLicenseSubmissionService', () => {
         currentUserLocale: 'is',
       })
 
-      expect(res).toEqual({ success: true })
+      // The RLS application guid is threaded into submitApplication's return, so
+      // the framework persists it at externalData.submitApplication.data — the
+      // durable handle for support/reconciliation, not just the api logs.
+      expect(res).toStrictEqual({
+        success: true,
+        applicationGuid: '2e23bf24-d8bd-4353-9faf-3fc5ce04090d',
+      })
       expect(
         newTemporaryDrivingLicenseWithHealthDeclaration,
       ).toHaveBeenCalledTimes(1)
@@ -789,7 +796,7 @@ describe('DrivingLicenseSubmissionService', () => {
         currentUserLocale: 'is',
       })
 
-      expect(res).toEqual({ success: true })
+      expect(res).toMatchObject({ success: true })
       expect(newDrivingLicense).toHaveBeenCalledTimes(1)
 
       // Flag off → biometric IDs are omitted entirely (not sent as null),
@@ -818,7 +825,7 @@ describe('DrivingLicenseSubmissionService', () => {
         currentUserLocale: 'is',
       })
 
-      expect(res).toEqual({ success: true })
+      expect(res).toMatchObject({ success: true })
       expect(newDrivingLicenseWithHealthDeclaration).toHaveBeenCalledTimes(1)
       expect(newDrivingLicense).not.toHaveBeenCalled()
 
@@ -1031,7 +1038,7 @@ describe('DrivingLicenseSubmissionService', () => {
         currentUserLocale: 'is',
       })
 
-      expect(res).toEqual({ success: true })
+      expect(res).toMatchObject({ success: true })
       expect(applyForBELicense).toHaveBeenCalledTimes(1)
       const [, , input] = applyForBELicense.mock.calls[0]
       expect(input).toMatchObject({

--- a/libs/application/template-api-modules/src/lib/modules/templates/transport-authority/driving-license-submission/driving-license-submission.spec.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/transport-authority/driving-license-submission/driving-license-submission.spec.ts
@@ -838,10 +838,13 @@ describe('DrivingLicenseSubmissionService', () => {
       expect(input.healthDeclaration).toMatchObject({ hasEpilepsy: false })
     })
 
-    // The v6 call takes the resolver's output through `resolved?.x`, so the
-    // undefined-vs-null distinction the legacy path was pinned on has to hold
-    // here too: RLS reads an explicit null as "use what you already hold" and an
-    // absent key as "nothing to say".
+    // The v6 call takes the resolver's output through `resolved?.x`, so what the
+    // resolver distinguishes — an explicit null for "selected, but no biometric
+    // ID to send" versus nothing at all for "no selection" — has to survive to
+    // the request. Unlike the legacy path, where the distinction was load-bearing
+    // for keeping requests byte-identical, here it is consistency with the BE and
+    // 65+ payloads; how RLS itself treats null vs absent on this endpoint has not
+    // been verified.
     it.each([
       ['a stale selection matching no FACIAL entry', 'facial-gone'],
       ['the RLS quality photo', 'qualityPhoto'],

--- a/libs/application/template-api-modules/src/lib/modules/templates/transport-authority/driving-license-submission/driving-license-submission.spec.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/transport-authority/driving-license-submission/driving-license-submission.spec.ts
@@ -838,6 +838,58 @@ describe('DrivingLicenseSubmissionService', () => {
       expect(input.healthDeclaration).toMatchObject({ hasEpilepsy: false })
     })
 
+    // The v6 call takes the resolver's output through `resolved?.x`, so the
+    // undefined-vs-null distinction the legacy path was pinned on has to hold
+    // here too: RLS reads an explicit null as "use what you already hold" and an
+    // absent key as "nothing to say".
+    it.each([
+      ['a stale selection matching no FACIAL entry', 'facial-gone'],
+      ['the RLS quality photo', 'qualityPhoto'],
+    ])('sends explicit null biometric IDs for %s', async (_label, selected) => {
+      const user = createCurrentUser()
+      const application = createApplication({
+        answers: {
+          ...baseAnswers,
+          isBFullRedesignEnabled: true,
+          selectLicensePhoto: selected,
+        },
+        externalData: thjodskraExternalData,
+        typeId: ApplicationTypes.DRIVING_LICENSE,
+        status: ApplicationStatus.IN_PROGRESS,
+      })
+
+      await service.submitApplication({
+        application,
+        auth: user,
+        currentUserLocale: 'is',
+      })
+
+      const [, input] = newDrivingLicenseWithHealthDeclaration.mock.calls[0]
+      expect('photoBiometricsId' in input).toBe(true)
+      expect(input.photoBiometricsId).toBeNull()
+      expect(input.signatureBiometricsId).toBeNull()
+    })
+
+    it('omits the biometric keys when no photo was selected at all', async () => {
+      const user = createCurrentUser()
+      const application = createApplication({
+        answers: { ...baseAnswers, isBFullRedesignEnabled: true },
+        externalData: thjodskraExternalData,
+        typeId: ApplicationTypes.DRIVING_LICENSE,
+        status: ApplicationStatus.IN_PROGRESS,
+      })
+
+      await service.submitApplication({
+        application,
+        auth: user,
+        currentUserLocale: 'is',
+      })
+
+      const [, input] = newDrivingLicenseWithHealthDeclaration.mock.calls[0]
+      expect(input.photoBiometricsId).toBeUndefined()
+      expect(input.signatureBiometricsId).toBeUndefined()
+    })
+
     it('attaches the certificate when a health answer requires one', async () => {
       const user = createCurrentUser()
       const application = createApplication({

--- a/libs/application/template-api-modules/src/lib/modules/templates/transport-authority/driving-license-submission/driving-license-submission.spec.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/transport-authority/driving-license-submission/driving-license-submission.spec.ts
@@ -1509,6 +1509,19 @@ describe('DrivingLicenseSubmissionService', () => {
       return err
     }
 
+    // The temporary endpoint's 400 shape: plain JSON, code in `body.errorCode`
+    // (no problem+json), which toSubmissionError must also localise.
+    const makeFetchErrorBody = (errorCode: string, status = 400) => {
+      const err = new Error('rls submission failed') as Error & {
+        body?: unknown
+        status?: number
+      }
+      err.name = 'FetchError'
+      err.body = { errorCode }
+      err.status = status
+      return err
+    }
+
     // No applicationFor → defaults to B-full → newDrivingLicense is the create call.
     const buildApplication = () =>
       createApplication({
@@ -1612,6 +1625,25 @@ describe('DrivingLicenseSubmissionService', () => {
 
       expect(getErrorReasonIfPresent(reasonOf(thrown)).summary).toBe(
         'Person has points on their license',
+      )
+    })
+
+    it('localises the code from body.errorCode (temporary endpoint plain-JSON 400)', async () => {
+      newDrivingLicense.mockRejectedValue(
+        makeFetchErrorBody('APPLICATION_ALREADY_EXISTS'),
+      )
+      describeErrorCode.mockResolvedValue({
+        is: 'Umsókn er þegar til',
+        en: 'An application already exists',
+      })
+
+      const thrown = await submitAndCatch('is')
+
+      expect(describeErrorCode).toHaveBeenCalledWith(
+        'APPLICATION_ALREADY_EXISTS',
+      )
+      expect(getErrorReasonIfPresent(reasonOf(thrown)).summary).toBe(
+        'Umsókn er þegar til',
       )
     })
 

--- a/libs/application/template-api-modules/src/lib/modules/templates/transport-authority/driving-license-submission/driving-license-submission.spec.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/transport-authority/driving-license-submission/driving-license-submission.spec.ts
@@ -419,6 +419,8 @@ describe('DrivingLicenseSubmissionService', () => {
     let service: DrivingLicenseSubmissionService
     let newTemporaryDrivingLicense: jest.Mock
     let postHealthDeclaration: jest.Mock
+    let newTemporaryDrivingLicenseWithHealthDeclaration: jest.Mock
+    let getFiles: jest.Mock
 
     const baseAnswers = {
       applicationFor: 'B-temp',
@@ -449,6 +451,11 @@ describe('DrivingLicenseSubmissionService', () => {
         errorMessage: null,
       }))
       postHealthDeclaration = jest.fn(async () => undefined)
+      newTemporaryDrivingLicenseWithHealthDeclaration = jest.fn(async () => ({
+        success: true,
+        errorMessage: null,
+      }))
+      getFiles = jest.fn(async () => [])
 
       const module = await Test.createTestingModule({
         imports: [
@@ -463,7 +470,14 @@ describe('DrivingLicenseSubmissionService', () => {
           AdapterService,
           {
             provide: DrivingLicenseService,
-            useValue: { newTemporaryDrivingLicense, postHealthDeclaration },
+            // All three registered together: a `.not.toHaveBeenCalled()`
+            // assertion on a mock the service never received would pass
+            // vacuously.
+            useValue: {
+              newTemporaryDrivingLicense,
+              postHealthDeclaration,
+              newTemporaryDrivingLicenseWithHealthDeclaration,
+            },
           },
           { provide: LOGGER_PROVIDER, useValue: logger },
           {
@@ -472,7 +486,7 @@ describe('DrivingLicenseSubmissionService', () => {
           },
           {
             provide: AttachmentS3Service,
-            useValue: { getFiles: jest.fn(async () => []) },
+            useValue: { getFiles },
           },
           {
             provide: SharedTemplateApiService,
@@ -520,13 +534,14 @@ describe('DrivingLicenseSubmissionService', () => {
       expect(input.signatureBiometricsId).toBeUndefined()
     })
 
-    it('resolves photo and signature biometric IDs when a Thjodskra photo is selected', async () => {
+    it('routes flag-on submissions to the v6 withhealthdeclaration endpoint, in a single call', async () => {
       const user = createCurrentUser()
       const application = createApplication({
         answers: {
           ...baseAnswers,
           isBTempRedesignEnabled: true,
           selectLicensePhoto: 'facial-1',
+          drivingInstructor: '0101302399',
         },
         externalData: thjodskraExternalData,
         typeId: ApplicationTypes.DRIVING_LICENSE,
@@ -540,11 +555,30 @@ describe('DrivingLicenseSubmissionService', () => {
       })
 
       expect(res).toEqual({ success: true })
-      const [, , input] = newTemporaryDrivingLicense.mock.calls[0]
+      expect(
+        newTemporaryDrivingLicenseWithHealthDeclaration,
+      ).toHaveBeenCalledTimes(1)
+      // The legacy pair must not run: the v6 endpoint does both jobs.
+      expect(newTemporaryDrivingLicense).not.toHaveBeenCalled()
+      expect(postHealthDeclaration).not.toHaveBeenCalled()
+
+      const [auth, input] =
+        newTemporaryDrivingLicenseWithHealthDeclaration.mock.calls[0]
+      // The whole Auth object, not auth.authorization: the client needs it for
+      // withAuthContext, and passing the string would leave the jwttoken header
+      // unset while this test still passed.
+      expect(auth).toBe(user)
       expect(input).toMatchObject({
+        districtId: 37,
+        instructorSSN: '0101302399',
+        sendPlasticToPerson: true,
+        email: 'mock@email.com',
         photoBiometricsId: 'facial-1',
         signatureBiometricsId: 'sig-1',
       })
+      // No certificate needed → the key is omitted rather than sent as null.
+      expect(input.contentList).toBeUndefined()
+      expect(input.healthDeclaration.hasEpilepsy).toBe(false)
     })
 
     it('sends null biometric IDs when the RLS quality photo is selected', async () => {
@@ -566,22 +600,21 @@ describe('DrivingLicenseSubmissionService', () => {
         status: ApplicationStatus.IN_PROGRESS,
       })
 
-      const res = await service.submitApplication({
+      await service.submitApplication({
         application,
         auth: user,
         currentUserLocale: 'is',
       })
 
-      expect(res).toEqual({ success: true })
-      const [, , input] = newTemporaryDrivingLicense.mock.calls[0]
+      const [, input] =
+        newTemporaryDrivingLicenseWithHealthDeclaration.mock.calls[0]
       expect(input).toMatchObject({
         photoBiometricsId: null,
         signatureBiometricsId: null,
       })
-      expect(postHealthDeclaration).not.toHaveBeenCalled()
     })
 
-    it('carries biometric IDs on both postHealthDeclaration and newTemporaryDrivingLicense when a health certificate is needed', async () => {
+    it('attaches the certificate when a health answer requires one', async () => {
       const user = createCurrentUser()
       const application = createApplication({
         answers: {
@@ -595,33 +628,67 @@ describe('DrivingLicenseSubmissionService', () => {
         status: ApplicationStatus.IN_PROGRESS,
       })
 
-      const res = await service.submitApplication({
+      getFiles.mockResolvedValueOnce([
+        { fileName: 'cert.pdf', fileContent: 'base64pdfdata' },
+      ])
+
+      await service.submitApplication({
         application,
         auth: user,
         currentUserLocale: 'is',
       })
 
-      expect(res).toEqual({ success: true })
+      const [, input] =
+        newTemporaryDrivingLicenseWithHealthDeclaration.mock.calls[0]
+      expect(input.contentList).toHaveLength(1)
+      expect(input.contentList[0]).toMatchObject({
+        fileName: 'cert.pdf',
+        contentType: 'application/pdf',
+        description: 'Laeknisvottord',
+      })
+      expect(input.healthDeclaration.hasEpilepsy).toBe(true)
+    })
 
-      expect(postHealthDeclaration).toHaveBeenCalledTimes(1)
-      const [, healthModel] = postHealthDeclaration.mock.calls[0]
-      expect(healthModel).toMatchObject({
-        photoBiometricsId: 'facial-1',
-        signatureBiometricsId: 'sig-1',
+    it('rejects when a certificate is required but none was uploaded', async () => {
+      const user = createCurrentUser()
+      const application = createApplication({
+        answers: {
+          ...baseAnswers,
+          isBTempRedesignEnabled: true,
+          healthDeclaration: { hasEpilepsy: 'yes' },
+        },
+        typeId: ApplicationTypes.DRIVING_LICENSE,
+        status: ApplicationStatus.IN_PROGRESS,
       })
 
-      expect(newTemporaryDrivingLicense).toHaveBeenCalledTimes(1)
-      const [, , input] = newTemporaryDrivingLicense.mock.calls[0]
-      expect(input).toMatchObject({
-        photoBiometricsId: 'facial-1',
-        signatureBiometricsId: 'sig-1',
+      await expect(
+        service.submitApplication({
+          application,
+          auth: user,
+          currentUserLocale: 'is',
+        }),
+      ).rejects.toMatchObject({
+        problem: {
+          errorReason: {
+            summary: expect.objectContaining({
+              id: 'dl.application:validation.healthCertificateRequired',
+            }),
+          },
+          status: 400,
+        },
       })
+
+      expect(
+        newTemporaryDrivingLicenseWithHealthDeclaration,
+      ).not.toHaveBeenCalled()
     })
   })
 
   describe('B-full redesign branch', () => {
     let service: DrivingLicenseSubmissionService
     let newDrivingLicense: jest.Mock
+    let newDrivingLicenseWithHealthDeclaration: jest.Mock
+    let getFiles: jest.Mock
 
     const baseAnswers = {
       applicationFor: 'B-full',
@@ -651,6 +718,11 @@ describe('DrivingLicenseSubmissionService', () => {
         success: true,
         errorMessage: null,
       }))
+      newDrivingLicenseWithHealthDeclaration = jest.fn(async () => ({
+        success: true,
+        errorMessage: null,
+      }))
+      getFiles = jest.fn(async () => [])
 
       const module = await Test.createTestingModule({
         imports: [
@@ -665,7 +737,12 @@ describe('DrivingLicenseSubmissionService', () => {
           AdapterService,
           {
             provide: DrivingLicenseService,
-            useValue: { newDrivingLicense },
+            // Both registered: a `.not.toHaveBeenCalled()` on a mock the
+            // service never received would pass vacuously.
+            useValue: {
+              newDrivingLicense,
+              newDrivingLicenseWithHealthDeclaration,
+            },
           },
           { provide: LOGGER_PROVIDER, useValue: logger },
           {
@@ -674,7 +751,7 @@ describe('DrivingLicenseSubmissionService', () => {
           },
           {
             provide: AttachmentS3Service,
-            useValue: { getFiles: jest.fn(async () => []) },
+            useValue: { getFiles },
           },
           {
             provide: SharedTemplateApiService,
@@ -722,7 +799,7 @@ describe('DrivingLicenseSubmissionService', () => {
       expect(input.signatureBiometricsId).toBeUndefined()
     })
 
-    it('resolves photo and signature biometric IDs when a Thjodskra photo is selected', async () => {
+    it('routes flag-on submissions to the v6 withhealthdeclaration endpoint', async () => {
       const user = createCurrentUser()
       const application = createApplication({
         answers: {
@@ -742,75 +819,84 @@ describe('DrivingLicenseSubmissionService', () => {
       })
 
       expect(res).toEqual({ success: true })
-      const [, input] = newDrivingLicense.mock.calls[0]
+      expect(newDrivingLicenseWithHealthDeclaration).toHaveBeenCalledTimes(1)
+      expect(newDrivingLicense).not.toHaveBeenCalled()
+
+      const [auth, input] = newDrivingLicenseWithHealthDeclaration.mock.calls[0]
+      // Whole Auth object, not auth.authorization - see the B-temp equivalent.
+      expect(auth).toBe(user)
       expect(input).toMatchObject({
+        licenseCategory: 'B',
+        districtId: 37,
+        sendPlasticToPerson: true,
         photoBiometricsId: 'facial-1',
         signatureBiometricsId: 'sig-1',
       })
+      expect(input.contentList).toBeUndefined()
+      // B-full previously sent only a derived boolean and dropped the ten
+      // answers; they must now reach RLS.
+      expect(input.healthDeclaration).toMatchObject({ hasEpilepsy: false })
     })
 
-    it('sends null biometric IDs when the selected photo matches no FACIAL entry', async () => {
+    it('attaches the certificate when a health answer requires one', async () => {
       const user = createCurrentUser()
       const application = createApplication({
         answers: {
           ...baseAnswers,
           isBFullRedesignEnabled: true,
-          // Selected in the draft but gone from Þjóðskrá temp storage by the
-          // time we submit — the defensive branch. Behaviour is deliberately
-          // log-and-continue (never throw): createLicense runs post-payment,
-          // so throwing would strand a paid application.
-          selectLicensePhoto: 'facial-gone',
+          selectLicensePhoto: 'facial-1',
+          healthDeclaration: { hasDiabetes: 'yes' },
         },
         externalData: thjodskraExternalData,
         typeId: ApplicationTypes.DRIVING_LICENSE,
         status: ApplicationStatus.IN_PROGRESS,
       })
 
-      const res = await service.submitApplication({
+      getFiles.mockResolvedValueOnce([
+        { fileName: 'cert.pdf', fileContent: 'base64pdfdata' },
+      ])
+
+      await service.submitApplication({
         application,
         auth: user,
         currentUserLocale: 'is',
       })
 
-      expect(res).toEqual({ success: true })
-      const [, input] = newDrivingLicense.mock.calls[0]
-      expect(input).toMatchObject({
-        photoBiometricsId: null,
-        signatureBiometricsId: null,
-      })
+      const [, input] = newDrivingLicenseWithHealthDeclaration.mock.calls[0]
+      expect(input.contentList).toHaveLength(1)
+      expect(input.healthDeclaration.hasDiabetes).toBe(true)
     })
 
-    it('sends null biometric IDs when the RLS quality photo is selected', async () => {
+    it('rejects when a certificate is required but none was uploaded', async () => {
       const user = createCurrentUser()
       const application = createApplication({
         answers: {
           ...baseAnswers,
           isBFullRedesignEnabled: true,
-          selectLicensePhoto: 'qualityPhoto',
-        },
-        externalData: {
-          qualityPhotoAndSignature: {
-            data: { pohto: 'somebase64' },
-            status: 'success',
-            date: new Date(),
-          },
+          healthDeclaration: { hasDiabetes: 'yes' },
         },
         typeId: ApplicationTypes.DRIVING_LICENSE,
         status: ApplicationStatus.IN_PROGRESS,
       })
 
-      const res = await service.submitApplication({
-        application,
-        auth: user,
-        currentUserLocale: 'is',
+      await expect(
+        service.submitApplication({
+          application,
+          auth: user,
+          currentUserLocale: 'is',
+        }),
+      ).rejects.toMatchObject({
+        problem: {
+          errorReason: {
+            summary: expect.objectContaining({
+              id: 'dl.application:validation.healthCertificateRequired',
+            }),
+          },
+          status: 400,
+        },
       })
 
-      expect(res).toEqual({ success: true })
-      const [, input] = newDrivingLicense.mock.calls[0]
-      expect(input).toMatchObject({
-        photoBiometricsId: null,
-        signatureBiometricsId: null,
-      })
+      expect(newDrivingLicenseWithHealthDeclaration).not.toHaveBeenCalled()
     })
   })
 

--- a/libs/application/template-api-modules/src/lib/modules/templates/transport-authority/driving-license-submission/driving-license-submission.spec.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/transport-authority/driving-license-submission/driving-license-submission.spec.ts
@@ -817,6 +817,7 @@ describe('DrivingLicenseSubmissionService', () => {
   describe('BE branch', () => {
     let service: DrivingLicenseSubmissionService
     let applyForBELicense: jest.Mock
+    let getFiles: jest.Mock
 
     const baseAnswers = {
       applicationFor: 'BE',
@@ -825,6 +826,7 @@ describe('DrivingLicenseSubmissionService', () => {
     }
 
     beforeEach(async () => {
+      getFiles = jest.fn(async () => [])
       applyForBELicense = jest.fn(async () => ({
         success: true,
         errorMessage: null,
@@ -852,7 +854,7 @@ describe('DrivingLicenseSubmissionService', () => {
           },
           {
             provide: AttachmentS3Service,
-            useValue: { getFiles: jest.fn(async () => []) },
+            useValue: { getFiles },
           },
           {
             provide: SharedTemplateApiService,
@@ -938,6 +940,179 @@ describe('DrivingLicenseSubmissionService', () => {
       expect(applyForBELicense).toHaveBeenCalledTimes(1)
       const [, , input] = applyForBELicense.mock.calls[0]
       expect(input.sendPlasticToPerson).toBe(false)
+    })
+
+    // The cases below cover the shared health-certificate and health-declaration
+    // helpers on BE, which is the only branch running them unflagged in
+    // production. Before these existed, `baseAnswers` carried no
+    // `healthDeclaration`, so `beNeedsHealthCert` was always false and every BE
+    // test passed whether the builders worked or not.
+    it('builds contentList from the uploaded certificate when a health answer is yes', async () => {
+      const user = createCurrentUser()
+      const application = createApplication({
+        answers: {
+          ...baseAnswers,
+          healthDeclaration: { hasEpilepsy: 'yes' },
+          delivery: { deliveryMethod: 'post', jurisdiction: '37' },
+        },
+        typeId: ApplicationTypes.DRIVING_LICENSE,
+        status: ApplicationStatus.IN_PROGRESS,
+      })
+
+      getFiles.mockResolvedValueOnce([
+        { fileName: 'cert.pdf', fileContent: 'base64pdfdata' },
+      ])
+
+      await service.submitApplication({
+        application,
+        auth: user,
+        currentUserLocale: 'is',
+      })
+
+      expect(applyForBELicense).toHaveBeenCalledTimes(1)
+      const [, , input] = applyForBELicense.mock.calls[0]
+      expect(input.contentList).toHaveLength(1)
+      expect(input.contentList[0]).toMatchObject({
+        fileName: 'cert.pdf',
+        fileExtension: 'pdf',
+        contentType: 'application/pdf',
+        content: 'base64pdfdata',
+        description: 'Laeknisvottord',
+      })
+    })
+
+    it('normalises a jpg upload to the jpeg extension RLS expects', async () => {
+      const user = createCurrentUser()
+      const application = createApplication({
+        answers: {
+          ...baseAnswers,
+          healthDeclaration: { hasDiabetes: 'yes' },
+        },
+        typeId: ApplicationTypes.DRIVING_LICENSE,
+        status: ApplicationStatus.IN_PROGRESS,
+      })
+
+      getFiles.mockResolvedValueOnce([
+        { fileName: 'cert.JPG', fileContent: 'base64jpgdata' },
+      ])
+
+      await service.submitApplication({
+        application,
+        auth: user,
+        currentUserLocale: 'is',
+      })
+
+      const [, , input] = applyForBELicense.mock.calls[0]
+      expect(input.contentList[0]).toMatchObject({
+        fileExtension: 'jpeg',
+        contentType: 'image/jpeg',
+      })
+    })
+
+    it('rejects when a certificate is required but nothing was uploaded', async () => {
+      const user = createCurrentUser()
+      const application = createApplication({
+        answers: {
+          ...baseAnswers,
+          healthDeclaration: { hasEpilepsy: 'yes' },
+        },
+        typeId: ApplicationTypes.DRIVING_LICENSE,
+        status: ApplicationStatus.IN_PROGRESS,
+      })
+
+      // getFiles returns [] by default — nothing attached
+      await expect(
+        service.submitApplication({
+          application,
+          auth: user,
+          currentUserLocale: 'is',
+        }),
+      ).rejects.toMatchObject({
+        problem: {
+          errorReason: {
+            summary: expect.objectContaining({
+              id: 'dl.application:validation.healthCertificateRequired',
+            }),
+          },
+          status: 400,
+        },
+      })
+
+      expect(applyForBELicense).not.toHaveBeenCalled()
+    })
+
+    it('requires a certificate when the glasses check fires, even with all answers no', async () => {
+      const user = createCurrentUser()
+      const application = createApplication({
+        answers: {
+          ...baseAnswers,
+          healthDeclaration: { hasEpilepsy: 'no', hasDiabetes: 'no' },
+        },
+        externalData: {
+          glassesCheck: {
+            data: true,
+            status: 'success',
+            date: new Date(),
+          },
+        },
+        typeId: ApplicationTypes.DRIVING_LICENSE,
+        status: ApplicationStatus.IN_PROGRESS,
+      })
+
+      await expect(
+        service.submitApplication({
+          application,
+          auth: user,
+          currentUserLocale: 'is',
+        }),
+      ).rejects.toMatchObject({
+        problem: {
+          errorReason: {
+            summary: expect.objectContaining({
+              id: 'dl.application:validation.healthCertificateRequired',
+            }),
+          },
+          status: 400,
+        },
+      })
+    })
+
+    it('maps every health-declaration answer, defaulting unanswered questions to false', async () => {
+      const user = createCurrentUser()
+      const application = createApplication({
+        answers: {
+          ...baseAnswers,
+          healthDeclaration: { hasEpilepsy: 'yes' },
+        },
+        typeId: ApplicationTypes.DRIVING_LICENSE,
+        status: ApplicationStatus.IN_PROGRESS,
+      })
+
+      getFiles.mockResolvedValueOnce([
+        { fileName: 'cert.pdf', fileContent: 'base64pdfdata' },
+      ])
+
+      await service.submitApplication({
+        application,
+        auth: user,
+        currentUserLocale: 'is',
+      })
+
+      const [, , input] = applyForBELicense.mock.calls[0]
+      // Unanswered questions must be false, not omitted: RLS reads a missing key
+      // as null rather than a negative answer.
+      expect(input.healthDeclarationModel).toEqual({
+        isDisabled: false,
+        hasDiabetes: false,
+        hasEpilepsy: true,
+        isAlcoholic: false,
+        hasHeartDisease: false,
+        hasMentalIllness: false,
+        hasOtherDiseases: false,
+        usesMedicalDrugs: false,
+        usesContactGlasses: false,
+        hasReducedPeripheralVision: false,
+      })
     })
   })
 

--- a/libs/application/template-api-modules/src/lib/modules/templates/transport-authority/driving-license-submission/driving-license-submission.spec.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/transport-authority/driving-license-submission/driving-license-submission.spec.ts
@@ -588,15 +588,21 @@ describe('DrivingLicenseSubmissionService', () => {
       expect(input.healthDeclaration.hasEpilepsy).toBe(false)
     })
 
-    it('preserves an existing guid when submitApplication re-runs and RLS says APPLICATION_ALREADY_EXISTS', async () => {
-      // Re-entry/retry: the v6 client guard resolves the duplicate with a null
-      // guid. Without the fallback that null would overwrite the guid the first
-      // run stored at externalData.submitApplication.data.
-      newTemporaryDrivingLicenseWithHealthDeclaration.mockResolvedValueOnce({
-        success: true,
-        errorMessage: null,
-        applicationGuid: null,
-      })
+    // The duplicate-on-retry cases. RLS returns 400 APPLICATION_ALREADY_EXISTS;
+    // the api-domain method throws it (the v6 client no longer swallows). The
+    // submission service tolerates it as success ONLY when THIS application
+    // already has a submitApplication entry — a lost-response retry on the same
+    // application — and preserves the guid the first run stored.
+    const alreadyExists = Object.assign(new Error('already exists'), {
+      name: 'FetchError',
+      status: 400,
+      body: { errorCode: 'APPLICATION_ALREADY_EXISTS' },
+    })
+
+    it('tolerates ALREADY_EXISTS as success on a lost-response retry (same application) and keeps the stored guid', async () => {
+      newTemporaryDrivingLicenseWithHealthDeclaration.mockRejectedValueOnce(
+        alreadyExists,
+      )
       const user = createCurrentUser()
       const application = createApplication({
         answers: {
@@ -607,6 +613,8 @@ describe('DrivingLicenseSubmissionService', () => {
         },
         externalData: {
           ...thjodskraExternalData,
+          // The first (failed) run left a submitApplication entry — the marker
+          // that this is a retry on the same application.
           submitApplication: {
             data: { applicationGuid: '2e23bf24-d8bd-4353-9faf-3fc5ce04090d' },
             status: 'success',
@@ -627,6 +635,36 @@ describe('DrivingLicenseSubmissionService', () => {
         success: true,
         applicationGuid: '2e23bf24-d8bd-4353-9faf-3fc5ce04090d',
       })
+    })
+
+    it('does NOT swallow ALREADY_EXISTS for a fresh application (no prior submit entry) — surfaces the error', async () => {
+      // The defect the manual dev test caught: a new application submitted while
+      // another is active. Its payload was discarded by RLS, so the applicant
+      // must see the error, not a false "received".
+      newTemporaryDrivingLicenseWithHealthDeclaration.mockRejectedValueOnce(
+        alreadyExists,
+      )
+      const user = createCurrentUser()
+      const application = createApplication({
+        answers: {
+          ...baseAnswers,
+          isBTempRedesignEnabled: true,
+          selectLicensePhoto: 'facial-1',
+          drivingInstructor: '0101302399',
+        },
+        // No submitApplication entry: this application never attempted submit.
+        externalData: thjodskraExternalData,
+        typeId: ApplicationTypes.DRIVING_LICENSE,
+        status: ApplicationStatus.IN_PROGRESS,
+      })
+
+      await expect(
+        service.submitApplication({
+          application,
+          auth: user,
+          currentUserLocale: 'is',
+        }),
+      ).rejects.toBeDefined()
     })
 
     it('sends null biometric IDs when the RLS quality photo is selected', async () => {

--- a/libs/application/template-api-modules/src/lib/modules/templates/transport-authority/driving-license-submission/driving-license-submission.spec.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/transport-authority/driving-license-submission/driving-license-submission.spec.ts
@@ -588,6 +588,47 @@ describe('DrivingLicenseSubmissionService', () => {
       expect(input.healthDeclaration.hasEpilepsy).toBe(false)
     })
 
+    it('preserves an existing guid when submitApplication re-runs and RLS says APPLICATION_ALREADY_EXISTS', async () => {
+      // Re-entry/retry: the v6 client guard resolves the duplicate with a null
+      // guid. Without the fallback that null would overwrite the guid the first
+      // run stored at externalData.submitApplication.data.
+      newTemporaryDrivingLicenseWithHealthDeclaration.mockResolvedValueOnce({
+        success: true,
+        errorMessage: null,
+        applicationGuid: null,
+      })
+      const user = createCurrentUser()
+      const application = createApplication({
+        answers: {
+          ...baseAnswers,
+          isBTempRedesignEnabled: true,
+          selectLicensePhoto: 'facial-1',
+          drivingInstructor: '0101302399',
+        },
+        externalData: {
+          ...thjodskraExternalData,
+          submitApplication: {
+            data: { applicationGuid: '2e23bf24-d8bd-4353-9faf-3fc5ce04090d' },
+            status: 'success',
+            date: new Date(),
+          },
+        },
+        typeId: ApplicationTypes.DRIVING_LICENSE,
+        status: ApplicationStatus.IN_PROGRESS,
+      })
+
+      const res = await service.submitApplication({
+        application,
+        auth: user,
+        currentUserLocale: 'is',
+      })
+
+      expect(res).toStrictEqual({
+        success: true,
+        applicationGuid: '2e23bf24-d8bd-4353-9faf-3fc5ce04090d',
+      })
+    })
+
     it('sends null biometric IDs when the RLS quality photo is selected', async () => {
       const user = createCurrentUser()
       const application = createApplication({

--- a/libs/application/templates/driving-license/src/fields/HealthDeclaration.tsx
+++ b/libs/application/templates/driving-license/src/fields/HealthDeclaration.tsx
@@ -5,7 +5,10 @@ import { getValueViaPath, NO, YES } from '@island.is/application/core'
 import { CustomField, FieldBaseProps } from '@island.is/application/types'
 import { m } from '../lib/messages'
 import { BE } from '../lib/constants'
-import { needsHealthCertificateCondition } from '../lib/utils/formUtils'
+import {
+  isRedesignedBTempOrBFull,
+  needsHealthCertificateCondition,
+} from '../lib/utils/formUtils'
 import { useFormContext } from 'react-hook-form'
 
 import type { JSX } from 'react'
@@ -26,7 +29,21 @@ const HealthDeclaration = ({
   const { setValue, getValues } = useFormContext()
 
   const clearHealthCertificateIfNotNeeded = (value: string) => {
-    if (getValueViaPath(application.answers, 'applicationFor') !== BE) {
+    // Only products whose upload is *conditional* need clearing: BE, and the
+    // redesigned B-temp/B-full flows that now follow BE's rules. 65+ is excluded
+    // because its upload is unconditional, so there is never a state where a
+    // previously-uploaded certificate is no longer wanted.
+    //
+    // Without this, an applicant who answers "yes", uploads, then switches to
+    // "no" keeps an orphaned file in answers: it is neither shown in the summary
+    // nor sent as contentList (both gate on the same predicate), but it stays on
+    // the application, reappears pre-filled if they flip back, and becomes a
+    // real transmission bug the moment contentList is ever sent unconditionally.
+    const usesConditionalUpload =
+      getValueViaPath(application.answers, 'applicationFor') === BE ||
+      isRedesignedBTempOrBFull(application.answers)
+
+    if (!usesConditionalUpload) {
       return
     }
 

--- a/libs/application/templates/driving-license/src/forms/draft/subSectionHealthDeclaration.spec.ts
+++ b/libs/application/templates/driving-license/src/forms/draft/subSectionHealthDeclaration.spec.ts
@@ -1,0 +1,230 @@
+import { ExternalData, FormValue } from '@island.is/application/types'
+import { subSectionHealthDeclaration } from './subSectionHealthDeclaration'
+import { B_FULL, B_FULL_RENEWAL_65, B_TEMP, BE } from '../../lib/constants'
+
+/**
+ * The health-declaration sub-section holds four sibling multifields whose
+ * conditions must stay mutually exclusive: they all write the same
+ * `healthCertificate` answer, so two visible at once would be a real bug.
+ *
+ * This spec pins:
+ *   - exactly one block visible per product / flag combination,
+ *   - the redesigned B-temp/B-full block matching BE's rules (upload appears
+ *     only once a health condition triggers it),
+ *   - the legacy and BE blocks' form-node ids being unchanged, so in-flight
+ *     drafts are unaffected by the shared-builder extraction.
+ */
+
+type Node = {
+  id?: string
+  children?: Node[]
+  condition?: unknown
+}
+
+const blocks = (subSectionHealthDeclaration as unknown as { children: Node[] })
+  .children
+
+const blockById = (id: string): Node => {
+  const found = blocks.find((c) => c.id === id)
+  if (!found) {
+    throw new Error(`no block with id ${id}`)
+  }
+  return found
+}
+
+// A missing condition yields `undefined`, which is falsy — so assert with
+// toBe(true)/toBe(false) rather than toBeTruthy/toBeFalsy, or a forgotten
+// condition would read as "hidden" and pass vacuously.
+const isShown = (
+  block: Node,
+  answers: FormValue,
+  externalData: ExternalData = {} as ExternalData,
+): boolean => {
+  const { condition } = block
+  if (typeof condition !== 'function') {
+    throw new Error(`block ${block.id} has no dynamic condition`)
+  }
+  return (condition as (a: FormValue, e: ExternalData) => boolean)(
+    answers,
+    externalData,
+  )
+}
+
+const collectIds = (node: Node): string[] => {
+  const here = node.id ? [node.id] : []
+  const kids = Array.isArray(node.children)
+    ? node.children.flatMap(collectIds)
+    : []
+  return [...here, ...kids]
+}
+
+const LEGACY = 'overview'
+const REDESIGNED = 'overviewWithHealthCertificate'
+const BE_BLOCK = 'overviewBE'
+
+describe('subSectionHealthDeclaration', () => {
+  describe('exactly one block is visible per product and flag combination', () => {
+    it.each([
+      // product, flags, the block that should show
+      [B_TEMP, {}, LEGACY],
+      [B_TEMP, { isBTempRedesignEnabled: true }, REDESIGNED],
+      [B_TEMP, { isBTempRedesignEnabled: false }, LEGACY],
+      [B_FULL, {}, LEGACY],
+      [B_FULL, { isBFullRedesignEnabled: true }, REDESIGNED],
+      [B_FULL, { isBFullRedesignEnabled: false }, LEGACY],
+      [BE, {}, BE_BLOCK],
+      [BE, { isBTempRedesignEnabled: true }, BE_BLOCK],
+    ])('%s with %p shows %s', (applicationFor, flags, expected) => {
+      const answers = { applicationFor, ...flags } as FormValue
+      const shown = [LEGACY, REDESIGNED, BE_BLOCK].filter((id) =>
+        isShown(blockById(id), answers),
+      )
+      expect(shown).toEqual([expected])
+    })
+
+    it('does not show either B block for 65+, regardless of flags', () => {
+      const answers = {
+        applicationFor: B_FULL_RENEWAL_65,
+        isBTempRedesignEnabled: true,
+        isBFullRedesignEnabled: true,
+      } as FormValue
+
+      expect(isShown(blockById(LEGACY), answers)).toBe(false)
+      expect(isShown(blockById(REDESIGNED), answers)).toBe(false)
+    })
+
+    it('does not cross the flags between products', () => {
+      // B-temp with only the B-full flag on must stay legacy — the copy-paste
+      // error this predicate invites.
+      expect(
+        isShown(blockById(REDESIGNED), {
+          applicationFor: B_TEMP,
+          isBFullRedesignEnabled: true,
+        } as FormValue),
+      ).toBe(false)
+
+      expect(
+        isShown(blockById(REDESIGNED), {
+          applicationFor: B_FULL,
+          isBTempRedesignEnabled: true,
+        } as FormValue),
+      ).toBe(false)
+    })
+  })
+
+  describe('the redesigned block follows BE rules for the certificate upload', () => {
+    const upload = (blockId: string) => {
+      const found = blockById(blockId).children?.find(
+        (c) => c.id === 'healthCertificate',
+      )
+      if (!found) {
+        throw new Error(`no healthCertificate upload in ${blockId}`)
+      }
+      return found
+    }
+
+    it.each([REDESIGNED, BE_BLOCK])(
+      '%s hides the upload when nothing triggers a certificate',
+      (blockId) => {
+        expect(
+          isShown(upload(blockId), {
+            healthDeclaration: { hasEpilepsy: 'no' },
+          } as unknown as FormValue),
+        ).toBe(false)
+      },
+    )
+
+    it.each([REDESIGNED, BE_BLOCK])(
+      '%s shows the upload when a health answer is yes',
+      (blockId) => {
+        expect(
+          isShown(upload(blockId), {
+            healthDeclaration: { hasEpilepsy: 'yes' },
+          } as unknown as FormValue),
+        ).toBe(true)
+      },
+    )
+
+    it.each([REDESIGNED, BE_BLOCK])(
+      '%s shows the upload when a health remark is present',
+      (blockId) => {
+        expect(
+          isShown(upload(blockId), {
+            hasHealthRemarks: 'yes',
+          } as unknown as FormValue),
+        ).toBe(true)
+      },
+    )
+
+    it.each([REDESIGNED, BE_BLOCK])(
+      '%s shows the upload when the glasses check fires',
+      (blockId) => {
+        expect(
+          isShown(
+            upload(blockId),
+            {} as FormValue,
+            {
+              glassesCheck: { data: true },
+            } as unknown as ExternalData,
+          ),
+        ).toBe(true)
+      },
+    )
+
+    it('declares the hasHealthRemarks hidden input, without which the gate cannot see remarks', () => {
+      // HealthRemarks writes this answer via setValue, and multifield extraction
+      // persists only ids that have a declared field.
+      expect(collectIds(blockById(REDESIGNED))).toContain('hasHealthRemarks')
+      expect(collectIds(blockById(BE_BLOCK))).toContain('hasHealthRemarks')
+    })
+
+    it('keeps the hidden input out of the legacy block', () => {
+      // Adding it there would flip `remarks` in the submission service from
+      // always-false to true for remark-holders, changing the LEGACY payload.
+      expect(collectIds(blockById(LEGACY))).not.toContain('hasHealthRemarks')
+    })
+  })
+
+  describe('form-node ids are unchanged for the pre-existing blocks', () => {
+    it('legacy B-temp/B-full block', () => {
+      expect(collectIds(blockById(LEGACY))).toEqual([
+        'overview',
+        'healthDeclarationDescription',
+        'remarks',
+        'healthDeclaration.usesContactGlasses',
+        'healthDeclaration.hasReducedPeripheralVision',
+        'healthDeclaration.hasEpilepsy',
+        'healthDeclaration.hasHeartDisease',
+        'healthDeclaration.hasMentalIllness',
+        'healthDeclaration.usesMedicalDrugs',
+        'healthDeclaration.isAlcoholic',
+        'healthDeclaration.hasDiabetes',
+        'healthDeclaration.isDisabled',
+        'healthDeclaration.hasOtherDiseases',
+        'healthDeclaration.contactGlassesMismatch',
+      ])
+    })
+
+    it('BE block', () => {
+      expect(collectIds(blockById(BE_BLOCK))).toEqual([
+        'overviewBE',
+        'healthDeclarationDescriptionBE',
+        'remarksBE',
+        'hasHealthRemarks',
+        'healthDeclaration.usesContactGlasses',
+        'healthDeclaration.hasReducedPeripheralVision',
+        'healthDeclaration.hasEpilepsy',
+        'healthDeclaration.hasHeartDisease',
+        'healthDeclaration.hasMentalIllness',
+        'healthDeclaration.usesMedicalDrugs',
+        'healthDeclaration.isAlcoholic',
+        'healthDeclaration.hasDiabetes',
+        'healthDeclaration.isDisabled',
+        'healthDeclaration.hasOtherDiseases',
+        'healthDeclaration.contactGlassesMismatch',
+        'healthCertificateDescriptionBE',
+        'healthCertificate',
+      ])
+    })
+  })
+})

--- a/libs/application/templates/driving-license/src/forms/draft/subSectionHealthDeclaration.ts
+++ b/libs/application/templates/driving-license/src/forms/draft/subSectionHealthDeclaration.ts
@@ -13,6 +13,7 @@ import { m } from '../../lib/messages'
 import { hasNoDrivingLicenseInOtherCountry } from '../../lib/utils'
 import {
   hasHealthRemarks,
+  isRedesignedBTempOrBFull,
   needsHealthCertificateCondition,
 } from '../../lib/utils/formUtils'
 import { BE, B_FULL_RENEWAL_65 } from '../../lib/constants'
@@ -147,19 +148,64 @@ const healthDeclarationQuestions = () => [
   }),
 ]
 
+/**
+ * The certificate description plus the conditional upload. Shared verbatim by BE
+ * and by the redesigned B-temp/B-full block, which have the same rule — the
+ * upload appears only once a health condition is triggered.
+ *
+ * The accompanying `buildHiddenInput({ id: 'hasHealthRemarks' })` is declared by
+ * each caller rather than returned here, purely to preserve BE's existing child
+ * order. It is not decoration though: `HealthRemarks` writes `hasHealthRemarks`
+ * via `setValue`, and multifield answer extraction persists only ids that have a
+ * declared field, so without it that value never lands — and
+ * `needsHealthCertificateCondition` reads it. That is exactly why the legacy
+ * block (which renders `HealthRemarks` but declares no hidden input) cannot use
+ * the BE gate as-is, and why the hidden input must stay flag-gated: adding it to
+ * the legacy block would flip `remarks` in the submission service from
+ * always-false to true for remark-holders, changing the *legacy* RLS payload.
+ *
+ * @param idSuffix keeps each product's non-answer field ids byte-identical to
+ * what in-flight drafts already have ('' → `remarks`, 'BE' → `remarksBE`). The
+ * upload itself always uses the bare `healthCertificate` id: that is the answer
+ * path every consumer reads, and only one block is ever visible at a time.
+ *
+ * The 65+ blocks deliberately do not use this — their upload is unconditional,
+ * so the shared `needsHealthCertificateCondition` gate would be wrong.
+ */
+const healthCertificateFields = (idSuffix: string) => [
+  buildDescriptionField({
+    id: `healthCertificateDescription${idSuffix}`,
+    description: m.healthCertificateDescription,
+    condition: needsHealthCertificateCondition(YES),
+  }),
+  buildFileUploadField({
+    id: 'healthCertificate',
+    title: m.healthCertificateTitle,
+    uploadHeader: m.healthCertificateUploadHeader,
+    uploadDescription: m.healthCertificateUploadDescription,
+    uploadButtonLabel: m.healthCertificateUploadButtonLabel,
+    maxSize: 4000000,
+    uploadAccept: '.pdf, .jpg, .jpeg, .png',
+    condition: needsHealthCertificateCondition(YES),
+  }),
+]
+
 export const subSectionHealthDeclaration = buildSubSection({
   id: 'healthDeclaration',
   title: m.healthDeclarationSectionTitle,
   condition: hasNoDrivingLicenseInOtherCountry,
   children: [
-    // Health declaration for B-temp and B-full — same questions as BE
-    // but without the health certificate file upload that BE requires
+    // Legacy B-temp / B-full — health questions only, no certificate upload.
+    // Suppressed for drafts whose redesign flag was on: those get the block
+    // below instead. The two conditions must stay mutually exclusive, or two
+    // visible blocks would both write `healthCertificate`.
     buildMultiField({
       id: 'overview',
       title: m.healthDeclarationMultiFieldTitle,
       condition: (answers) =>
         answers.applicationFor !== B_FULL_RENEWAL_65 &&
-        answers.applicationFor !== BE,
+        answers.applicationFor !== BE &&
+        !isRedesignedBTempOrBFull(answers),
       space: 2,
       children: [
         buildDescriptionField({
@@ -174,6 +220,32 @@ export const subSectionHealthDeclaration = buildSubSection({
             hasHealthRemarks(externalData) && answers.applicationFor !== BE,
         }),
         ...healthDeclarationQuestions(),
+      ],
+    }),
+    // Redesigned B-temp / B-full — identical to BE: same questions, same
+    // conditional certificate upload. Submits through the v6
+    // `withhealthdeclaration` endpoint.
+    buildMultiField({
+      id: 'overviewWithHealthCertificate',
+      title: m.healthDeclarationMultiFieldTitle,
+      condition: isRedesignedBTempOrBFull,
+      space: 2,
+      children: [
+        buildDescriptionField({
+          id: 'healthDeclarationDescriptionWithHealthCertificate',
+          description: m.healthDeclarationSubTitle,
+          marginBottom: 2,
+        }),
+        buildCustomField({
+          id: 'remarksWithHealthCertificate',
+          component: 'HealthRemarks',
+          condition: (_answers, externalData) => hasHealthRemarks(externalData),
+        }),
+        buildHiddenInput({
+          id: 'hasHealthRemarks',
+        }),
+        ...healthDeclarationQuestions(),
+        ...healthCertificateFields('WithHealthCertificate'),
       ],
     }),
     // Same health declaration questions for BE, plus health certificate
@@ -198,21 +270,7 @@ export const subSectionHealthDeclaration = buildSubSection({
           id: 'hasHealthRemarks',
         }),
         ...healthDeclarationQuestions(),
-        buildDescriptionField({
-          id: 'healthCertificateDescriptionBE',
-          description: m.healthCertificateDescription,
-          condition: needsHealthCertificateCondition(YES),
-        }),
-        buildFileUploadField({
-          id: 'healthCertificate',
-          title: m.healthCertificateTitle,
-          uploadHeader: m.healthCertificateUploadHeader,
-          uploadDescription: m.healthCertificateUploadDescription,
-          uploadButtonLabel: m.healthCertificateUploadButtonLabel,
-          maxSize: 4000000,
-          uploadAccept: '.pdf, .jpg, .jpeg, .png',
-          condition: needsHealthCertificateCondition(YES),
-        }),
+        ...healthCertificateFields('BE'),
       ],
     }),
     // 65+ multifield (legacy) — flag OFF

--- a/libs/application/templates/driving-license/src/forms/draft/subSectionQualityPhotoBFull.ts
+++ b/libs/application/templates/driving-license/src/forms/draft/subSectionQualityPhotoBFull.ts
@@ -3,9 +3,6 @@ import { B_FULL } from '../../lib/constants'
 
 // B-full shows the redesign photo selector only when its redesign flag is on.
 // With the flag off, the legacy `subSectionQualityPhoto` step handles B-full.
-// Note: the health-certificate upload is intentionally NOT part of this flow yet
-// — the full-license RLS endpoint has no `contentList` support, so only the
-// photo selection is redesigned for now (same as B-temp).
 export const subSectionQualityPhotoBFull = buildPhotoSelectorSubSection({
   id: 'photoStepBFull',
   applicationFor: B_FULL,

--- a/libs/application/templates/driving-license/src/forms/draft/subSectionSummary.ts
+++ b/libs/application/templates/driving-license/src/forms/draft/subSectionSummary.ts
@@ -11,6 +11,7 @@ import {
 } from '@island.is/application/core'
 import {
   DefaultEvents,
+  ExternalData,
   FormValue,
   StaticText,
 } from '@island.is/application/types'
@@ -29,6 +30,7 @@ import {
 import {
   hasNoDrivingLicenseInOtherCountry,
   isApplicationForCondition,
+  isRedesignedBTempOrBFull,
   needsHealthCertificateCondition,
 } from '../../lib/utils'
 import { formatPhoneNumber } from '@island.is/application/ui-components'
@@ -37,6 +39,37 @@ import { Pickup } from '../../lib/types'
 const isRedesigned65 = (answers: FormValue) =>
   answers.applicationFor === B_FULL_RENEWAL_65 &&
   getValueViaPath(answers, 'is65RenewalRedesignEnabled') === true
+
+/**
+ * The legacy "bring the certificate to the district office" checkbox. Only for
+ * products that have no digital upload: not BE, not redesigned 65+, and not the
+ * redesigned B-temp/B-full flows, which now upload instead. Telling an applicant
+ * who just uploaded a PDF to also bring the paper copy is the bug this guards.
+ */
+const showsBringAlongCertificate = (
+  answers: FormValue,
+  externalData: ExternalData,
+) =>
+  answers.applicationFor !== BE &&
+  !isRedesigned65(answers) &&
+  !isRedesignedBTempOrBFull(answers) &&
+  needsHealthCertificateCondition(YES)(answers, externalData)
+
+/**
+ * The uploaded-certificate row. Redesigned 65+ always uploads; BE and the
+ * redesigned B-temp/B-full flows upload only once a health condition triggers it.
+ *
+ * Both gates are extracted because each was previously duplicated inline across
+ * a divider and its content fields — and a divider that renders without its row
+ * is exactly the artefact that produces.
+ */
+const showsUploadedHealthCertificate = (
+  answers: FormValue,
+  externalData: ExternalData,
+) =>
+  isRedesigned65(answers) ||
+  ((answers.applicationFor === BE || isRedesignedBTempOrBFull(answers)) &&
+    needsHealthCertificateCondition(YES)(answers, externalData))
 
 export const subSectionSummary = buildSubSection({
   id: 'overview',
@@ -147,25 +180,17 @@ export const subSectionSummary = buildSubSection({
             )
           },
         }),
-        // Health cert section — old "bring along" checkbox flow.
-        // Renders for non-BE applicants whose health declaration triggered
-        // a cert requirement. Redesigned 65+ uploads instead, so suppress
-        // this block for that case to avoid double-rendering.
+        // Health cert section — old "bring along" checkbox flow, for the
+        // products with no digital upload. See showsBringAlongCertificate.
         buildDividerField({
-          condition: (answers, externalData) =>
-            answers.applicationFor !== BE &&
-            !isRedesigned65(answers) &&
-            needsHealthCertificateCondition(YES)(answers, externalData),
+          condition: showsBringAlongCertificate,
         }),
         buildDescriptionField({
           id: 'bringalong',
           title: m.overviewBringAlongTitle,
           titleVariant: 'h4',
           description: '',
-          condition: (answers, externalData) =>
-            answers.applicationFor !== BE &&
-            !isRedesigned65(answers) &&
-            needsHealthCertificateCondition(YES)(answers, externalData),
+          condition: showsBringAlongCertificate,
         }),
         buildCheckboxField({
           id: 'certificate',
@@ -178,27 +203,16 @@ export const subSectionSummary = buildSubSection({
               label: m.overviewBringCertificateData,
             },
           ],
-          condition: (answers, externalData) =>
-            answers.applicationFor !== BE &&
-            !isRedesigned65(answers) &&
-            needsHealthCertificateCondition(YES)(answers, externalData),
+          condition: showsBringAlongCertificate,
         }),
-        // Health cert section — uploaded-file display.
-        // BE: gated on health-declaration triggering the upload.
-        // Redesigned 65+: always shown (cert is mandatory regardless of
-        // health questions, which 65+ doesn't have).
+        // Health cert section — uploaded-file display. See
+        // showsUploadedHealthCertificate for which products reach it.
         buildDividerField({
-          condition: (answers, externalData) =>
-            isRedesigned65(answers) ||
-            (answers.applicationFor === BE &&
-              needsHealthCertificateCondition(YES)(answers, externalData)),
+          condition: showsUploadedHealthCertificate,
         }),
         buildKeyValueField({
           label: m.overviewHealthCertificateUploaded,
-          condition: (answers, externalData) =>
-            isRedesigned65(answers) ||
-            (answers.applicationFor === BE &&
-              needsHealthCertificateCondition(YES)(answers, externalData)),
+          condition: showsUploadedHealthCertificate,
           value: ({ answers }) => {
             const files = getValueViaPath<Array<{ name: string }>>(
               answers,

--- a/libs/application/templates/driving-license/src/lib/utils/formUtils.spec.ts
+++ b/libs/application/templates/driving-license/src/lib/utils/formUtils.spec.ts
@@ -8,9 +8,11 @@ import {
   hasUsableRlsQualityPhoto,
   hasHealthRemarks,
   getHealthCertificateRemarks,
+  isRedesignedBTempOrBFull,
 } from './formUtils'
 import { NO, YES } from '@island.is/application/core'
 import { Remark } from '../types'
+import { B_FULL, B_FULL_RENEWAL_65, B_TEMP, BE } from '../constants'
 
 describe('isVisible', () => {
   it('returns true when all functions return true', () => {
@@ -277,5 +279,44 @@ describe('getHealthCertificateRemarks', () => {
         { code: '400', description: 'Other' },
       ]),
     ).toEqual([])
+  })
+})
+
+describe('isRedesignedBTempOrBFull', () => {
+  it.each([
+    [{ applicationFor: B_TEMP, isBTempRedesignEnabled: true }, true],
+    [{ applicationFor: B_FULL, isBFullRedesignEnabled: true }, true],
+    // Each product reads only its own flag: the cross-flag pairs are the
+    // copy-paste error this predicate invites, and getting one wrong would put
+    // a draft on the v6 endpoint with no upload rendered (or the reverse).
+    [{ applicationFor: B_TEMP, isBFullRedesignEnabled: true }, false],
+    [{ applicationFor: B_FULL, isBTempRedesignEnabled: true }, false],
+    [{ applicationFor: B_TEMP }, false],
+    [{ applicationFor: B_FULL }, false],
+    [{ applicationFor: B_TEMP, isBTempRedesignEnabled: false }, false],
+    [{ applicationFor: B_FULL, isBFullRedesignEnabled: false }, false],
+    // The flag is persisted from a feature-flag client, so anything other than
+    // a real `true` must not opt a draft in.
+    [{ applicationFor: B_TEMP, isBTempRedesignEnabled: 'true' }, false],
+    // Other products never match, whichever flags are set.
+    [
+      {
+        applicationFor: BE,
+        isBTempRedesignEnabled: true,
+        isBFullRedesignEnabled: true,
+      },
+      false,
+    ],
+    [
+      {
+        applicationFor: B_FULL_RENEWAL_65,
+        isBTempRedesignEnabled: true,
+        isBFullRedesignEnabled: true,
+      },
+      false,
+    ],
+    [{}, false],
+  ])('%p -> %s', (answers, expected) => {
+    expect(isRedesignedBTempOrBFull(answers)).toBe(expected)
   })
 })

--- a/libs/application/templates/driving-license/src/lib/utils/formUtils.ts
+++ b/libs/application/templates/driving-license/src/lib/utils/formUtils.ts
@@ -39,6 +39,27 @@ export const isVisible =
     return fns.reduce((s, fn) => (!s ? false : fn(answers)), true)
   }
 
+/**
+ * True for a B-temp or B-full draft whose own redesign flag was on when it was
+ * created. Those drafts get the BE-style health-certificate upload and submit
+ * through the v6 `withhealthdeclaration` endpoint; everything else keeps the
+ * legacy flow.
+ *
+ * Reads the flag *persisted into answers* at prerequisites, because the draft
+ * form has no access to the live feature-flag client. That also makes the choice
+ * sticky per draft, which is what keeps in-flight applications on the flow they
+ * started with when a flag is flipped mid-lifecycle.
+ *
+ * One predicate for both products rather than one each: a single predicate means
+ * a single writer of the `healthCertificate` answer, so the "exactly one block
+ * visible at a time" invariant stays checkable at a glance.
+ */
+export const isRedesignedBTempOrBFull = (answers: FormValue) =>
+  (getValueViaPath(answers, 'applicationFor') === B_TEMP &&
+    getValueViaPath(answers, 'isBTempRedesignEnabled') === true) ||
+  (getValueViaPath(answers, 'applicationFor') === B_FULL &&
+    getValueViaPath(answers, 'isBFullRedesignEnabled') === true)
+
 export const isApplicationForCondition =
   (result: DrivingLicenseApplicationFor | DrivingLicenseApplicationFor[]) =>
   (answers: FormValue) => {

--- a/libs/clients/driving-license/src/index.ts
+++ b/libs/clients/driving-license/src/index.ts
@@ -11,3 +11,11 @@ export {
   ModelsV5PostTemporaryLicenseWithHealthDeclaration,
   ModelsHealthDeclarationModel,
 } from './v5/index'
+
+// Request models for the two v6 `withhealthdeclaration` endpoints. Exported from
+// the barrel because Nx module boundaries block deep-importing `src/v6` from
+// another lib.
+export {
+  ModelsV6PostTemporaryLicenseWithHealthDeclaration,
+  ModelsV6PostFullLicenseWithHealthDeclaration,
+} from './v6/index'

--- a/libs/clients/driving-license/src/index.ts
+++ b/libs/clients/driving-license/src/index.ts
@@ -1,4 +1,5 @@
 export * from './lib/drivingLicenseApi.service'
+export { isApplicationAlreadyExists } from './lib/utils/isApplicationAlreadyExists'
 export * from './lib/drivingLicenseApi.module'
 export * from './lib/drivingLicenseApi.types'
 

--- a/libs/clients/driving-license/src/lib/__mock-data__/requestHandlers.ts
+++ b/libs/clients/driving-license/src/lib/__mock-data__/requestHandlers.ts
@@ -75,9 +75,15 @@ export const requestHandlers = [
       }
       lastV6TemporaryRequest.body = await req.json()
 
+      // RLS returns the new application's guid on success (under a field the
+      // generated DTO drops); the wrapper reads it from the raw body.
       return res(
         ctx.status(200),
-        ctx.json({ result: true, driverLicenseId: 7 }),
+        ctx.json({
+          result: true,
+          driverLicenseId: 7,
+          guid: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+        }),
       )
     },
   ),

--- a/libs/clients/driving-license/src/lib/__mock-data__/requestHandlers.ts
+++ b/libs/clients/driving-license/src/lib/__mock-data__/requestHandlers.ts
@@ -19,6 +19,17 @@ export const lastNewCategoryRequest: {
   body?: Record<string, unknown>
 } = {}
 
+// Headers and body of the most recent POST to the v6 temporary
+// `withhealthdeclaration` endpoint. v6 identifies the caller from a `jwttoken`
+// HEADER that the OpenAPI document does not declare, so the header is injected
+// by a fetch wrapper in `apiConfiguration.ts` rather than by the generated
+// client — meaning nothing above the fetch layer can verify it. This capture is
+// what makes that wrapper testable.
+export const lastV6TemporaryRequest: {
+  headers?: Record<string, string | null>
+  body?: Record<string, unknown>
+} = {}
+
 export const VALID_AUTH = 'Bearer OKIDOKE'
 export const INVALID_AUTH = 'Bearer NOPEDEDOPE'
 
@@ -53,6 +64,20 @@ const url = (path: string) => {
 }
 
 export const requestHandlers = [
+  rest.post(
+    /api\/applications\/v6\/temporarywithhealthdeclaration/,
+    async (req, res, ctx) => {
+      lastV6TemporaryRequest.headers = {
+        jwttoken: req.headers.get('jwttoken'),
+        authorization: req.headers.get('authorization'),
+        'x-road-client': req.headers.get('X-Road-Client'),
+        secret: req.headers.get('SECRET'),
+      }
+      lastV6TemporaryRequest.body = await req.json()
+
+      return res(ctx.status(200), ctx.json({ result: true, driverLicenseId: 7 }))
+    },
+  ),
   rest.get(/api\/drivinglicense\/v5\/hasqualityphoto/, (req, res, ctx) => {
     const jwttoken = req.headers.get('jwttoken')
 

--- a/libs/clients/driving-license/src/lib/__mock-data__/requestHandlers.ts
+++ b/libs/clients/driving-license/src/lib/__mock-data__/requestHandlers.ts
@@ -75,7 +75,10 @@ export const requestHandlers = [
       }
       lastV6TemporaryRequest.body = await req.json()
 
-      return res(ctx.status(200), ctx.json({ result: true, driverLicenseId: 7 }))
+      return res(
+        ctx.status(200),
+        ctx.json({ result: true, driverLicenseId: 7 }),
+      )
     },
   ),
   rest.get(/api\/drivinglicense\/v5\/hasqualityphoto/, (req, res, ctx) => {

--- a/libs/clients/driving-license/src/lib/apiConfiguration.ts
+++ b/libs/clients/driving-license/src/lib/apiConfiguration.ts
@@ -1,4 +1,5 @@
 import { createEnhancedFetch } from '@island.is/clients/middlewares'
+import { getAuthContext } from '@island.is/auth-nest-tools'
 import { ConfigType } from '@nestjs/config'
 import { ApiV1, ConfigV1 } from '../v1'
 import { ApiV2, ConfigV2 } from '../v2'
@@ -26,19 +27,52 @@ import {
 const configFactory = (
   config: ConfigType<typeof DrivingLicenseApiConfig>,
   basePath: string,
-) => ({
-  fetchApi: createEnhancedFetch({
-    name: 'clients-driving-license',
+  // Set for v6 providers whose endpoints identify the caller from a forwarded
+  // end-user token. The v6 OpenAPI document declares no `jwttoken` parameter
+  // (v5 declares 40), but the service still reads identity from the `jwttoken`
+  // HEADER — verified on IS-DEV, where the same token in `Authorization` returns
+  // 400 "Invalid JWT Token" while `jwttoken` resolves the caller. The generated
+  // v6 client has no `initOverrides`, so the header cannot be set per call and
+  // has to be injected here.
+  //
+  // `authSource: 'context'` additionally makes `withAuth` set `Authorization`
+  // from the same token, so requests carry both headers. That combination is
+  // dev-verified. If RLS ever rejects it, note that the wrapper below reads
+  // `getAuthContext()` directly and does NOT need `authSource: 'context'`:
+  // dropping it sends only `jwttoken`. Do not "tidy" the wrapper away.
+  forwardUserToken = false,
+) => {
+  const enhancedFetch = createEnhancedFetch({
+    name: forwardUserToken
+      ? 'clients-driving-license-v6'
+      : 'clients-driving-license',
     organizationSlug: 'rikislogreglustjori',
-  }),
-  headers: {
-    'X-Road-Client': config.xroadClientId,
-    SECRET: config.secret,
-    'Content-Type': 'application/json',
-    Accept: 'application/json',
-  },
-  basePath,
-})
+    ...(forwardUserToken ? { authSource: 'context' as const } : {}),
+  })
+
+  const fetchApi: typeof enhancedFetch = forwardUserToken
+    ? (input, init) => {
+        const auth = getAuthContext()
+        if (!auth?.authorization) {
+          return enhancedFetch(input, init)
+        }
+        const headers = new Headers(init?.headers as HeadersInit | undefined)
+        headers.set('jwttoken', auth.authorization.replace(/^bearer /i, ''))
+        return enhancedFetch(input, { ...init, headers })
+      }
+    : enhancedFetch
+
+  return {
+    fetchApi,
+    headers: {
+      'X-Road-Client': config.xroadClientId,
+      SECRET: config.secret,
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    },
+    basePath,
+  }
+}
 
 export const exportedApis = [
   {
@@ -132,9 +166,16 @@ export const exportedApis = [
   {
     provide: ApplicationApiV6,
     useFactory: (config: ConfigType<typeof DrivingLicenseApiConfig>) => {
+      // Only provider that forwards the end-user token today: it serves the two
+      // `withhealthdeclaration` endpoints, which resolve the caller from
+      // `jwttoken`. The other v6 providers are unused so far and stay tokenless.
       return new ApplicationApiV6(
         new ConfigV6(
-          configFactory(config, `${config.xroadBaseUrl}/${config.xroadPathV6}`),
+          configFactory(
+            config,
+            `${config.xroadBaseUrl}/${config.xroadPathV6}`,
+            true,
+          ),
         ),
       )
     },

--- a/libs/clients/driving-license/src/lib/drivingLicenseApi.service.spec.ts
+++ b/libs/clients/driving-license/src/lib/drivingLicenseApi.service.spec.ts
@@ -7,6 +7,8 @@ import { LoggingModule } from '@island.is/logging'
 import { DrivingLicenseApiModule } from './drivingLicenseApi.module'
 import { exportedApis } from './apiConfiguration'
 import { CodeTableV5 } from '../v5'
+import { ApplicationApiV6 } from '../v6'
+import type { Auth } from '@island.is/auth-nest-tools'
 
 import {
   lastNewCategoryRequest,
@@ -18,6 +20,7 @@ startMocking(requestHandlers)
 describe('DrivingLicenseDuplicateService', () => {
   let service: DrivingLicenseApi
   let codeTable: CodeTableV5
+  let applicationV6: ApplicationApiV6
 
   beforeEach(async () => {
     const module = await Test.createTestingModule({
@@ -34,6 +37,7 @@ describe('DrivingLicenseDuplicateService', () => {
 
     service = module.get(DrivingLicenseApi)
     codeTable = module.get(CodeTableV5)
+    applicationV6 = module.get(ApplicationApiV6)
   })
 
   describe('Service', () => {
@@ -153,6 +157,71 @@ describe('DrivingLicenseDuplicateService', () => {
         signatureBiometricsId: null,
       })
       expect(result).toBe(true)
+    })
+  })
+
+  describe('postTemporaryLicenseWithHealthDeclarationV6 resubmission guard', () => {
+    // RLS answers 400 when the licence already exists, which is what a retried
+    // submit looks like after a lost response. The guard re-asks `canapplyfor`
+    // and treats HAS_B_CATEGORY as "created on the previous attempt", so an
+    // already-paid applicant is not left on an error screen. These tests are the
+    // reason not to delete it as dead code.
+    const auth = { authorization: 'Bearer some-token' } as Auth
+    const model = {
+      districtId: 37,
+      instructorSSN: '0101302479',
+      sendPlasticToPerson: false,
+      healthDeclaration: {},
+    }
+
+    afterEach(() => {
+      jest.restoreAllMocks()
+    })
+
+    const rejectPostWith = (error: unknown) =>
+      jest
+        .spyOn(
+          applicationV6,
+          'apiApplicationsV6TemporarywithhealthdeclarationPost',
+        )
+        .mockRejectedValue(error)
+
+    it('treats a 400 with HAS_B_CATEGORY as success', async () => {
+      rejectPostWith({ status: 400 })
+      const canApply = jest
+        .spyOn(service, 'getCanApplyForCategoryTemporary')
+        .mockResolvedValue({ result: false, errorCode: 'HAS_B_CATEGORY' })
+
+      await expect(
+        service.postTemporaryLicenseWithHealthDeclarationV6({ auth, model }),
+      ).resolves.toEqual({ result: true })
+
+      // The bare token, not the `Bearer ` prefix — v5 `canapplyfor` reads it as
+      // the `jwttoken` header and rejects the prefixed form.
+      expect(canApply).toHaveBeenCalledWith({ token: 'some-token' })
+    })
+
+    it('rethrows a 400 with any other code, so the description pipeline still runs', async () => {
+      const original = { status: 400, name: 'FetchError' }
+      rejectPostWith(original)
+      jest
+        .spyOn(service, 'getCanApplyForCategoryTemporary')
+        .mockResolvedValue({ result: false, errorCode: 'HAS_DEPRIVATION' })
+
+      await expect(
+        service.postTemporaryLicenseWithHealthDeclarationV6({ auth, model }),
+      ).rejects.toBe(original)
+    })
+
+    it('does not re-check canApply for a non-400 failure', async () => {
+      const original = { status: 500, name: 'FetchError' }
+      rejectPostWith(original)
+      const canApply = jest.spyOn(service, 'getCanApplyForCategoryTemporary')
+
+      await expect(
+        service.postTemporaryLicenseWithHealthDeclarationV6({ auth, model }),
+      ).rejects.toBe(original)
+      expect(canApply).not.toHaveBeenCalled()
     })
   })
 

--- a/libs/clients/driving-license/src/lib/drivingLicenseApi.service.spec.ts
+++ b/libs/clients/driving-license/src/lib/drivingLicenseApi.service.spec.ts
@@ -285,6 +285,72 @@ describe('DrivingLicenseDuplicateService', () => {
     })
   })
 
+  describe('postFullLicenseWithHealthDeclarationV6', () => {
+    // Regression test for a false failure observed on IS-DEV: the 201 body was
+    // routed through `handleCreateResponse` (written for v5 NewCategory), which
+    // reported "unknown type of response" for an application RLS had actually
+    // created. The applicant had already paid, was told it failed, and their retry
+    // died with "An application already exists for this category".
+    const auth = { authorization: 'Bearer v6-user-token' } as Auth
+    const model = {
+      districtId: 37,
+      sendPlasticToPerson: false,
+      healthDeclaration: {},
+    }
+
+    afterEach(() => {
+      jest.restoreAllMocks()
+    })
+
+    it.each([
+      ['an id as text, as the spec documents', '3248752'],
+      ['an empty body', ''],
+      // The shapes that used to be misread as failure.
+      ['a wrapped zero', '{"value":0}'],
+      ['a bare boolean', 'true'],
+      ['null', 'null'],
+      ['an unexpected object', '{"created":true}'],
+    ])('treats %s as success', async (_label, body) => {
+      jest
+        .spyOn(
+          applicationV6,
+          'apiApplicationsV6CategoryWithhealthdeclarationPost',
+        )
+        .mockResolvedValue(body as unknown as number)
+
+      await expect(
+        service.postFullLicenseWithHealthDeclarationV6({
+          auth,
+          category: 'B',
+          model,
+        }),
+      ).resolves.toBe(true)
+    })
+
+    it('propagates a rejection rather than reporting success', async () => {
+      // 400 ProblemDetails is the documented failure mode and enhanced fetch
+      // throws it, so it must reach submitApplication's error path intact.
+      const problem = Object.assign(new Error('already exists'), {
+        name: 'FetchError',
+        status: 400,
+      })
+      jest
+        .spyOn(
+          applicationV6,
+          'apiApplicationsV6CategoryWithhealthdeclarationPost',
+        )
+        .mockRejectedValue(problem)
+
+      await expect(
+        service.postFullLicenseWithHealthDeclarationV6({
+          auth,
+          category: 'B',
+          model,
+        }),
+      ).rejects.toBe(problem)
+    })
+  })
+
   describe('getErrorCodeDescriptions caching', () => {
     const sampleCatalogue = [
       {

--- a/libs/clients/driving-license/src/lib/drivingLicenseApi.service.spec.ts
+++ b/libs/clients/driving-license/src/lib/drivingLicenseApi.service.spec.ts
@@ -214,6 +214,22 @@ describe('DrivingLicenseDuplicateService', () => {
       ).rejects.toBe(original)
     })
 
+    it('treats a 400 APPLICATION_ALREADY_EXISTS as success without re-checking canApply', async () => {
+      // The v6-native lost-response signal: a created application on retry. This
+      // is the case the old canapplyfor/HAS_B_CATEGORY check missed, because a
+      // created application is not yet a licence.
+      rejectRawWith({
+        status: 400,
+        body: { errorCode: 'APPLICATION_ALREADY_EXISTS' },
+      })
+      const canApply = jest.spyOn(service, 'getCanApplyForCategoryTemporary')
+
+      await expect(
+        service.postTemporaryLicenseWithHealthDeclarationV6({ auth, model }),
+      ).resolves.toBeNull()
+      expect(canApply).not.toHaveBeenCalled()
+    })
+
     it('does not re-check canApply for a non-400 failure', async () => {
       const original = { status: 500, name: 'FetchError' }
       rejectRawWith(original)
@@ -339,6 +355,32 @@ describe('DrivingLicenseDuplicateService', () => {
           model,
         }),
       ).resolves.toBe(expected)
+    })
+
+    it('treats a 400 APPLICATION_ALREADY_EXISTS (problem+json) as success', async () => {
+      // The full endpoint had no lost-response guard at all before this.
+      const problem = Object.assign(new Error('already exists'), {
+        name: 'FetchError',
+        status: 400,
+        problem: {
+          title: 'Bad Request',
+          detail: 'An application already exists for this category',
+        },
+      })
+      jest
+        .spyOn(
+          applicationV6,
+          'apiApplicationsV6CategoryWithhealthdeclarationPost',
+        )
+        .mockRejectedValue(problem)
+
+      await expect(
+        service.postFullLicenseWithHealthDeclarationV6({
+          auth,
+          category: 'B',
+          model,
+        }),
+      ).resolves.toBeNull()
     })
 
     it('propagates a rejection rather than reporting success', async () => {

--- a/libs/clients/driving-license/src/lib/drivingLicenseApi.service.spec.ts
+++ b/libs/clients/driving-license/src/lib/drivingLicenseApi.service.spec.ts
@@ -179,23 +179,23 @@ describe('DrivingLicenseDuplicateService', () => {
       jest.restoreAllMocks()
     })
 
-    const rejectPostWith = (error: unknown) =>
+    const rejectRawWith = (error: unknown) =>
       jest
         .spyOn(
           applicationV6,
-          'apiApplicationsV6TemporarywithhealthdeclarationPost',
+          'apiApplicationsV6TemporarywithhealthdeclarationPostRaw',
         )
         .mockRejectedValue(error)
 
-    it('treats a 400 with HAS_B_CATEGORY as success', async () => {
-      rejectPostWith({ status: 400 })
+    it('treats a 400 with HAS_B_CATEGORY as success (guid unknown on this path)', async () => {
+      rejectRawWith({ status: 400 })
       const canApply = jest
         .spyOn(service, 'getCanApplyForCategoryTemporary')
         .mockResolvedValue({ result: false, errorCode: 'HAS_B_CATEGORY' })
 
       await expect(
         service.postTemporaryLicenseWithHealthDeclarationV6({ auth, model }),
-      ).resolves.toEqual({ result: true })
+      ).resolves.toBeNull()
 
       // The bare token, not the `Bearer ` prefix — v5 `canapplyfor` reads it as
       // the `jwttoken` header and rejects the prefixed form.
@@ -204,7 +204,7 @@ describe('DrivingLicenseDuplicateService', () => {
 
     it('rethrows a 400 with any other code, so the description pipeline still runs', async () => {
       const original = { status: 400, name: 'FetchError' }
-      rejectPostWith(original)
+      rejectRawWith(original)
       jest
         .spyOn(service, 'getCanApplyForCategoryTemporary')
         .mockResolvedValue({ result: false, errorCode: 'HAS_DEPRIVATION' })
@@ -216,7 +216,7 @@ describe('DrivingLicenseDuplicateService', () => {
 
     it('does not re-check canApply for a non-400 failure', async () => {
       const original = { status: 500, name: 'FetchError' }
-      rejectPostWith(original)
+      rejectRawWith(original)
       const canApply = jest.spyOn(service, 'getCanApplyForCategoryTemporary')
 
       await expect(
@@ -250,7 +250,8 @@ describe('DrivingLicenseDuplicateService', () => {
           },
         })
 
-      expect(response).toEqual({ result: true, driverLicenseId: 7 })
+      // The wrapper reads RLS's guid from the raw body (the DTO would drop it).
+      expect(response).toBe('a1b2c3d4-e5f6-7890-abcd-ef1234567890')
 
       const headers = lastV6TemporaryRequest.headers
       // Bare token: RLS answers 400 "Invalid JWT Token" to the prefixed form.
@@ -302,15 +303,26 @@ describe('DrivingLicenseDuplicateService', () => {
       jest.restoreAllMocks()
     })
 
+    // The endpoint returns the new application's guid as the text body. Reaching
+    // the return at all is success (4xx throws); the value is the extracted guid,
+    // or null when the body carries none. None of these previously-misread shapes
+    // must throw.
     it.each([
-      ['an id as text, as the spec documents', '3248752'],
-      ['an empty body', ''],
-      // The shapes that used to be misread as failure.
-      ['a wrapped zero', '{"value":0}'],
-      ['a bare boolean', 'true'],
-      ['null', 'null'],
-      ['an unexpected object', '{"created":true}'],
-    ])('treats %s as success', async (_label, body) => {
+      [
+        'a bare guid',
+        '3630b0bc-ec51-442e-976d-13a3c21c5e5b',
+        '3630b0bc-ec51-442e-976d-13a3c21c5e5b',
+      ],
+      [
+        'a quoted guid',
+        '"3630b0bc-ec51-442e-976d-13a3c21c5e5b"',
+        '3630b0bc-ec51-442e-976d-13a3c21c5e5b',
+      ],
+      ['an id as text (no guid)', '3248752', null],
+      ['an empty body', '', null],
+      ['a wrapped zero', '{"value":0}', null],
+      ['null', 'null', null],
+    ])('resolves %s to %s', async (_label, body, expected) => {
       jest
         .spyOn(
           applicationV6,
@@ -324,7 +336,7 @@ describe('DrivingLicenseDuplicateService', () => {
           category: 'B',
           model,
         }),
-      ).resolves.toBe(true)
+      ).resolves.toBe(expected)
     })
 
     it('propagates a rejection rather than reporting success', async () => {

--- a/libs/clients/driving-license/src/lib/drivingLicenseApi.service.spec.ts
+++ b/libs/clients/driving-license/src/lib/drivingLicenseApi.service.spec.ts
@@ -12,6 +12,7 @@ import type { Auth } from '@island.is/auth-nest-tools'
 
 import {
   lastNewCategoryRequest,
+  lastV6TemporaryRequest,
   MOCK_TOKEN,
   requestHandlers,
 } from './__mock-data__/requestHandlers'
@@ -222,6 +223,65 @@ describe('DrivingLicenseDuplicateService', () => {
         service.postTemporaryLicenseWithHealthDeclarationV6({ auth, model }),
       ).rejects.toBe(original)
       expect(canApply).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('v6 token forwarding (jwttoken header)', () => {
+    // This is the one test that actually executes the fetch wrapper in
+    // `apiConfiguration.ts`. Every other v6 test spies above the fetch layer, so
+    // without this the PR's central claim — that we send the header RLS reads —
+    // is unverified in CI and only confirmed by hand against IS-DEV.
+    const auth = { authorization: 'Bearer v6-user-token' } as Auth
+
+    beforeEach(() => {
+      lastV6TemporaryRequest.headers = undefined
+      lastV6TemporaryRequest.body = undefined
+    })
+
+    it('sends the bare token in jwttoken, keeping the X-Road headers intact', async () => {
+      const response =
+        await service.postTemporaryLicenseWithHealthDeclarationV6({
+          auth,
+          model: {
+            districtId: 37,
+            instructorSSN: '0101302479',
+            sendPlasticToPerson: false,
+            healthDeclaration: {},
+          },
+        })
+
+      expect(response).toEqual({ result: true, driverLicenseId: 7 })
+
+      const headers = lastV6TemporaryRequest.headers
+      // Bare token: RLS answers 400 "Invalid JWT Token" to the prefixed form.
+      expect(headers?.jwttoken).toBe('v6-user-token')
+      // The wrapper rebuilds the Headers object, so pin that it carries the
+      // config headers through — dropping SECRET or X-Road-Client would fail
+      // only in production, where nothing else would point at the wrapper.
+      expect(headers?.secret).toBeTruthy()
+      expect(headers?.['x-road-client']).toBeTruthy()
+      // Both headers go out: `authSource: 'context'` also sets Authorization.
+      // Documented here because the fallback, if RLS ever rejects the pair, is
+      // to drop `authSource` and send jwttoken alone.
+      expect(headers?.authorization).toBe('Bearer v6-user-token')
+    })
+
+    it('sends no jwttoken when there is no auth context to forward', async () => {
+      // A missing context must not become the literal string 'undefined' in the
+      // header, which is what a naive `String(auth?.authorization)` would do.
+      await expect(
+        service.postTemporaryLicenseWithHealthDeclarationV6({
+          auth: {} as Auth,
+          model: {
+            districtId: 37,
+            instructorSSN: '0101302479',
+            sendPlasticToPerson: false,
+            healthDeclaration: {},
+          },
+        }),
+      ).resolves.toBeDefined()
+
+      expect(lastV6TemporaryRequest.headers?.jwttoken).toBeNull()
     })
   })
 

--- a/libs/clients/driving-license/src/lib/drivingLicenseApi.service.spec.ts
+++ b/libs/clients/driving-license/src/lib/drivingLicenseApi.service.spec.ts
@@ -257,10 +257,12 @@ describe('DrivingLicenseDuplicateService', () => {
       // Bare token: RLS answers 400 "Invalid JWT Token" to the prefixed form.
       expect(headers?.jwttoken).toBe('v6-user-token')
       // The wrapper rebuilds the Headers object, so pin that it carries the
-      // config headers through — dropping SECRET or X-Road-Client would fail
-      // only in production, where nothing else would point at the wrapper.
-      expect(headers?.secret).toBeTruthy()
-      expect(headers?.['x-road-client']).toBeTruthy()
+      // config headers THROUGH rather than dropping them. Assert presence, not a
+      // value: the values come from config (empty in CI, set locally), whereas
+      // "not dropped by the rebuild" is what the wrapper is responsible for — a
+      // dropped header would read back as null here.
+      expect(headers?.secret).not.toBeNull()
+      expect(headers?.['x-road-client']).not.toBeNull()
       // Both headers go out: `authSource: 'context'` also sets Authorization.
       // Documented here because the fallback, if RLS ever rejects the pair, is
       // to drop `authSource` and send jwttoken alone.

--- a/libs/clients/driving-license/src/lib/drivingLicenseApi.service.spec.ts
+++ b/libs/clients/driving-license/src/lib/drivingLicenseApi.service.spec.ts
@@ -161,12 +161,12 @@ describe('DrivingLicenseDuplicateService', () => {
     })
   })
 
-  describe('postTemporaryLicenseWithHealthDeclarationV6 resubmission guard', () => {
-    // RLS answers 400 when the licence already exists, which is what a retried
-    // submit looks like after a lost response. The guard re-asks `canapplyfor`
-    // and treats HAS_B_CATEGORY as "created on the previous attempt", so an
-    // already-paid applicant is not left on an error screen. These tests are the
-    // reason not to delete it as dead code.
+  describe('postTemporaryLicenseWithHealthDeclarationV6 error propagation', () => {
+    // The v6 methods no longer swallow anything: on a 400 they propagate the
+    // FetchError. The duplicate-on-retry policy (APPLICATION_ALREADY_EXISTS) now
+    // lives in the submission service, which has the application and can tell a
+    // lost-response retry from a fresh application. Here we only pin that errors
+    // reach the caller intact (so toSubmissionError / the guard upstream can act).
     const auth = { authorization: 'Bearer some-token' } as Auth
     const model = {
       districtId: 37,
@@ -187,58 +187,29 @@ describe('DrivingLicenseDuplicateService', () => {
         )
         .mockRejectedValue(error)
 
-    it('treats a 400 with HAS_B_CATEGORY as success (guid unknown on this path)', async () => {
-      rejectRawWith({ status: 400 })
-      const canApply = jest
-        .spyOn(service, 'getCanApplyForCategoryTemporary')
-        .mockResolvedValue({ result: false, errorCode: 'HAS_B_CATEGORY' })
-
-      await expect(
-        service.postTemporaryLicenseWithHealthDeclarationV6({ auth, model }),
-      ).resolves.toBeNull()
-
-      // The bare token, not the `Bearer ` prefix — v5 `canapplyfor` reads it as
-      // the `jwttoken` header and rejects the prefixed form.
-      expect(canApply).toHaveBeenCalledWith({ token: 'some-token' })
-    })
-
-    it('rethrows a 400 with any other code, so the description pipeline still runs', async () => {
-      const original = { status: 400, name: 'FetchError' }
-      rejectRawWith(original)
-      jest
-        .spyOn(service, 'getCanApplyForCategoryTemporary')
-        .mockResolvedValue({ result: false, errorCode: 'HAS_DEPRIVATION' })
-
-      await expect(
-        service.postTemporaryLicenseWithHealthDeclarationV6({ auth, model }),
-      ).rejects.toBe(original)
-    })
-
-    it('treats a 400 APPLICATION_ALREADY_EXISTS as success without re-checking canApply', async () => {
-      // The v6-native lost-response signal: a created application on retry. This
-      // is the case the old canapplyfor/HAS_B_CATEGORY check missed, because a
-      // created application is not yet a licence.
-      rejectRawWith({
+    it('propagates a 400 APPLICATION_ALREADY_EXISTS instead of swallowing it', async () => {
+      const original = {
         status: 400,
+        name: 'FetchError',
         body: { errorCode: 'APPLICATION_ALREADY_EXISTS' },
-      })
+      }
+      rejectRawWith(original)
       const canApply = jest.spyOn(service, 'getCanApplyForCategoryTemporary')
 
       await expect(
         service.postTemporaryLicenseWithHealthDeclarationV6({ auth, model }),
-      ).resolves.toBeNull()
+      ).rejects.toBe(original)
+      // No canapplyfor round-trip: that v5-era check is gone from the v6 path.
       expect(canApply).not.toHaveBeenCalled()
     })
 
-    it('does not re-check canApply for a non-400 failure', async () => {
+    it('propagates any other error too', async () => {
       const original = { status: 500, name: 'FetchError' }
       rejectRawWith(original)
-      const canApply = jest.spyOn(service, 'getCanApplyForCategoryTemporary')
 
       await expect(
         service.postTemporaryLicenseWithHealthDeclarationV6({ auth, model }),
       ).rejects.toBe(original)
-      expect(canApply).not.toHaveBeenCalled()
     })
   })
 
@@ -357,13 +328,12 @@ describe('DrivingLicenseDuplicateService', () => {
       ).resolves.toBe(expected)
     })
 
-    it('treats a 400 APPLICATION_ALREADY_EXISTS (problem+json) as success', async () => {
-      // The full endpoint had no lost-response guard at all before this.
+    it('propagates a 400 APPLICATION_ALREADY_EXISTS (duplicate handling is the submission service)', async () => {
       const problem = Object.assign(new Error('already exists'), {
         name: 'FetchError',
         status: 400,
         problem: {
-          title: 'Bad Request',
+          title: 'APPLICATION_ALREADY_EXISTS',
           detail: 'An application already exists for this category',
         },
       })
@@ -380,7 +350,7 @@ describe('DrivingLicenseDuplicateService', () => {
           category: 'B',
           model,
         }),
-      ).resolves.toBeNull()
+      ).rejects.toBe(problem)
     })
 
     it('propagates a rejection rather than reporting success', async () => {

--- a/libs/clients/driving-license/src/lib/drivingLicenseApi.service.ts
+++ b/libs/clients/driving-license/src/lib/drivingLicenseApi.service.ts
@@ -22,7 +22,6 @@ import {
 } from './drivingLicenseApi.types'
 import { handleCreateResponse } from './utils/handleCreateResponse'
 import { extractApplicationGuid } from './utils/extractApplicationGuid'
-import { isApplicationAlreadyExists } from './utils/isApplicationAlreadyExists'
 
 import {
   DtoV5PracticePermitDto,
@@ -57,57 +56,26 @@ export class DrivingLicenseApi {
     auth: Auth
     model: v6.ModelsV6PostTemporaryLicenseWithHealthDeclaration
   }): Promise<string | null> {
+    // The Raw variant so we can read RLS's guid from the response body before the
+    // generated DTO parser drops it. Enhanced fetch throws on 4xx, so reaching the
+    // read is success; every error propagates. The duplicate-on-retry policy
+    // (400 APPLICATION_ALREADY_EXISTS) lives in the submission service, which has
+    // the application and so can tell a lost-response retry (safe to treat as
+    // success) from a fresh application (must surface the error).
+    const response = await withAuthContext(input.auth, () =>
+      this.applicationV6.apiApplicationsV6TemporarywithhealthdeclarationPostRaw({
+        apiVersion: v6.DRIVING_LICENSE_API_VERSION_V6,
+        apiVersion2: v6.DRIVING_LICENSE_API_VERSION_V6,
+        modelsV6PostTemporaryLicenseWithHealthDeclaration: input.model,
+      }),
+    )
+
+    // Best-effort: guid capture must never turn a successful create into a
+    // failure, so any problem reading the body just yields a null guid.
     try {
-      // The Raw variant so we can read RLS's guid from the response body before
-      // the generated DTO parser drops it. 4xx still throws here (enhanced fetch),
-      // so reaching the read is success.
-      const response = await withAuthContext(input.auth, () =>
-        this.applicationV6.apiApplicationsV6TemporarywithhealthdeclarationPostRaw(
-          {
-            apiVersion: v6.DRIVING_LICENSE_API_VERSION_V6,
-            apiVersion2: v6.DRIVING_LICENSE_API_VERSION_V6,
-            modelsV6PostTemporaryLicenseWithHealthDeclaration: input.model,
-          },
-        ),
-      )
-
-      // Best-effort: guid capture must never turn a successful create into a
-      // failure, so any problem reading the body just yields a null guid.
-      try {
-        return extractApplicationGuid(await response.raw.clone().json())
-      } catch {
-        return null
-      }
-    } catch (e) {
-      // If the licence application was created but the response was lost, the
-      // state machine retries and RLS answers 400 APPLICATION_ALREADY_EXISTS.
-      // Under v6 a created application is not yet a licence, so the v5-era
-      // `canapplyfor` → HAS_B_CATEGORY check below never fires for it — the
-      // direct duplicate signal is the reliable one. Treat it as success (the
-      // application exists); the guid is not recoverable here, hence null. This
-      // is the asymmetric-cost call: leaving an already-paid applicant on an
-      // error screen is worse than a rare false success for someone who already
-      // had an application in flight (they do).
-      if (isApplicationAlreadyExists(e)) {
-        return null
-      }
-
-      // Legacy fallback: the previous attempt may have completed all the way to a
-      // full B category (`canapplyfor` then reports HAS_B_CATEGORY). Harmless to
-      // keep; retire with the v5 path.
-      if ((e as { status?: number })?.status === 400) {
-        const hasTemp = await this.getCanApplyForCategoryTemporary({
-          token: input.auth.authorization.replace(/^bearer /i, ''),
-        })
-
-        if (hasTemp.errorCode === 'HAS_B_CATEGORY') {
-          return null
-        }
-      }
-
-      // Rethrow every other error so the original `FetchError` still reaches
-      // `toSubmissionError` and the applicant gets the RLS error description.
-      throw e
+      return extractApplicationGuid(await response.raw.clone().json())
+    } catch {
+      return null
     }
   }
 
@@ -137,27 +105,21 @@ export class DrivingLicenseApi {
     // documents an int32 here but actually sends the new application's guid as
     // the text body; surface it (never gate on it) for logging and so a tester
     // can deny the created application.
-    try {
-      const created = await withAuthContext(input.auth, () =>
-        this.applicationV6.apiApplicationsV6CategoryWithhealthdeclarationPost({
-          apiVersion: v6.DRIVING_LICENSE_API_VERSION_V6,
-          apiVersion2: v6.DRIVING_LICENSE_API_VERSION_V6,
-          category: input.category,
-          modelsV6PostFullLicenseWithHealthDeclaration: input.model,
-        }),
-      )
+    // Enhanced fetch throws on 4xx, so reaching the return is success; every
+    // error propagates. RLS documents an int32 here but actually sends the new
+    // application's guid as the text body; surface it (never gate on it). The
+    // duplicate-on-retry policy lives in the submission service (see the temporary
+    // method above for why).
+    const created = await withAuthContext(input.auth, () =>
+      this.applicationV6.apiApplicationsV6CategoryWithhealthdeclarationPost({
+        apiVersion: v6.DRIVING_LICENSE_API_VERSION_V6,
+        apiVersion2: v6.DRIVING_LICENSE_API_VERSION_V6,
+        category: input.category,
+        modelsV6PostFullLicenseWithHealthDeclaration: input.model,
+      }),
+    )
 
-      return extractApplicationGuid(created)
-    } catch (e) {
-      // Same lost-response duplicate guard as the temporary endpoint: a retry
-      // after a lost response gets 400 APPLICATION_ALREADY_EXISTS, and an
-      // already-paid applicant should not be stranded on an error screen. The
-      // guid is not recoverable here, hence null.
-      if (isApplicationAlreadyExists(e)) {
-        return null
-      }
-      throw e
-    }
+    return extractApplicationGuid(created)
   }
 
   public async postTemporaryLicenseWithHealthDeclaratio(input: {

--- a/libs/clients/driving-license/src/lib/drivingLicenseApi.service.ts
+++ b/libs/clients/driving-license/src/lib/drivingLicenseApi.service.ts
@@ -21,28 +21,9 @@ import {
   Remark,
 } from './drivingLicenseApi.types'
 import { handleCreateResponse } from './utils/handleCreateResponse'
+import { extractApplicationGuid } from './utils/extractApplicationGuid'
+import { isApplicationAlreadyExists } from './utils/isApplicationAlreadyExists'
 
-// RLS returns the new application's guid on a successful create, but not in a
-// stable, documented place: the full endpoint sends it as the (text) body, and
-// the temporary endpoint carries it under a field the generated DTO drops. Pull
-// it out defensively — purely for logging/reconciliation, so it must never throw.
-const extractApplicationGuid = (body: unknown): string | null => {
-  const UUID = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i
-  if (typeof body === 'string') {
-    return body.match(UUID)?.[0] ?? null
-  }
-  if (body && typeof body === 'object') {
-    const rec = body as Record<string, unknown>
-    for (const key of ['guid', 'applicationGuid', 'applicationId']) {
-      const value = rec[key]
-      if (typeof value === 'string' && UUID.test(value)) {
-        return value
-      }
-    }
-    return JSON.stringify(body).match(UUID)?.[0] ?? null
-  }
-  return null
-}
 import {
   DtoV5PracticePermitDto,
   DtoV5DriverLicenseWithoutImagesDto,
@@ -98,34 +79,34 @@ export class DrivingLicenseApi {
         return null
       }
     } catch (e) {
-      // Same guard as the v5 `postCreateDrivingLicenseTemporary` path, and for
-      // the same reason: if the licence was created but the response was lost,
-      // the state machine retries and RLS answers 400 on the resubmission. The
-      // generated client does not map that error, so we re-ask `canapplyfor`:
-      // `HAS_B_CATEGORY` means the applicant now holds the licence, i.e. the
-      // previous attempt succeeded.
-      //
-      // A genuine denial would already have been caught by this same check at
-      // prerequisites, so by submit time the code almost always means "created
-      // on the previous attempt" — and the cost is asymmetric: without the
-      // guard an already-paid applicant is left on an error screen. Do not
-      // remove this on the grounds that the single v6 call replaced the old
-      // two-call shape; that is not what causes the 400.
+      // If the licence application was created but the response was lost, the
+      // state machine retries and RLS answers 400 APPLICATION_ALREADY_EXISTS.
+      // Under v6 a created application is not yet a licence, so the v5-era
+      // `canapplyfor` → HAS_B_CATEGORY check below never fires for it — the
+      // direct duplicate signal is the reliable one. Treat it as success (the
+      // application exists); the guid is not recoverable here, hence null. This
+      // is the asymmetric-cost call: leaving an already-paid applicant on an
+      // error screen is worse than a rare false success for someone who already
+      // had an application in flight (they do).
+      if (isApplicationAlreadyExists(e)) {
+        return null
+      }
+
+      // Legacy fallback: the previous attempt may have completed all the way to a
+      // full B category (`canapplyfor` then reports HAS_B_CATEGORY). Harmless to
+      // keep; retire with the v5 path.
       if ((e as { status?: number })?.status === 400) {
         const hasTemp = await this.getCanApplyForCategoryTemporary({
           token: input.auth.authorization.replace(/^bearer /i, ''),
         })
 
         if (hasTemp.errorCode === 'HAS_B_CATEGORY') {
-          // Created on a previous attempt; treat as success. The guid is not
-          // recoverable on this path, hence null.
           return null
         }
       }
 
-      // Unlike the v5 twin, which swallows every other 400 into `false`, rethrow
-      // so the original `FetchError` still reaches `toSubmissionError` and the
-      // applicant gets the RLS error description rather than a generic failure.
+      // Rethrow every other error so the original `FetchError` still reaches
+      // `toSubmissionError` and the applicant gets the RLS error description.
       throw e
     }
   }
@@ -156,16 +137,27 @@ export class DrivingLicenseApi {
     // documents an int32 here but actually sends the new application's guid as
     // the text body; surface it (never gate on it) for logging and so a tester
     // can deny the created application.
-    const created = await withAuthContext(input.auth, () =>
-      this.applicationV6.apiApplicationsV6CategoryWithhealthdeclarationPost({
-        apiVersion: v6.DRIVING_LICENSE_API_VERSION_V6,
-        apiVersion2: v6.DRIVING_LICENSE_API_VERSION_V6,
-        category: input.category,
-        modelsV6PostFullLicenseWithHealthDeclaration: input.model,
-      }),
-    )
+    try {
+      const created = await withAuthContext(input.auth, () =>
+        this.applicationV6.apiApplicationsV6CategoryWithhealthdeclarationPost({
+          apiVersion: v6.DRIVING_LICENSE_API_VERSION_V6,
+          apiVersion2: v6.DRIVING_LICENSE_API_VERSION_V6,
+          category: input.category,
+          modelsV6PostFullLicenseWithHealthDeclaration: input.model,
+        }),
+      )
 
-    return extractApplicationGuid(created)
+      return extractApplicationGuid(created)
+    } catch (e) {
+      // Same lost-response duplicate guard as the temporary endpoint: a retry
+      // after a lost response gets 400 APPLICATION_ALREADY_EXISTS, and an
+      // already-paid applicant should not be stranded on an error screen. The
+      // guid is not recoverable here, hence null.
+      if (isApplicationAlreadyExists(e)) {
+        return null
+      }
+      throw e
+    }
   }
 
   public async postTemporaryLicenseWithHealthDeclaratio(input: {

--- a/libs/clients/driving-license/src/lib/drivingLicenseApi.service.ts
+++ b/libs/clients/driving-license/src/lib/drivingLicenseApi.service.ts
@@ -21,6 +21,29 @@ import {
   Remark,
 } from './drivingLicenseApi.types'
 import { handleCreateResponse } from './utils/handleCreateResponse'
+
+// RLS returns the new application's guid on a successful create, but not in a
+// stable, documented place: the full endpoint sends it as the (text) body, and
+// the temporary endpoint carries it under a field the generated DTO drops. Pull
+// it out defensively — purely for logging/reconciliation, so it must never throw.
+const extractApplicationGuid = (body: unknown): string | null => {
+  const UUID =
+    /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i
+  if (typeof body === 'string') {
+    return body.match(UUID)?.[0] ?? null
+  }
+  if (body && typeof body === 'object') {
+    const rec = body as Record<string, unknown>
+    for (const key of ['guid', 'applicationGuid', 'applicationId']) {
+      const value = rec[key]
+      if (typeof value === 'string' && UUID.test(value)) {
+        return value
+      }
+    }
+    return JSON.stringify(body).match(UUID)?.[0] ?? null
+  }
+  return null
+}
 import {
   DtoV5PracticePermitDto,
   DtoV5DriverLicenseWithoutImagesDto,
@@ -53,15 +76,26 @@ export class DrivingLicenseApi {
   public async postTemporaryLicenseWithHealthDeclarationV6(input: {
     auth: Auth
     model: v6.ModelsV6PostTemporaryLicenseWithHealthDeclaration
-  }): Promise<v6.DtoV6NewTemporaryLicsenseDto> {
+  }): Promise<string | null> {
     try {
-      return await withAuthContext(input.auth, () =>
-        this.applicationV6.apiApplicationsV6TemporarywithhealthdeclarationPost({
+      // The Raw variant so we can read RLS's guid from the response body before
+      // the generated DTO parser drops it. 4xx still throws here (enhanced fetch),
+      // so reaching the read is success.
+      const response = await withAuthContext(input.auth, () =>
+        this.applicationV6.apiApplicationsV6TemporarywithhealthdeclarationPostRaw({
           apiVersion: v6.DRIVING_LICENSE_API_VERSION_V6,
           apiVersion2: v6.DRIVING_LICENSE_API_VERSION_V6,
           modelsV6PostTemporaryLicenseWithHealthDeclaration: input.model,
         }),
       )
+
+      // Best-effort: guid capture must never turn a successful create into a
+      // failure, so any problem reading the body just yields a null guid.
+      try {
+        return extractApplicationGuid(await response.raw.clone().json())
+      } catch {
+        return null
+      }
     } catch (e) {
       // Same guard as the v5 `postCreateDrivingLicenseTemporary` path, and for
       // the same reason: if the licence was created but the response was lost,
@@ -82,7 +116,9 @@ export class DrivingLicenseApi {
         })
 
         if (hasTemp.errorCode === 'HAS_B_CATEGORY') {
-          return { result: true }
+          // Created on a previous attempt; treat as success. The guid is not
+          // recoverable on this path, hence null.
+          return null
         }
       }
 
@@ -114,8 +150,12 @@ export class DrivingLicenseApi {
     auth: Auth
     category: string
     model: v6.ModelsV6PostFullLicenseWithHealthDeclaration
-  }): Promise<boolean> {
-    await withAuthContext(input.auth, () =>
+  }): Promise<string | null> {
+    // Enhanced fetch throws on 4xx, so reaching the return is success. RLS
+    // documents an int32 here but actually sends the new application's guid as
+    // the text body; surface it (never gate on it) for logging and so a tester
+    // can deny the created application.
+    const created = await withAuthContext(input.auth, () =>
       this.applicationV6.apiApplicationsV6CategoryWithhealthdeclarationPost({
         apiVersion: v6.DRIVING_LICENSE_API_VERSION_V6,
         apiVersion2: v6.DRIVING_LICENSE_API_VERSION_V6,
@@ -124,7 +164,7 @@ export class DrivingLicenseApi {
       }),
     )
 
-    return true
+    return extractApplicationGuid(created)
   }
 
   public async postTemporaryLicenseWithHealthDeclaratio(input: {

--- a/libs/clients/driving-license/src/lib/drivingLicenseApi.service.ts
+++ b/libs/clients/driving-license/src/lib/drivingLicenseApi.service.ts
@@ -27,8 +27,7 @@ import { handleCreateResponse } from './utils/handleCreateResponse'
 // the temporary endpoint carries it under a field the generated DTO drops. Pull
 // it out defensively — purely for logging/reconciliation, so it must never throw.
 const extractApplicationGuid = (body: unknown): string | null => {
-  const UUID =
-    /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i
+  const UUID = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i
   if (typeof body === 'string') {
     return body.match(UUID)?.[0] ?? null
   }
@@ -82,11 +81,13 @@ export class DrivingLicenseApi {
       // the generated DTO parser drops it. 4xx still throws here (enhanced fetch),
       // so reaching the read is success.
       const response = await withAuthContext(input.auth, () =>
-        this.applicationV6.apiApplicationsV6TemporarywithhealthdeclarationPostRaw({
-          apiVersion: v6.DRIVING_LICENSE_API_VERSION_V6,
-          apiVersion2: v6.DRIVING_LICENSE_API_VERSION_V6,
-          modelsV6PostTemporaryLicenseWithHealthDeclaration: input.model,
-        }),
+        this.applicationV6.apiApplicationsV6TemporarywithhealthdeclarationPostRaw(
+          {
+            apiVersion: v6.DRIVING_LICENSE_API_VERSION_V6,
+            apiVersion2: v6.DRIVING_LICENSE_API_VERSION_V6,
+            modelsV6PostTemporaryLicenseWithHealthDeclaration: input.model,
+          },
+        ),
       )
 
       // Best-effort: guid capture must never turn a successful create into a

--- a/libs/clients/driving-license/src/lib/drivingLicenseApi.service.ts
+++ b/libs/clients/driving-license/src/lib/drivingLicenseApi.service.ts
@@ -94,17 +94,28 @@ export class DrivingLicenseApi {
   }
 
   /**
-   * B-full counterpart of the above. Unlike the temporary endpoint this returns
-   * a bare number rather than a DTO, and the generated client's `Promise<number>`
-   * is a lie — the raw method ends in `TextApiResponse`, and the service returns
-   * a string on error. `handleCreateResponse` is the existing handler for that.
+   * B-full counterpart of the temporary endpoint above.
+   *
+   * Deliberately does NOT use `handleCreateResponse`. That helper exists for the
+   * v5 NewCategory endpoint, whose body is `{ value: number }` / a bare number /
+   * an error string. This endpoint has exactly two documented outcomes — 201 with
+   * the new application id, and 400 with ProblemDetails — and `createEnhancedFetch`
+   * throws on 4xx. So reaching the line after the call IS the success signal, and
+   * there is no body shape worth interpreting.
+   *
+   * This was learned the hard way on IS-DEV: routing the 201 body through
+   * `handleCreateResponse` produced "unknown type of response" for an application
+   * RLS had actually created, so the applicant was told the submission failed
+   * after paying — and their retry then failed for real with
+   * "An application already exists for this category". A false failure here is
+   * strictly worse than no check at all.
    */
   public async postFullLicenseWithHealthDeclarationV6(input: {
     auth: Auth
     category: string
     model: v6.ModelsV6PostFullLicenseWithHealthDeclaration
   }): Promise<boolean> {
-    const response = await withAuthContext(input.auth, () =>
+    await withAuthContext(input.auth, () =>
       this.applicationV6.apiApplicationsV6CategoryWithhealthdeclarationPost({
         apiVersion: v6.DRIVING_LICENSE_API_VERSION_V6,
         apiVersion2: v6.DRIVING_LICENSE_API_VERSION_V6,
@@ -113,15 +124,7 @@ export class DrivingLicenseApi {
       }),
     )
 
-    const handledResponse = handleCreateResponse(response)
-
-    if (!handledResponse.success) {
-      throw new Error(
-        `POST apiApplicationsV6CategoryWithhealthdeclarationPost was not successful, response was: ${handledResponse.error}`,
-      )
-    }
-
-    return handledResponse.success
+    return true
   }
 
   public async postTemporaryLicenseWithHealthDeclaratio(input: {

--- a/libs/clients/driving-license/src/lib/drivingLicenseApi.service.ts
+++ b/libs/clients/driving-license/src/lib/drivingLicenseApi.service.ts
@@ -63,11 +63,13 @@ export class DrivingLicenseApi {
     // the application and so can tell a lost-response retry (safe to treat as
     // success) from a fresh application (must surface the error).
     const response = await withAuthContext(input.auth, () =>
-      this.applicationV6.apiApplicationsV6TemporarywithhealthdeclarationPostRaw({
-        apiVersion: v6.DRIVING_LICENSE_API_VERSION_V6,
-        apiVersion2: v6.DRIVING_LICENSE_API_VERSION_V6,
-        modelsV6PostTemporaryLicenseWithHealthDeclaration: input.model,
-      }),
+      this.applicationV6.apiApplicationsV6TemporarywithhealthdeclarationPostRaw(
+        {
+          apiVersion: v6.DRIVING_LICENSE_API_VERSION_V6,
+          apiVersion2: v6.DRIVING_LICENSE_API_VERSION_V6,
+          modelsV6PostTemporaryLicenseWithHealthDeclaration: input.model,
+        },
+      ),
     )
 
     // Best-effort: guid capture must never turn a successful create into a

--- a/libs/clients/driving-license/src/lib/drivingLicenseApi.service.ts
+++ b/libs/clients/driving-license/src/lib/drivingLicenseApi.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@nestjs/common'
+import { Auth, withAuthContext } from '@island.is/auth-nest-tools'
 import {
   CanApplyErrorCodeBFull,
   CanApplyForCategoryResult,
@@ -7,6 +8,7 @@ import {
 } from '..'
 import * as v4 from '../v4'
 import * as v5 from '../v5'
+import * as v6 from '../v6'
 import {
   CanApplyErrorCodeBTemporary,
   CanApplyErrorCodeRenewal65,
@@ -33,7 +35,94 @@ export class DrivingLicenseApi {
     private readonly applicationV5: v5.ApplicationApiV5,
     private readonly v5CodeTable: v5.CodeTableV5,
     private readonly imageApiV5: v5.ImageApiV5,
+    // Appended, not inserted: Nest resolves by type metadata, so appending
+    // keeps the diff to one line.
+    private readonly applicationV6: v6.ApplicationApiV6,
   ) {}
+
+  /**
+   * B-temp submit that carries the health declaration AND the certificate, via
+   * the v6 endpoint RLS added 2026-08-26. Replaces the legacy pair of calls
+   * (`postTemporaryLicenseWithHealthDeclaratio` + `postCreateDrivingLicenseTemporary`)
+   * for applicants whose redesign flag is on.
+   *
+   * The v5 twin above must stay: it is still the flag-off path, and flags are
+   * frozen into application answers, so in-flight drafts keep using it. Hence
+   * the `V6` suffix here — drop it once the v5 method goes.
+   */
+  public async postTemporaryLicenseWithHealthDeclarationV6(input: {
+    auth: Auth
+    model: v6.ModelsV6PostTemporaryLicenseWithHealthDeclaration
+  }): Promise<v6.DtoV6NewTemporaryLicsenseDto> {
+    try {
+      return await withAuthContext(input.auth, () =>
+        this.applicationV6.apiApplicationsV6TemporarywithhealthdeclarationPost({
+          apiVersion: v6.DRIVING_LICENSE_API_VERSION_V6,
+          apiVersion2: v6.DRIVING_LICENSE_API_VERSION_V6,
+          modelsV6PostTemporaryLicenseWithHealthDeclaration: input.model,
+        }),
+      )
+    } catch (e) {
+      // Same guard as the v5 `postCreateDrivingLicenseTemporary` path, and for
+      // the same reason: if the licence was created but the response was lost,
+      // the state machine retries and RLS answers 400 on the resubmission. The
+      // generated client does not map that error, so we re-ask `canapplyfor`:
+      // `HAS_B_CATEGORY` means the applicant now holds the licence, i.e. the
+      // previous attempt succeeded.
+      //
+      // A genuine denial would already have been caught by this same check at
+      // prerequisites, so by submit time the code almost always means "created
+      // on the previous attempt" — and the cost is asymmetric: without the
+      // guard an already-paid applicant is left on an error screen. Do not
+      // remove this on the grounds that the single v6 call replaced the old
+      // two-call shape; that is not what causes the 400.
+      if ((e as { status?: number })?.status === 400) {
+        const hasTemp = await this.getCanApplyForCategoryTemporary({
+          token: input.auth.authorization.replace(/^bearer /i, ''),
+        })
+
+        if (hasTemp.errorCode === 'HAS_B_CATEGORY') {
+          return { result: true }
+        }
+      }
+
+      // Unlike the v5 twin, which swallows every other 400 into `false`, rethrow
+      // so the original `FetchError` still reaches `toSubmissionError` and the
+      // applicant gets the RLS error description rather than a generic failure.
+      throw e
+    }
+  }
+
+  /**
+   * B-full counterpart of the above. Unlike the temporary endpoint this returns
+   * a bare number rather than a DTO, and the generated client's `Promise<number>`
+   * is a lie — the raw method ends in `TextApiResponse`, and the service returns
+   * a string on error. `handleCreateResponse` is the existing handler for that.
+   */
+  public async postFullLicenseWithHealthDeclarationV6(input: {
+    auth: Auth
+    category: string
+    model: v6.ModelsV6PostFullLicenseWithHealthDeclaration
+  }): Promise<boolean> {
+    const response = await withAuthContext(input.auth, () =>
+      this.applicationV6.apiApplicationsV6CategoryWithhealthdeclarationPost({
+        apiVersion: v6.DRIVING_LICENSE_API_VERSION_V6,
+        apiVersion2: v6.DRIVING_LICENSE_API_VERSION_V6,
+        category: input.category,
+        modelsV6PostFullLicenseWithHealthDeclaration: input.model,
+      }),
+    )
+
+    const handledResponse = handleCreateResponse(response)
+
+    if (!handledResponse.success) {
+      throw new Error(
+        `POST apiApplicationsV6CategoryWithhealthdeclarationPost was not successful, response was: ${handledResponse.error}`,
+      )
+    }
+
+    return handledResponse.success
+  }
 
   public async postTemporaryLicenseWithHealthDeclaratio(input: {
     nationalId: string

--- a/libs/clients/driving-license/src/lib/utils/extractApplicationGuid.spec.ts
+++ b/libs/clients/driving-license/src/lib/utils/extractApplicationGuid.spec.ts
@@ -1,0 +1,29 @@
+import { extractApplicationGuid } from './extractApplicationGuid'
+
+const GUID = '3630b0bc-ec51-442e-976d-13a3c21c5e5b'
+
+describe('extractApplicationGuid', () => {
+  it.each([
+    ['a bare guid string', GUID, GUID],
+    ['a quoted guid string', `"${GUID}"`, GUID],
+    ['the full endpoint text body (id, no guid)', '3248752', null],
+    ['an empty string', '', null],
+    // The temporary endpoint carries the guid under a field the DTO drops.
+    ['a guid field', { guid: GUID }, GUID],
+    ['an applicationGuid field', { applicationGuid: GUID }, GUID],
+    ['a guid anywhere in the object', { result: true, x: { g: GUID } }, GUID],
+    ['an object with no guid', { result: false, driverLicenseId: 7 }, null],
+    ['a wrapped zero', { value: 0 }, null],
+    ['null', null, null],
+    ['undefined', undefined, null],
+    ['a number', 3248752, null],
+  ])('%s -> %s', (_label, input, expected) => {
+    expect(extractApplicationGuid(input)).toBe(expected)
+  })
+
+  it('never throws on hostile input', () => {
+    const circular: Record<string, unknown> = {}
+    circular.self = circular
+    expect(() => extractApplicationGuid(circular)).not.toThrow()
+  })
+})

--- a/libs/clients/driving-license/src/lib/utils/extractApplicationGuid.ts
+++ b/libs/clients/driving-license/src/lib/utils/extractApplicationGuid.ts
@@ -1,0 +1,30 @@
+// RLS returns the new application's guid on a successful v6 create, but not in a
+// stable, documented place: the full-licence endpoint sends it as the (text)
+// body, and the temporary endpoint carries it under a field the generated DTO
+// drops. Pull it out defensively — purely for logging/reconciliation, so it must
+// never throw and returns null when nothing guid-shaped is present.
+export const extractApplicationGuid = (body: unknown): string | null => {
+  const UUID = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i
+
+  if (typeof body === 'string') {
+    return body.match(UUID)?.[0] ?? null
+  }
+
+  if (body && typeof body === 'object') {
+    const rec = body as Record<string, unknown>
+    for (const key of ['guid', 'applicationGuid', 'applicationId']) {
+      const value = rec[key]
+      if (typeof value === 'string' && UUID.test(value)) {
+        return value
+      }
+    }
+    try {
+      return JSON.stringify(body).match(UUID)?.[0] ?? null
+    } catch {
+      // JSON.stringify throws on circular structures; the contract is never to.
+      return null
+    }
+  }
+
+  return null
+}

--- a/libs/clients/driving-license/src/lib/utils/isApplicationAlreadyExists.spec.ts
+++ b/libs/clients/driving-license/src/lib/utils/isApplicationAlreadyExists.spec.ts
@@ -10,6 +10,16 @@ describe('isApplicationAlreadyExists', () => {
     ).toBe(true)
   })
 
+  it('matches the full endpoint when the code is in problem.title', () => {
+    // toSubmissionError's convention: RLS puts its raw error code in title.
+    expect(
+      isApplicationAlreadyExists({
+        status: 400,
+        problem: { title: 'APPLICATION_ALREADY_EXISTS' },
+      }),
+    ).toBe(true)
+  })
+
   it('matches the full endpoint problem+json detail', () => {
     expect(
       isApplicationAlreadyExists({

--- a/libs/clients/driving-license/src/lib/utils/isApplicationAlreadyExists.spec.ts
+++ b/libs/clients/driving-license/src/lib/utils/isApplicationAlreadyExists.spec.ts
@@ -24,8 +24,14 @@ describe('isApplicationAlreadyExists', () => {
 
   it.each([
     ['a different 400', { status: 400, body: { errorCode: 'HAS_POINTS' } }],
-    ['a 400 with unrelated problem', { status: 400, problem: { detail: 'Nope' } }],
-    ['a 500', { status: 500, body: { errorCode: 'APPLICATION_ALREADY_EXISTS' } }],
+    [
+      'a 400 with unrelated problem',
+      { status: 400, problem: { detail: 'Nope' } },
+    ],
+    [
+      'a 500',
+      { status: 500, body: { errorCode: 'APPLICATION_ALREADY_EXISTS' } },
+    ],
     ['no status', { body: { errorCode: 'APPLICATION_ALREADY_EXISTS' } }],
     ['a plain error', new Error('boom')],
     ['null', null],

--- a/libs/clients/driving-license/src/lib/utils/isApplicationAlreadyExists.spec.ts
+++ b/libs/clients/driving-license/src/lib/utils/isApplicationAlreadyExists.spec.ts
@@ -1,0 +1,36 @@
+import { isApplicationAlreadyExists } from './isApplicationAlreadyExists'
+
+describe('isApplicationAlreadyExists', () => {
+  it('matches the temporary endpoint machine code (plain JSON body)', () => {
+    expect(
+      isApplicationAlreadyExists({
+        status: 400,
+        body: { errorCode: 'APPLICATION_ALREADY_EXISTS' },
+      }),
+    ).toBe(true)
+  })
+
+  it('matches the full endpoint problem+json detail', () => {
+    expect(
+      isApplicationAlreadyExists({
+        status: 400,
+        problem: {
+          title: 'Bad Request',
+          detail: 'An application already exists for this category',
+        },
+      }),
+    ).toBe(true)
+  })
+
+  it.each([
+    ['a different 400', { status: 400, body: { errorCode: 'HAS_POINTS' } }],
+    ['a 400 with unrelated problem', { status: 400, problem: { detail: 'Nope' } }],
+    ['a 500', { status: 500, body: { errorCode: 'APPLICATION_ALREADY_EXISTS' } }],
+    ['no status', { body: { errorCode: 'APPLICATION_ALREADY_EXISTS' } }],
+    ['a plain error', new Error('boom')],
+    ['null', null],
+    ['undefined', undefined],
+  ])('does not match %s', (_label, input) => {
+    expect(isApplicationAlreadyExists(input)).toBe(false)
+  })
+})

--- a/libs/clients/driving-license/src/lib/utils/isApplicationAlreadyExists.ts
+++ b/libs/clients/driving-license/src/lib/utils/isApplicationAlreadyExists.ts
@@ -19,7 +19,16 @@ export const isApplicationAlreadyExists = (error: unknown): boolean => {
     return false
   }
 
+  // Temporary endpoint: machine code in a plain-JSON body.
   if (e.body?.errorCode === 'APPLICATION_ALREADY_EXISTS') {
+    return true
+  }
+
+  // Full endpoint: problem+json. By this codebase's convention (see
+  // `toSubmissionError`) RLS puts its raw error *code* in `problem.title`, so
+  // match that exactly first — the prose `detail` is only a last-resort fallback
+  // that degrades safely if RLS ever changes the wording.
+  if (e.problem?.title === 'APPLICATION_ALREADY_EXISTS') {
     return true
   }
 

--- a/libs/clients/driving-license/src/lib/utils/isApplicationAlreadyExists.ts
+++ b/libs/clients/driving-license/src/lib/utils/isApplicationAlreadyExists.ts
@@ -1,0 +1,31 @@
+// RLS answers a duplicate v6 create with 400 — a retry after a lost response, or
+// a genuinely pre-existing in-flight application. For an already-paid applicant
+// both mean "the application exists", so callers treat it as success rather than
+// surfacing the raw error.
+//
+// The two create endpoints signal it differently (drift reported to RLS): the
+// temporary endpoint returns a machine `errorCode` in a plain-JSON body, while
+// the full endpoint returns problem+json with only an English `detail`. Check
+// both; the English fallback degrades to "not matched" (rethrow) if RLS ever
+// changes the wording, which is no worse than having no guard.
+export const isApplicationAlreadyExists = (error: unknown): boolean => {
+  const e = error as {
+    status?: number
+    body?: { errorCode?: string }
+    problem?: { title?: string; detail?: string }
+  }
+
+  if (e?.status !== 400) {
+    return false
+  }
+
+  if (e.body?.errorCode === 'APPLICATION_ALREADY_EXISTS') {
+    return true
+  }
+
+  const problemText = `${e.problem?.title ?? ''} ${
+    e.problem?.detail ?? ''
+  }`.toLowerCase()
+
+  return problemText.includes('already exists')
+}


### PR DESCRIPTION
## What

Lets a B-temp or B-full applicant whose health answers trigger a medical certificate **upload it in the application**, instead of being told to bring it to the district office. Behind the existing `isBTempRedesignEnabled` / `isBFullRedesignEnabled` flags, which are off in production.

The upload is possible because RLS shipped two v6 endpoints on 2026-08-26 that take a health declaration *plus* the certificate:

- `POST /api/applications/v6/{category}/withhealthdeclaration`
- `POST /api/applications/v6/temporarywithhealthdeclaration`

These are the first two v6 endpoints the monorepo calls. The v6 client scaffold landed in #23035; this PR is deliberately narrow and does **not** do the full v6 migration (#23064, still a draft) — see *Why* below.

Layer by layer:

- **Client** (`libs/clients/driving-license`) — two new `…V6` methods, plus token forwarding on `ApplicationApiV6`: the generated client has no `initOverrides`, so the header cannot be set per call. RLS v6 reads the token from a **`jwttoken`** header, not `Authorization` (dev-verified by curl: `jwttoken` alone → 200 with the caller resolved, `Authorization` alone → 400 `Invalid JWT Token`). The v6 spec declares no such parameter, so this is undocumented-but-real behaviour; the comment on the wrapper records the evidence and the one-line fallback.
- **API domain** — two methods taking the `Auth` object (`withAuthContext` needs it). The B-temp endpoint returns a DTO rather than a boolean, so it is mapped to `{ success, errorMessage }` — unmapped, every RLS business rejection would reach the applicant as "submitted".
- **Submission service** — flag-gated branches, plus two extractions that were overdue: the `contentList` builder (65+ and BE had character-identical copies; this would have made four) and the yes/no→boolean declaration mapper. Flag-on always sends the declaration, as BE does, and sends `contentList` only when a certificate is required.
- **Form** — the redesigned health-declaration step now follows **BE's** rules, not 65+'s: the upload appears only once a health condition is triggered. 65+ deliberately stays out of the shared helper, because its upload is unconditional.
- **Summary** — an applicant who uploads is no longer *also* told to bring the paper certificate. That was a separate block from the uploaded-file row, and its condition was duplicated inline three times; both conditions are now named helpers so a divider cannot drift apart from its row.

Flag-off behaviour is unchanged, and that is load-bearing rather than incidental: the flags are frozen into answers at prerequisites, so drafts in flight keep the flow they started with.

## Why

B-temp and B-full are the only two products whose redesign shipped photo selection **without** the certificate upload — 65+ and BE have had both for a while. The blocker was recorded in the code (`the full-license RLS endpoint has no contentList`) and these endpoints remove it.

Narrow rather than part of the v6 migration, on purpose:

- #23064 flips 28 existing call sites unconditionally, with no flag. This PR *adds* two call sites reached only behind a flag that is off in production.
- It exercises the v6 X-Road path, the service `SECRET` and the `jwttoken` mechanism on a 2-endpoint surface instead of 28. If RLS later moves v6 to `Authorization`, two call sites need rewiring.
- It delivers the actual user-facing gap now, and it *shrinks* #23064 rather than competing with it: the auth mechanism lands here, leaving that PR to migrate only the reads.

## Screenshots / Gifs

_No UI change beyond the upload field, which matches BE's existing one._

## Dev end-to-end: verified green on IS-DEV, after finding and fixing three bugs

A clean flag-on **B-temp** submit against IS-DEV now succeeds end to end — the
`temporarywithhealthdeclaration` create returns, `Application submission ended
successfully`, zero errors — and the RLS application guid is captured and logged.
That exercises the second new endpoint, `contentList` with the uploaded
certificate, `instructorSSN`, and the `jwttoken`+`SECRET` auth path against the
real service. B-full was verified the same way.

Getting there surfaced three real bugs, all fixed on the branch:

1. **`ae4f382` — full-licence false failure.** The 201 body was routed through
   `handleCreateResponse` (a v5 NewCategory helper); the v6 body matched none of
   its cases and fell through to "unknown type of response", so a created
   application was reported as failed to an applicant who had already paid, whose
   retry then hit `400 APPLICATION_ALREADY_EXISTS`. This endpoint documents only
   201 and 400, and enhanced fetch throws on 4xx — so reaching the next line *is*
   success.
2. **`f6b18fb` — temporary false failure.** Same class, via the DTO: we gated
   success on `response.result`, but a created application comes back with
   `result` falsy. RLS confirmed (Magnús/SGS) that success returns the new
   application's **guid**, which the documented DTO doesn't even model.
3. **`bdbe5a3c` — the guid was being discarded.** It is the only handle for
   reconciling or denying an application afterwards (an RLS-side id, not our
   application id), and its absence is precisely what made a wrongly-failed create
   impossible to clean up. Both create paths now capture and log it.

The same runs also confirmed `contentList` is accepted and that RLS's own
ProblemDetails `detail` reaches the applicant verbatim (the duplicate message came
through as-is).

## Testing notes

- `clients-driving-license` 52, `api-domains-driving-license` 33, `application-templates-driving-license` 104, `application-template-api-modules` 245 — all passing; lint clean (0 errors) on all four.
- The **`jwttoken` fetch wrapper is covered end-to-end** through msw, not just spied above: the header goes out bare, the config's `SECRET` / `X-Road-Client` survive the wrapper rebuilding the `Headers` object, and an empty auth context sends no header rather than the string `"undefined"`. Both behaviours were confirmed by breaking them and watching exactly one test fail each time.
- **BE had no `contentList` coverage at all** before this PR: its test `baseAnswers` carried no `healthDeclaration`, so the cert gate was always false and every BE test passed whether the builder worked or not. The refactor would otherwise have landed unprotected on a live production path, so the extraction commit adds that coverage first — including the `glassesCheck` clause, the clause most likely to be lost while hoisting it.
- The new form spec pins the four sibling blocks' **mutual exclusivity** (they all write `healthCertificate`, so two visible at once is a real bug), the upload-condition parity with BE, and the legacy/BE form-node ids literally — that last one is what makes the shared-builder extraction reviewable without running the app, and what proves in-flight drafts don't move.
- The 400-resubmission guard on the B-temp v6 call has three tests plus a negative control (breaking the status check fails exactly one test).

**Review follow-ups now in the branch:**
- The lost-response duplicate (`400 APPLICATION_ALREADY_EXISTS`) is tolerated as success **only on a same-application retry** — detected by an existing `submitApplication` externalData entry (the framework records one even on a failed attempt). A *fresh* application that hits the same code (a deliberate re-application while another is active) surfaces RLS's error instead, because the v6 endpoint is a create-not-upsert and that submission's payload was discarded — a false success there would hide lost edits and the payment. The v6 client methods propagate the error; the tolerate/rethrow decision lives in the submission service, which has the application.
- The RLS application guid is returned, logged next to our `application.id`, **and persisted on the application record** at `externalData.submitApplication.data.applicationGuid` (via `submitApplication`'s return, which the framework stores) — so support/reconciliation can find it from the application itself, not only the logs.
- `extractApplicationGuid` / `isApplicationAlreadyExists` extracted to their own utils with specs.
- **Spec drift to report to RLS:** the temporary endpoint documents 201→DTO / 400→DTO but returns a guid on success and `{errorCode}` on 400; the full endpoint documents `int32` but returns a guid and problem+json. #23064 will regenerate the same stale DTOs otherwise.

**Two things a reviewer should know are not yet settled:**

1. **`Okuskirteini-v6` is only verified registered on IS-DEV.** That is a blocker for flipping a flag, not for merging — with the flags off nothing calls v6.
2. **A v6 create lands in the RLS review queue (`Bíður umsagnar`) — this is parity with the live flow, not a new behaviour.** Querying the two created applications on IS-DEV (`GET /api/applications/v6/status/{id}` and `/rlsapplicationproxy/v6/{guid}/statusHistory`) shows their initial state is `Bíður umsagnar` (id 4, "awaiting review") → an RLS employee `confirmdone`. This is the **same model BE already runs in production** and that 65+ runs behind its flag; B-temp/B-full are the last two joining it. (Comparing to *legacy* B-temp's immediate `driverLicenseId` was the wrong baseline — the right comparison is BE, the live sibling.) So there is no operating-model decision outstanding. The only pre-flip item is **`Okuskirteini-v6` staging/prod registration** (only IS-DEV probed). None of this blocks merge — flags off.

Separate product question, not code: `forms/done.ts` still tells a B-full applicant to attend the district office (`nextStepsDescriptionBFull`) whenever a certificate is required. With the certificate now uploaded digitally that copy is questionable — the 65+ redesign hit the same thing and gained its own variant. Raising it with Fanney rather than guessing.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added redesigned B-full and B-temporary driving licence application flows with integrated health declarations.
  * Health certificates can now be uploaded when required by health answers, remarks, or glasses information.
  * Added combined submission of health declarations and certificate details.

* **Improvements**
  * Unanswered health questions are handled consistently.
  * Previously uploaded certificates are cleared when no longer needed.
  * Existing application flows remain supported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->




