### PR TITLE
feat(native-app): Use activatedAt/expiredAt from server for video appointments and add props

### DIFF
--- a/apps/native/app/src/app/(auth)/(tabs)/health/appointments/[id].tsx
+++ b/apps/native/app/src/app/(auth)/(tabs)/health/appointments/[id].tsx
@@ -22,6 +22,7 @@ import videoCameraIcon from '@/assets/icons/video-camera.png'
 import {
   AppointmentFragmentFragmentDoc,
   HealthDirectorateAppointment,
+  HealthDirectorateAppointmentAssigneeType,
   HealthDirectorateAppointmentLinkType,
   HealthDirectorateAppointmentModality,
   useGetAppointmentDetailQuery,
@@ -57,6 +58,22 @@ const MapLink = styled.TouchableOpacity`
 
 const LocationItem = styled.View`
   gap: ${({ theme }) => theme.spacing[1]}px;
+`
+
+const InlineLink = styled.TouchableOpacity`
+  flex-direction: row;
+  align-items: center;
+  gap: ${({ theme }) => theme.spacing.smallGutter}px;
+  border-bottom-width: 1px;
+  border-bottom-color: ${({ theme }) => theme.color.blue400};
+`
+
+const MoreInfoRow = styled.View`
+  margin-horizontal: ${({ theme }) => theme.spacing[2]}px;
+  padding-vertical: ${({ theme }) => theme.spacing[3]}px;
+  gap: ${({ theme }) => theme.spacing[1]}px;
+  border-bottom-width: ${({ theme }) => theme.border.width.standard}px;
+  border-bottom-color: ${({ theme }) => theme.color.blue200};
 `
 
 const EyebrowContainer = styled.View`
@@ -152,15 +169,73 @@ export default function AppointmentDetailScreen() {
     void openExternalUrl(mapsLink)
   }, [mapsLink, openExternalUrl])
 
+  const renderSeeMore = (
+    url: string,
+    alignSelf: 'center' | 'flex-start' = 'center',
+  ) => (
+    <InlineLink
+      style={{ alignSelf }}
+      onPress={() => void openExternalUrl(url)}
+    >
+      <Typography variant="eyebrow" color={theme.color.blue400}>
+        {intl.formatMessage({ id: 'health.appointments.seeMore' })}
+      </Typography>
+      <Icon
+        source={externalLink as ImageSourcePropType}
+        width={16}
+        height={16}
+      />
+    </InlineLink>
+  )
+
   const locationLinks = appointment?.location?.locationLinks
   const locationLink =
     locationLinks?.find((l) => l.type === 'WEBSITE')?.url ??
     locationLinks?.[0]?.url
 
+  // assignees and the finer location fields only exist on the detail type,
+  // not the cached list fragment, so read them off the query result directly.
+  const detail = data?.healthDirectorateAppointment
+
+  const findLink = (type: HealthDirectorateAppointmentLinkType) =>
+    detail?.links?.find((l) => l.type === type)?.url
+  const preparationLink = findLink(
+    HealthDirectorateAppointmentLinkType.Preparation,
+  )
+  const patientInstructionsLink = findLink(
+    HealthDirectorateAppointmentLinkType.PatientInstructions,
+  )
+  const organizationInfoLink = findLink(
+    HealthDirectorateAppointmentLinkType.OrganizationInfo,
+  )
+
+  const assigneeTypeLabel = (type: HealthDirectorateAppointmentAssigneeType) => {
+    switch (type) {
+      case HealthDirectorateAppointmentAssigneeType.Role:
+        return intl.formatMessage({ id: 'health.appointments.assigneeTypeRole' })
+      case HealthDirectorateAppointmentAssigneeType.Room:
+        return intl.formatMessage({ id: 'health.appointments.assigneeTypeRoom' })
+      case HealthDirectorateAppointmentAssigneeType.Equipment:
+        return intl.formatMessage({
+          id: 'health.appointments.assigneeTypeEquipment',
+        })
+      case HealthDirectorateAppointmentAssigneeType.Service:
+        return intl.formatMessage({
+          id: 'health.appointments.assigneeTypeService',
+        })
+      case HealthDirectorateAppointmentAssigneeType.Team:
+        return intl.formatMessage({ id: 'health.appointments.assigneeTypeTeam' })
+      default:
+        return intl.formatMessage({
+          id: 'health.appointments.assigneeTypeOther',
+        })
+    }
+  }
+
   const isVideo =
     appointment?.modality === HealthDirectorateAppointmentModality.Video
 
