### PR TITLE
fix(j-s): Notify every other party when an appeal is withdrawn

### DIFF
--- a/apps/judicial-system/backend/src/app/modules/notification/services/appealCaseNotification/appealCaseNotification.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/services/appealCaseNotification/appealCaseNotification.service.ts
@@ -1701,9 +1701,10 @@ export class AppealCaseNotificationService extends BaseNotificationService {
             withdrawnByProsecution: wasWithdrawnByProsecution,
             courtCaseNumber: this.getCourtCaseNumber(theCase, appealCase),
           })
-        : this.formatMessage(strings.caseAppealWithdrawn.bodyWithoutAppellant, {
-            courtCaseNumber: this.getCourtCaseNumber(theCase, appealCase),
-          })
+        : `Kæra í máli ${this.getCourtCaseNumber(
+            theCase,
+            appealCase,
+          )} hefur verið afturkölluð.`
 
     // Notify district court judge
     promises.push(

--- a/apps/judicial-system/backend/src/app/modules/notification/services/appealCaseNotification/appealCaseNotification.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/services/appealCaseNotification/appealCaseNotification.service.ts
@@ -1688,14 +1688,22 @@ export class AppealCaseNotificationService extends BaseNotificationService {
   ): Promise<DeliverResponse> {
     const promises: Promise<Recipient>[] = []
     const wasWithdrawnByProsecution = isProsecutionUser(user)
+    const wasWithdrawnByDefence = isDefenceUser(user)
 
     const subject = this.formatMessage(strings.caseAppealWithdrawn.subject, {
       courtCaseNumber: this.getCourtCaseNumber(theCase, appealCase),
     })
-    const html = this.formatMessage(strings.caseAppealWithdrawn.body, {
-      withdrawnByProsecution: wasWithdrawnByProsecution ?? false,
-      courtCaseNumber: this.getCourtCaseNumber(theCase, appealCase),
-    })
+    // A court user ends the appeal by correcting the court record, not by
+    // withdrawing on its own behalf, so no party is named as the appellant.
+    const html =
+      wasWithdrawnByProsecution || wasWithdrawnByDefence
+        ? this.formatMessage(strings.caseAppealWithdrawn.body, {
+            withdrawnByProsecution: wasWithdrawnByProsecution,
+            courtCaseNumber: this.getCourtCaseNumber(theCase, appealCase),
+          })
+        : this.formatMessage(strings.caseAppealWithdrawn.bodyWithoutAppellant, {
+            courtCaseNumber: this.getCourtCaseNumber(theCase, appealCase),
+          })
 
     // Notify district court judge
     promises.push(
@@ -1732,24 +1740,16 @@ export class AppealCaseNotificationService extends BaseNotificationService {
       )
     }
 
-    if (isProsecutionUser(user)) {
-      // Notify ALL defenders and civil claimant lawyers
-      const defenceRecipients = this.getIndictmentDefenceRecipients(theCase)
-
-      for (const recipient of defenceRecipients) {
-        promises.push(
-          this.sendEmail({
-            subject,
-            html,
-            recipientName: recipient.name,
-            recipientEmail: recipient.email,
-            skipTail: !recipient.nationalId,
-          }),
-        )
-      }
-    }
-
-    if (isDefenceUser(user)) {
+    // Every party is notified except the one that just withdrew the appeal. The
+    // exclusion is the acting user alone - not every party that appealed: when
+    // several parties appealed a ruling in court, the appeal stands until the
+    // last of them withdraws, so a party that withdrew earlier has heard nothing
+    // yet and this is the first word it gets that the appeal is over.
+    // A court user can also end the appeal, by correcting the court record so
+    // that no standing appeal remains (see
+    // CourtSessionService.reconcileInCourtRulingOrderAppeal). Nobody withdrew
+    // just now, so every party is notified.
+    if (!wasWithdrawnByProsecution) {
       // Notify prosecutor
       promises.push(
         this.sendEmail({
@@ -1759,24 +1759,24 @@ export class AppealCaseNotificationService extends BaseNotificationService {
           recipientEmail: theCase.prosecutor?.email,
         }),
       )
+    }
 
-      // Notify all OTHER defenders and civil claimant lawyers
-      const defenceRecipients = this.getIndictmentDefenceRecipients(
-        theCase,
-        appellantRepresentativeNationalIds(theCase, appealCase),
+    // Notify all other defenders and civil claimant lawyers
+    const defenceRecipients = this.getIndictmentDefenceRecipients(
+      theCase,
+      wasWithdrawnByDefence ? new Set([user.nationalId]) : undefined,
+    )
+
+    for (const recipient of defenceRecipients) {
+      promises.push(
+        this.sendEmail({
+          subject,
+          html,
+          recipientName: recipient.name,
+          recipientEmail: recipient.email,
+          skipTail: !recipient.nationalId,
+        }),
       )
-
-      for (const recipient of defenceRecipients) {
-        promises.push(
-          this.sendEmail({
-            subject,
-            html,
-            recipientName: recipient.name,
-            recipientEmail: recipient.email,
-            skipTail: !recipient.nationalId,
-          }),
-        )
-      }
     }
 
     // If appeal was already received by CoA → notify CoA email

--- a/apps/judicial-system/backend/src/app/modules/notification/services/appealCaseNotification/appealCaseNotification.strings.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/services/appealCaseNotification/appealCaseNotification.strings.ts
@@ -140,5 +140,11 @@ export const strings = {
         '{withdrawnByProsecution, select, true {Sækjandi} other {Verjandi}} hefur afturkallað kæru í máli {courtCaseNumber}.',
       description: 'Texti í pósti til aðila máls þegar kæra er afturkölluð',
     },
+    bodyWithoutAppellant: {
+      id: 'judicial.system.backend:notifications.case_appeal_withdrawn.body_without_appellant',
+      defaultMessage: 'Kæra í máli {courtCaseNumber} hefur verið afturkölluð.',
+      description:
+        'Texti í pósti til aðila máls þegar kæra fellur niður án þess að aðili afturkalli hana, t.d. við leiðréttingu þingbókar',
+    },
   }),
 }

--- a/apps/judicial-system/backend/src/app/modules/notification/services/appealCaseNotification/appealCaseNotification.strings.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/services/appealCaseNotification/appealCaseNotification.strings.ts
@@ -140,11 +140,5 @@ export const strings = {
         '{withdrawnByProsecution, select, true {Sækjandi} other {Verjandi}} hefur afturkallað kæru í máli {courtCaseNumber}.',
       description: 'Texti í pósti til aðila máls þegar kæra er afturkölluð',
     },
-    bodyWithoutAppellant: {
-      id: 'judicial.system.backend:notifications.case_appeal_withdrawn.body_without_appellant',
-      defaultMessage: 'Kæra í máli {courtCaseNumber} hefur verið afturkölluð.',
-      description:
-        'Texti í pósti til aðila máls þegar kæra fellur niður án þess að aðili afturkalli hana, t.d. við leiðréttingu þingbókar',
-    },
   }),
 }

