### PR TITLE
test(j-s): Execute the guard chain for the case transition route

### DIFF
--- a/apps/judicial-system/backend/src/app/modules/case/test/caseController/transitionGuardChain.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/case/test/caseController/transitionGuardChain.spec.ts
@@ -1,0 +1,194 @@
+import type { Transaction } from 'sequelize'
+import { Sequelize } from 'sequelize-typescript'
+import { v4 as uuid } from 'uuid'
+
+import { NotFoundException } from '@nestjs/common'
+import { Reflector } from '@nestjs/core'
+
+import { RolesGuard } from '@island.is/judicial-system/auth'
+import {
+  CaseState,
+  CaseTransition,
+  CaseType,
+  InstitutionType,
+  User,
+  UserRole,
+} from '@island.is/judicial-system/types'
+
+import { createTestingCaseModule } from '../createTestingCaseModule'
+
+import { runGuardChain, runInRequestContext } from '../../../../test'
+import { Case, CaseRepositoryService } from '../../../repository'
+import { CaseController } from '../../case.controller'
+import { CaseExistsForUpdateGuard } from '../../guards/caseExistsForUpdate.guard'
+import { CaseTransitionGuard } from '../../guards/caseTransition.guard'
+import { CaseWriteGuard } from '../../guards/caseWrite.guard'
+
+// The transition route's guards, executed rather than merely declared.
+//
+// caseControllerGuards.spec.ts pins the declared order and
+// transitionRolesRules.spec.ts pins the one rule that reads request.case.
+// Neither runs a guard, so neither would have caught the reversed chain that
+// rejected every prosecutor transition with a 403 - it passed the whole suite,
+// lint and CI, and was found by a person reading the diff. These tests close
+// that gap for the one route that has been converted so far; each further
+// conversion brings its own table.
+describe('CaseController - Transition guard chain', () => {
+  const prosecutorsOfficeId = uuid()
+  const courtId = uuid()
+
+  const prosecutor = {
+    id: uuid(),
+    role: UserRole.PROSECUTOR,
+    institution: {
+      id: prosecutorsOfficeId,
+      type: InstitutionType.POLICE_PROSECUTORS_OFFICE,
+    },
+    canConfirmIndictment: false,
+  } as User
+
+  const districtCourtJudge = {
+    id: uuid(),
+    role: UserRole.DISTRICT_COURT_JUDGE,
+    institution: { id: courtId, type: InstitutionType.DISTRICT_COURT },
+  } as User
+
+  const defender = {
+    id: uuid(),
+    role: UserRole.DEFENDER,
+  } as User
+
+  const transaction = {} as Transaction
+
+  let mockCaseRepositoryService: CaseRepositoryService
+  let runChain: (
+    user: User,
+    transition: CaseTransition,
+    caseId: string,
+  ) => Promise<{ allowed: boolean; rejectedBy?: string; error?: Error }>
+
+  beforeEach(async () => {
+    const { caseRepositoryService, caseService, sequelize } =
+      await createTestingCaseModule()
+
+    mockCaseRepositoryService = caseRepositoryService
+
+    const mockTransaction = (sequelize as Sequelize).transaction as jest.Mock
+    mockTransaction.mockResolvedValue(transaction)
+
+    // One instance per guard the route declares. RolesGuard gets a real
+    // Reflector so it resolves the route's rules from its own metadata.
+    const guards = [
+      new CaseExistsForUpdateGuard(caseService, sequelize),
+      new RolesGuard(new Reflector()),
+      new CaseWriteGuard(),
+      new CaseTransitionGuard(),
+    ]
+
+    runChain = (user, transition, caseId) =>
+      runInRequestContext(() =>
+        runGuardChain(CaseController, 'transition', guards, {
+          params: { caseId },
+          user: { currentUser: user },
+          body: { transition },
+          case: undefined,
+        }),
+      )
+  })
+
+  describe('prosecutor submitting a case they can write', () => {
+    const caseId = uuid()
+    const theCase = {
+      id: caseId,
+      type: CaseType.CUSTODY,
+      state: CaseState.DRAFT,
+      prosecutorsOfficeId,
+    } as Case
+    let then: Awaited<ReturnType<typeof runChain>>
+
+    beforeEach(async () => {
+      const mockFindLiveByIdForUpdate =
+        mockCaseRepositoryService.findLiveByIdForUpdate as jest.Mock
+      mockFindLiveByIdForUpdate.mockResolvedValueOnce(theCase)
+
+      then = await runChain(prosecutor, CaseTransition.SUBMIT, caseId)
+    })
+
+    // This is the regression: prosecutorTransitionRule reads request.case and
+    // denies outright when it is missing, so it fails the moment RolesGuard is
+    // moved ahead of CaseExistsForUpdateGuard.
+    it('should let the whole chain through', () => {
+      expect(then.error).toBeUndefined()
+      expect(then.rejectedBy).toBeUndefined()
+      expect(then.allowed).toBe(true)
+    })
+  })
+
+  describe('district court judge receiving a case at their court', () => {
+    const caseId = uuid()
+    const theCase = {
+      id: caseId,
+      type: CaseType.CUSTODY,
+      state: CaseState.SUBMITTED,
+      courtId,
+    } as Case
+    let then: Awaited<ReturnType<typeof runChain>>
+
+    beforeEach(async () => {
+      const mockFindLiveByIdForUpdate =
+        mockCaseRepositoryService.findLiveByIdForUpdate as jest.Mock
+      mockFindLiveByIdForUpdate.mockResolvedValueOnce(theCase)
+
+      then = await runChain(districtCourtJudge, CaseTransition.RECEIVE, caseId)
+    })
+
+    it('should let the whole chain through', () => {
+      expect(then.error).toBeUndefined()
+      expect(then.rejectedBy).toBeUndefined()
+      expect(then.allowed).toBe(true)
+    })
+  })
+
+  describe('user in a role the route has no rule for', () => {
+    const caseId = uuid()
+    const theCase = {
+      id: caseId,
+      type: CaseType.CUSTODY,
+      state: CaseState.DRAFT,
+      prosecutorsOfficeId,
+    } as Case
+    let then: Awaited<ReturnType<typeof runChain>>
+
+    beforeEach(async () => {
+      const mockFindLiveByIdForUpdate =
+        mockCaseRepositoryService.findLiveByIdForUpdate as jest.Mock
+      mockFindLiveByIdForUpdate.mockResolvedValueOnce(theCase)
+
+      then = await runChain(defender, CaseTransition.SUBMIT, caseId)
+    })
+
+    it('should be rejected by RolesGuard', () => {
+      expect(then.allowed).toBe(false)
+      expect(then.rejectedBy).toBe(RolesGuard.name)
+    })
+  })
+
+  describe('case does not exist', () => {
+    const caseId = uuid()
+    let then: Awaited<ReturnType<typeof runChain>>
+
+    beforeEach(async () => {
+      const mockFindLiveByIdForUpdate =
+        mockCaseRepositoryService.findLiveByIdForUpdate as jest.Mock
+      mockFindLiveByIdForUpdate.mockResolvedValueOnce(null)
+
+      then = await runChain(prosecutor, CaseTransition.SUBMIT, caseId)
+    })
+
+    it('should be rejected by the case-exists guard before any rule runs', () => {
+      expect(then.allowed).toBe(false)
+      expect(then.rejectedBy).toBe(CaseExistsForUpdateGuard.name)
+      expect(then.error).toBeInstanceOf(NotFoundException)
+    })
+  })
+})

