### PR TITLE
fix(j-s): Repair the indictment e2e regression suite

### DIFF
--- a/apps/system-e2e/src/tests/judicial-system/regression/indictment-completing-for-some-tests.spec.ts
+++ b/apps/system-e2e/src/tests/judicial-system/regression/indictment-completing-for-some-tests.spec.ts
@@ -86,11 +86,20 @@ test.describe.serial('Indictment completing for some tests', () => {
 
     // The overview moves a defendant whose indictment was cancelled out of the
     // defendant list and into a section of its own, titled with the decision.
-    // ('Niðurfellt' is only rendered for defendants still on the list.)
-    await expect(page.getByText('Niðurfelling máls').first()).toBeVisible()
-    await expect(page.getByText(accusedName).first()).toBeVisible()
+    // ('Niðurfellt' is only rendered for defendants still on the list.) The
+    // innermost div carrying the title is the info card item that holds it.
+    const cancelledSection = page
+      .locator('div')
+      .filter({ hasText: 'Niðurfelling máls' })
+      .last()
 
-    // The case is not completed - it remains active for the other defendant
+    // Scoping the names to that section is what makes this an assertion about
+    // the right defendant - page-wide locators would pass either way round.
+    await expect(cancelledSection.getByText(accusedName)).toBeVisible()
+
+    // The case is not completed - the second defendant is still on it, and is
+    // not among the ones whose indictment was cancelled
+    await expect(cancelledSection.getByText(secondAccusedName)).toHaveCount(0)
     await expect(page.getByText(secondAccusedName).first()).toBeVisible()
   })
 })

