### PR TITLE
fix(change-operator-of-vehicle): remove vehicleDebtLess check (#620321)

### DIFF
--- a/libs/api/domains/transport-authority/src/lib/graphql/models/getCurrentVehicles.model.ts
+++ b/libs/api/domains/transport-authority/src/lib/graphql/models/getCurrentVehicles.model.ts
@@ -57,9 +57,12 @@ export class VehicleOwnerchangeChecksByPermno {
 
 @ObjectType()
 export class VehicleOperatorChangeChecksByPermno {
-  @Field(() => Boolean, { nullable: true })
+  @Field(() => Boolean, {
+    nullable: true,
+    deprecationReason:
+      'No longer checked for operator change; Samgöngustofa already validates debt status for this flow via validationErrorMessages.',
+  })
   isDebtLess?: boolean
-
   @Field(() => [VehicleValidationErrorMessage], { nullable: true })
   validationErrorMessages?: VehicleValidationErrorMessage[] | null
 

--- a/libs/api/domains/transport-authority/src/lib/transportAuthority.module.ts
+++ b/libs/api/domains/transport-authority/src/lib/transportAuthority.module.ts
@@ -27,10 +27,6 @@ import {
   ExemptionForTransportationClientModule,
 } from '@island.is/clients/transport-authority/exemption-for-transportation'
 import {
-  VehicleServiceFjsV1ClientConfig,
-  VehicleServiceFjsV1ClientModule,
-} from '@island.is/clients/vehicle-service-fjs-v1'
-import {
   VehiclesClientModule,
   VehiclesClientConfig,
 } from '@island.is/clients/vehicles'
@@ -47,7 +43,6 @@ import {
     VehiclePlateOrderingClientModule,
     VehiclePlateRenewalClientModule,
     ExemptionForTransportationClientModule,
-    VehicleServiceFjsV1ClientModule,
     VehiclesClientModule,
     VehiclesMileageClientModule,
     ConfigModule.forRoot({
@@ -59,7 +54,6 @@ import {
         VehiclePlateOrderingClientConfig,
         VehiclePlateRenewalClientConfig,
         ExemptionForTransportationClientConfig,
-        VehicleServiceFjsV1ClientConfig,
         VehiclesClientConfig,
         VehiclesMileageClientConfig,
       ],

--- a/libs/api/domains/transport-authority/src/lib/transportAuthority.service.ts
+++ b/libs/api/domains/transport-authority/src/lib/transportAuthority.service.ts
@@ -9,7 +9,6 @@ import {
   VehiclePlateOrderingClient,
 } from '@island.is/clients/transport-authority/vehicle-plate-ordering'
 import { VehiclePlateRenewalClient } from '@island.is/clients/transport-authority/vehicle-plate-renewal'
-import { VehicleServiceFjsV1Client } from '@island.is/clients/vehicle-service-fjs-v1'
 import {
   BasicVehicleInformationDto,
   VehicleSearchApi,
@@ -47,7 +46,6 @@ export class TransportAuthorityApi {
     private readonly vehiclePlateOrderingClient: VehiclePlateOrderingClient,
     private readonly vehiclePlateRenewalClient: VehiclePlateRenewalClient,
     private readonly exemptionForTransportationClient: ExemptionForTransportationClient,
-    private readonly vehicleServiceFjsV1Client: VehicleServiceFjsV1Client,
     private readonly vehiclesApi: VehicleSearchApi,
     private readonly mileageReadingApi: MileageReadingApi,
   ) {}
@@ -273,11 +271,7 @@ export class TransportAuthorityApi {
     const { vehicle, mileageReadings } =
       await this.fetchVehicleDataAndMileageForOwnerCoOwner(auth, permno)
 
-    // Get debt status
-    const debtStatus =
-      await this.vehicleServiceFjsV1Client.getVehicleDebtStatus(auth, permno)
-
-    // Get owner change validation
+    // Get operator change validation
     const operatorChangeValidation =
       await this.vehicleOperatorsClient.validateVehicleForOperatorChange(
         auth,
@@ -285,7 +279,7 @@ export class TransportAuthorityApi {
       )
 
     return {
-      isDebtLess: debtStatus.isDebtLess,
+      isDebtLess: true,
       validationErrorMessages: operatorChangeValidation?.hasError
         ? operatorChangeValidation.errorMessages
         : null,

--- a/libs/application/template-api-modules/src/lib/modules/templates/transport-authority/change-operator-of-vehicle/change-operator-of-vehicle.module.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/transport-authority/change-operator-of-vehicle/change-operator-of-vehicle.module.ts
@@ -15,10 +15,6 @@ import {
   VehicleCodetablesClientConfig,
 } from '@island.is/clients/transport-authority/vehicle-codetables'
 import {
-  VehicleServiceFjsV1ClientModule,
-  VehicleServiceFjsV1ClientConfig,
-} from '@island.is/clients/vehicle-service-fjs-v1'
-import {
   VehiclesClientModule,
   VehiclesClientConfig,
 } from '@island.is/clients/vehicles'
@@ -33,7 +29,6 @@ import { PaymentModule } from '@island.is/application/api/payment'
     VehicleOperatorsClientModule,
     VehicleOwnerChangeClientModule,
     VehicleCodetablesClientModule,
-    VehicleServiceFjsV1ClientModule,
     VehiclesClientModule,
     VehiclesMileageClientModule,
     PaymentModule,
@@ -43,7 +38,6 @@ import { PaymentModule } from '@island.is/application/api/payment'
         VehicleOperatorsClientConfig,
         VehicleOwnerChangeClientConfig,
         VehicleCodetablesClientConfig,
-        VehicleServiceFjsV1ClientConfig,
         VehiclesClientConfig,
         VehiclesMileageClientConfig,
       ],

--- a/libs/application/template-api-modules/src/lib/modules/templates/transport-authority/change-operator-of-vehicle/change-operator-of-vehicle.service.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/transport-authority/change-operator-of-vehicle/change-operator-of-vehicle.service.ts
@@ -13,7 +13,6 @@ import { getPaymentIdFromExternalData } from '@island.is/clients/charge-fjs-v2'
 import { ChangeOperatorOfVehicleAnswers } from '@island.is/application/templates/transport-authority/change-operator-of-vehicle'
 import { VehicleOperatorsClient } from '@island.is/clients/transport-authority/vehicle-operators'
 import { VehicleOwnerChangeClient } from '@island.is/clients/transport-authority/vehicle-owner-change'
-import { VehicleServiceFjsV1Client } from '@island.is/clients/vehicle-service-fjs-v1'
 import { VehicleSearchApi } from '@island.is/clients/vehicles'
 import { MileageReadingApi } from '@island.is/clients/vehicles-mileage'
 import { TemplateApiError } from '@island.is/nest/problem'
@@ -42,7 +41,6 @@ export class ChangeOperatorOfVehicleService extends BaseTemplateApiService {
     private readonly sharedTemplateAPIService: SharedTemplateApiService,
     private readonly vehicleOperatorsClient: VehicleOperatorsClient,
     private readonly vehicleOwnerChangeClient: VehicleOwnerChangeClient,
-    private readonly vehicleServiceFjsV1Client: VehicleServiceFjsV1Client,
     private readonly vehiclesApi: VehicleSearchApi,
     private readonly mileageReadingApi: MileageReadingApi,
     private readonly paymentService: PaymentService,
@@ -100,7 +98,6 @@ export class ChangeOperatorOfVehicleService extends BaseTemplateApiService {
         if (totalRecords > 5) {
           return mapVehicle(auth, vehicle, false, {
             vehicleOperatorsClient: this.vehicleOperatorsClient,
-            vehicleServiceFjsV1Client: this.vehicleServiceFjsV1Client,
             mileageReadingApi: this.mileageReadingApi,
           })
         }
@@ -109,7 +106,6 @@ export class ChangeOperatorOfVehicleService extends BaseTemplateApiService {
         // Display radio buttons, validate all vehicles now
         return mapVehicle(auth, vehicle, true, {
           vehicleOperatorsClient: this.vehicleOperatorsClient,
-          vehicleServiceFjsV1Client: this.vehicleServiceFjsV1Client,
           mileageReadingApi: this.mileageReadingApi,
         })
       }),

--- a/libs/application/template-api-modules/src/lib/modules/templates/transport-authority/utils/mapVehicle.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/transport-authority/utils/mapVehicle.ts
@@ -16,17 +16,12 @@ import {
   VehiclePlateOrderingClient,
 } from '@island.is/clients/transport-authority/vehicle-plate-ordering'
 import {
-  VehicleDebtStatus,
-  VehicleServiceFjsV1Client,
-} from '@island.is/clients/vehicle-service-fjs-v1'
-import {
   MileageReadingApi,
   MileageReadingDto,
 } from '@island.is/clients/vehicles-mileage'
 import { AuthMiddleware } from '@island.is/auth-nest-tools'
 
 interface MapVehicleDeps {
-  vehicleServiceFjsV1Client?: VehicleServiceFjsV1Client
   vehicleOperatorsClient?: VehicleOperatorsClient
   vehiclePlateOrderingClient?: VehiclePlateOrderingClient
   vehicleOwnerChangeClient?: VehicleOwnerChangeClient
@@ -45,7 +40,6 @@ export const mapVehicle = async (
     | OperatorChangeValidation
     | PlateOrderValidation
     | undefined
-  let debtStatus: VehicleDebtStatus | undefined
   let mileageReadings: MileageReadingDto[] | undefined
   let regGroup: string | undefined
 
@@ -102,14 +96,6 @@ export const mapVehicle = async (
         permno: vehicle.permno || '',
       })
     }
-
-    // Get debt status
-    if (deps.vehicleServiceFjsV1Client) {
-      debtStatus = await deps.vehicleServiceFjsV1Client.getVehicleDebtStatus(
-        auth,
-        vehicle.permno || '',
-      )
-    }
   }
 
   return {
@@ -123,6 +109,6 @@ export const mapVehicle = async (
       : null,
     requireMileage: vehicle.requiresMileageRegistration,
     mileageReading: mileageReadings?.[0]?.mileage?.toString() ?? '',
-    isDebtLess: deps.vehicleServiceFjsV1Client ? debtStatus?.isDebtLess : true,
+    isDebtLess: true,
   }
 }

--- a/libs/application/templates/transport-authority/change-operator-of-vehicle/src/fields/VehiclesField/index.tsx
+++ b/libs/application/templates/transport-authority/change-operator-of-vehicle/src/fields/VehiclesField/index.tsx
@@ -83,7 +83,6 @@ export const VehiclesField: FC<React.PropsWithChildren<FieldBaseProps>> = (
               additionalErrors: true,
               fallbackErrorMessage:
                 applicationCheck.validation.fallbackErrorMessage,
-              isNotDebtLessTag: information.labels.pickVehicle.isNotDebtLessTag,
               findPlatePlaceholder:
                 information.labels.pickVehicle.findPlatePlaceholder,
               findVehicleButtonText: information.labels.pickVehicle.findButton,
@@ -107,7 +106,6 @@ export const VehiclesField: FC<React.PropsWithChildren<FieldBaseProps>> = (
               itemList: currentVehicleList?.vehicles,
               getDetails: createGetVehicleDetailsWrapper(getVehicleDetails),
               shouldValidateErrorMessages: true,
-              shouldValidateDebtStatus: true,
               inputLabelText: information.labels.pickVehicle.vehicle,
               inputPlaceholderText: information.labels.pickVehicle.placeholder,
               alertMessageErrorTitle:
@@ -116,8 +114,6 @@ export const VehiclesField: FC<React.PropsWithChildren<FieldBaseProps>> = (
               validationErrorFallbackMessage:
                 applicationCheck.validation.fallbackErrorMessage,
               inputErrorMessage: error.requiredValidVehicle,
-              debtStatusErrorMessage:
-                information.labels.pickVehicle.isNotDebtLessTag,
             }}
           />
         ) : (
@@ -132,15 +128,12 @@ export const VehiclesField: FC<React.PropsWithChildren<FieldBaseProps>> = (
               itemType: 'VEHICLE',
               itemList: currentVehicleList?.vehicles,
               shouldValidateErrorMessages: true,
-              shouldValidateDebtStatus: true,
               alertMessageErrorTitle:
                 information.labels.pickVehicle.hasErrorTitle,
               validationErrorMessages: applicationCheck.validation,
               validationErrorFallbackMessage:
                 applicationCheck.validation.fallbackErrorMessage,
               inputErrorMessage: error.requiredValidVehicle,
-              debtStatusErrorMessage:
-                information.labels.pickVehicle.isNotDebtLessTag,
             }}
           />
         )}

--- a/libs/application/templates/transport-authority/change-operator-of-vehicle/src/graphql/queries.ts
+++ b/libs/application/templates/transport-authority/change-operator-of-vehicle/src/graphql/queries.ts
@@ -33,7 +33,6 @@ export const IDENTITY_QUERY = `
 export const GET_VEHICLE_OPERATOR_CHANGE_CHECKS_BY_PERMNO = `
   query GetVehicleOperatorChangeChecksByPermno($permno: String!) {
     vehicleOperatorChangeChecksByPermno(permno: $permno) {
-      isDebtLess
       validationErrorMessages {
         errorNo
         defaultMessage

--- a/libs/application/templates/transport-authority/change-operator-of-vehicle/src/lib/messages/information.ts
+++ b/libs/application/templates/transport-authority/change-operator-of-vehicle/src/lib/messages/information.ts
@@ -66,11 +66,6 @@ export const information = {
         defaultMessage: 'Ekki er hægt að selja þessa bifreið vegna:',
         description: 'Pick vehicle has an error title',
       },
-      isNotDebtLessTag: {
-        id: 'ta.cov.application:information.labels.pickVehicle.isNotDebtLessTag',
-        defaultMessage: 'Ógreidd bifreiðagjöld',
-        description: 'Pick vehicle is not debt less tag',
-      },
     }),
     owner: defineMessages({
       sectionTitle: {

--- a/libs/application/templates/transport-authority/change-operator-of-vehicle/src/shared/types.ts
+++ b/libs/application/templates/transport-authority/change-operator-of-vehicle/src/shared/types.ts
@@ -29,7 +29,6 @@ export type VehiclesCurrentVehicleWithOperatorChangeChecks = {
   role?: string
   requireMileage?: boolean | null
   mileageReading?: string | null
-  isDebtLess?: boolean | null
   validationErrorMessages?: VehicleValidationErrorMessage[] | null
 }
 


### PR DESCRIPTION
# Fix(change-operator-of-vehicle): remove vehicleDebtLess check (#620321)

Related Zendesk ticket: #620321

## What

- Removed `vehicleDebtLess` / `VehicleServiceFjsV1Client` call and validation in `change-operator-of-vehicle`.
- Removed `isNotDebtLessTag`, `shouldValidateDebtStatus: true`, and `debtStatusErrorMessage` from the `VehiclesField` form components.
- Removed `isDebtLess` from `GET_VEHICLE_OPERATOR_CHANGE_CHECKS_BY_PERMNO` query and related shared types.
- Marked `isDebtLess` as deprecated on `VehicleOperatorChangeChecksByPermno` in the GraphQL API model, returning `true`.
- Removed unused `VehicleServiceFjsV1ClientModule` and configuration imports from `transportAuthority.module.ts` and `change-operator-of-vehicle.module.ts`.

## Why

Samgöngustofa requested removing the call to Fjársýslan (`vehicleDebtLess`) when accessing the vehicle operator change application (`https://island.is/skraning-a-umradamanni-okutaekis`), following the same deprecation pattern implemented in PR #23344 (`7d3af976f2`) for vehicle ownership transfers and co-owner changes. Samgöngustofa validates vehicle debts and eligibility through their own operator validation endpoints (`validationErrorMessages`).

## Screenshots / Gifs

N/A

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude (Oh My Pi harness)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Vehicle operator changes no longer display or perform separate unpaid-fee checks.
  * Removed unpaid vehicle-fee messaging from the vehicle selection experience.
  * Vehicle selection and validation continue using the remaining eligibility checks.
* **Maintenance**
  * Simplified vehicle operator change processing by removing an unused external vehicle-service integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->