-  const videoCall = data?.healthDirectorateAppointment?.links?.find(
+  const videoCall = detail?.links?.find(
     (l) => l.type === HealthDirectorateAppointmentLinkType.VideoCall,
   )
   const videoCallLink = videoCall?.url
@@ -213,9 +288,15 @@ export default function AppointmentDetailScreen() {
   const hasMoreInfo =
     !!appointment &&
     ((appointment.practitioners?.length ?? 0) > 0 ||
+      (detail?.assignees?.length ?? 0) > 0 ||
       !!appointment.instruction ||
-      !!appointment.location?.openingHoursText ||
+      !!preparationLink ||
+      !!detail?.location?.department ||
+      !!detail?.location?.wing ||
+      !!detail?.location?.floor ||
+      !!detail?.location?.room ||
       !!appointment.location?.phoneNumber ||
+      !!appointment.location?.openingHoursText ||
       !!appointment.location?.organization)
 
   return (
@@ -227,7 +308,7 @@ export default function AppointmentDetailScreen() {
       />
       <ScrollView
         style={{ flex: 1 }}
-        contentContainerStyle={{ paddingBottom: 64 }}
+        contentContainerStyle={{ paddingBottom: 240 }}
         contentInsetAdjustmentBehavior="automatic"
       >
         {error && !appointment && (
@@ -422,6 +503,15 @@ export default function AppointmentDetailScreen() {
               </InputRow>
             )}
 
+            {detail?.assignees?.map((assignee, index) => (
+              <InputRow key={`assignee-${index}`}>
+                <Input
+                  label={assigneeTypeLabel(assignee.type)}
+                  value={assignee.name}
+                />
+              </InputRow>
+            ))}
+
             {appointment.instruction && (
               <InputRow>
                 <Input
@@ -429,6 +519,61 @@ export default function AppointmentDetailScreen() {
                     id: 'health.appointments.instructions',
                   })}
                   value={appointment.instruction}
+                  rightElement={
+                    patientInstructionsLink
+                      ? renderSeeMore(patientInstructionsLink)
+                      : undefined
+                  }
+                />
+              </InputRow>
+            )}
+
+            {preparationLink && (
+              <MoreInfoRow>
+                <Typography variant="body3">
+                  {intl.formatMessage({
+                    id: 'health.appointments.preparation',
+                  })}
+                </Typography>
+                {renderSeeMore(preparationLink, 'flex-start')}
+              </MoreInfoRow>
+            )}
+
+            {[
+              {
+                id: 'health.appointments.locationDepartment',
+                value: detail?.location?.department,
+              },
+              {
+                id: 'health.appointments.locationWing',
+                value: detail?.location?.wing,
+              },
+              {
+                id: 'health.appointments.locationFloor',
+                value: detail?.location?.floor,
+              },
+              {
+                id: 'health.appointments.locationRoom',
+                value: detail?.location?.room,
+              },
+            ]
+              .filter((line) => !!line.value)
+              .map((line) => (
+                <InputRow key={line.id}>
+                  <Input
+                    label={intl.formatMessage({ id: line.id })}
+                    value={line.value}
+                  />
+                </InputRow>
+              ))}
+
+            {appointment.location?.phoneNumber && (
+              <InputRow>
+                <Input
+                  label={intl.formatMessage({
+                    id: 'health.appointments.phoneNumber',
+                  })}
+                  value={appointment.location.phoneNumber}
                 />
               </InputRow>
             )}
@@ -444,17 +589,6 @@ export default function AppointmentDetailScreen() {
               </InputRow>
             )}
 
-            {appointment.location?.phoneNumber && (
-              <InputRow>
-                <Input
-                  label={intl.formatMessage({
-                    id: 'health.appointments.phoneNumber',
-                  })}
-                  value={appointment.location.phoneNumber}
-                />
-              </InputRow>
-            )}
-
             {appointment.location?.organization && (
               <InputRow>
                 <Input
@@ -462,6 +596,11 @@ export default function AppointmentDetailScreen() {
                     id: 'health.appointments.organization',
                   })}
                   value={appointment.location.organization}
+                  rightElement={
+                    organizationInfoLink
+                      ? renderSeeMore(organizationInfoLink)
+                      : undefined
+                  }
                 />
               </InputRow>
             )}