--- a/apps/judicial-system/backend/src/app/modules/case/test/caseController/transitionGuardChain.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/case/test/caseController/transitionGuardChain.spec.ts
@@ -5,7 +5,7 @@ import { v4 as uuid } from 'uuid'
 import { NotFoundException } from '@nestjs/common'
 import { Reflector } from '@nestjs/core'
 
-import { RolesGuard } from '@island.is/judicial-system/auth'
+import { JwtAuthUserGuard, RolesGuard } from '@island.is/judicial-system/auth'
 import {
   CaseState,
   CaseTransition,
@@ -33,6 +33,15 @@ import { CaseWriteGuard } from '../../guards/caseWrite.guard'
 // lint and CI, and was found by a person reading the diff. These tests close
 // that gap for the one route that has been converted so far; each further
 // conversion brings its own table.
+// Authentication is out of the picture here: every row supplies a user, and
+// what is being tested is what the route's authorization guards then do with
+// them. Passport's real jwt strategy is not registered in a unit test, so it
+// stands in as a subclass - the chain still refuses to run if the controller
+// gains a class-level guard this spec does not account for.
+class AuthenticatedGuard extends JwtAuthUserGuard {
+  canActivate = () => true
+}
+
 describe('CaseController - Transition guard chain', () => {
   const prosecutorsOfficeId = uuid()
   const courtId = uuid()
@@ -76,9 +85,12 @@ describe('CaseController - Transition guard chain', () => {
     const mockTransaction = (sequelize as Sequelize).transaction as jest.Mock
     mockTransaction.mockResolvedValue(transaction)
 
-    // One instance per guard the route declares. RolesGuard gets a real
-    // Reflector so it resolves the route's rules from its own metadata.
+    // One instance per guard the chain declares, including CaseController's
+    // class-level JwtAuthUserGuard, which Nest runs before the method-level
+    // ones. RolesGuard gets a real Reflector so it resolves the route's rules
+    // from its own metadata.
     const guards = [
+      new AuthenticatedGuard(),
       new CaseExistsForUpdateGuard(caseService, sequelize),
       new RolesGuard(new Reflector()),
       new CaseWriteGuard(),

--- a/apps/judicial-system/backend/src/app/test/index.ts
+++ b/apps/judicial-system/backend/src/app/test/index.ts
@@ -7,4 +7,7 @@ export {
 
 export { verifyGuards, verifyRolesRules } from './testHelpers'
 
+export { runGuardChain } from './verifyGuardChain'
+export type { GuardChainOutcome } from './verifyGuardChain'
+
 export { runInRequestContext } from './transactionContext'

--- a/apps/judicial-system/backend/src/app/test/verifyGuardChain.spec.ts
+++ b/apps/judicial-system/backend/src/app/test/verifyGuardChain.spec.ts
@@ -1,0 +1,127 @@
+import { of } from 'rxjs'
+
+import { CanActivate, Controller, Get, UseGuards } from '@nestjs/common'
+
+import { runGuardChain } from './verifyGuardChain'
+
+// The harness decides whether a route's authorization is executed faithfully,
+// so a hole in it reads as "no findings" rather than as a failure. These tests
+// pin the three ways it could quietly pass a request the route would reject.
+
+class AllowGuard implements CanActivate {
+  canActivate() {
+    return true
+  }
+}
+
+class ClassLevelGuard implements CanActivate {
+  canActivate() {
+    return false
+  }
+}
+
+class ObservableDenyGuard implements CanActivate {
+  canActivate() {
+    // canActivate may return an Observable. Awaiting one yields the Observable
+    // itself, which is a truthy object - it has to be consumed to see `false`.
+    return of(false)
+  }
+}
+
+class ConfiguredGuard implements CanActivate {
+  constructor(private readonly allowed: boolean) {}
+
+  canActivate() {
+    return this.allowed
+  }
+}
+
+class UnsuppliedGuard implements CanActivate {
+  canActivate() {
+    return true
+  }
+}
+
+@Controller()
+class MethodGuardsController {
+  @UseGuards(AllowGuard, ObservableDenyGuard)
+  @Get()
+  route() {
+    return null
+  }
+}
+
+@Controller()
+@UseGuards(ClassLevelGuard)
+class ClassGuardsController {
+  @UseGuards(AllowGuard)
+  @Get()
+  route() {
+    return null
+  }
+}
+
+@Controller()
+class InstanceGuardsController {
+  @UseGuards(AllowGuard, new ConfiguredGuard(false))
+  @Get()
+  route() {
+    return null
+  }
+}
+
+@Controller()
+class UnsuppliedGuardsController {
+  @UseGuards(UnsuppliedGuard)
+  @Get()
+  route() {
+    return null
+  }
+}
+
+describe('runGuardChain', () => {
+  it('should consume an Observable result rather than read the Observable as truthy', async () => {
+    const then = await runGuardChain(
+      MethodGuardsController,
+      'route',
+      [new AllowGuard(), new ObservableDenyGuard()],
+      {},
+    )
+
+    expect(then.allowed).toBe(false)
+    expect(then.rejectedBy).toBe(ObservableDenyGuard.name)
+  })
+
+  it('should run controller-level guards before method-level ones', async () => {
+    const then = await runGuardChain(
+      ClassGuardsController,
+      'route',
+      [new ClassLevelGuard(), new AllowGuard()],
+      {},
+    )
+
+    // Rejected by the class-level guard, so the method-level chain never ran.
+    expect(then.allowed).toBe(false)
+    expect(then.rejectedBy).toBe(ClassLevelGuard.name)
+  })
+
+  it('should run a guard declared as a configured instance', async () => {
+    // `new ConfiguredGuard(false)` carries its own configuration, so the caller
+    // supplies nothing for it - and `instanceof` against it would throw.
+    const then = await runGuardChain(
+      InstanceGuardsController,
+      'route',
+      [new AllowGuard()],
+      {},
+    )
+
+    expect(then.allowed).toBe(false)
+    expect(then.rejectedBy).toBe(ConfiguredGuard.name)
+  })
+
+  it('should refuse to run a chain with a guard the caller did not supply', async () => {
+    await expect(
+      runGuardChain(UnsuppliedGuardsController, 'route', [], {}),
+    ).rejects.toThrow('No instance supplied for UnsuppliedGuard')
+  })
+})

--- a/apps/judicial-system/backend/src/app/test/verifyGuardChain.ts
+++ b/apps/judicial-system/backend/src/app/test/verifyGuardChain.ts
@@ -1,0 +1,89 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { CanActivate, ExecutionContext, Type } from '@nestjs/common'
+
+/**
+ * The result of running a route's guard chain. `rejectedBy` names the guard
+ * that stopped the chain - a test that can only say "the chain failed" cannot
+ * diagnose an ordering bug, which is the whole reason this helper exists.
+ */
+export interface GuardChainOutcome {
+  allowed: boolean
+  rejectedBy?: string
+  error?: Error
+}
+
+/**
+ * Runs the guards a route actually declares, in the order it declares them,
+ * and reports whether the request gets through and which guard stopped it.
+ *
+ * This complements `verifyGuards`, which asserts the declared order without
+ * ever calling `canActivate`. That makes it a change-detector: it agrees with
+ * whatever is written down. It agreed with the reversed chain that would have
+ * rejected every prosecutor transition with a 403, because guards do not run
+ * in controller unit tests either. This helper runs them.
+ *
+ * Two details make it faithful rather than a re-implementation of the route:
+ *
+ * - The chain is read from the route's `__guards__` metadata, so the test is
+ *   tied to the real declaration rather than to a list retyped in the spec.
+ * - The execution context's `getHandler()` returns the real controller method,
+ *   so `RolesGuard` finds the route's roles rules through the `Reflector` -
+ *   without that it would find none, deny everything, and prove nothing.
+ *
+ * Guard instances are supplied by the caller, one per declared guard class, so
+ * that dependency injection stays explicit at the call site. A guard added to
+ * the route without being added to the test throws here rather than being
+ * silently skipped.
+ */
+export const runGuardChain = async (
+  controller: Type<unknown>,
+  methodName: string,
+  guardInstances: CanActivate[],
+  request: unknown,
+): Promise<GuardChainOutcome> => {
+  const handler = (controller as any).prototype[methodName]
+
+  if (!handler) {
+    throw new Error(`${controller.name} has no method ${methodName}()`)
+  }
+
+  const declaredGuards: Type<CanActivate>[] =
+    Reflect.getMetadata('__guards__', handler) ?? []
+
+  if (declaredGuards.length === 0) {
+    throw new Error(
+      `${controller.name}.${methodName}() declares no guards - there is no chain to run`,
+    )
+  }
+
+  const chain = declaredGuards.map((declaredGuard) => {
+    const instance = guardInstances.find((g) => g instanceof declaredGuard)
+
+    if (!instance) {
+      throw new Error(
+        `No instance supplied for ${declaredGuard.name}, declared on ${controller.name}.${methodName}()`,
+      )
+    }
+
+    return { name: declaredGuard.name, instance }
+  })
+
+  const context = {
+    getHandler: () => handler,
+    getClass: () => controller,
+    getType: () => 'http',
+    switchToHttp: () => ({ getRequest: () => request }),
+  } as unknown as ExecutionContext
+
+  for (const { name, instance } of chain) {
+    try {
+      if (!(await instance.canActivate(context))) {
+        return { allowed: false, rejectedBy: name }
+      }
+    } catch (error) {
+      return { allowed: false, rejectedBy: name, error: error as Error }
+    }
+  }
+
+  return { allowed: true }
+}

--- a/apps/judicial-system/backend/src/app/test/verifyGuardChain.ts
+++ b/apps/judicial-system/backend/src/app/test/verifyGuardChain.ts
@@ -1,5 +1,9 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import { isObservable, lastValueFrom } from 'rxjs'
+
 import { CanActivate, ExecutionContext, Type } from '@nestjs/common'
+
+type DeclaredGuard = Type<CanActivate> | CanActivate
 
 /**
  * The result of running a route's guard chain. `rejectedBy` names the guard
@@ -12,9 +16,18 @@ export interface GuardChainOutcome {
   error?: Error
 }
 
+const readDeclaredGuards = (target: unknown): DeclaredGuard[] =>
+  Reflect.getMetadata('__guards__', target as object) ?? []
+
+// `@UseGuards()` takes either a class, which Nest instantiates through the
+// injector, or a ready-made instance - this codebase declares both, e.g.
+// `@UseGuards(RolesGuard, CaseExistsGuard, new CaseTypeGuard(indictmentCases))`.
+const isGuardClass = (declared: DeclaredGuard): declared is Type<CanActivate> =>
+  typeof declared === 'function'
+
 /**
- * Runs the guards a route actually declares, in the order it declares them,
- * and reports whether the request gets through and which guard stopped it.
+ * Runs the guards a route actually declares, in the order Nest runs them, and
+ * reports whether the request gets through and which guard stopped it.
  *
  * This complements `verifyGuards`, which asserts the declared order without
  * ever calling `canActivate`. That makes it a change-detector: it agrees with
@@ -22,18 +35,24 @@ export interface GuardChainOutcome {
  * rejected every prosecutor transition with a 403, because guards do not run
  * in controller unit tests either. This helper runs them.
  *
- * Two details make it faithful rather than a re-implementation of the route:
+ * Three details make it faithful rather than a re-implementation of the route:
  *
- * - The chain is read from the route's `__guards__` metadata, so the test is
- *   tied to the real declaration rather than to a list retyped in the spec.
+ * - The chain is read from `__guards__` metadata on the controller class and
+ *   on the method, class-level first, which is the order Nest applies them in.
+ *   So the test is tied to the real declaration rather than to a list retyped
+ *   in the spec, and a class-level guard cannot be silently skipped.
  * - The execution context's `getHandler()` returns the real controller method,
  *   so `RolesGuard` finds the route's roles rules through the `Reflector` -
  *   without that it would find none, deny everything, and prove nothing.
+ * - `canActivate` may return `boolean`, `Promise<boolean>` or
+ *   `Observable<boolean>`, and an awaited Observable is a truthy object rather
+ *   than its value. Observables are consumed, as Nest's `GuardsConsumer` does.
  *
- * Guard instances are supplied by the caller, one per declared guard class, so
- * that dependency injection stays explicit at the call site. A guard added to
- * the route without being added to the test throws here rather than being
- * silently skipped.
+ * Instances for guards declared *as classes* are supplied by the caller, one
+ * per declared class, so that dependency injection stays explicit at the call
+ * site. A guard added to the route without being added to the test throws here
+ * rather than being silently skipped. Guards declared as instances carry their
+ * own configuration and need nothing from the caller.
  */
 export const runGuardChain = async (
   controller: Type<unknown>,
@@ -47,8 +66,11 @@ export const runGuardChain = async (
     throw new Error(`${controller.name} has no method ${methodName}()`)
   }
 
-  const declaredGuards: Type<CanActivate>[] =
-    Reflect.getMetadata('__guards__', handler) ?? []
+  // Nest runs controller-level guards before method-level ones.
+  const declaredGuards = [
+    ...readDeclaredGuards(controller),
+    ...readDeclaredGuards(handler),
+  ]
 
   if (declaredGuards.length === 0) {
     throw new Error(
@@ -57,6 +79,13 @@ export const runGuardChain = async (
   }
 
   const chain = declaredGuards.map((declaredGuard) => {
+    if (!isGuardClass(declaredGuard)) {
+      return {
+        name: declaredGuard.constructor.name,
+        instance: declaredGuard,
+      }
+    }
+
     const instance = guardInstances.find((g) => g instanceof declaredGuard)
 
     if (!instance) {
@@ -77,7 +106,12 @@ export const runGuardChain = async (
 
   for (const { name, instance } of chain) {
     try {
-      if (!(await instance.canActivate(context))) {
+      const result = instance.canActivate(context)
+      const allowed = isObservable(result)
+        ? await lastValueFrom(result)
+        : await result
+
+      if (!allowed) {
         return { allowed: false, rejectedBy: name }
       }
     } catch (error) {


### PR DESCRIPTION
# Execute the guard chain for the case transition route

[Prófa guard-röð fyrir stöðubreytingu máls](https://app.asana.com/1/203394141643832/project/1199153462262248/task/1217933717023361)

Nothing in the backend suite runs a route's guards.

`verifyGuards` reads `Reflect.getMetadata('__guards__')` and asserts the declared order and types, but never calls `canActivate` — it agrees with whatever is written down. Controller unit tests call the handler directly, so guards do not run there either. The consequence showed up recently: reversing `CaseExistsForUpdateGuard` and `RolesGuard` on the transition route would have rejected every prosecutor transition with a 403, because `prosecutorTransitionRule` reads `request.case` and denies outright when it is missing — and that reversal passed `tsc`, the full suite, lint, twelve CI checks and a review. It was caught by a person reading the diff.

This is test-only. No production file changes.

## `test/verifyGuardChain.ts`

`runGuardChain(controller, methodName, guardInstances, request)` runs the guards a route actually declares, in the order it declares them, and reports whether the request gets through and which guard stopped it. Three details keep it faithful rather than a re-implementation of the route:

- The chain is read from the route's `__guards__` metadata, as `verifyGuards` does, so the test is tied to the real declaration rather than to a list retyped in the spec.
- The `ExecutionContext`'s `getHandler()` returns the **real controller method**, so `RolesGuard` resolves the route's rules through the `Reflector`. Without that it would find no rules, deny everything, and prove nothing.
- Guard instances are supplied by the caller, one per declared class, so DI stays explicit at the call site. A guard added to the route without being added to the test throws rather than being silently skipped.

It returns `{ allowed, rejectedBy, error }` — naming the guard matters, because a test that can only say "the chain failed" will not diagnose the next ordering bug.

## `transitionGuardChain.spec.ts`

Applies it to `PATCH case/:caseId/state`, the one route converted to `CaseExistsForUpdateGuard` so far, over a table of callers:

| caller | expected |
| --- | --- |
| prosecutor submitting a case they can write | allowed |
| district court judge receiving a case at their court | allowed |
| a role none of the route's rules cover | rejected, by `RolesGuard` |
| case does not exist | rejected by `CaseExistsForUpdateGuard`, before any rule runs |

**The harness was verified to fail on the bug it exists for.** Reversing the two guards locally turns the prosecutor row red with `rejectedBy: "RolesGuard"` — the 403 that reversal produces in production — and turns it green again when restored. A harness that cannot detect that is worse than none, because it makes the gap look closed.

`verifyGuards` and `verifyRolesRules` are untouched and their specs stay; they are cheap change-detectors, and this adds execution alongside them.

## Out of scope

- Extending the harness to the other ~115 `CaseExistsGuard` routes — each route conversion brings its own table.
- Converting another route to a request-owned transaction.
- HTTP-level e2e: there is no precedent for it in this app, it would be slow, and it would mostly test Nest's guard execution rather than this codebase's authorization logic.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added request-level verification for case transition authorization.
  - Confirmed valid submissions and receipts for prosecutors and district court judges.
  - Confirmed unauthorized defender access is rejected.
  - Confirmed missing cases are rejected before authorization rules run.
- **Quality Improvements**
  - Added reusable validation for executing route guard chains in their declared order.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->