### PR TITLE
feat(clients-middlewares): add tokenRequestHeaders option to AutoAuthOptions

### DIFF
--- a/libs/clients/middlewares/src/lib/withAutoAuth.ts
+++ b/libs/clients/middlewares/src/lib/withAutoAuth.ts
@@ -77,8 +77,7 @@ export interface AutoAuthOptions {
   audience?: string
 
   /**
-   * Additional headers to include in the token request. Useful when the token
-   * endpoint is behind a proxy (e.g. X-Road) that requires identification headers.
+   * Additional headers to include in the token request. Useful when the token endpoint is behind a proxy (e.g. X-Road) that requires identification headers.
    */
   tokenRequestHeaders?: Record<string, string>
 }

--- a/libs/clients/middlewares/src/lib/withAutoAuth.ts
+++ b/libs/clients/middlewares/src/lib/withAutoAuth.ts
@@ -214,8 +214,8 @@ export const withAutoAuth = ({
     const response = await innerFetch(tokenEndpoint, {
       method: 'POST',
       headers: {
-        'Content-Type': 'application/x-www-form-urlencoded',
         ...options.tokenRequestHeaders,
+        'Content-Type': 'application/x-www-form-urlencoded',
       },
       body: params,
       auth,

--- a/libs/clients/middlewares/src/lib/withAutoAuth.ts
+++ b/libs/clients/middlewares/src/lib/withAutoAuth.ts
@@ -75,6 +75,12 @@ export interface AutoAuthOptions {
   tokenEndpoint?: string
 
   audience?: string
+
+  /**
+   * Additional headers to include in the token request. Useful when the token
+   * endpoint is behind a proxy (e.g. X-Road) that requires identification headers.
+   */
+  tokenRequestHeaders?: Record<string, string>
 }
 
 export interface AuthMiddlewareOptions {
@@ -210,6 +216,7 @@ export const withAutoAuth = ({
       method: 'POST',
       headers: {
         'Content-Type': 'application/x-www-form-urlencoded',
+        ...options.tokenRequestHeaders,
       },
       body: params,
       auth,


### PR DESCRIPTION
## What

Added a tokenRequestHeaders option to AutoAuthOptions in withAutoAuth.ts that merges additional headers into the token request.

## Why

The autoAuth mechanism makes its token fetch internally with only Content-Type. There was no way to pass additional headers to that request through AutoAuthOptions. This became necessary when connecting to a service where the token endpoint sits behind X-Road, which requires X-Road-Client on every request including the token fetch.

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [x] No AI tools were used in preparing this pull request
- [ ] AI tools were used in preparing this pull request
      Tools used:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for including custom headers when requesting authentication tokens.

* **Bug Fixes**
  * Authentication token requests now consistently use the correct form-encoded content type, even when custom headers are provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->