### PR TITLE
fix(auth): recover from unique-constraint race when creating a delegation

### DIFF
--- a/apps/services/auth/delegation-api/src/app/delegations/test/me-delegations.access-outgoing.spec.ts
+++ b/apps/services/auth/delegation-api/src/app/delegations/test/me-delegations.access-outgoing.spec.ts
@@ -5,7 +5,7 @@ import addYears from 'date-fns/addYears'
 import startOfDay from 'date-fns/startOfDay'
 import faker from 'faker'
 import differenceWith from 'lodash/differenceWith'
-import { Op } from 'sequelize'
+import { Op, UniqueConstraintError } from 'sequelize'
 import request from 'supertest'
 
 import {
@@ -233,6 +233,64 @@ describe.each(Object.keys(accessOutgoingTestCases))(
               validTo: scope.validTo.toISOString(),
             })),
           })
+        },
+      )
+
+      it.each(accessible)(
+        'POST /v1/me/delegations recovers from a unique-constraint race in $name',
+        async (domain) => {
+          // Arrange: a concurrent request already inserted the delegation row
+          // for (fromNationalId, toNationalId, domainName) with no scopes yet.
+          const delegationModel = app.get<typeof Delegation>(
+            getModelToken(Delegation),
+          )
+          const delegationScopeModel = app.get<typeof DelegationScope>(
+            getModelToken(DelegationScope),
+          )
+          const toNationalId = createNationalId('person')
+          const existing = await factory.createCustomDelegation({
+            fromNationalId: testCase.user.nationalId,
+            toNationalId,
+            domainName: domain.name,
+          })
+
+          // The existence check misses, the insert trips the unique index, and
+          // the fallback lookup must find `existing`.
+          const findOneSpy = jest
+            .spyOn(delegationModel, 'findOne')
+            .mockResolvedValueOnce(null)
+          const createSpy = jest
+            .spyOn(delegationModel, 'create')
+            .mockRejectedValueOnce(new UniqueConstraintError({}))
+
+          const delegationScopeDtos = domain.scopes.map(({ name }) => ({
+            name,
+            validTo: startOfDay(addYears(new Date(), 1)),
+          }))
+          const delegationDto: CreateDelegationDTO = {
+            toNationalId,
+            domainName: domain.name,
+            scopes: delegationScopeDtos,
+          }
+
+          // Act
+          const res = await server
+            .post('/v1/me/delegations')
+            .send(delegationDto)
+
+          // Assert: succeeded instead of surfacing the unique error, and the
+          // scopes were attached to the pre-existing delegation row.
+          expect(createSpy).toHaveBeenCalledTimes(1)
+          expect(res.status).toEqual(201)
+          const scopes = await delegationScopeModel.findAll({
+            where: { delegationId: existing.id },
+          })
+          expect(scopes.map((s) => s.scopeName)).toEqual(
+            expect.arrayContaining(delegationScopeDtos.map((s) => s.name)),
+          )
+
+          findOneSpy.mockRestore()
+          createSpy.mockRestore()
         },
       )
 

--- a/libs/auth-api-lib/src/lib/delegations/delegations-outgoing.service.ts
+++ b/libs/auth-api-lib/src/lib/delegations/delegations-outgoing.service.ts
@@ -278,11 +278,6 @@ export class DelegationsOutgoingService {
           toName,
         })
       } catch (error) {
-        // A concurrent request (e.g. a double-submit) can create the same
-        // delegation between our findOne above and this create, tripping the
-        // (domainName, fromNationalId, toNationalId) unique index. Fall back to
-        // the row the other request created and continue adding scopes to it,
-        // instead of surfacing a unique-constraint error.
         if (error instanceof UniqueConstraintError) {
           delegation = await this.delegationModel.findOne({
             where: {

--- a/libs/auth-api-lib/src/lib/delegations/delegations-outgoing.service.ts
+++ b/libs/auth-api-lib/src/lib/delegations/delegations-outgoing.service.ts
@@ -6,7 +6,7 @@ import {
   Logger,
 } from '@nestjs/common'
 import { InjectModel } from '@nestjs/sequelize'
-import { and, Op, WhereOptions } from 'sequelize'
+import { and, Op, UniqueConstraintError, WhereOptions } from 'sequelize'
 import { Sequelize } from 'sequelize-typescript'
 import { isUuid, uuid } from 'uuidv4'
 import startOfDay from 'date-fns/startOfDay'
@@ -265,17 +265,38 @@ export class DelegationsOutgoingService {
         ),
       ])
 
-      delegation = await this.delegationModel.create({
-        id: uuid(),
-        fromNationalId: user.nationalId,
-        toNationalId: createDelegation.toNationalId,
-        domainName: createDelegation.domainName,
-        createdByNationalId: user.actor?.nationalId ?? user.nationalId,
-        // TODO: should not persist names with the delegation
-        // should always look it up to avoid being out of sync
-        fromDisplayName,
-        toName,
-      })
+      try {
+        delegation = await this.delegationModel.create({
+          id: uuid(),
+          fromNationalId: user.nationalId,
+          toNationalId: createDelegation.toNationalId,
+          domainName: createDelegation.domainName,
+          createdByNationalId: user.actor?.nationalId ?? user.nationalId,
+          // TODO: should not persist names with the delegation
+          // should always look it up to avoid being out of sync
+          fromDisplayName,
+          toName,
+        })
+      } catch (error) {
+        // A concurrent request (e.g. a double-submit) can create the same
+        // delegation between our findOne above and this create, tripping the
+        // (domainName, fromNationalId, toNationalId) unique index. Fall back to
+        // the row the other request created and continue adding scopes to it,
+        // instead of surfacing a unique-constraint error.
+        if (error instanceof UniqueConstraintError) {
+          delegation = await this.delegationModel.findOne({
+            where: {
+              fromNationalId: user.nationalId,
+              toNationalId: createDelegation.toNationalId,
+              domainName: createDelegation.domainName,
+            },
+          })
+        }
+
+        if (!delegation) {
+          throw error
+        }
+      }
     }
 
     await this.delegationScopeService.createOrUpdate(


### PR DESCRIPTION
# Recover from unique-constraint race when creating a delegation

## What

- Catch the `(domainName, fromNationalId, toNationalId)` unique-constraint error on delegation create, fall back to the row the other request created, and continue adding scopes.

## Why

- The `findOne` → `create` check isn't atomic, so concurrent/duplicate submits (double-click, retries) both saw no existing delegation and both tried to create; the losing request failed with a Sequelize unique-constraint error — surfacing frequent error logs and a spurious failure even though the delegation was created. This makes create idempotent, matching the intended "existing delegation → add scopes to it" behaviour.

## Screenshots / Gifs

N/A

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of simultaneous delegation requests to prevent duplicate creation errors.
  * Existing delegations are now reused when created concurrently, allowing associated scopes to be added successfully.
  * Unexpected errors continue to be reported when the delegation cannot be found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->