--- a/apps/system-e2e/src/tests/judicial-system/regression/indictment-completing-for-some-tests.spec.ts
+++ b/apps/system-e2e/src/tests/judicial-system/regression/indictment-completing-for-some-tests.spec.ts
@@ -11,10 +11,22 @@ import {
 
 test.use({ baseURL: urls.judicialSystemBaseUrl })
 
+// The assertions tell the two defendants apart by name, so the names have to
+// differ - faker will hand out the same one twice often enough to matter.
+const nameOtherThan = (name: string) => {
+  let candidate = faker.name.findName()
+
+  while (candidate === name) {
+    candidate = faker.name.findName()
+  }
+
+  return candidate
+}
+
 test.describe.serial('Indictment completing for some tests', () => {
   let caseId = ''
   const accusedName = faker.name.findName()
-  const secondAccusedName = faker.name.findName()
+  const secondAccusedName = nameOtherThan(accusedName)
 
   test('prosecutor should create a new indictment case with two defendants', async ({
     prosecutorPage,

--- a/apps/system-e2e/src/tests/judicial-system/regression/indictment-completing-for-some-tests.spec.ts
+++ b/apps/system-e2e/src/tests/judicial-system/regression/indictment-completing-for-some-tests.spec.ts
@@ -51,9 +51,16 @@ test.describe.serial('Indictment completing for some tests', () => {
       .filter({ hasText: 'Skrá lyktir á einstaka aðila án þess að ljúka máli' })
       .click()
 
-    // A conclusion can be registered for all but one defendant -
-    // cancel the indictment against the first defendant
-    await page.getByText('Veldu lyktir ef á við').first().click()
+    // A conclusion can be registered for all but one defendant - cancel the
+    // indictment against the first defendant. Click the select control rather
+    // than the placeholder: react-select lays the input container over the
+    // placeholder in the same grid cell, so a click aimed at the placeholder
+    // never reaches it.
+    await page
+      .locator('.island-select__control')
+      .filter({ hasText: 'Veldu lyktir ef á við' })
+      .first()
+      .click()
     await page.getByRole('option', { name: 'Niðurfelling máls' }).click()
 
     await page.getByTestId('continueButton').click()
@@ -75,8 +82,15 @@ test.describe.serial('Indictment completing for some tests', () => {
       verifyRequestCompletion(page, '/api/graphql', 'UpdateCase'),
     ])
 
-    // The case is not completed - it remains active for the other defendant
     await expect(page).toHaveURL(`domur/akaera/yfirlit/${caseId}`)
-    await expect(page.getByText('Niðurfellt').first()).toBeVisible()
+
+    // The overview moves a defendant whose indictment was cancelled out of the
+    // defendant list and into a section of its own, titled with the decision.
+    // ('Niðurfellt' is only rendered for defendants still on the list.)
+    await expect(page.getByText('Niðurfelling máls').first()).toBeVisible()
+    await expect(page.getByText(accusedName).first()).toBeVisible()
+
+    // The case is not completed - it remains active for the other defendant
+    await expect(page.getByText(secondAccusedName).first()).toBeVisible()
   })
 })

--- a/apps/system-e2e/src/tests/judicial-system/regression/indictment-fine-tests.spec.ts
+++ b/apps/system-e2e/src/tests/judicial-system/regression/indictment-fine-tests.spec.ts
@@ -46,10 +46,11 @@ test.describe.serial('Indictment fine tests', () => {
     await expect(page.getByTestId('entries')).toBeVisible({ timeout: 15000 })
     await expect(page.getByTestId('confirm-court-record')).toBeVisible()
 
+    // The rich text editor is TipTap, which renders a contenteditable
+    // element - there is no iframe to reach into.
     await page
       .getByTestId('entries')
-      .frameLocator('iframe')
-      .locator('body')
+      .locator('[contenteditable="true"]')
       .fill('Þinghald vegna viðurlagaákvörðunar')
 
     // No judgement or order is pronounced in the session

--- a/apps/system-e2e/src/tests/judicial-system/regression/indictment-tests.spec.ts
+++ b/apps/system-e2e/src/tests/judicial-system/regression/indictment-tests.spec.ts
@@ -39,10 +39,11 @@ test.describe.serial('Indictment tests', () => {
       page.getByRole('button', { name: 'Bæta við þinghaldi' }).click(),
       verifyRequestCompletion(page, '/api/graphql', 'CreateCourtSession'),
     ])
+    // The rich text editor is TipTap, which renders a contenteditable
+    // element - there is no iframe to reach into.
     await page
       .getByTestId('entries')
-      .frameLocator('iframe')
-      .locator('body')
+      .locator('[contenteditable="true"]')
       .fill('Afstaða, málflutningur, og bókun')
 
     await page.locator('label').filter({ hasText: 'Dómur kveðinn upp' }).click()

--- a/apps/system-e2e/src/tests/judicial-system/regression/shared-steps/indictment-to-court-record.ts
+++ b/apps/system-e2e/src/tests/judicial-system/regression/shared-steps/indictment-to-court-record.ts
@@ -52,19 +52,29 @@ export const prosecutorCreatesIndictmentCase = async (
   if (secondAccusedName) {
     // The case does not exist yet, so this only adds a defendant locally -
     // it is persisted with a CreateDefendant mutation when the case is
-    // created below. The second defendant has no Icelandic national id to
-    // avoid a duplicate national registry lookup.
+    // created below. Every defendant in an indictment must have an Icelandic
+    // national id, and the national registry lookup is also what fills in the
+    // gender the step needs to be valid, so the second defendant is looked up
+    // just like the first one.
     await page.getByTestId('addDefendantButton').click()
-    await page
-      .getByRole('checkbox', {
-        name: 'Varnaraðili er ekki með íslenska kennitölu',
-      })
-      .last()
-      .check()
-    await page.getByTestId('inputNationalId').last().fill('12.12.2000')
+
+    const secondNationalIdInput = page.getByTestId('inputNationalId').last()
     const secondNameInput = page.getByTestId('inputName').last()
+
+    await Promise.all([
+      page.waitForResponse(
+        (resp) =>
+          resp.url().includes('/api/nationalRegistry/getPersonByNationalId') &&
+          resp.request().method() === 'GET',
+      ),
+      secondNationalIdInput.fill('000000-0000'),
+    ])
+
+    // Let the looked up data land before overwriting the name, otherwise the
+    // lookup overwrites what we type.
+    await expect(secondNameInput).not.toHaveValue('')
+
     await secondNameInput.fill(secondAccusedName)
-    await page.getByTestId('accusedAddress').last().fill('Einhversstaðar 2')
     await secondNameInput.press('Tab')
     await expect(secondNameInput).toHaveValue(secondAccusedName)
   }
@@ -198,17 +208,38 @@ export const judgeReceivesIndictmentThroughAdvocates = async (
 
   await expect(page).toHaveURL(`domur/akaera/mottaka/${caseId}`)
 
-  await page
-    .getByTestId('courtCaseNumber')
-    .fill(randomIndictmentCourtCaseNumber())
-  await page.keyboard.press('Tab')
+  // Navigating to a case screen refreshes the case, and the refresh response
+  // replaces the whole form state - so a court case number or judge entered
+  // while that refresh is still in flight is silently wiped, which leaves the
+  // continue button disabled with nothing to refill it. Enter both until they
+  // survive. The heavier the case, the slower the refresh, so this bites with
+  // more than one defendant.
+  const courtCaseNumber = randomIndictmentCourtCaseNumber()
+  const courtCaseNumberInput = page.getByTestId('courtCaseNumber')
+  const judgeSelect = page.getByTestId('select-judge')
+  const receptionContinueButton = page.getByTestId('continueButton')
 
-  await page.getByText('Veldu dómara/aðstoðarmann').click()
-  await page.getByTestId('select-judge').getByText('Test Dómari').last().click()
+  await expect(async () => {
+    if ((await courtCaseNumberInput.inputValue()) !== courtCaseNumber) {
+      await courtCaseNumberInput.fill(courtCaseNumber)
+      await page.keyboard.press('Tab')
+    }
+
+    // 'Veldu héraðsdómara' is the placeholder, shown only until a judge is
+    // selected - unlike the judge's name it cannot be confused with an option
+    // in a menu left open by a failed attempt. 'Veldu dómara/aðstoðarmann' is
+    // the label, and clicking it opens the menu.
+    if (await judgeSelect.getByText('Veldu héraðsdómara').isVisible()) {
+      await judgeSelect.getByText('Veldu dómara/aðstoðarmann').click()
+      await judgeSelect.getByText('Test Dómari').last().click()
+    }
+
+    await expect(receptionContinueButton).toBeEnabled({ timeout: 2000 })
+  }).toPass({ timeout: 30000 })
 
   await Promise.all([
     verifyRequestCompletion(page, '/api/graphql', 'Case'),
-    page.getByTestId('continueButton').click(),
+    receptionContinueButton.click(),
   ])
 
   await expect(page).toHaveURL(`domur/akaera/fyrirkall/${caseId}`)
@@ -246,8 +277,17 @@ export const judgeReceivesIndictmentThroughAdvocates = async (
   for (let i = 0; i < defenderChoiceCount; i++) {
     await defenderChoiceOptions.nth(i).click()
   }
-  await page.getByRole('button', { name: 'Staðfesta val' }).click()
-  await page.getByTestId('modalPrimaryButton').click()
+  // One defender choice confirmation per defendant. The confirm button is
+  // removed once the choice is confirmed, so we always act on the first one
+  // still standing and wait for it to disappear before moving on.
+  const confirmDefenderChoiceButtons = page.getByRole('button', {
+    name: 'Staðfesta val',
+  })
+  for (let remaining = defenderChoiceCount; remaining > 0; remaining--) {
+    await confirmDefenderChoiceButtons.first().click()
+    await page.getByTestId('modalPrimaryButton').click()
+    await expect(confirmDefenderChoiceButtons).toHaveCount(remaining - 1)
+  }
 
   await Promise.all([
     verifyRequestCompletion(page, '/api/graphql', 'Case'),

--- a/apps/system-e2e/src/tests/judicial-system/regression/shared-steps/indictment-to-court-record.ts
+++ b/apps/system-e2e/src/tests/judicial-system/regression/shared-steps/indictment-to-court-record.ts
@@ -67,7 +67,9 @@ export const prosecutorCreatesIndictmentCase = async (
           resp.url().includes('/api/nationalRegistry/getPersonByNationalId') &&
           resp.request().method() === 'GET',
       ),
-      secondNationalIdInput.fill('000000-0000'),
+      // A different Gervimaður than the first defendant - two defendants on
+      // one case must not share a national id.
+      secondNationalIdInput.fill('010130-2399'),
     ])
 
     // Let the looked up data land before overwriting the name, otherwise the

--- a/apps/system-e2e/src/tests/judicial-system/regression/shared-steps/ruling-order-appeal.ts
+++ b/apps/system-e2e/src/tests/judicial-system/regression/shared-steps/ruling-order-appeal.ts
@@ -80,10 +80,11 @@ const judgeCreatesOrderRulingSession = async (
   await expect(page.getByTestId('entries')).toBeVisible({ timeout: 15000 })
   await expect(page.getByTestId('confirm-court-record')).toBeVisible()
 
+  // The rich text editor is TipTap, which renders a contenteditable
+  // element - there is no iframe to reach into.
   await page
     .getByTestId('entries')
-    .frameLocator('iframe')
-    .locator('body')
+    .locator('[contenteditable="true"]')
     .fill('Afstaða, málflutningur, og bókun vegna úrskurðar')
 
   await Promise.all([


### PR DESCRIPTION
# Repair the indictment e2e regression suite

[Fix broken indictment e2e regression tests](https://app.asana.com/1/203394141643832/project/1199153462262248/task/1217952446161534)

Five separate breakages in the judicial-system indictment e2e regression suite, all found while getting `indictment-completing-for-some-tests` to run end to end. Test-only change — no production code is touched.

## 1. The second defendant used a UI escape hatch that no longer exists

`prosecutorCreatesIndictmentCase` ticked the **"Varnaraðili er ekki með íslenska kennitölu"** checkbox for the second defendant, but `DefendantInfo.tsx:155` guards that checkbox with `!isIndictmentCase(workingCase.type)` — every defendant in an ákæra must have a kennitala (#21621). The step could never pass.

Fixing only the checkbox would have failed a second time: `isDefendantInvalid` requires `gender`, and gender is only populated by the national registry lookup. So the second defendant is now looked up like the first, which also fills in the address.

## 2. "Staðfesta val" was clicked once for two defendants

`SelectDefender.tsx` renders one confirm button per defendant, so the single click was a strict mode violation. The button is removed once the choice is confirmed, so the loop always clicks the first one still standing and asserts the count dropped — which doubles as a sync point on the `UpdateDefendant` round-trip.

## 3. The reception screen lost the court case number and judge

`FormProvider` fires a fresh `Case` query on every route change and its handler replaces the whole form state. The query is issued on arrival at `/domur/akaera/mottaka`, so its response carries `courtCaseNumber: null, judge: null`; if it lands after the test has filled both in, they are wiped and the continue button stays disabled for good — nothing refetches afterwards. The writes themselves succeed server-side, only the client state goes stale.

That window is the duration of the `Case` query, which is why it started biting at two defendants: bigger payload, slower response. The entries are now retried until they survive, gated on the continue button actually being enabled.

## 4. The conclusion select could not be clicked

The spec clicked the select's placeholder. react-select puts the placeholder and the input container in the same grid cell, so the hit test lands on a sibling and Playwright retries until it times out. Every select click that works elsewhere in the suite targets a label or a wrapper. This one now targets the react-select control.

## 5. The court record editor is no longer an iframe

`RichTextEditor` uses TipTap, whose `EditorContent` renders a plain contenteditable div — the `frameLocator('iframe')` calls are left over from the TinyMCE editor that was swapped out. Fixed at all three call sites (`indictment-fine-tests`, `indictment-tests`, `ruling-order-appeal`).

## Also

The completing-for-some spec asserted on `Niðurfellt`, which the overview never renders for a cancelled defendant: `InfoCardActiveIndictment.tsx:49` pulls those defendants out of the main list and renders them in their own section titled **"Niðurfelling máls"**. The assertion now checks that section plus both defendant names, so it actually verifies the "for some" semantics — first defendant cancelled, second still on the case.

## Verification

`nx format:check` and `tsc -p apps/system-e2e/tsconfig.json` are clean for the changed files. I have not been able to run the suite itself — it needs a running environment — so the fixes are reasoned from the app code rather than observed green.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability across judicial workflows, including indictment completion, case receipt, and ruling-session creation.
  * Improved handling of defendant details, court case numbers, judge selections, and defender confirmations.
  * Updated rich-text editor interactions to work reliably with the current editor experience.
  * Improved validation for cancelled and active defendants.
  * Strengthened coverage for cases involving multiple defendants and distinct identifying details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->