### PR TITLE
docs(core): update README Node/Yarn prerequisites to the pinned versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ If you want to contribute to the repository, please make sure to follow [this gu
 
 ## Prerequisites
 
-- You have Node installed `^20.15.0` and Yarn at `^3.2.3`.
+- You have Node `22.22.3` and Yarn `4.6` installed (pinned in `package.json` under `volta`; `.npmrc` is `engine-strict`, so other Node versions fail `yarn install`).
 - You have [Docker](https://docs.docker.com/desktop/) installed.
 - You have [direnv](https://direnv.net/) installed.
 - You have [Java](https://www.java.com/en/download/manual.jsp) `>= 1.8` installed (for schema generation).


### PR DESCRIPTION
## What

Fixes the README prerequisites line, which still said Node `^20.15.0` and Yarn `^3.2.3`. It now states the pinned versions — Node `22.22.3` and Yarn `4.6` — and points at where the pin lives (`package.json` `volta`/`engines`, enforced by `.npmrc` `engine-strict`).

## Why

`package.json` has pinned Node 22.22.3 since #23240 (Nx 22 / React 19 / Next 16 / NestJS 11 upgrade), and Yarn 4.6 for longer. A contributor following the README installs a Node version that `yarn install` then rejects, and Nx's "Failed to start plugin worker" error on a version mismatch does not point back at the runtime. Docs only.

## Screenshots / Gifs

N/A — one-line docs change.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated setup prerequisites to require Node 22.22.3 and Yarn 4.6.
  * Clarified that unsupported Node versions are rejected during installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->