### PR TITLE
fix(j-s): Refuse an after-commit callback once the request transaction has settled

### DIFF
--- a/apps/judicial-system/backend/src/app/interceptors/test/transactionCommit.interceptor.spec.ts
+++ b/apps/judicial-system/backend/src/app/interceptors/test/transactionCommit.interceptor.spec.ts
@@ -2,7 +2,11 @@ import { lastValueFrom, of, tap, throwError } from 'rxjs'
 import type { Transaction } from 'sequelize'
 import type { Sequelize } from 'sequelize-typescript'
 
-import { CallHandler, ExecutionContext } from '@nestjs/common'
+import {
+  CallHandler,
+  ExecutionContext,
+  InternalServerErrorException,
+} from '@nestjs/common'
 
 import type { Logger } from '@island.is/logging'
 
@@ -134,6 +138,31 @@ describe('TransactionCommitInterceptor', () => {
       expect(logger.error).toHaveBeenCalledWith(
         'An after commit callback failed',
         { error },
+      )
+    })
+
+    it('should refuse a callback that registers another callback, without failing the request', async () => {
+      const second = jest.fn()
+      const next: CallHandler = { handle: () => of('some value') }
+
+      const value = await runInRequestContext(async () => {
+        await getOrCreateTransaction(sequelize)
+        registerAfterCommit(async () => {
+          // The slot is settled by the time the callbacks are drained, so this
+          // registration is refused: the callback would be appended to the
+          // array being iterated, and would run in a drain that has already
+          // passed the commit it was meant to follow.
+          registerAfterCommit(second)
+        })
+
+        return await lastValueFrom(interceptor.intercept(context, next))
+      })
+
+      expect(second).not.toHaveBeenCalled()
+      expect(value).toBe('some value')
+      expect(logger.error).toHaveBeenCalledWith(
+        'An after commit callback failed',
+        { error: expect.any(InternalServerErrorException) },
       )
     })
 

--- a/apps/judicial-system/backend/src/app/middleware/test/transactionContext.middleware.spec.ts
+++ b/apps/judicial-system/backend/src/app/middleware/test/transactionContext.middleware.spec.ts
@@ -246,6 +246,39 @@ describe('TransactionContextMiddleware', () => {
         expect(getTransactionContext()?.afterCommit).toEqual([first, second])
       })
     })
+
+    it('should refuse to register an after commit callback while the slot is being settled', async () => {
+      await givenARequest(() => {
+        const context = getTransactionContext()
+
+        if (context) {
+          context.settlement = 'settling'
+        }
+
+        expect(() => registerAfterCommit(async () => undefined)).toThrow(
+          InternalServerErrorException,
+        )
+        expect(context?.afterCommit).toEqual([])
+      })
+    })
+
+    it('should refuse to register an after commit callback once the slot is settled', async () => {
+      await givenARequest(() => {
+        const context = getTransactionContext()
+
+        // The interceptor settles the slot before it drains the callbacks, and
+        // the close handler never drains them at all, so a callback registered
+        // now would be one nothing ever runs.
+        if (context) {
+          context.settlement = 'settled'
+        }
+
+        expect(() => registerAfterCommit(async () => undefined)).toThrow(
+          InternalServerErrorException,
+        )
+        expect(context?.afterCommit).toEqual([])
+      })
+    })
   })
 
   describe('when the response ends', () => {

--- a/apps/judicial-system/backend/src/app/middleware/transactionContext.middleware.ts
+++ b/apps/judicial-system/backend/src/app/middleware/transactionContext.middleware.ts
@@ -114,7 +114,21 @@ export const getOrCreateTransaction = async (
  * risks claiming an outcome the database never accepted.
  */
 export const registerAfterCommit = (callback: AfterCommitCallback) => {
-  requireTransactionContext().afterCommit.push(callback)
+  const context = requireTransactionContext()
+
+  // Nothing drains the array once the slot has been claimed: the interceptor
+  // settles it before it iterates, and the close handler never drains at all.
+  // A callback registered now would sit there until the request's store is
+  // discarded, losing the side effect without a trace - the exact outcome this
+  // hook exists to prevent. As with reopening a transaction, it is a
+  // programming error rather than a condition the caller can recover from.
+  if (context.settlement !== 'open') {
+    throw new InternalServerErrorException(
+      `The request transaction is already ${context.settlement}; an after commit callback registered now would never run.`,
+    )
+  }
+
+  context.afterCommit.push(callback)
 }
 
 @Injectable()


### PR DESCRIPTION
# Refuse an after-commit callback once the request transaction has settled

[Verja registerAfterCommit eftir að færslu er lokið](https://app.asana.com/1/203394141643832/project/1199153462262248/task/1217916325243342)

`registerAfterCommit` was the one entry point into the request's transaction slot that ignored `settlement`. Its two siblings already refuse a non-`open` slot — `getOrCreateTransaction` (`transactionContext.middleware.ts:88`) and the middleware's `close` handler — but registration pushed onto the callback array unconditionally.

Nothing drains that array after the slot has been claimed: `TransactionCommitInterceptor.commit()` settles the slot in its `finally` before it iterates, and the `close` handler never drains it at all. So a callback registered after settlement was silently lost — which is the exact failure the hook exists to prevent, since a dropped `postEvent` leaves no trace. It now throws instead, matching the sibling guard in behaviour and wording. Throwing rather than logging and dropping is deliberate: it is a programming error, not a condition the caller can recover from.

Not reachable on `main` today — the one converted route (`PATCH case/:caseId/state`) registers synchronously inside its handler — but reachable as soon as a route registers from an async path.

**One behaviour change worth reviewing.** Because the interceptor settles the slot before draining, a callback that itself calls `registerAfterCommit` during the drain now throws. That is the right outcome: such a callback would be appended to the array being iterated, i.e. run in a drain that had already passed the commit it was meant to follow. The interceptor already catches and logs a failing callback, so the request is unaffected — and there is now a test pinning exactly that.

Scope: one source file and two specs. No route, guard, handler or module changed (`git diff --name-only origin/main -- modules/` is empty), and the three-state settlement lifecycle itself is untouched.

**Testing**

- New middleware specs: registering while the slot is `settling` or `settled` throws and does not push; registering on an `open` slot still pushes in order (existing test kept). The pre-existing "outside a request" assertion is left alone — that is `requireTransactionContext`, a different guard, not folded in.
- New interceptor spec: a callback that registers another callback during the drain is refused, the interceptor logs it, the request still returns its value, and the second callback never runs.
- Coverage check: with the guard removed, exactly the three new tests fail.
- `npx tsc --noEmit -p apps/judicial-system/backend/tsconfig.app.json` clean; full backend suite green (433 suites / 97 807 tests); lint clean; `judicial-system-backend:codegen/backend-schema` produces an unchanged `openapi.yaml`.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented after-commit callbacks from being registered after transaction settlement has started or completed.
  - Invalid callback registrations now fail with an internal server error instead of being silently accepted.
  - Preserved normal request processing and improved error handling for callbacks registered during commit processing.

- **Tests**
  - Added coverage for rejected registrations during settling, after settlement, and nested after-commit callbacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->