### PR TITLE
fix(j-s): indent and required field fixes

### DIFF
--- a/apps/judicial-system/web/src/components/RichTextEditor/RichTextEditor.css.ts
+++ b/apps/judicial-system/web/src/components/RichTextEditor/RichTextEditor.css.ts
@@ -215,7 +215,8 @@ globalStyle(`${content} .ProseMirror`, {
   // input element's own padding (8px mobile, 16px desktop); the editor has no
   // inner element, so the sum is applied here to line the text up with them.
   padding: `${theme.spacing[2]}px ${theme.spacing[2]}px`,
-  whiteSpace: 'pre-wrap',
+  // TinyMCE used normal white-space; pre-wrap made literal Word tab characters
+  // look indented in the editor even when they were not stored as indent-N.
   overflowWrap: 'break-word',
   '@media': {
     [`screen and (min-width: ${theme.breakpoints.md}px)`]: {

--- a/apps/judicial-system/web/src/components/RichTextEditor/RichTextEditor.tsx
+++ b/apps/judicial-system/web/src/components/RichTextEditor/RichTextEditor.tsx
@@ -120,7 +120,10 @@ const RichTextEditor = ({
     immediatelyRender: false,
     editorProps,
     onUpdate: ({ editor }) => {
-      const html = editor.getHTML()
+      // Every read goes through normalizeRichTextHtml — same as TinyMCE's
+      // GetContent hook — so blank documents serialize as '' and required-field
+      // validation sees an empty string, not '<p></p>'.
+      const html = normalizeRichTextHtml(editor.getHTML())
       onChange?.(html)
       if (!disabled) {
         debouncedSave(html, onDebouncedChange)
@@ -129,7 +132,7 @@ const RichTextEditor = ({
     onFocus: () => setFocused(true),
     onBlur: ({ editor }) => {
       setFocused(false)
-      onBlur?.(editor.getHTML())
+      onBlur?.(normalizeRichTextHtml(editor.getHTML()))
       // Blur already persisted; drop any pending debounced save.
       debouncedSave.cancel()
     },
@@ -140,15 +143,15 @@ const RichTextEditor = ({
   }, [editor, disabled])
 
   // Sync externally-driven value changes (e.g. autofill regeneration) into
-  // the editor. Editor-originated changes round-trip through onChange and
-  // match getHTML(), so this only writes on genuinely external updates.
+  // the editor. Editor-originated changes round-trip through onChange as
+  // normalized HTML, so this only writes on genuinely external updates.
   // A focused editor is left alone so the user's typing isn't clobbered.
   useEffect(() => {
     if (
       !editor ||
       value === undefined ||
       editor.isFocused ||
-      value === editor.getHTML()
+      value === normalizeRichTextHtml(editor.getHTML())
     ) {
       return
     }

--- a/apps/judicial-system/web/src/components/RichTextEditor/richTextEditorSchema.spec.ts
+++ b/apps/judicial-system/web/src/components/RichTextEditor/richTextEditorSchema.spec.ts
@@ -1,6 +1,7 @@
 import { Editor } from '@tiptap/core'
 
 import { buildEditorExtensions } from './richTextEditorExtensions'
+import { normalizeRichTextHtml } from './richTextNormalization'
 
 // The schema is the paste whitelist: whatever it cannot represent is dropped
 // at parse time and can never be serialized towards the API. These tests
@@ -16,6 +17,17 @@ const roundTrip = (html: string): string => {
 }
 
 describe('rich text editor schema', () => {
+  it('serializes an empty document as markup that normalizes to an empty string', () => {
+    const editor = new Editor({
+      extensions: buildEditorExtensions(''),
+      content: '',
+    })
+    const html = editor.getHTML()
+    editor.destroy()
+    expect(html).toMatch(/<p/)
+    expect(normalizeRichTextHtml(html)).toBe('')
+  })
+
   describe('representable content survives', () => {
     it('keeps paragraphs, bold and italic', () => {
       expect(roundTrip('<p>a <strong>b</strong> <em>c</em></p>')).toBe(

--- a/apps/judicial-system/web/src/components/RichTextEditor/richTextNormalization.spec.ts
+++ b/apps/judicial-system/web/src/components/RichTextEditor/richTextNormalization.spec.ts
@@ -333,6 +333,32 @@ describe('normalizeRichTextHtml', () => {
         ),
       ).toBe('<ul><li><p class="indent-1">x</p></li></ul>')
     })
+
+    it('converts margin-left in inches to an indent class', () => {
+      expect(
+        normalizeRichTextHtml("<p style=\"margin-left:0.5in\">x</p>"),
+      ).toBe('<p class="indent-1">x</p>')
+    })
+
+    it('converts each leading tab character to one indent level', () => {
+      expect(normalizeRichTextHtml('<p>\t\tx</p>')).toBe(
+        '<p class="indent-2">x</p>',
+      )
+    })
+
+    it('adds leading tabs on top of an existing indent class', () => {
+      expect(
+        normalizeRichTextHtml('<p class="indent-1">\tx</p>'),
+      ).toBe('<p class="indent-2">x</p>')
+    })
+
+    it('hoists an indent class from a wrapper div onto its paragraph', () => {
+      expect(
+        normalizeRichTextHtml(
+          "<div style='margin-left:36.0pt'><p>Hello</p></div>",
+        ),
+      ).toBe('<p class="indent-1">Hello</p>')
+    })
   })
 
   describe('inline bold and italic', () => {

--- a/apps/judicial-system/web/src/components/RichTextEditor/richTextNormalization.spec.ts
+++ b/apps/judicial-system/web/src/components/RichTextEditor/richTextNormalization.spec.ts
@@ -335,9 +335,9 @@ describe('normalizeRichTextHtml', () => {
     })
 
     it('converts margin-left in inches to an indent class', () => {
-      expect(
-        normalizeRichTextHtml("<p style=\"margin-left:0.5in\">x</p>"),
-      ).toBe('<p class="indent-1">x</p>')
+      expect(normalizeRichTextHtml('<p style="margin-left:0.5in">x</p>')).toBe(
+        '<p class="indent-1">x</p>',
+      )
     })
 
     it('converts each leading tab character to one indent level', () => {
@@ -347,9 +347,9 @@ describe('normalizeRichTextHtml', () => {
     })
 
     it('adds leading tabs on top of an existing indent class', () => {
-      expect(
-        normalizeRichTextHtml('<p class="indent-1">\tx</p>'),
-      ).toBe('<p class="indent-2">x</p>')
+      expect(normalizeRichTextHtml('<p class="indent-1">\tx</p>')).toBe(
+        '<p class="indent-2">x</p>',
+      )
     })
 
     it('hoists an indent class from a wrapper div onto its paragraph', () => {

--- a/apps/judicial-system/web/src/components/RichTextEditor/richTextNormalization.ts
+++ b/apps/judicial-system/web/src/components/RichTextEditor/richTextNormalization.ts
@@ -154,8 +154,7 @@ export const MARKER_NONE_CLASS = 'marker-none'
 
 const MARKER_NONE_REGEX = /list-style-type\s*:\s*none/i
 const BACKGROUND_REGEX = /background(?:-color)?\s*:\s*([^;]+)/i
-const LEFT_OFFSET_REGEX =
-  /(?:margin|padding)-left\s*:\s*([\d.]+)(pt|px|in|cm)/i
+const LEFT_OFFSET_REGEX = /(?:margin|padding)-left\s*:\s*([\d.]+)(pt|px|in|cm)/i
 // Word's AutoFormat turns a Tab at the start of a paragraph into a first-line
 // indent, which reaches the clipboard as text-indent (in pt) — indenting a
 // multi-paragraph selection uses margin-left instead. It can be negative

--- a/apps/judicial-system/web/src/components/RichTextEditor/richTextNormalization.ts
+++ b/apps/judicial-system/web/src/components/RichTextEditor/richTextNormalization.ts
@@ -154,18 +154,111 @@ export const MARKER_NONE_CLASS = 'marker-none'
 
 const MARKER_NONE_REGEX = /list-style-type\s*:\s*none/i
 const BACKGROUND_REGEX = /background(?:-color)?\s*:\s*([^;]+)/i
-const LEFT_OFFSET_REGEX = /(?:margin|padding)-left\s*:\s*([\d.]+)(pt|px)/i
+const LEFT_OFFSET_REGEX =
+  /(?:margin|padding)-left\s*:\s*([\d.]+)(pt|px|in|cm)/i
 // Word's AutoFormat turns a Tab at the start of a paragraph into a first-line
 // indent, which reaches the clipboard as text-indent (in pt) — indenting a
 // multi-paragraph selection uses margin-left instead. It can be negative
 // (hanging indents), so the sign is captured and the offsets are summed.
-const TEXT_INDENT_REGEX = /text-indent\s*:\s*(-?[\d.]+)(pt|px)/i
+const TEXT_INDENT_REGEX = /text-indent\s*:\s*(-?[\d.]+)(pt|px|in|cm)/i
 const BOLD_REGEX = /font-weight\s*:\s*(?:bold|bolder|[6-9]00)/i
 const ITALIC_REGEX = /font-style\s*:\s*(?:italic|oblique)/i
 
 const offsetToPx = (offset: RegExpMatchArray): number => {
   const numeric = parseFloat(offset[1])
-  return offset[2].toLowerCase() === 'pt' ? numeric * (96 / 72) : numeric
+  switch (offset[2].toLowerCase()) {
+    case 'pt':
+      return numeric * (96 / 72)
+    case 'in':
+      return numeric * 96
+    case 'cm':
+      return numeric * (96 / 2.54)
+    default:
+      return numeric
+  }
+}
+
+const indentLevelFromElement = (el: Element): number => {
+  let level = 0
+  for (const className of Array.from(el.classList)) {
+    const parsed = levelFromIndentClass(className)
+    if (parsed !== null) {
+      level = Math.max(level, parsed)
+    }
+  }
+  return level
+}
+
+const setIndentLevelOnElement = (el: Element, level: number) => {
+  for (const className of Array.from(el.classList)) {
+    if (levelFromIndentClass(className) !== null) {
+      el.classList.remove(className)
+    }
+  }
+  if (level > 0) {
+    el.classList.add(indentClassFromLevel(level))
+  } else if (el.classList.length === 0) {
+    el.removeAttribute('class')
+  }
+}
+
+const addIndentLevelOnElement = (el: Element, delta: number) => {
+  if (delta <= 0) return
+  setIndentLevelOnElement(
+    el,
+    Math.min(MAX_INDENT_LEVEL, indentLevelFromElement(el) + delta),
+  )
+}
+
+// Word sometimes wraps an indented paragraph in a div/blockquote. The editor
+// schema only keeps indent on <p>, so hoist the class down and unwrap a lone
+// div wrapper — the same block indent TinyMCE kept on the paragraph itself.
+const hoistWrapperIndentToParagraph = (doc: Document) => {
+  for (const wrapper of Array.from(
+    doc.body.querySelectorAll('div, blockquote'),
+  )) {
+    const wrapperLevel = indentLevelFromElement(wrapper)
+    if (wrapperLevel === 0) continue
+
+    const paragraphs = Array.from(wrapper.querySelectorAll(':scope > p'))
+    if (paragraphs.length !== 1) continue
+
+    const paragraph = paragraphs[0]
+    setIndentLevelOnElement(
+      paragraph,
+      Math.min(
+        MAX_INDENT_LEVEL,
+        wrapperLevel + indentLevelFromElement(paragraph),
+      ),
+    )
+    setIndentLevelOnElement(wrapper, 0)
+
+    if (
+      wrapper.tagName === 'DIV' &&
+      wrapper.childNodes.length === 1 &&
+      wrapper.firstChild === paragraph
+    ) {
+      wrapper.replaceWith(paragraph)
+    }
+  }
+}
+
+// When Word emits literal Tab characters (common for 2+ tabs at line start)
+// instead of a larger text-indent, map each leading tab to one indent step.
+// TinyMCE's paste filter retained text-indent CSS; this covers the remainder.
+const convertLeadingTabsToIndent = (doc: Document) => {
+  for (const paragraph of Array.from(doc.body.querySelectorAll('p'))) {
+    const walker = doc.createTreeWalker(paragraph, NodeFilter.SHOW_TEXT)
+    const firstText = walker.nextNode()
+    if (!firstText) continue
+
+    const content = firstText.textContent ?? ''
+    const match = content.match(/^\t+/)
+    if (!match) continue
+
+    addIndentLevelOnElement(paragraph, match[0].length)
+    firstText.textContent = content.slice(match[0].length)
+  }
 }
 
 // LI is deliberately absent: a list item's level is expressed by how deeply it
@@ -276,6 +369,9 @@ const normalizeDoc = (doc: Document) => {
       item.removeAttribute('class')
     }
   }
+
+  hoistWrapperIndentToParagraph(doc)
+  convertLeadingTabsToIndent(doc)
 }
 
 // --- External-paste pipeline -----------------------------------------------

--- a/apps/judicial-system/web/src/components/RichTextEditor/richTextNormalization.wordPaste.spec.ts
+++ b/apps/judicial-system/web/src/components/RichTextEditor/richTextNormalization.wordPaste.spec.ts
@@ -119,4 +119,10 @@ describe('normalizePastedHtml — Word artifacts', () => {
       '<p class="indent-1">Inndregið</p>',
     )
   })
+
+  it('converts literal leading tabs in pasted paragraphs to indent classes', () => {
+    expect(normalizePastedHtml('<p>\t\tInndregið</p>')).toBe(
+      '<p class="indent-2">Inndregið</p>',
+    )
+  })
 })

--- a/apps/judicial-system/web/src/routes/Court/Indictments/CourtRecord/CourtSessionAccordionItem.tsx
+++ b/apps/judicial-system/web/src/routes/Court/Indictments/CourtRecord/CourtSessionAccordionItem.tsx
@@ -1499,9 +1499,7 @@ const CourtSessionAccordionItem: FC<Props> = (props) => {
                     )
                   }
                   onBlur={(html) => {
-                    // Visually blank markup arrives normalized to '' (see
-                    // normalizeRichTextHtml), so the html can be validated
-                    // directly.
+                    // RichTextEditor normalizes blank documents to '' on output.
                     validateAndSetErrorMessage(
                       ['empty'],
                       html,

--- a/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Indictment/IndictmentCount.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Indictment/IndictmentCount.tsx
@@ -70,12 +70,6 @@ interface Props {
 
 type Law = [number, number]
 
-// Decodes entities and strips tags so an otherwise-empty editor document
-// (e.g. a lone &nbsp; paragraph) doesn't pass the required check.
-const htmlToPlainText = (html: string) =>
-  new DOMParser().parseFromString(html, 'text/html').body.textContent?.trim() ??
-  ''
-
 const driversLicenceLaws: Law[] = [[58, 1]]
 const generalLaws: Law[] = [[95, 1]]
 
@@ -655,7 +649,7 @@ export const IndictmentCount: FC<Props> = ({
             onChange={(html) => {
               removeErrorMessageIfValid(
                 ['empty'],
-                htmlToPlainText(html),
+                html,
                 incidentDescriptionErrorMessage,
                 setIncidentDescriptionErrorMessage,
               )
@@ -670,19 +664,13 @@ export const IndictmentCount: FC<Props> = ({
               onChange(indictmentCount.id, { incidentDescription: html })
             }
             onBlur={(html) => {
-              const plainText = htmlToPlainText(html)
-
               validateAndSetErrorMessage(
                 ['empty'],
-                plainText,
+                html,
                 setIncidentDescriptionErrorMessage,
               )
 
-              // An entity-only document (e.g. a lone &nbsp;) still serializes
-              // as markup; store it as empty so validation treats it as missing.
-              onChange(indictmentCount.id, {
-                incidentDescription: plainText ? html : '',
-              })
+              onChange(indictmentCount.id, { incidentDescription: html })
             }}
             required
           />


### PR DESCRIPTION
[Asana](https://app.asana.com/1/203394141643832/project/1212657017130395/task/1217765606004624?focus=true)
[Asana](https://app.asana.com/1/203394141643832/project/1212657017130395/task/1217915765938143?focus=true)

## What

RichTextEditor fields marked as required would look empty but still pass validation because of empty <p> </p> elements saved as a string to our db. Applied the same patch as we had for TinyMCE before to the new TipTap RichTextEditor

Hardened pasting indented content into the editor. 
## Why

The user should not be able to continue without filling in fields such as the indictment and court record on their respective screens.
Pasting indented content was flaky, worked in some cases and not others.

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Cursor


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved rich-text indentation handling for pasted content, including tabs and measurements in inches or centimeters.
  - Prevented blank documents from being saved as empty paragraph markup.
  - Preserved valid HTML content during validation and blur events.
  - Corrected editor display behavior for literal tab characters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->