### PR TITLE
fix(driving-license): only tolerate duplicate RLS submit after a recorded success

### DIFF
--- a/libs/application/template-api-modules/src/lib/modules/templates/transport-authority/driving-license-submission/driving-license-submission.service.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/transport-authority/driving-license-submission/driving-license-submission.service.ts
@@ -432,40 +432,38 @@ export class DrivingLicenseSubmissionService extends BaseTemplateApiService {
 
   // A v6 create returns 400 APPLICATION_ALREADY_EXISTS when RLS already holds an
   // application for this person+category. Treat that as success ONLY when THIS
-  // application already has a `submitApplication` entry — i.e. a lost-response
-  // retry re-running submit on the same application (the framework records that
-  // entry even when the first attempt failed, so it is present on the retry).
+  // application provably created it — the guid a previous successful run stored
+  // on `submitApplication.data` — and return that guid again.
   //
-  // A fresh application with no such entry means a *different* application created
-  // the RLS one; the v6 endpoint is a create, not an upsert, so this submission's
-  // (possibly changed) payload was discarded. Rethrow so the applicant sees RLS's
-  // own error via `toSubmissionError` — the truthful outcome, matching BE — rather
-  // than a false "Umsókn móttekin" that hides the lost edits and the payment.
-  private async createToleratingLostResponse(
+  // Mere existence of a `submitApplication` entry is NOT proof: the framework
+  // persists one (with `data: {}`) even when the attempt FAILED, so gating on
+  // the entry lets "Try again" after a duplicate rejection flip into a false
+  // "Umsókn móttekin" while RLS discarded this submission's payload. Without a
+  // stored guid, rethrow so the applicant sees RLS's own error via
+  // `toSubmissionError`, matching BE — a genuine lost-response retry then also
+  // shows an error, but that is recoverable (the RLS application exists),
+  // whereas a false success hiding discarded edits and a payment is not.
+  private async createToleratingRerunAfterSuccess(
     application: ApplicationWithAttachments,
     create: () => Promise<NewDrivingLicenseResult>,
   ): Promise<NewDrivingLicenseResult> {
     try {
       return await create()
     } catch (e) {
-      if (
-        isApplicationAlreadyExists(e) &&
-        getValueViaPath(application.externalData, 'submitApplication') !==
-          undefined
-      ) {
+      const priorGuid = getValueViaPath<string>(
+        application.externalData,
+        'submitApplication.data.applicationGuid',
+      )
+      if (isApplicationAlreadyExists(e) && priorGuid) {
         this.log(
           'info',
-          'RLS application already exists on submit retry; treating as success',
-          { applicationId: application.id },
+          'RLS application already created by this application; treating re-run as success',
+          { applicationId: application.id, applicationGuid: priorGuid },
         )
         return {
           success: true,
           errorMessage: null,
-          applicationGuid:
-            getValueViaPath<string>(
-              application.externalData,
-              'submitApplication.data.applicationGuid',
-            ) ?? null,
+          applicationGuid: priorGuid,
         }
       }
       throw e
@@ -665,7 +663,7 @@ export class DrivingLicenseSubmissionService extends BaseTemplateApiService {
           application,
         )
 
-        const fullResult = await this.createToleratingLostResponse(
+        const fullResult = await this.createToleratingRerunAfterSuccess(
           application,
           async () =>
             this.drivingLicenseService.newDrivingLicenseWithHealthDeclaration(
@@ -731,7 +729,7 @@ export class DrivingLicenseSubmissionService extends BaseTemplateApiService {
           application,
         )
 
-        const tempResult = await this.createToleratingLostResponse(
+        const tempResult = await this.createToleratingRerunAfterSuccess(
           application,
           async () =>
             this.drivingLicenseService.newTemporaryDrivingLicenseWithHealthDeclaration(

--- a/libs/application/template-api-modules/src/lib/modules/templates/transport-authority/driving-license-submission/driving-license-submission.spec.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/transport-authority/driving-license-submission/driving-license-submission.spec.ts
@@ -588,18 +588,21 @@ describe('DrivingLicenseSubmissionService', () => {
       expect(input.healthDeclaration.hasEpilepsy).toBe(false)
     })
 
-    // The duplicate-on-retry cases. RLS returns 400 APPLICATION_ALREADY_EXISTS;
+    // The duplicate-submit cases. RLS returns 400 APPLICATION_ALREADY_EXISTS;
     // the api-domain method throws it (the v6 client no longer swallows). The
     // submission service tolerates it as success ONLY when THIS application
-    // already has a submitApplication entry — a lost-response retry on the same
-    // application — and preserves the guid the first run stored.
+    // provably created the RLS application — a guid stored by a previous
+    // successful run — and returns that guid again. A prior FAILED attempt
+    // (entry present, `data: {}`) must NOT count: the framework persists an
+    // entry on failure too, so gating on entry existence let "Try again" after
+    // a duplicate rejection flip into a false success (seen live on dev01).
     const alreadyExists = Object.assign(new Error('already exists'), {
       name: 'FetchError',
       status: 400,
       body: { errorCode: 'APPLICATION_ALREADY_EXISTS' },
     })
 
-    it('tolerates ALREADY_EXISTS as success on a lost-response retry (same application) and keeps the stored guid', async () => {
+    it('tolerates ALREADY_EXISTS as success when this application already created it (guid on record) and returns the stored guid', async () => {
       newTemporaryDrivingLicenseWithHealthDeclaration.mockRejectedValueOnce(
         alreadyExists,
       )
@@ -613,8 +616,8 @@ describe('DrivingLicenseSubmissionService', () => {
         },
         externalData: {
           ...thjodskraExternalData,
-          // The first (failed) run left a submitApplication entry — the marker
-          // that this is a retry on the same application.
+          // A previous run SUCCEEDED and stored the guid — the only proof that
+          // this application is the one that created the RLS application.
           submitApplication: {
             data: { applicationGuid: '2e23bf24-d8bd-4353-9faf-3fc5ce04090d' },
             status: 'success',
@@ -635,6 +638,47 @@ describe('DrivingLicenseSubmissionService', () => {
         success: true,
         applicationGuid: '2e23bf24-d8bd-4353-9faf-3fc5ce04090d',
       })
+    })
+
+    it('does NOT swallow ALREADY_EXISTS when the prior attempt on this application FAILED (no guid stored) — a duplicate retry keeps failing', async () => {
+      // The case dev01 exposed: another application holds the active RLS one,
+      // so the first submit correctly errors — and the framework persists a
+      // failure entry with `data: {}`. Clicking "Try again" re-runs submit with
+      // that entry present; without the guid gate this flipped to a false
+      // success while RLS had discarded the payload.
+      newTemporaryDrivingLicenseWithHealthDeclaration.mockRejectedValueOnce(
+        alreadyExists,
+      )
+      const user = createCurrentUser()
+      const application = createApplication({
+        answers: {
+          ...baseAnswers,
+          isBTempRedesignEnabled: true,
+          selectLicensePhoto: 'facial-1',
+          drivingInstructor: '0101302399',
+        },
+        externalData: {
+          ...thjodskraExternalData,
+          // What templateApiActionRunner persists after a failed attempt.
+          submitApplication: {
+            data: {},
+            status: 'failure',
+            reason: 'some failure',
+            statusCode: 400,
+            date: new Date(),
+          },
+        },
+        typeId: ApplicationTypes.DRIVING_LICENSE,
+        status: ApplicationStatus.IN_PROGRESS,
+      })
+
+      await expect(
+        service.submitApplication({
+          application,
+          auth: user,
+          currentUserLocale: 'is',
+        }),
+      ).rejects.toBeDefined()
     })
 
     it('does NOT swallow ALREADY_EXISTS for a fresh application (no prior submit entry) — surfaces the error', async () => {


### PR DESCRIPTION
## What

Tightens the `APPLICATION_ALREADY_EXISTS` guard added in #23496: a duplicate RLS response is now resolved as success **only when this application provably created the RLS application** — i.e. a previous successful run stored its guid at `externalData.submitApplication.data.applicationGuid`. The stored guid is returned again (idempotent re-run). Anything else rethrows, so the applicant sees RLS's own error via `toSubmissionError`, matching live BE behaviour.

## Why

The merged guard tolerated the duplicate whenever *any* `submitApplication` entry existed. But the framework (`templateApiActionRunner.buildExternalData`) persists an entry with `status: 'failure', data: {}` even when the attempt **failed** — so after a first, correctly-surfaced duplicate rejection, clicking **"Try again"** re-armed the guard and flipped into a false "Umsókn móttekin" while RLS had discarded the submission's payload (and the applicant had paid).

Confirmed live on dev01 (2026-08-31, app `f4333546…`): first submit → correct error; "Try again" → `RLS application already exists on submit retry; treating as success` → false success screen.

With the guid gate:
- prior **failure** entry (`data: {}`, no guid) → rethrow → duplicate retry keeps failing ✅
- **fresh** application (no entry) → rethrow, unchanged ✅
- prior **success** (guid on record) → resolve as success with the same guid ✅

Trade-off, deliberate: a genuine lost-response retry (created at RLS, response lost, no guid stored) now also surfaces an error — recoverable, since the RLS application exists and support can reconcile via the guid logging — whereas a false success hiding discarded edits and a payment is not.

Flag-gated code only (`isBTempRedesignEnabled`/`isBFullRedesignEnabled`, off in prod); no flag-off behaviour changes.

## Testing

- New spec: prior failed attempt (`status: 'failure', data: {}`) + `ALREADY_EXISTS` → rejects (the dev01 case). Negative-controlled: fails against the previous guard, passes with this one.
- Updated tolerate spec: success-with-guid fixture → resolves with the stored guid.
- `driving-license-submission.spec.ts`: 42/42 passing.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (n/a)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review

## AI-tools disclosure

This PR was authored with assistance from Claude Code; all changes reviewed and verified by the author.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved duplicate application submission handling.
  * Existing submissions are treated as successful only when a valid application identifier is stored.
  * Previous failed attempts no longer incorrectly appear successful.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->