--- a/apps/judicial-system/backend/src/app/modules/notification/test/internalNotificationController/sendIndictmentAppealNotifications.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/test/internalNotificationController/sendIndictmentAppealNotifications.spec.ts
@@ -44,6 +44,12 @@ const defender1AppealedEvent = {
   defendantId: defendant1Id,
 } as AppealEventLog
 
+// Defendant2 appealed the same ruling in court, so both parties are appellants.
+const defender2AppealedEvent = {
+  eventType: AppealEventType.APPEALED,
+  defendantId: defendant2Id,
+} as AppealEventLog
+
 const defendants = [
   {
     id: defendant1Id,
@@ -795,7 +801,27 @@ describe('InternalNotificationController - Send indictment appeal withdrawn noti
 
   let mockEmailService: EmailService
 
-  type GivenWhenThen = (userRole: UserRole) => Promise<Then>
+  const prosecutionUser = {
+    role: UserRole.PROSECUTOR,
+    institution: { type: InstitutionType.POLICE_PROSECUTORS_OFFICE },
+  } as User
+  const defender1User = {
+    role: UserRole.DEFENDER,
+    nationalId: defender1NationalId,
+  } as User
+  const defender2User = {
+    role: UserRole.DEFENDER,
+    nationalId: defender2NationalId,
+  } as User
+  const districtCourtUser = {
+    role: UserRole.DISTRICT_COURT_JUDGE,
+    institution: { type: InstitutionType.DISTRICT_COURT },
+  } as User
+
+  type GivenWhenThen = (
+    user: User,
+    appealEventLogs?: AppealEventLog[],
+  ) => Promise<Then>
   let givenWhenThen: GivenWhenThen
 
   beforeEach(async () => {
@@ -806,23 +832,14 @@ describe('InternalNotificationController - Send indictment appeal withdrawn noti
 
     mockEmailService = emailService
 
-    givenWhenThen = async (userRole: UserRole) => {
+    givenWhenThen = async (
+      user,
+      appealEventLogs = [defender1AppealedEvent],
+    ) => {
       const then = {} as Then
 
-      const user =
-        userRole === UserRole.PROSECUTOR
-          ? ({
-              role: UserRole.PROSECUTOR,
-              institution: {
-                type: InstitutionType.POLICE_PROSECUTORS_OFFICE,
-              },
-            } as User)
-          : ({
-              role: UserRole.DEFENDER,
-            } as User)
-
       const appealCase = {
-        appealEventLogs: [defender1AppealedEvent],
+        appealEventLogs,
         appealState: AppealCaseState.APPEALED,
       } as AppealCase
 
@@ -863,7 +880,7 @@ describe('InternalNotificationController - Send indictment appeal withdrawn noti
     let then: Then
 
     beforeEach(async () => {
-      then = await givenWhenThen(UserRole.PROSECUTOR)
+      then = await givenWhenThen(prosecutionUser)
     })
 
     it('should send emails to judge, court, registrar, all defenders and spokesperson', () => {
@@ -924,7 +941,7 @@ describe('InternalNotificationController - Send indictment appeal withdrawn noti
     let then: Then
 
     beforeEach(async () => {
-      then = await givenWhenThen(UserRole.DEFENDER)
+      then = await givenWhenThen(defender1User)
     })
 
     it('should send emails to judge, court, registrar, prosecutor, defender2 and spokesperson (NOT defender1)', () => {
@@ -956,7 +973,7 @@ describe('InternalNotificationController - Send indictment appeal withdrawn noti
           subject: expect.stringContaining(courtCaseNumber),
         }),
       )
-      // Defender 2 (defender1 excluded as the appellant's current defender)
+      // Defender 2 (defender1 excluded as the withdrawing defender)
       expect(mockEmailService.sendEmail).toHaveBeenCalledWith(
         expect.objectContaining({
           to: [{ name: 'Defender Two', address: 'defender2@omnitrix.is' }],
@@ -978,6 +995,169 @@ describe('InternalNotificationController - Send indictment appeal withdrawn noti
       // 6 emails: judge + court + registrar + prosecutor + defender2 + spokesperson
       expect(mockEmailService.sendEmail).toHaveBeenCalledTimes(6)
       expect(then.result).toEqual({ delivered: true })
+    })
+  })
+
+  describe('the last appellant withdraws after another appellant withdrew earlier', () => {
+    let then: Then
+
+    beforeEach(async () => {
+      // Both parties appealed the ruling in court. Defender1 withdrew earlier -
+      // the appeal stood, so no notification went out - and defender2 now
+      // withdraws the last standing appeal.
+      then = await givenWhenThen(defender2User, [
+        defender1AppealedEvent,
+        defender2AppealedEvent,
+      ])
+    })
+
+    it('should send emails to judge, court, registrar, prosecutor, defender1 and spokesperson (NOT defender2)', () => {
+      // Judge
+      expect(mockEmailService.sendEmail).toHaveBeenCalledWith(
+        expect.objectContaining({
+          to: [{ name: judge.name, address: judge.email }],
+          subject: expect.stringContaining(courtCaseNumber),
+        }),
+      )
+      // Court
+      expect(mockEmailService.sendEmail).toHaveBeenCalledWith(
+        expect.objectContaining({
+          to: [{ name: 'Héraðsdómur Reykjavíkur', address: court.email }],
+          subject: expect.stringContaining(courtCaseNumber),
+        }),
+      )
+      // Registrar
+      expect(mockEmailService.sendEmail).toHaveBeenCalledWith(
+        expect.objectContaining({
+          to: [{ name: registrar.name, address: registrar.email }],
+          subject: expect.stringContaining(courtCaseNumber),
+        }),
+      )
+      // Prosecutor
+      expect(mockEmailService.sendEmail).toHaveBeenCalledWith(
+        expect.objectContaining({
+          to: [{ name: prosecutor.name, address: prosecutor.email }],
+          subject: expect.stringContaining(courtCaseNumber),
+        }),
+      )
+      // Defender 1 - withdrew earlier, but is only now told the appeal is over
+      expect(mockEmailService.sendEmail).toHaveBeenCalledWith(
+        expect.objectContaining({
+          to: [{ name: 'Defender One', address: 'defender1@omnitrix.is' }],
+          subject: expect.stringContaining(courtCaseNumber),
+        }),
+      )
+      // Spokesperson
+      expect(mockEmailService.sendEmail).toHaveBeenCalledWith(
+        expect.objectContaining({
+          to: [
+            {
+              name: 'Spokesperson One',
+              address: 'spokesperson1@omnitrix.is',
+            },
+          ],
+          subject: expect.stringContaining(courtCaseNumber),
+        }),
+      )
+      // Defender 2 withdrew the appeal, so is not notified
+      expect(mockEmailService.sendEmail).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          to: [{ name: 'Defender Two', address: 'defender2@omnitrix.is' }],
+        }),
+      )
+      // 6 emails: judge + court + registrar + prosecutor + defender1 + spokesperson
+      expect(mockEmailService.sendEmail).toHaveBeenCalledTimes(6)
+      expect(then.result).toEqual({ delivered: true })
+    })
+  })
+
+  describe('a district court user ends the appeal by correcting the court record', () => {
+    let then: Then
+
+    beforeEach(async () => {
+      // Both parties appealed and both have withdrawn, and a court record
+      // correction removed the last standing appeal decision, so the appeal case
+      // is withdrawn without any party acting.
+      then = await givenWhenThen(districtCourtUser, [
+        defender1AppealedEvent,
+        defender2AppealedEvent,
+      ])
+    })
+
+    it('should send emails to judge, court, registrar, prosecutor, all defenders and spokesperson', () => {
+      // Judge
+      expect(mockEmailService.sendEmail).toHaveBeenCalledWith(
+        expect.objectContaining({
+          to: [{ name: judge.name, address: judge.email }],
+          subject: expect.stringContaining(courtCaseNumber),
+        }),
+      )
+      // Court
+      expect(mockEmailService.sendEmail).toHaveBeenCalledWith(
+        expect.objectContaining({
+          to: [{ name: 'Héraðsdómur Reykjavíkur', address: court.email }],
+          subject: expect.stringContaining(courtCaseNumber),
+        }),
+      )
+      // Registrar
+      expect(mockEmailService.sendEmail).toHaveBeenCalledWith(
+        expect.objectContaining({
+          to: [{ name: registrar.name, address: registrar.email }],
+          subject: expect.stringContaining(courtCaseNumber),
+        }),
+      )
+      // Prosecutor
+      expect(mockEmailService.sendEmail).toHaveBeenCalledWith(
+        expect.objectContaining({
+          to: [{ name: prosecutor.name, address: prosecutor.email }],
+          subject: expect.stringContaining(courtCaseNumber),
+        }),
+      )
+      // Defender 1
+      expect(mockEmailService.sendEmail).toHaveBeenCalledWith(
+        expect.objectContaining({
+          to: [{ name: 'Defender One', address: 'defender1@omnitrix.is' }],
+          subject: expect.stringContaining(courtCaseNumber),
+        }),
+      )
+      // Defender 2
+      expect(mockEmailService.sendEmail).toHaveBeenCalledWith(
+        expect.objectContaining({
+          to: [{ name: 'Defender Two', address: 'defender2@omnitrix.is' }],
+          subject: expect.stringContaining(courtCaseNumber),
+        }),
+      )
+      // Spokesperson
+      expect(mockEmailService.sendEmail).toHaveBeenCalledWith(
+        expect.objectContaining({
+          to: [
+            {
+              name: 'Spokesperson One',
+              address: 'spokesperson1@omnitrix.is',
+            },
+          ],
+          subject: expect.stringContaining(courtCaseNumber),
+        }),
+      )
+      // 7 emails: judge + court + registrar + prosecutor + defender1 + defender2 + spokesperson
+      expect(mockEmailService.sendEmail).toHaveBeenCalledTimes(7)
+      expect(then.result).toEqual({ delivered: true })
+    })
+
+    it('should not name a party as the one that withdrew the appeal', () => {
+      expect(mockEmailService.sendEmail).toHaveBeenCalledWith(
+        expect.objectContaining({
+          to: [{ name: judge.name, address: judge.email }],
+          html: expect.stringContaining(
+            `Kæra í máli ${courtCaseNumber} hefur verið afturkölluð.`,
+          ),
+        }),
+      )
+      expect(mockEmailService.sendEmail).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          html: expect.stringContaining('hefur afturkallað kæru'),
+        }),
+      )
     })
   })
 })


### PR DESCRIPTION
# Notify every other party when an appeal is withdrawn

[Kærur á ÚURM - tilkynning þegar kæra er afturkölluð](https://app.asana.com/1/203394141643832/project/1199153462262248/task/1217550295770690)

Two defenders appeal a ruling in court. A withdraws — the appeal still stands, so nothing is sent (by design). Later B withdraws the last standing appeal and the appeal case is withdrawn, but A is never told: the withdrawal notification excluded `appellantRepresentativeNationalIds`, i.e. every party that ever appealed. By the time the appeal is finally withdrawn all appellants have withdrawn, so every appellant defender was silenced — including the ones that had heard nothing since their own withdrawal.

The exclusion is now the acting user alone. Everyone else — the other defenders, the civil claimant spokespersons, the prosecutor, the district court and the Court of Appeals — is notified as before.

While in there, the same function had a second gap. It only built party recipients inside `isProsecutionUser` / `isDefenceUser` branches, so when a district court user ends the appeal by correcting the court record (`CourtSessionService.reconcileInCourtRulingOrderAppeal` withdraws the appeal case once no standing appeal decision remains) neither branch fired and no party was notified at all — only the judge, court, registrar and Court of Appeals. The two branches are now one flow: the prosecutor is notified whenever the withdrawer is not the prosecution, and the defence recipients are built once, with the exclusion only when a defence user withdrew.

That path also claimed "Verjandi hefur afturkallað kæru" when no party had acted, so it gets a neutral body: "Kæra í máli {courtCaseNumber} hefur verið afturkölluð." This is a new message id rather than a third branch of the existing select — the existing string may be overridden in Contentful, where a changed placeholder set would silently keep rendering the old text.

Unchanged: the request-case recipient list (single collective defender, unreachable by a court user) and the deliberate silence when one of several appellants withdraws while the appeal still stands.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved notifications when an indictment appeal is withdrawn.
  * Withdrawal messages now identify the responsible party where applicable.
  * Court-initiated appeal closures display a dedicated message.
  * Prosecutors, defence representatives, and civil claimant lawyers now receive notifications according to their involvement, without unnecessary self-notifications.
  * Added coverage for final-appellant withdrawals and court corrections that end an appeal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->