### PR TITLE
fix(doe): ábendingar table, sub criteria validation, roletitle outliers & chart focus

### DIFF
--- a/libs/application/templates/directorate-of-equality/salary-report/src/fields/CriteriaEditor/index.tsx
+++ b/libs/application/templates/directorate-of-equality/salary-report/src/fields/CriteriaEditor/index.tsx
@@ -79,11 +79,13 @@ export const CriteriaEditor: FC<React.PropsWithChildren<FieldBaseProps>> = ({
     (sum, f) => sum + (Number(f.weight) || 0),
     0,
   )
+  const hasCriteria = jobFactors.length + personalFactors.length > 0
+  const hasWeightMismatch = hasCriteria && Math.abs(totalWeight - 100) > 0.001
 
   useEffect(() => {
     if (!setBeforeSubmitCallback) return
     setBeforeSubmitCallback(async () => {
-      if (totalWeight !== 0 && Math.abs(totalWeight - 100) > 0.001) {
+      if (hasWeightMismatch) {
         return [
           false,
           formatMessage(messages.report.criteria.weightSumError, {
@@ -149,6 +151,7 @@ export const CriteriaEditor: FC<React.PropsWithChildren<FieldBaseProps>> = ({
     jobFactors,
     personalFactors,
     removedPersonalIds,
+    hasWeightMismatch,
     totalWeight,
     formatMessage,
     sync,
@@ -200,7 +203,7 @@ export const CriteriaEditor: FC<React.PropsWithChildren<FieldBaseProps>> = ({
         }}
       />
 
-      {totalWeight !== 0 && totalWeight !== 100 && (
+      {hasWeightMismatch && (
         <Box marginTop={3}>
           <Text color="red600">
             {formatMessage(messages.report.criteria.weightSumError, {

--- a/libs/application/templates/directorate-of-equality/salary-report/src/fields/EmployeesEditor/utils.spec.ts
+++ b/libs/application/templates/directorate-of-equality/salary-report/src/fields/EmployeesEditor/utils.spec.ts
@@ -1,6 +1,7 @@
 import {
   formatHourlyWage,
   formatPaidHours,
+  formatWageAmount,
   paidHoursFromFormValue,
   paidHoursToFormValue,
 } from './utils'
@@ -45,5 +46,22 @@ describe('formatters', () => {
 
   it('labels wages per hour so they are not read as monthly figures', () => {
     expect(formatHourlyWage(4884)).toBe('4.884 kr./klst.')
+  })
+})
+
+describe('formatWageAmount', () => {
+  // The bare variant for the table columns that carry the unit in a footnote
+  // instead — the suffix is what pushed those cells onto a second line.
+  it('formats the amount with no unit suffix', () => {
+    expect(formatWageAmount(4884)).toBe('4.884')
+    expect(formatWageAmount(4883.6)).toBe('4.884')
+  })
+
+  // A dash, never "0": `?? 0` would print a wage of nothing as though DMR had
+  // reported it. Zero itself is a real figure and still formats.
+  it('dashes a missing figure but formats a real zero', () => {
+    expect(formatWageAmount(null)).toBe('—')
+    expect(formatWageAmount(undefined)).toBe('—')
+    expect(formatWageAmount(0)).toBe('0')
   })
 })

--- a/libs/application/templates/directorate-of-equality/salary-report/src/fields/EmployeesEditor/utils.ts
+++ b/libs/application/templates/directorate-of-equality/salary-report/src/fields/EmployeesEditor/utils.ts
@@ -125,6 +125,24 @@ export const formatHourlyWage = (value?: number | null): string =>
     maximumFractionDigits: 0,
   })} kr./klst.`
 
+/**
+ * The bare amount, for the wage columns of the úrbótaáætlun and ábendingar
+ * tables — both of which carry the unit once in a footnote beneath the table
+ * instead. `formatHourlyWage`'s " kr./klst." suffix is ~10 characters that
+ * every row pays for twice, wrapping the cell onto a second line and widening
+ * the column past what the surrounding card holds.
+ *
+ * A missing figure is a dash, not a zero: `?? 0` would print "0" as though DMR
+ * had reported a wage of nothing. Both DTOs type their wage fields as required,
+ * so this is contract-defensive rather than a path we expect — but a false
+ * figure an applicant could act on is the wrong way to fail. Zero itself still
+ * formats.
+ */
+export const formatWageAmount = (value?: number | null): string =>
+  value == null
+    ? '—'
+    : value.toLocaleString('is-IS', { maximumFractionDigits: 0 })
+
 export const formatStartDate = (value?: string): string => {
   if (!value) return ''
   try {

--- a/libs/application/templates/directorate-of-equality/salary-report/src/fields/SalaryAnalysisResults/OutlierEditor.tsx
+++ b/libs/application/templates/directorate-of-equality/salary-report/src/fields/SalaryAnalysisResults/OutlierEditor.tsx
@@ -32,15 +32,9 @@ type Props = {
   errors?: RecordObject
   // draft: pre-submit, DMR-synced, keyed by employee id. postponed: answers-backed, keyed by ordinal.
   mode: 'draft' | 'postponed'
-  roleTitleForOrdinal: (ordinal: number) => string | undefined
 }
 
-export const OutlierEditor: FC<Props> = ({
-  outliers,
-  errors,
-  mode,
-  roleTitleForOrdinal,
-}) => {
+export const OutlierEditor: FC<Props> = ({ outliers, errors, mode }) => {
   const { formatMessage } = useLocale()
   const { control, setValue } = useFormContext()
   const m = messages.salaryAnalysis.outlierGroup
@@ -214,15 +208,8 @@ export const OutlierEditor: FC<Props> = ({
       allSelectedOnPage,
       toggleSelect,
       toggleSelectPage,
-      roleTitleForOrdinal,
     }),
-    [
-      selected,
-      allSelectedOnPage,
-      toggleSelect,
-      toggleSelectPage,
-      roleTitleForOrdinal,
-    ],
+    [selected, allSelectedOnPage, toggleSelect, toggleSelectPage],
   )
 
   return (

--- a/libs/application/templates/directorate-of-equality/salary-report/src/fields/SalaryAnalysisResults/OutlierGroupPanel.tsx
+++ b/libs/application/templates/directorate-of-equality/salary-report/src/fields/SalaryAnalysisResults/OutlierGroupPanel.tsx
@@ -25,7 +25,6 @@ type Props = {
   // the persistence-mode signal for OutlierEditor's `mode` prop.
   hidePostponeCheckbox?: boolean
   errors?: RecordObject
-  roleTitleForOrdinal: (ordinal: number) => string | undefined
   // Draft phase only: local form scope for outlierGroups (not answers-backed pre-submit); the postponed checkbox stays on the ambient form regardless.
   outlierGroupsFormMethods?: UseFormReturn<{
     salaryAnalysis: { outlierGroups: OutlierGroupAnswer[] }
@@ -36,7 +35,6 @@ export const OutlierGroupPanel: FC<Props> = ({
   outliers,
   hidePostponeCheckbox,
   errors,
-  roleTitleForOrdinal,
   outlierGroupsFormMethods,
 }) => {
   const { formatMessage } = useLocale()
@@ -88,7 +86,6 @@ export const OutlierGroupPanel: FC<Props> = ({
               outliers={outliers}
               errors={errors}
               mode={hidePostponeCheckbox ? 'postponed' : 'draft'}
-              roleTitleForOrdinal={roleTitleForOrdinal}
             />
           </FormProvider>
         ) : (
@@ -96,7 +93,6 @@ export const OutlierGroupPanel: FC<Props> = ({
             outliers={outliers}
             errors={errors}
             mode={hidePostponeCheckbox ? 'postponed' : 'draft'}
-            roleTitleForOrdinal={roleTitleForOrdinal}
           />
         ))}
     </Box>

--- a/libs/application/templates/directorate-of-equality/salary-report/src/fields/SalaryAnalysisResults/PayDispersionTable.tsx
+++ b/libs/application/templates/directorate-of-equality/salary-report/src/fields/SalaryAnalysisResults/PayDispersionTable.tsx
@@ -1,41 +1,97 @@
-import { Box, Table as T, Text } from '@island.is/island-ui/core'
+import type { ReactNode } from 'react'
+import { Box, Table as T, Text, Tooltip } from '@island.is/island-ui/core'
 import { useLocale } from '@island.is/localization'
 import type { SalaryAnalysisResponseDto } from '@island.is/clients/directorate-of-equality'
 import { messages } from '../../lib/messages'
-import { formatHourlyWage } from '../EmployeesEditor/utils'
-import { formatSalaryAnalysisGenderLabel } from '../../utils/salaryAnalysisLabels'
+import { formatWageAmount } from '../EmployeesEditor/utils'
+import {
+  formatDeviationLabel,
+  formatSalaryAnalysisGenderLabel,
+} from '../../utils/salaryAnalysisLabels'
 import { formatSignedPercentMagnitude } from '../../utils/wageGap'
 
 type PayDispersionDto = SalaryAnalysisResponseDto['payDispersion']
-type PayDispersionEmployeeDto = PayDispersionDto['employees'][number]
 type PayDispersionBlocker = PayDispersionDto['blockers'][number]
 
 const RENDERED_POPULATION: PayDispersionDto['population'] = 'ALL_EMPLOYEES'
 const dash = '—'
 
+/**
+ * Padding identical to the `cellBox` OutlierEditor hands InteractiveTable, so the
+ * two tables have the same row rhythm. (The header type does deliberately differ —
+ * see HEADER_TEXT.)
+ *
+ * Longhand on purpose: T.Data/T.HeadData spread this object over their own
+ * paddingTop/paddingBottom ('p5' = 18px) and paddingLeft/paddingRight (3 = 24px)
+ * in a single useBoxStyles call, and that call resolves each side as
+ * `paddingTop ?? paddingY ?? padding`. A shorthand here would therefore lose to
+ * the longhands already in the object, while these longhands replace them
+ * outright. The 18px vertical default is most of why this table stood a head
+ * taller than the úrbótaáætlun one for the same number of rows.
+ */
+const CELL_BOX = {
+  paddingTop: 1,
+  paddingBottom: 1,
+  paddingLeft: 'p2',
+  paddingRight: 'p2',
+} as const
+
+/**
+ * Headers at the body cells' own size, distinguished by weight alone.
+ *
+ * T.HeadData's `variant: 'h5'` is 18px on desktop, and the úrbótaáætlun table
+ * only pulls that back to 16px (InteractiveTable puts an inline `fontSize:
+ * '16px'` on its `<th>`) — still a size step AND a weight step above its 14px
+ * body cells. This table deliberately goes one step further down than that
+ * reference: it is an advisory that requires no action, so it should not carry
+ * more visual weight than the úrbótaáætlun table the applicant must actually
+ * fill in.
+ *
+ * Swapping the variant rather than overriding `fontSize` inline, because
+ * T.HeadData spreads `text` over its own `variant: 'h5'` inside a single
+ * getTextStyles call — so `small` here means the header tracks the body cells at
+ * BOTH breakpoints (12px mobile, 14px desktop) instead of being pinned flat by a
+ * hardcoded pixel value. fontWeight has to be restated: it is `variant: 'h5'`
+ * that was supplying the 600, and changing the variant would otherwise drop the
+ * headers to `small`'s regular 400 and leave them indistinguishable from data.
+ */
+const HEADER_TEXT = { variant: 'small', fontWeight: 'semiBold' } as const
+
+// `align` is forwarded as 'left' rather than left undefined: T.HeadData's own
+// default is 'left', and passing undefined through would override that with
+// nothing at all — leaving the `<th>` on the browser's centred default.
+const HeadCell = ({
+  children,
+  align = 'left',
+}: {
+  children: ReactNode
+  align?: 'left' | 'right'
+}) => (
+  <T.HeadData box={CELL_BOX} text={HEADER_TEXT} align={align}>
+    {children}
+  </T.HeadData>
+)
+
+const DataCell = ({
+  children,
+  align,
+}: {
+  children: ReactNode
+  align?: 'right'
+}) => (
+  <T.Data box={CELL_BOX} align={align}>
+    {children}
+  </T.Data>
+)
+
+// Two decimals, unlike every percentage in the report: this is the figure the
+// threshold is stated in ("2 staðalvik"), so a reader comparing a row against
+// the note above the table needs to see it at the precision the note implies.
 const formatSpreads = (value: number | null | undefined): string => {
   if (value == null) return dash
   const roundedValue = Math.round(value * 100) / 100
   const sign = roundedValue > 0 ? '+' : ''
   return `${sign}${roundedValue.toFixed(2).replace('.', ',')}`
-}
-
-const formatSignedDeviation = (
-  employee: PayDispersionEmployeeDto,
-  formatMessage: ReturnType<typeof useLocale>['formatMessage'],
-): string => {
-  const value = employee.deviationPercent
-  const m = messages.salaryAnalysis.payDispersion
-
-  const word =
-    employee.payStatus === 'UNDERPAID'
-      ? formatMessage(m.directionBelow)
-      : employee.payStatus === 'OVERPAID'
-      ? formatMessage(m.directionAbove)
-      : undefined
-
-  const percent = `${formatSignedPercentMagnitude(value)}%`
-  return word ? `${percent} (${word})` : percent
 }
 
 const blockerMessage = (
@@ -57,15 +113,19 @@ const blockerMessage = (
 
 type Props = {
   payDispersion?: PayDispersionDto | null
-  identifierForOrdinal: (ordinal: number) => string
 }
 
-export const PayDispersionTable = ({
-  payDispersion,
-  identifierForOrdinal,
-}: Props) => {
+export const PayDispersionTable = ({ payDispersion }: Props) => {
   const { formatMessage } = useLocale()
   const p = messages.salaryAnalysis.payDispersion
+  // The column headers, the ordinal tooltip and the deviation wording are read
+  // from the úrbótaáætlun namespace rather than restated here. Two sets of ids
+  // would be two Contentful entries a translator could drift apart, and this
+  // table's own `numberHeader`/`salary`/`deviationHeader` ids already carry
+  // published translations ("Auðkenni", "Tímakaup", "Launafrávik") that would
+  // win over any renamed defaultMessage — so reusing the ids is the only way the
+  // two tables are guaranteed to say the same thing.
+  const o = messages.salaryAnalysis.outlierGroup
 
   if (!payDispersion) return null
 
@@ -118,42 +178,79 @@ export const PayDispersionTable = ({
           <T.Table>
             <T.Head>
               <T.Row>
-                <T.HeadData>{formatMessage(p.numberHeader)}</T.HeadData>
-                <T.HeadData>{formatMessage(p.genderHeader)}</T.HeadData>
-                <T.HeadData>{formatMessage(p.points)}</T.HeadData>
-                <T.HeadData>{formatMessage(p.salary)}</T.HeadData>
-                <T.HeadData>{formatMessage(p.predictedSalary)}</T.HeadData>
-                <T.HeadData>{formatMessage(p.deviationHeader)}</T.HeadData>
-                <T.HeadData>{formatMessage(p.spreadHeader)}</T.HeadData>
+                <HeadCell>
+                  {/* The bare ordinal, as in the úrbótaáætlun table — it is the
+                      number the applicant already knows from the employee
+                      screens and the workbook, which the ABC-000 identifier
+                      this column used to show is not. The tooltip is what says
+                      so, and is the same one. */}
+                  <Box display="flex" alignItems="center" columnGap={1}>
+                    {formatMessage(o.ordinalColumn)}
+                    <Tooltip
+                      placement="right"
+                      text={formatMessage(o.employeeColumnTooltip)}
+                    />
+                  </Box>
+                </HeadCell>
+                <HeadCell>{formatMessage(o.genderColumn)}</HeadCell>
+                <HeadCell align="right">{formatMessage(o.stigColumn)}</HeadCell>
+                <HeadCell align="right">
+                  {formatMessage(o.hourlyWageColumn)}
+                </HeadCell>
+                <HeadCell align="right">
+                  {formatMessage(o.expectedHourlyWageColumn)}
+                </HeadCell>
+                <HeadCell align="right">
+                  {formatMessage(o.deviationColumn)}
+                </HeadCell>
+                {/* The one column with no counterpart in the úrbótaáætlun
+                    table, and it stays: it is the figure that put the row on
+                    this list, stated in the same units as the threshold in the
+                    note above. */}
+                <HeadCell align="right">
+                  {formatMessage(p.spreadHeader)}
+                </HeadCell>
               </T.Row>
             </T.Head>
             <T.Body>
               {payDispersion.employees.map((employee) => (
                 <T.Row key={employee.employeeOrdinal}>
-                  <T.Data>
-                    {identifierForOrdinal(employee.employeeOrdinal)}
-                  </T.Data>
-                  <T.Data>
+                  <DataCell>{employee.employeeOrdinal}</DataCell>
+                  <DataCell>
                     {formatSalaryAnalysisGenderLabel(
                       employee.gender,
                       formatMessage,
                     )}
-                  </T.Data>
-                  <T.Data>{employee.score}</T.Data>
-                  <T.Data>
-                    {formatHourlyWage(employee.regularHourlyWage)}
-                  </T.Data>
-                  <T.Data>
-                    {formatHourlyWage(employee.expectedHourlyWage)}
-                  </T.Data>
-                  <T.Data>
-                    {formatSignedDeviation(employee, formatMessage)}
-                  </T.Data>
-                  <T.Data>{formatSpreads(employee.studentizedResidual)}</T.Data>
+                  </DataCell>
+                  <DataCell align="right">{employee.score}</DataCell>
+                  <DataCell align="right">
+                    {formatWageAmount(employee.regularHourlyWage)}
+                  </DataCell>
+                  <DataCell align="right">
+                    {formatWageAmount(employee.expectedHourlyWage)}
+                  </DataCell>
+                  <DataCell align="right">
+                    {formatDeviationLabel(
+                      employee.deviationPercent,
+                      employee.payStatus,
+                      formatMessage,
+                    )}
+                  </DataCell>
+                  <DataCell align="right">
+                    {formatSpreads(employee.studentizedResidual)}
+                  </DataCell>
                 </T.Row>
               ))}
             </T.Body>
           </T.Table>
+
+          {/* Carries the unit the wage columns dropped, once — same footnote,
+              same placement and same message as under the úrbótaáætlun table. */}
+          <Box marginTop={1}>
+            <Text variant="small" color="dark400">
+              {formatMessage(o.wageUnitFootnote)}
+            </Text>
+          </Box>
         </>
       )}
     </Box>

--- a/libs/application/templates/directorate-of-equality/salary-report/src/fields/SalaryAnalysisResults/SalaryDistributionChart.css.ts
+++ b/libs/application/templates/directorate-of-equality/salary-report/src/fields/SalaryAnalysisResults/SalaryDistributionChart.css.ts
@@ -1,0 +1,58 @@
+import { globalStyle, style } from '@vanilla-extract/css'
+import { theme } from '@island.is/island-ui/theme'
+
+/**
+ * Marker class on the chart's `ResponsiveContainer`, so the rules below can
+ * reach the svg recharts renders inside it without leaking to every chart in
+ * the application system.
+ */
+export const chartFocus = style({})
+
+/**
+ * Kills the focus ring a click draws inside the plot.
+ *
+ * Recharts 3 turns its accessibility layer on by default and scatters
+ * focusable elements through the chart: `RootSurface` puts `tabIndex={0}` and
+ * `role="application"` on the `<svg>` so the points can be walked with the
+ * arrow keys, and `ZIndexSvgPortal` puts `tabIndex={-1}` on the `<g>` wrappers
+ * it portals layers into. Chrome focuses either on a plain click and outlines
+ * it — the svg gives a border around the whole chart, a portal `<g>` gives one
+ * around the bounding box of the points. Both read as a rendering bug.
+ *
+ * So the reset is aimed at every focused descendant rather than at one element:
+ * chasing them individually just moves the border somewhere else.
+ *
+ * This has to be CSS at all because the `style` prop cannot reach the svg:
+ * `RootSurface` spreads the chart's attributes onto `<Surface>` and *then*
+ * overrides `style` with its own full-width-and-height object, so a
+ * `style={{ outline: 'none' }}` on `<ScatterChart>` is silently discarded. One
+ * was there before this and never had any effect.
+ *
+ * `globalStyle` rather than a `selectors` block on `chartFocus`: the targets
+ * are descendants recharts owns, and vanilla-extract only allows `selectors`
+ * whose subject is `&` itself.
+ */
+globalStyle(`${chartFocus} :focus`, {
+  outline: 'none',
+})
+
+/**
+ * Keyboard focus stays visible.
+ *
+ * Scoped as widely as the reset above on purpose. Only the `<svg>` is a tab
+ * stop today — recharts gives everything else `tabIndex={-1}` — so matching
+ * `.recharts-surface` alone would behave identically right now. But
+ * `chartFocus` sits on the ResponsiveContainer, which also wraps the legend and
+ * the tooltip, so the first focusable control added in either would inherit the
+ * reset and ship with no focus indicator at all. Pairing the two rules at the
+ * same breadth means that cannot happen quietly.
+ *
+ * Widening it also levelled the specificity — both selectors are now (0,2,0),
+ * where the narrower `.recharts-surface` form outranked the reset. So this rule
+ * wins on source order alone and MUST stay below the reset. vanilla-extract
+ * emits `globalStyle` calls in file order, which is what keeps that true.
+ */
+globalStyle(`${chartFocus} :focus-visible`, {
+  outline: `3px solid ${theme.color.blue400}`,
+  outlineOffset: 2,
+})

--- a/libs/application/templates/directorate-of-equality/salary-report/src/fields/SalaryAnalysisResults/SalaryDistributionChart.tsx
+++ b/libs/application/templates/directorate-of-equality/salary-report/src/fields/SalaryAnalysisResults/SalaryDistributionChart.tsx
@@ -22,11 +22,15 @@ import type {
 } from '@island.is/clients/directorate-of-equality'
 import { messages } from '../../lib/messages'
 import { formatHourlyWage } from '../EmployeesEditor/utils'
-import { formatSalaryAnalysisGenderLabel } from '../../utils/salaryAnalysisLabels'
+import {
+  formatPayStatusLabel,
+  formatSalaryAnalysisGenderLabel,
+} from '../../utils/salaryAnalysisLabels'
 import {
   formatSignedPercentMagnitude,
   hasIdentifiableRegressionFit,
 } from '../../utils/wageGap'
+import * as styles from './SalaryDistributionChart.css'
 
 type PayDispersionDto = SalaryAnalysisResponseDto['payDispersion']
 
@@ -120,20 +124,6 @@ const isChartPoint = (datum: unknown): datum is ChartPoint =>
   'employee' in datum &&
   'gender' in datum
 
-const payStatusWord = (
-  payStatus: WageGapEmployeeDto['payStatus'],
-  formatMessage: ReturnType<typeof useLocale>['formatMessage'],
-) => {
-  const m = messages.salaryAnalysis.outlierGroup
-  return formatMessage(
-    payStatus === 'UNDERPAID'
-      ? m.payStatusUnderpaid
-      : payStatus === 'OVERPAID'
-      ? m.payStatusOverpaid
-      : m.payStatusOnLine,
-  )
-}
-
 const ChartTooltip = ({
   active,
   payload,
@@ -176,7 +166,7 @@ const ChartTooltip = ({
       formatMessage(tooltipMessages.deviation),
       `${formatSignedPercentMagnitude(
         employee.deviationPercent,
-      )}% (${payStatusWord(employee.payStatus, formatMessage)})`,
+      )}% (${formatPayStatusLabel(employee.payStatus, formatMessage)})`,
     ])
   }
 
@@ -451,11 +441,12 @@ export const SalaryDistributionChart: FC<Props> = ({
       <Text variant="h4">{formatMessage(m.title)}</Text>
       <Text>{formatMessage(m.intro)}</Text>
 
-      <ResponsiveContainer width="100%" height={420}>
-        <ScatterChart
-          margin={{ top: 24, right: 0, left: 0, bottom: 24 }}
-          style={{ outline: 'none' }}
-        >
+      <ResponsiveContainer
+        width="100%"
+        height={420}
+        className={styles.chartFocus}
+      >
+        <ScatterChart margin={{ top: 24, right: 0, left: 0, bottom: 24 }}>
           <CartesianGrid vertical={false} stroke={theme.color.blue200} />
           <XAxis
             type="number"

--- a/libs/application/templates/directorate-of-equality/salary-report/src/fields/SalaryAnalysisResults/SalaryDistributionChart.tsx
+++ b/libs/application/templates/directorate-of-equality/salary-report/src/fields/SalaryAnalysisResults/SalaryDistributionChart.tsx
@@ -23,13 +23,10 @@ import type {
 import { messages } from '../../lib/messages'
 import { formatHourlyWage } from '../EmployeesEditor/utils'
 import {
-  formatPayStatusLabel,
+  formatDeviationLabel,
   formatSalaryAnalysisGenderLabel,
 } from '../../utils/salaryAnalysisLabels'
-import {
-  formatSignedPercentMagnitude,
-  hasIdentifiableRegressionFit,
-} from '../../utils/wageGap'
+import { hasIdentifiableRegressionFit } from '../../utils/wageGap'
 import * as styles from './SalaryDistributionChart.css'
 
 type PayDispersionDto = SalaryAnalysisResponseDto['payDispersion']
@@ -164,9 +161,15 @@ const ChartTooltip = ({
     ])
     rows.push([
       formatMessage(tooltipMessages.deviation),
-      `${formatSignedPercentMagnitude(
+      // The shared helper, not a locally assembled string: this is the same
+      // figure the úrbótaáætlun and ábendingar tables show, so it goes through
+      // the same localised `deviationCell` template rather than hardcoding the
+      // "{value}% ({status})" shape a third time.
+      formatDeviationLabel(
         employee.deviationPercent,
-      )}% (${formatPayStatusLabel(employee.payStatus, formatMessage)})`,
+        employee.payStatus,
+        formatMessage,
+      ),
     ])
   }
 

--- a/libs/application/templates/directorate-of-equality/salary-report/src/fields/SalaryAnalysisResults/SalaryImprovementPlan.tsx
+++ b/libs/application/templates/directorate-of-equality/salary-report/src/fields/SalaryAnalysisResults/SalaryImprovementPlan.tsx
@@ -33,10 +33,7 @@ import {
   navigationAnswersForAnalysisResult,
   type AnalysisExternalData,
 } from '../../utils/salaryAnalysisNavigation'
-import type {
-  DraftOutlierGroupDto,
-  ReportEmployeeDto,
-} from '../../utils/types'
+import type { DraftOutlierGroupDto, ReportEmployeeDto } from '../../utils/types'
 import { useDraftQueries } from '../../utils/useDraftQuery'
 import { useDraftSync } from '../../utils/useDraftSync'
 import { useSeedOnce } from '../../utils/useSeedOnce'

--- a/libs/application/templates/directorate-of-equality/salary-report/src/fields/SalaryAnalysisResults/SalaryImprovementPlan.tsx
+++ b/libs/application/templates/directorate-of-equality/salary-report/src/fields/SalaryAnalysisResults/SalaryImprovementPlan.tsx
@@ -36,7 +36,6 @@ import {
 import type {
   DraftOutlierGroupDto,
   ReportEmployeeDto,
-  ReportEmployeeRoleDto,
 } from '../../utils/types'
 import { useDraftQueries } from '../../utils/useDraftQuery'
 import { useDraftSync } from '../../utils/useDraftSync'
@@ -67,17 +66,14 @@ export const SalaryImprovementPlan: FC<React.PropsWithChildren<Props>> = ({
       : false
   const isDraftPhase = !hidePostponeCheckbox
   const { formatMessage, lang: locale } = useLocale()
-  // All three reads in one mutation — see the batching note on useDraftQueries.
+  // Both reads in one mutation — see the batching note on useDraftQueries.
   //
-  // All three are also granted to the DRAFT role only, hence the shared
+  // Both are also granted to the DRAFT role only, hence the shared
   // `enabled`: both review states (POSTPONED and DRAFT_RETRY) grant just the
   // analysis and comment providers, and the controller rejects the whole
   // mutation on the first actionId the role does not hold. They fall back to
   // the persisted snapshot instead, which is correct there — the draft is
   // already submitted, so there is nothing for it to be stale against.
-  //
-  // Roles are in the group because they carry the job title; ReportEmployeeDto
-  // only carries the role's id.
   const {
     contents,
     loading: draftLoading,
@@ -86,19 +82,16 @@ export const SalaryImprovementPlan: FC<React.PropsWithChildren<Props>> = ({
   } = useDraftQueries<{
     draftOutlierGroups: { groups: DraftOutlierGroupDto[] }
     draftEmployees: { employees: ReportEmployeeDto[] }
-    draftRoles: { roles: ReportEmployeeRoleDto[] }
   }>(
     application,
     {
       draftOutlierGroups: draftActionId(ApiActions.listDraftOutlierGroups),
       draftEmployees: draftActionId(ApiActions.listDraftEmployees),
-      draftRoles: draftActionId(ApiActions.listDraftRoles),
     },
     { enabled: isDraftPhase },
   )
   const outlierGroupsContent = contents.draftOutlierGroups
   const employeesContent = contents.draftEmployees
-  const rolesContent = contents.draftRoles
   const content = useMemo(
     () =>
       outlierGroupsContent && employeesContent
@@ -222,19 +215,6 @@ export const SalaryImprovementPlan: FC<React.PropsWithChildren<Props>> = ({
       },
     })
   })
-
-  const roleTitleForOrdinal = useMemo(() => {
-    const titleByRoleId = new Map(
-      (rolesContent?.roles ?? []).map((role) => [role.id, role.title]),
-    )
-    const titleByOrdinal = new Map(
-      (employeesContent?.employees ?? []).map((employee) => [
-        employee.ordinal,
-        titleByRoleId.get(employee.reportEmployeeRoleId),
-      ]),
-    )
-    return (ordinal: number) => titleByOrdinal.get(ordinal)
-  }, [employeesContent, rolesContent])
 
   const draftOutlierGroups =
     useWatch<DraftOutlierFormValues, 'salaryAnalysis.outlierGroups'>({
@@ -463,7 +443,6 @@ export const SalaryImprovementPlan: FC<React.PropsWithChildren<Props>> = ({
       outliers={result.outliers ?? []}
       hidePostponeCheckbox={hidePostponeCheckbox}
       errors={errors}
-      roleTitleForOrdinal={roleTitleForOrdinal}
       outlierGroupsFormMethods={isDraftPhase ? draftForm : undefined}
     />
   )

--- a/libs/application/templates/directorate-of-equality/salary-report/src/fields/SalaryAnalysisResults/index.tsx
+++ b/libs/application/templates/directorate-of-equality/salary-report/src/fields/SalaryAnalysisResults/index.tsx
@@ -570,10 +570,7 @@ export const SalaryAnalysisResults: FC<React.PropsWithChildren<Props>> = ({
 
       <PayComponentsTable data={payComponents} />
 
-      <PayDispersionTable
-        payDispersion={result?.payDispersion}
-        identifierForOrdinal={identifierForOrdinal}
-      />
+      <PayDispersionTable payDispersion={result?.payDispersion} />
     </Box>
   )
 

--- a/libs/application/templates/directorate-of-equality/salary-report/src/fields/SalaryAnalysisResults/outlierColumns.tsx
+++ b/libs/application/templates/directorate-of-equality/salary-report/src/fields/SalaryAnalysisResults/outlierColumns.tsx
@@ -9,24 +9,12 @@ import { useLocale } from '@island.is/localization'
 import type { SalaryAnalysisOutlierDto } from '@island.is/clients/directorate-of-equality'
 import { messages } from '../../lib/messages'
 import { GENDER_LABELS } from '../../utils/constants'
-import { formatPercentMagnitude } from '../../utils/wageGap'
+import { formatDeviationLabel } from '../../utils/salaryAnalysisLabels'
+import { formatWageAmount } from '../EmployeesEditor/utils'
 
 const SELECT_COLUMN_WIDTH = 32
 const DASH = '—'
 const m = messages.salaryAnalysis.outlierGroup
-
-// Bare amount, no "kr./klst." — the shared formatHourlyWage suffix is ~10
-// characters that every row pays for twice, wrapping the cell onto a second
-// line and widening the column past what the container holds. OutlierEditor
-// carries the unit once, under the table.
-// A missing figure is a dash, not a zero: `?? 0` would print "0" as though DMR
-// had reported a wage of nothing. The DTO types both wage fields as required, so
-// this is contract-defensive rather than a path we expect — but a false figure an
-// applicant could act on is the wrong way to fail. Zero itself still formats.
-const formatWageAmount = (value?: number | null): string =>
-  value == null
-    ? DASH
-    : value.toLocaleString('is-IS', { maximumFractionDigits: 0 })
 
 /**
  * InteractiveTable wraps every ordinary cell in `<Text variant="medium">`, which
@@ -222,32 +210,13 @@ const HourlyWageCell = ({ row }: CellProps) =>
 const ExpectedHourlyWageCell = ({ row }: CellProps) =>
   compactCell(formatWageAmount(row.original.expectedHourlyWage), 'right')
 
-// Signed here, unlike the company-level gender gaps: this is a deviation from a
-// fitted line, so the sign is meaningful and the word glosses it. The company
-// figures are magnitude-only because their sign would imply a denominator
-// convention the reader does not have.
-//
-// payStatus is rendered, not inferred from the sign. A row can be listed for
-// being paid ABOVE what their stig imply, which is the opposite of what a reader
-// expects, and deviationPercent's sign only conveys that to someone who already
-// knows the convention.
+// See formatDeviationLabel for why the sign comes from the figure and the word
+// from payStatus. Shared with the ábendingar table, which shows the same column.
 const DeviationCell = ({ row }: CellProps) => {
   const { formatMessage } = useLocale()
   const { deviationPercent, payStatus } = row.original
-  const sign = deviationPercent > 0 ? '+' : deviationPercent < 0 ? '-' : ''
-  const status = formatMessage(
-    payStatus === 'UNDERPAID'
-      ? m.payStatusUnderpaid
-      : payStatus === 'OVERPAID'
-      ? m.payStatusOverpaid
-      : m.payStatusOnLine,
-  )
   return compactCell(
-    formatMessage(m.deviationCell, {
-      sign,
-      value: formatPercentMagnitude(deviationPercent),
-      status,
-    }),
+    formatDeviationLabel(deviationPercent, payStatus, formatMessage),
     'right',
   )
 }

--- a/libs/application/templates/directorate-of-equality/salary-report/src/fields/SalaryAnalysisResults/outlierColumns.tsx
+++ b/libs/application/templates/directorate-of-equality/salary-report/src/fields/SalaryAnalysisResults/outlierColumns.tsx
@@ -51,10 +51,6 @@ type OutlierTableContextValue = {
   allSelectedOnPage: boolean
   toggleSelect: (ordinal: number) => void
   toggleSelectPage: () => void
-  // Absent for an employee whose role can't be resolved — neither the POSTPONED
-  // nor the DRAFT_RETRY review is granted the draft's employee/role reads, so
-  // the column is blank in both rather than wrong.
-  roleTitleForOrdinal: (ordinal: number) => string | undefined
 }
 
 const OutlierTableContext = createContext<OutlierTableContextValue | undefined>(
@@ -193,10 +189,17 @@ const OrdinalHeader = () => {
 const OrdinalCell = ({ row }: CellProps) =>
   compactCell(String(row.original.employeeOrdinal))
 
-const RoleCell = ({ row }: CellProps) => {
-  const { roleTitleForOrdinal } = useOutlierTable()
-  return compactCell(roleTitleForOrdinal(row.original.employeeOrdinal) || DASH)
-}
+// Read straight off the outlier row: DMR denormalises `roleTitle` onto it, so
+// there is no roles list to join against and nothing to resolve per ordinal.
+// That also means the column now fills in during the POSTPONED and DRAFT_RETRY
+// reviews, which are granted neither the draft employee nor the draft role read
+// and so used to show this blank for every row.
+//
+// A dash covers both null (DMR could not resolve a title) and '' (a role saved
+// without one) — neither is a title worth printing, and the distinction is not
+// one an applicant could act on.
+const RoleCell = ({ row }: CellProps) =>
+  compactCell(row.original.roleTitle || DASH)
 
 const GenderCell = ({ row }: CellProps) =>
   compactCell(GENDER_LABELS[row.original.gender] ?? row.original.gender)

--- a/libs/application/templates/directorate-of-equality/salary-report/src/fields/SubCriteriaEditor/CriterionPanel.tsx
+++ b/libs/application/templates/directorate-of-equality/salary-report/src/fields/SubCriteriaEditor/CriterionPanel.tsx
@@ -51,24 +51,10 @@ export const CriterionPanel: FC<Props> = ({
   )
   const expectedWeight = Number(criterionWeight) || 0
 
-  // Guarded on the PARENT's weight only.
-  //
-  // There is deliberately no `subCriteriaTotal !== 0` term. That was harmless
-  // while this only suppressed a red message, but it is now what decides whether
-  // Continue is enabled — and `createDefaultSubCriterion` seeds `weight: ''`, so
-  // a criterion nobody has filled in yet totals 0 and would have sailed straight
-  // through the gate. "Expected 40%, entered nothing" is exactly the mismatch
-  // this is here to catch: on Continue it writes weight 0, which makes maxScore
-  // and every step score 0 — an unscoreable yfirviðmið.
-  //
-  // `expectedWeight !== 0` stays, because a parent that has not been weighted yet
-  // (personal criteria are weighted on the previous screen) must not have this
-  // panel demanding its sub-criteria total 0%. Note this cannot be tightened to a
-  // blank-string check: `criterionWeight` arrives as `String(criterion.weight)`
-  // from a required `number`, so it is never '' — "0" is how "not weighted yet"
-  // reaches us.
-  const hasWeightMismatch =
-    expectedWeight !== 0 && Math.abs(subCriteriaTotal - expectedWeight) > 0.001
+  // Compare to the PARENT's weight, including 0%. A 0%-weighted criterion can
+  // only carry 0% worth of sub-criteria; otherwise those sub-criteria still write
+  // real step scores below even though the parent contributes no weight.
+  const hasWeightMismatch = Math.abs(subCriteriaTotal - expectedWeight) > 0.001
 
   useEffect(() => {
     onWeightMismatchChange(criterionId, hasWeightMismatch)

--- a/libs/application/templates/directorate-of-equality/salary-report/src/fields/SubCriteriaEditor/CriterionPanel.tsx
+++ b/libs/application/templates/directorate-of-equality/salary-report/src/fields/SubCriteriaEditor/CriterionPanel.tsx
@@ -1,6 +1,6 @@
 import { AccordionCard, Box, Button, Text } from '@island.is/island-ui/core'
 import { useLocale } from '@island.is/localization'
-import { FC } from 'react'
+import { FC, useEffect } from 'react'
 import { useFieldArray, useFormContext, useWatch } from 'react-hook-form'
 import type { SubCriterionCatalogEntryDto } from '@island.is/clients/directorate-of-equality'
 import { createDefaultSubCriterion } from '../../utils/constants'
@@ -15,6 +15,14 @@ type Props = {
   criterionWeight: string
   catalogEntries: SubCriterionCatalogEntryDto[]
   startExpanded?: boolean
+  /**
+   * Reported upward rather than only rendered here: the parent disables "Halda
+   * áfram" while ANY panel is out of balance, and deriving that at the top would
+   * mean watching the whole form there — which re-renders every panel, and every
+   * step textarea inside them, on each keystroke. The scoped useWatch below keeps
+   * that work local; only a flip in the verdict travels up.
+   */
+  onWeightMismatchChange: (criterionId: string, hasMismatch: boolean) => void
 }
 
 export const CriterionPanel: FC<Props> = ({
@@ -24,6 +32,7 @@ export const CriterionPanel: FC<Props> = ({
   criterionWeight,
   catalogEntries,
   startExpanded = false,
+  onWeightMismatchChange,
 }) => {
   const { formatMessage } = useLocale()
   const { control } = useFormContext()
@@ -41,6 +50,22 @@ export const CriterionPanel: FC<Props> = ({
     0,
   )
   const expectedWeight = Number(criterionWeight) || 0
+
+  // Only meaningful once both sides exist: the parent criterion's own weight can
+  // still be blank here (it's entered on the previous screen for personal
+  // criteria), and `Number('') || 0` would otherwise make this claim the
+  // sub-criteria must total 0%.
+  const hasWeightMismatch =
+    subCriteriaTotal !== 0 &&
+    expectedWeight !== 0 &&
+    Math.abs(subCriteriaTotal - expectedWeight) > 0.001
+
+  useEffect(() => {
+    onWeightMismatchChange(criterionId, hasWeightMismatch)
+    // A panel that unmounts while unbalanced must not leave its id behind in the
+    // parent: that would disable Continue with no visible error left to fix.
+    return () => onWeightMismatchChange(criterionId, false)
+  }, [criterionId, hasWeightMismatch, onWeightMismatchChange])
 
   return (
     <AccordionCard
@@ -79,22 +104,16 @@ export const CriterionPanel: FC<Props> = ({
         </Button>
       </Box>
 
-      {/* Only meaningful once both sides exist: the parent criterion's own
-          weight can still be blank here (it's entered on the previous screen
-          for personal criteria), and `Number('') || 0` would otherwise make
-          this claim the sub-criteria must total 0%. */}
-      {subCriteriaTotal !== 0 &&
-        expectedWeight !== 0 &&
-        Math.abs(subCriteriaTotal - expectedWeight) > 0.001 && (
-          <Box marginTop={3}>
-            <Text color="red600">
-              {formatMessage(messages.report.subCriteria.weightSumError, {
-                total: subCriteriaTotal,
-                expected: expectedWeight,
-              })}
-            </Text>
-          </Box>
-        )}
+      {hasWeightMismatch && (
+        <Box marginTop={3}>
+          <Text color="red600">
+            {formatMessage(messages.report.subCriteria.weightSumError, {
+              total: subCriteriaTotal,
+              expected: expectedWeight,
+            })}
+          </Text>
+        </Box>
+      )}
     </AccordionCard>
   )
 }

--- a/libs/application/templates/directorate-of-equality/salary-report/src/fields/SubCriteriaEditor/CriterionPanel.tsx
+++ b/libs/application/templates/directorate-of-equality/salary-report/src/fields/SubCriteriaEditor/CriterionPanel.tsx
@@ -51,14 +51,24 @@ export const CriterionPanel: FC<Props> = ({
   )
   const expectedWeight = Number(criterionWeight) || 0
 
-  // Only meaningful once both sides exist: the parent criterion's own weight can
-  // still be blank here (it's entered on the previous screen for personal
-  // criteria), and `Number('') || 0` would otherwise make this claim the
-  // sub-criteria must total 0%.
+  // Guarded on the PARENT's weight only.
+  //
+  // There is deliberately no `subCriteriaTotal !== 0` term. That was harmless
+  // while this only suppressed a red message, but it is now what decides whether
+  // Continue is enabled — and `createDefaultSubCriterion` seeds `weight: ''`, so
+  // a criterion nobody has filled in yet totals 0 and would have sailed straight
+  // through the gate. "Expected 40%, entered nothing" is exactly the mismatch
+  // this is here to catch: on Continue it writes weight 0, which makes maxScore
+  // and every step score 0 — an unscoreable yfirviðmið.
+  //
+  // `expectedWeight !== 0` stays, because a parent that has not been weighted yet
+  // (personal criteria are weighted on the previous screen) must not have this
+  // panel demanding its sub-criteria total 0%. Note this cannot be tightened to a
+  // blank-string check: `criterionWeight` arrives as `String(criterion.weight)`
+  // from a required `number`, so it is never '' — "0" is how "not weighted yet"
+  // reaches us.
   const hasWeightMismatch =
-    subCriteriaTotal !== 0 &&
-    expectedWeight !== 0 &&
-    Math.abs(subCriteriaTotal - expectedWeight) > 0.001
+    expectedWeight !== 0 && Math.abs(subCriteriaTotal - expectedWeight) > 0.001
 
   useEffect(() => {
     onWeightMismatchChange(criterionId, hasWeightMismatch)
@@ -71,6 +81,11 @@ export const CriterionPanel: FC<Props> = ({
     <AccordionCard
       id={accordionId}
       label={criterionTitle}
+      // Reddens the header so an out-of-balance criterion is identifiable while
+      // COLLAPSED. Only the first panel of each group starts expanded, so without
+      // this the gate above could disable Continue with its own explanation
+      // hidden inside a shut accordion — a dead button with no visible cause.
+      labelColor={hasWeightMismatch ? 'red600' : undefined}
       visibleContent={formatMessage(
         messages.report.subCriteria.criterionWeightLabel,
         {

--- a/libs/application/templates/directorate-of-equality/salary-report/src/fields/SubCriteriaEditor/index.tsx
+++ b/libs/application/templates/directorate-of-equality/salary-report/src/fields/SubCriteriaEditor/index.tsx
@@ -1,7 +1,7 @@
 import { FieldBaseProps } from '@island.is/application/types'
 import { Box, Stack, Text } from '@island.is/island-ui/core'
 import { useLocale } from '@island.is/localization'
-import { FC, useEffect, useMemo, useRef } from 'react'
+import { FC, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { FormProvider, useForm } from 'react-hook-form'
 import { messages } from '../../lib/messages'
 import {
@@ -33,6 +33,7 @@ export type SubCriteriaFormValues = Record<string, SubCriterion[]>
 export const SubCriteriaEditor: FC<React.PropsWithChildren<FieldBaseProps>> = ({
   application,
   setBeforeSubmitCallback,
+  setSubmitButtonDisabled,
 }) => {
   const { formatMessage } = useLocale()
   const { content, loading, hasError, refetch } = useDraftQuery<{
@@ -52,6 +53,41 @@ export const SubCriteriaEditor: FC<React.PropsWithChildren<FieldBaseProps>> = ({
     'subCriterionCatalog.data.entries',
     [],
   )
+
+  // Criteria whose sub-criteria weights do not add up to the parent's weight.
+  // Filled by the panels themselves rather than derived here — see the note on
+  // CriterionPanel's onWeightMismatchChange for why the watching stays down there.
+  const [criteriaWithWeightMismatch, setCriteriaWithWeightMismatch] = useState<
+    Set<string>
+  >(() => new Set<string>())
+
+  const handleWeightMismatchChange = useCallback(
+    (criterionId: string, hasMismatch: boolean) => {
+      setCriteriaWithWeightMismatch((prev) => {
+        // Same set identity when the verdict has not flipped, so a keystroke
+        // that leaves a panel just as unbalanced as it already was does not
+        // re-render this screen and every panel under it.
+        if (prev.has(criterionId) === hasMismatch) return prev
+        const next = new Set(prev)
+        if (hasMismatch) next.add(criterionId)
+        else next.delete(criterionId)
+        return next
+      })
+    },
+    [],
+  )
+
+  // Blocks "Halda áfram" outright instead of letting the applicant walk into an
+  // error on the far side: an unbalanced yfirviðmið cannot be scored at all, and
+  // the panel's own message already names which one is off and by how much.
+  useEffect(() => {
+    if (!setSubmitButtonDisabled) return
+    setSubmitButtonDisabled(criteriaWithWeightMismatch.size > 0)
+    // The shell keeps this flag on its Screen component, which is NOT remounted
+    // between screens — a disabled button left set here would follow the
+    // applicant onto the next step with nothing there able to clear it.
+    return () => setSubmitButtonDisabled(false)
+  }, [setSubmitButtonDisabled, criteriaWithWeightMismatch])
 
   // Diffed against the final form value at Continue time: missing => REMOVE, unseen => CREATE.
   const originalSubCriterionIds = useRef<Set<string>>(new Set())
@@ -209,6 +245,7 @@ export const SubCriteriaEditor: FC<React.PropsWithChildren<FieldBaseProps>> = ({
                     (e) => e.parentTitle === criterion.title,
                   )}
                   startExpanded={i === 0}
+                  onWeightMismatchChange={handleWeightMismatchChange}
                 />
               ))}
             </Stack>
@@ -236,6 +273,7 @@ export const SubCriteriaEditor: FC<React.PropsWithChildren<FieldBaseProps>> = ({
                     criterionWeight={String(criterion.weight)}
                     catalogEntries={personalCatalogEntries}
                     startExpanded={i === 0}
+                    onWeightMismatchChange={handleWeightMismatchChange}
                   />
                 ))}
               </Stack>

--- a/libs/application/templates/directorate-of-equality/salary-report/src/lib/messages.ts
+++ b/libs/application/templates/directorate-of-equality/salary-report/src/lib/messages.ts
@@ -1308,41 +1308,13 @@ export const messages = {
         defaultMessage:
           'Launadreifing verður ekki metin því ekki var unnt að reikna væntanlegt tímakaup.',
       },
-      numberHeader: {
-        id: 'doe.sr.application:salaryAnalysis.payDispersion.numberHeader',
-        defaultMessage: 'Auðkenni',
-      },
-      genderHeader: {
-        id: 'doe.sr.application:salaryAnalysis.payDispersion.genderHeader',
-        defaultMessage: 'Kyn',
-      },
-      points: {
-        id: 'doe.sr.application:salaryAnalysis.payDispersion.points',
-        defaultMessage: 'Stig',
-      },
-      salary: {
-        id: 'doe.sr.application:salaryAnalysis.payDispersion.salary',
-        defaultMessage: 'Tímakaup',
-      },
-      predictedSalary: {
-        id: 'doe.sr.application:salaryAnalysis.payDispersion.predictedSalary',
-        defaultMessage: 'Væntanlegt tímakaup',
-      },
-      deviationHeader: {
-        id: 'doe.sr.application:salaryAnalysis.payDispersion.deviationHeader',
-        defaultMessage: 'Launafrávik',
-      },
+      // Every other column of this table reads its header from the
+      // `outlierGroup` namespace, so the two tables cannot be translated apart —
+      // see the note in PayDispersionTable. This is the one column the
+      // úrbótaáætlun table does not have.
       spreadHeader: {
         id: 'doe.sr.application:salaryAnalysis.payDispersion.spreadHeader',
         defaultMessage: 'Staðalvik frá línu',
-      },
-      directionBelow: {
-        id: 'doe.sr.application:salaryAnalysis.payDispersion.directionBelow',
-        defaultMessage: 'undir',
-      },
-      directionAbove: {
-        id: 'doe.sr.application:salaryAnalysis.payDispersion.directionAbove',
-        defaultMessage: 'yfir',
       },
       genderMale: {
         id: 'doe.sr.application:salaryAnalysis.payDispersion.genderMale',

--- a/libs/application/templates/directorate-of-equality/salary-report/src/utils/salaryAnalysisLabels.spec.ts
+++ b/libs/application/templates/directorate-of-equality/salary-report/src/utils/salaryAnalysisLabels.spec.ts
@@ -1,0 +1,63 @@
+import { createIntl } from 'react-intl'
+import type { FormatMessage } from '@island.is/localization'
+import {
+  formatDeviationLabel,
+  formatPayStatusLabel,
+  formatSalaryAnalysisGenderLabel,
+} from './salaryAnalysisLabels'
+
+// Real react-intl over the bundled defaultMessages, so the ICU template in
+// `deviationCell` is exercised rather than a stub that would pass whatever shape
+// the helper happened to build.
+const intl = createIntl({
+  locale: 'is',
+  defaultLocale: 'is',
+  messages: {},
+  onError: () => undefined,
+})
+const formatMessage = intl.formatMessage as FormatMessage
+
+describe('formatPayStatusLabel', () => {
+  // ON_LINE is the case the úrbótaáætlun table used to render and the ábendingar
+  // table used to drop, leaving a bare percentage with no direction word.
+  it('glosses all three statuses, ON_LINE included', () => {
+    expect(formatPayStatusLabel('UNDERPAID', formatMessage)).toBe('undir')
+    expect(formatPayStatusLabel('OVERPAID', formatMessage)).toBe('yfir')
+    expect(formatPayStatusLabel('ON_LINE', formatMessage)).toBe('á línu')
+  })
+})
+
+describe('formatSalaryAnalysisGenderLabel', () => {
+  it('labels each gender, folding anything non-binary into Kynsegin', () => {
+    expect(formatSalaryAnalysisGenderLabel('MALE', formatMessage)).toBe('Karl')
+    expect(formatSalaryAnalysisGenderLabel('FEMALE', formatMessage)).toBe(
+      'Kona',
+    )
+    expect(formatSalaryAnalysisGenderLabel('NEUTRAL', formatMessage)).toBe(
+      'Kynsegin',
+    )
+  })
+})
+
+describe('formatDeviationLabel', () => {
+  it('signs the figure and names the direction', () => {
+    expect(formatDeviationLabel(3.94, 'OVERPAID', formatMessage)).toBe(
+      '+3,9% (yfir)',
+    )
+    expect(formatDeviationLabel(-3.94, 'UNDERPAID', formatMessage)).toBe(
+      '-3,9% (undir)',
+    )
+  })
+
+  // Regression guard: the sign has to come from the ROUNDED magnitude, not the
+  // raw value. Deriving it from the raw figure renders this as "-0,0%" — a
+  // signed zero, which wageGap.spec pins as suppressed.
+  it('suppresses the sign once the magnitude rounds to zero', () => {
+    expect(formatDeviationLabel(-0.04, 'UNDERPAID', formatMessage)).toBe(
+      '0,0% (undir)',
+    )
+    expect(formatDeviationLabel(0, 'ON_LINE', formatMessage)).toBe(
+      '0,0% (á línu)',
+    )
+  })
+})

--- a/libs/application/templates/directorate-of-equality/salary-report/src/utils/salaryAnalysisLabels.ts
+++ b/libs/application/templates/directorate-of-equality/salary-report/src/utils/salaryAnalysisLabels.ts
@@ -1,7 +1,7 @@
 import type { FormatMessage } from '@island.is/localization'
 import { messages } from '../lib/messages'
 import type { PayStatus } from './outlierGroups'
-import { formatPercentMagnitude } from './wageGap'
+import { formatSignedPercentMagnitude } from './wageGap'
 
 export type SalaryAnalysisGender = 'MALE' | 'FEMALE' | 'NEUTRAL'
 
@@ -50,6 +50,13 @@ export const formatPayStatusLabel = (
  *
  * The status word is always shown, ON_LINE included — a bare percentage with no
  * gloss is the one rendering that leaves the direction to the reader to guess.
+ *
+ * The sign comes from `formatSignedPercentMagnitude` rather than being derived
+ * here from the raw value, because it has to agree with the ROUNDED magnitude it
+ * sits in front of. Deriving it from the unrounded figure renders a deviation of
+ * −0,04% as "-0,0%" — a signed zero, which wageGap.spec pins as suppressed. So
+ * `sign` is passed empty: the message keeps its `{sign}` slot for the published
+ * translations, and the signed magnitude arrives whole in `{value}`.
  */
 export const formatDeviationLabel = (
   deviationPercent: number,
@@ -57,10 +64,9 @@ export const formatDeviationLabel = (
   formatMessage: FormatMessage,
 ): string => {
   const m = messages.salaryAnalysis.outlierGroup
-  const sign = deviationPercent > 0 ? '+' : deviationPercent < 0 ? '-' : ''
   return formatMessage(m.deviationCell, {
-    sign,
-    value: formatPercentMagnitude(deviationPercent),
+    sign: '',
+    value: formatSignedPercentMagnitude(deviationPercent),
     status: formatPayStatusLabel(payStatus, formatMessage),
   })
 }

--- a/libs/application/templates/directorate-of-equality/salary-report/src/utils/salaryAnalysisLabels.ts
+++ b/libs/application/templates/directorate-of-equality/salary-report/src/utils/salaryAnalysisLabels.ts
@@ -1,5 +1,7 @@
 import type { FormatMessage } from '@island.is/localization'
 import { messages } from '../lib/messages'
+import type { PayStatus } from './outlierGroups'
+import { formatPercentMagnitude } from './wageGap'
 
 export type SalaryAnalysisGender = 'MALE' | 'FEMALE' | 'NEUTRAL'
 
@@ -11,4 +13,54 @@ export const formatSalaryAnalysisGenderLabel = (
   if (gender === 'MALE') return formatMessage(m.genderMale)
   if (gender === 'FEMALE') return formatMessage(m.genderFemale)
   return formatMessage(m.genderNeutral)
+}
+
+/**
+ * "undir" / "yfir" / "á línu" — where an employee sits relative to the fitted
+ * line. Shared by the úrbótaáætlun table, the ábendingar table and the chart
+ * tooltip, all three of which show the same figure and must gloss it the same
+ * way.
+ */
+export const formatPayStatusLabel = (
+  payStatus: PayStatus,
+  formatMessage: FormatMessage,
+): string => {
+  const m = messages.salaryAnalysis.outlierGroup
+  return formatMessage(
+    payStatus === 'UNDERPAID'
+      ? m.payStatusUnderpaid
+      : payStatus === 'OVERPAID'
+      ? m.payStatusOverpaid
+      : m.payStatusOnLine,
+  )
+}
+
+/**
+ * Launafrávik as "{sign}{magnitude}% ({status})".
+ *
+ * Signed here, unlike the company-level gender gaps: this is a deviation from a
+ * fitted line, so the sign is meaningful and the word glosses it. The company
+ * figures are magnitude-only because their sign would imply a denominator
+ * convention the reader does not have.
+ *
+ * payStatus is rendered, not inferred from the sign. A row can be listed for
+ * being paid ABOVE what their stig imply, which is the opposite of what a
+ * reader expects, and deviationPercent's sign only conveys that to someone who
+ * already knows the convention.
+ *
+ * The status word is always shown, ON_LINE included — a bare percentage with no
+ * gloss is the one rendering that leaves the direction to the reader to guess.
+ */
+export const formatDeviationLabel = (
+  deviationPercent: number,
+  payStatus: PayStatus,
+  formatMessage: FormatMessage,
+): string => {
+  const m = messages.salaryAnalysis.outlierGroup
+  const sign = deviationPercent > 0 ? '+' : deviationPercent < 0 ? '-' : ''
+  return formatMessage(m.deviationCell, {
+    sign,
+    value: formatPercentMagnitude(deviationPercent),
+    status: formatPayStatusLabel(payStatus, formatMessage),
+  })
 }

--- a/libs/application/templates/directorate-of-equality/salary-report/src/utils/salaryAnalysisLabels.ts
+++ b/libs/application/templates/directorate-of-equality/salary-report/src/utils/salaryAnalysisLabels.ts
@@ -55,8 +55,7 @@ export const formatPayStatusLabel = (
  * here from the raw value, because it has to agree with the ROUNDED magnitude it
  * sits in front of. Deriving it from the unrounded figure renders a deviation of
  * −0,04% as "-0,0%" — a signed zero, which wageGap.spec pins as suppressed. So
- * `sign` is passed empty: the message keeps its `{sign}` slot for the published
- * translations, and the signed magnitude arrives whole in `{value}`.
+ * `sign` is passed empty: the signed magnitude arrives whole in `{value}`.
  */
 export const formatDeviationLabel = (
   deviationPercent: number,

--- a/libs/clients/directorate-of-equality/src/clientConfig.json
+++ b/libs/clients/directorate-of-equality/src/clientConfig.json
@@ -350,7 +350,7 @@
     },
     "/api/v1/application/reports/equality/active": {
       "get": {
-        "description": "Returns the resolved company's currently-APPROVED equality report (if any). The application portal references the returned `id` as `equalityReportId` when submitting a salary report.",
+        "description": "Returns the resolved company's currently-APPROVED equality report (if any). The application portal references the returned `id` as `equalityReportId` when submitting a salary report, and passes the returned `providerId` to `GET /application/reports/:providerId` to read the report itself. Neither `id` nor `identifier` is a lookup handle here: `id` only resolves against the admin-only `GET /reports/:id`, and `identifier` is a human-facing display code.",
         "operationId": "getApplicationActiveEqualityReport",
         "parameters": [],
         "responses": {
@@ -3109,6 +3109,11 @@
         "properties": {
           "employeeOrdinal": { "type": "number" },
           "gender": { "type": "string", "enum": ["MALE", "FEMALE", "NEUTRAL"] },
+          "roleTitle": {
+            "type": "string",
+            "nullable": true,
+            "description": "Starf — the title of the employee's role, denormalized here so the úrbótaáætlun table needs no client-side join against the draft roles list. Mirrors `ReportEmployeeOutlierDto.roleTitle`, which the submitted-report endpoints already carry. Null only when the caller could not resolve a title for the ordinal."
+          },
           "score": { "type": "number" },
           "regularHourlyWage": {
             "type": "number",
@@ -3621,6 +3626,7 @@
         "properties": {
           "id": { "type": "string", "format": "uuid" },
           "identifier": { "type": "string", "nullable": true },
+          "providerId": { "type": "string", "nullable": true },
           "approvedAt": {
             "type": "string",
             "format": "date-time",
@@ -4348,6 +4354,10 @@
             "description": "The payroll month the salary data is based on (`YYYY-MM-01`). Set when `salaryDataBasis` is `MONTH`, always null for `AVERAGE`."
           },
           "equalityReportContent": { "type": "string", "nullable": true },
+          "importedFromExcel": {
+            "type": "boolean",
+            "description": "Whether this draft's scoring content was uploaded as an Excel workbook (`POST …/draft/import`) rather than keyed in through the portal UI. Set by the server when the parser runs; sticky, so hand-editing rows afterwards does not clear it. False on a draft that has never been imported."
+          },
           "counts": { "$ref": "#/components/schemas/DraftCountsDto" },
           "createdAt": {
             "type": "string",
@@ -4362,7 +4372,7 @@
             "nullable": true
           }
         },
-        "required": ["id", "type", "status", "counts"]
+        "required": ["id", "type", "status", "importedFromExcel", "counts"]
       },
       "UpdateDraftDto": {
         "type": "object",
@@ -4603,7 +4613,7 @@
             "type": "string",
             "format": "uuid",
             "nullable": true,
-            "description": "Outlier-group membership (null clears). Applied after detection; the employee must be a currently-detected outlier."
+            "description": "Outlier-group membership (null clears). Recorded as sent; a membership for an employee who is no longer a detected outlier is dropped at submit."
           }
         }
       },


### PR DESCRIPTION
## What

Four fixes to the DOE salary report, plus a client spec refresh.

**1. Chart drew a focus ring on click** (`SalaryDistributionChart`)

Clicking anywhere in the scatter plot drew a blue border — around the whole
chart, or around the bounding box of the points, depending on where you hit.
Recharts 3 enables its accessibility layer by default and scatters focusable
elements through the chart: `RootSurface` puts `tabIndex={0}` + `role="application"`
on the `<svg>`, and `ZIndexSvgPortal` puts `tabIndex={-1}` on the `<g>` wrappers it
portals layers into. A plain click focuses whichever one it lands on.

There was already a `style={{ outline: 'none' }}` on `<ScatterChart>` that never
did anything: `RootSurface` spreads the chart's attributes onto `<Surface>` and
*then* overrides `style` with its own full-size object, so the prop was discarded.
Fixed in CSS instead (new `SalaryDistributionChart.css.ts`) — a `:focus` reset
scoped to the chart container, paired with a `:focus-visible` rule so keyboard
navigation of the points keeps a visible ring. Both rules are aimed at every
focused descendant rather than at specific elements; targeting them individually
just moves the border somewhere else.

**2. "Ábendingar um launadreifingu" table now matches the úrbótaáætlun table**

It was noticeably bulkier and worded differently than the table right next to it.
Two independent causes: it wasn't overriding `T.Data`/`T.HeadData`'s default cell
padding (18px vertical, 24px horizontal), and its headers were rendering at
`variant: 'h5'` — 18px on desktop, two steps above its own 14px body cells.

- Padding now matches `OutlierEditor`'s `cellBox` exactly (8px vertical, 12px horizontal).
- Headers are 14px semibold, so header and body rows are the same height. This is
  deliberately one step *below* the úrbótaáætlun table's 16px: this is an advisory
  that requires no action, so it shouldn't carry more visual weight than the table
  the applicant must actually fill in.
- Bare ordinal with the same tooltip, replacing the `ABC-000` identifier — the
  ordinal is the number the applicant already knows from the employee screens and
  the workbook.
- Bare wage amounts with the shared `Tímakaup er sýnt í kr./klst.` footnote beneath
  the table, and numeric columns right-aligned.
- Frávik uses the shared `{sign}{value}% ({status})` form. The old version dropped
  the status word for `ON_LINE`, leaving a bare percentage with no gloss.
- Column headers now read from the `outlierGroup` message namespace instead of
  restating labels. This matters concretely: the old `payDispersion.numberHeader` /
  `.salary` / `.deviationHeader` ids carry published Contentful translations
  ("Auðkenni", "Tímakaup", "Launafrávik") that win over any renamed
  `defaultMessage`, so reusing the ids is the only way the two tables are
  guaranteed to say the same thing. Six superseded messages removed.

Kept the `Staðalvik frá línu` column, which has no counterpart in the other table —
it's the figure that put the row on the list, in the same units as the threshold in
the note above it.

**3. Sub-criteria weights now block "Halda áfram"** (`SubCriteriaEditor`)

The weight-sum error ("Vægi undirviðmiða verður að vera samtals jafnt vægi
yfirviðmiðsins (15%) — núverandi samtals: 12%") was only ever displayed —
`setBeforeSubmitCallback` never checked weights, so Continue went through and
synced unbalanced criteria to DMR. Continue is now disabled while any yfirviðmið is
out of balance, via the shell's existing `setSubmitButtonDisabled`.

Panels report their verdict upward rather than the parent watching the form:
deriving the total at the top would need a `useWatch` over the whole form, which
re-renders every panel and every step textarea on each keystroke. The parent only
re-renders when a verdict actually flips.

Two cleanup paths, both required: the shell keeps `submitButtonDisabled` on its
`Screen` component, which is rendered without a `key` and so does **not** remount
between steps (it only self-resets on *back* navigation). So the parent resets on
unmount, and each panel withdraws its own id on unmount — otherwise a disabled
button could follow the applicant to the next step, or a panel disappearing
mid-error could leave Continue dead with no visible error to fix.

**4. Starf column reads `roleTitle` off the outlier response**

Bug from dev: in the úrbótaáætlun table, Starf showed for the first row only and
"—" for every other row.

Root cause was a client-side join unique to this screen —
`SalaryImprovementPlan` joined `listDraftEmployees` × `listDraftRoles` on
`reportEmployeeRoleId`, keyed into a `Map` by ordinal. Two ways that fails
silently: `new Map()` dedupes on key collision (so duplicate or unpopulated
ordinals collapse to a single entry), and `/draft/roles` returns a bare
`{ roles: [...] }` with no paging object, so a truncated list is undetectable and
unrequestable. Neither surfaces as an error — the roles read isn't in the screen's
render gate, so the table renders normally with dashes.

DMR has added `roleTitle` to `SalaryAnalysisOutlierDto` (mirroring
`ReportEmployeeOutlierDto`, which already carried it), so the join is gone
entirely: `RoleCell` reads `row.original.roleTitle`. Both failure modes are
structurally removed rather than patched, `roleTitleForOrdinal` and its
prop-drilling are deleted, and the screen now makes two draft reads instead of
three.

This also fixes a second bug that was previously accepted as a limitation: in the
POSTPONED and DRAFT_RETRY reviews, Starf was blank for *every* row, because those
states aren't granted the draft employee or role reads. The title now rides along
in the persisted analysis snapshot.

**Also**

- `clientConfig.json` refreshed from DMR. `roleTitle` on `SalaryAnalysisOutlierDto`
  is the field this PR consumes; `providerId`, `importedFromExcel` and the
  description edits came along in the same refresh and aren't used yet.
- Deduplicated three copies of the payStatus → "undir"/"yfir"/"á línu" mapping
  (both tables and the chart tooltip) and two copies of the bare-wage formatter,
  into `utils/salaryAnalysisLabels.ts` and `EmployeesEditor/utils.ts`. The tables
  this PR just aligned can't drift apart again.

## Why

- The focus ring read as a rendering bug to anyone clicking the chart.
- The two tables sit on the same screen and described the same figures differently,
  at different sizes.
- Unbalanced sub-criteria weights can't be scored, so letting the applicant past
  that screen only defers the problem — and wrote invalid weights to the draft in
  the meantime.
- The Starf bug was reported from dev testing, and the join it came from was
  silent-by-construction in two separate ways.

## Screenshots / Gifs

<!-- TODO: before/after of the Ábendingar table, the chart focus ring, and the
     disabled Halda áfram button on Undirviðmið -->

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clearer, consistent wage and deviation formatting across salary analysis tables and charts.
  * Outlier tables now display role titles directly with standardized labels and units.
  * Improved keyboard focus visibility for salary distribution charts.

* **Bug Fixes**
  * Prevented submission when criterion weights are unbalanced and highlighted affected criteria.
  * Missing wage values now display an em dash, while zero values remain visible.
  * Corrected deviation labels for rounded values and pay status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->