--- a/apps/native/app/src/app/(auth)/(tabs)/health/appointments/[id].tsx
+++ b/apps/native/app/src/app/(auth)/(tabs)/health/appointments/[id].tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react'
+import React, { useCallback, useEffect, useReducer } from 'react'
 import { useIntl } from 'react-intl'
 import {
   ImageSourcePropType,
@@ -75,6 +75,35 @@ const StickyFooter = styled.View`
   background-color: ${({ theme }) => theme.color.white};
 `
 
+type VideoCallPhase = 'before' | 'active' | 'expired'
+
+// A missing/unparseable timestamp yields undefined, treated downstream as
+// "not time-gated" so the link stays usable rather than blocking the call.
+const toTimeMs = (value?: string | null): number | undefined => {
+  if (!value) {
+    return undefined
+  }
+  const ms = new Date(value).getTime()
+  return Number.isNaN(ms) ? undefined : ms
+}
+
+const getVideoCallPhase = (
+  activatesAtMs?: number,
+  expiresAtMs?: number,
+): VideoCallPhase => {
+  if (activatesAtMs === undefined || expiresAtMs === undefined) {
+    return 'active'
+  }
+  const now = Date.now()
+  if (now >= expiresAtMs) {
+    return 'expired'
+  }
+  if (now >= activatesAtMs) {
+    return 'active'
+  }
+  return 'before'
+}
+
 export default function AppointmentDetailScreen() {
   const { id: appointmentId } = useLocalSearchParams<{ id: string }>()
   const intl = useIntl()
@@ -131,60 +160,34 @@ export default function AppointmentDetailScreen() {
   const isVideo =
     appointment?.modality === HealthDirectorateAppointmentModality.Video
 
-  const videoCallLink = data?.healthDirectorateAppointment?.links?.find(
+  const videoCall = data?.healthDirectorateAppointment?.links?.find(
     (l) => l.type === HealthDirectorateAppointmentLinkType.VideoCall,
-  )?.url
+  )
+  const videoCallLink = videoCall?.url
 
-  type VideoCallPhase = 'before' | 'active' | 'expired'
-  const [videoCallPhase, setVideoCallPhase] = useState<VideoCallPhase>('before')
+  // Activation window (link becomes usable / expires) comes from the server.
+  const activatesAtMs = toTimeMs(videoCall?.activatesAt)
+  const expiresAtMs = toTimeMs(videoCall?.expiresAt)
 
+  const [, rerender] = useReducer((c) => c + 1, 0)
+  const videoCallPhase = getVideoCallPhase(activatesAtMs, expiresAtMs)
+
+  // Arm a timer for the next phase boundary. No dep array: it re-arms each
+  // render, so a capped long wait chains itself and a sleep-delayed timer
+  // self-corrects instead of getting stuck.
   useEffect(() => {
-    if (!appointment?.date) {
-      setVideoCallPhase('before')
+    if (
+      videoCallPhase === 'expired' ||
+      activatesAtMs === undefined ||
+      expiresAtMs === undefined
+    ) {
       return
     }
-    const appointmentMs = new Date(appointment.date).getTime()
-    const activateAtMs = appointmentMs - 5 * 60 * 1000
-    // 1 hour after the appointment start time, we stop showing anything related to the link
-    const deactivateAtMs = appointmentMs + 60 * 60 * 1000
-    const now = Date.now()
-
-    if (now >= deactivateAtMs) {
-      setVideoCallPhase('expired')
-      return
-    }
-
-    if (now >= activateAtMs) {
-      setVideoCallPhase('active')
-      const deactivateTimeout = setTimeout(
-        () => setVideoCallPhase('expired'),
-        deactivateAtMs - now,
-      )
-      return () => clearTimeout(deactivateTimeout)
-    }
-
-    setVideoCallPhase('before')
-
-    // setTimeout in JS overflows past ~24.8 days (2^31 - 1 ms) and fires
-    // immediately. For appointments further out, skip scheduling — the user
-    // will revisit closer to the date and the next mount will set it up.
-    const MAX_TIMEOUT_MS = 2 ** 31 - 1
-    if (activateAtMs - now > MAX_TIMEOUT_MS) {
-      return
-    }
-
-    const activateTimeout = setTimeout(() => {
-      setVideoCallPhase('active')
-    }, activateAtMs - now)
-    const deactivateTimeout = setTimeout(
-      () => setVideoCallPhase('expired'),
-      deactivateAtMs - now,
-    )
-    return () => {
-      clearTimeout(activateTimeout)
-      clearTimeout(deactivateTimeout)
-    }
-  }, [appointment?.date])
+    const boundary = videoCallPhase === 'before' ? activatesAtMs : expiresAtMs
+    const delay = Math.min(boundary - Date.now(), 60 * 60 * 1000)
+    const timeout = setTimeout(rerender, Math.max(delay, 1000))
+    return () => clearTimeout(timeout)
+  })
 
   const isVideoCallActive = videoCallPhase === 'active'
   const isVideoCallExpired = videoCallPhase === 'expired'

--- a/apps/native/app/src/app/(auth)/(tabs)/health/appointments/[id].tsx
+++ b/apps/native/app/src/app/(auth)/(tabs)/health/appointments/[id].tsx
@@ -173,10 +173,7 @@ export default function AppointmentDetailScreen() {
     url: string,
     alignSelf: 'center' | 'flex-start' = 'center',
   ) => (
-    <InlineLink
-      style={{ alignSelf }}
-      onPress={() => void openExternalUrl(url)}
-    >
+    <InlineLink style={{ alignSelf }} onPress={() => void openExternalUrl(url)}>
       <Typography variant="eyebrow" color={theme.color.blue400}>
         {intl.formatMessage({ id: 'health.appointments.seeMore' })}
       </Typography>
@@ -209,12 +206,18 @@ export default function AppointmentDetailScreen() {
     HealthDirectorateAppointmentLinkType.OrganizationInfo,
   )
 
-  const assigneeTypeLabel = (type: HealthDirectorateAppointmentAssigneeType) => {
+  const assigneeTypeLabel = (
+    type: HealthDirectorateAppointmentAssigneeType,
+  ) => {
     switch (type) {
       case HealthDirectorateAppointmentAssigneeType.Role:
-        return intl.formatMessage({ id: 'health.appointments.assigneeTypeRole' })
+        return intl.formatMessage({
+          id: 'health.appointments.assigneeTypeRole',
+        })
       case HealthDirectorateAppointmentAssigneeType.Room:
-        return intl.formatMessage({ id: 'health.appointments.assigneeTypeRoom' })
+        return intl.formatMessage({
+          id: 'health.appointments.assigneeTypeRoom',
+        })
       case HealthDirectorateAppointmentAssigneeType.Equipment:
         return intl.formatMessage({
           id: 'health.appointments.assigneeTypeEquipment',
@@ -224,7 +227,9 @@ export default function AppointmentDetailScreen() {
           id: 'health.appointments.assigneeTypeService',
         })
       case HealthDirectorateAppointmentAssigneeType.Team:
-        return intl.formatMessage({ id: 'health.appointments.assigneeTypeTeam' })
+        return intl.formatMessage({
+          id: 'health.appointments.assigneeTypeTeam',
+        })
       default:
         return intl.formatMessage({
           id: 'health.appointments.assigneeTypeOther',

--- a/apps/native/app/src/graphql/queries/health.graphql
+++ b/apps/native/app/src/graphql/queries/health.graphql
@@ -257,6 +257,10 @@ query getAppointmentDetail($id: String!) {
     duration
     modality
     practitioners
+    assignees {
+      type
+      name
+    }
     links {
       type
       url
@@ -266,8 +270,11 @@ query getAppointmentDetail($id: String!) {
     location {
       name
       organization
-      directions
       address
+      department
+      wing
+      floor
+      room
       city
       postalCode
       country

--- a/apps/native/app/src/graphql/queries/health.graphql
+++ b/apps/native/app/src/graphql/queries/health.graphql
@@ -260,6 +260,8 @@ query getAppointmentDetail($id: String!) {
     links {
       type
       url
+      activatesAt
+      expiresAt
     }
     location {
       name

--- a/apps/native/app/src/messages/en.ts
+++ b/apps/native/app/src/messages/en.ts
@@ -860,6 +860,17 @@ export const en: TranslatedMessages = {
     'Appointment not found. It may have been cancelled.',
   'health.appointments.minutesFormat': '{minutes} minutes',
   'health.appointments.moreInfo': 'More information',
+  'health.appointments.preparation': 'Preparation',
+  'health.appointments.locationDepartment': 'Department',
+  'health.appointments.locationWing': 'Wing',
+  'health.appointments.locationFloor': 'Floor',
+  'health.appointments.locationRoom': 'Room',
+  'health.appointments.assigneeTypeRole': 'Role',
+  'health.appointments.assigneeTypeRoom': 'Room',
+  'health.appointments.assigneeTypeEquipment': 'Equipment',
+  'health.appointments.assigneeTypeService': 'Service',
+  'health.appointments.assigneeTypeTeam': 'Team',
+  'health.appointments.assigneeTypeOther': 'Other',
 
   // health - messages
   'health.messages.screenTitle': 'Messages',

--- a/apps/native/app/src/messages/is.ts
+++ b/apps/native/app/src/messages/is.ts
@@ -858,6 +858,17 @@ export const is = {
     'Tímabókun fannst ekki. Hún kann að hafa verið felld niður.',
   'health.appointments.minutesFormat': '{minutes} mínútur',
   'health.appointments.moreInfo': 'Nánari upplýsingar',
+  'health.appointments.preparation': 'Undirbúningur',
+  'health.appointments.locationDepartment': 'Deild',
+  'health.appointments.locationWing': 'Álma',
+  'health.appointments.locationFloor': 'Hæð',
+  'health.appointments.locationRoom': 'Herbergi',
+  'health.appointments.assigneeTypeRole': 'Hlutverk',
+  'health.appointments.assigneeTypeRoom': 'Herbergi',
+  'health.appointments.assigneeTypeEquipment': 'Tæki',
+  'health.appointments.assigneeTypeService': 'Þjónusta',
+  'health.appointments.assigneeTypeTeam': 'Teymi',
+  'health.appointments.assigneeTypeOther': 'Annað',
 
   // health - messages
   'health.messages.screenTitle': 'Skilaboð',


### PR DESCRIPTION
Update appointments that are a video call to use activatedAt/expiresAt props from the server.
Also adding more available properties to show in the appointment detail view.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added expanded appointment details, including assignees, preparation guidance, patient instructions, and precise location information.
  * Added links for additional instructions and organization details.
  * Added English and Icelandic translations for the new appointment information.
* **Improvements**
  * Video call availability now follows the appointment’s configured activation and expiration times.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->