### PR TITLE
fix(driving-license): read RLS error code from errorCode before problem.title

### DIFF
--- a/libs/application/template-api-modules/src/lib/modules/templates/transport-authority/driving-license-submission/driving-license-submission.service.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/transport-authority/driving-license-submission/driving-license-submission.service.ts
@@ -213,26 +213,29 @@ export class DrivingLicenseSubmissionService extends BaseTemplateApiService {
   }
 
   /**
-   * Turn a failed RLS submission into the error the applicant sees. RLS puts its
-   * error code in `problem.title`; if that code exists in the RLS error-code
-   * table we surface the table's own human-readable text in the user's language
-   * instead of leaking the raw code. Anything we can't resolve (no code, code
-   * not in the table, or a best-effort lookup failure) keeps the previous
-   * behaviour: raw `problem.title` / generic message, with `problem.detail` as
-   * the summary. `describeErrorCode` is best-effort and never throws.
+   * Turn a failed RLS submission into the error the applicant sees. RLS's
+   * machine error code, when we can find one, is looked up in the RLS
+   * error-code table and the table's own human-readable text is surfaced in
+   * the user's language instead of the raw code. Anything we can't resolve (no
+   * code, code not in the table, or a best-effort lookup failure) keeps the
+   * previous behaviour: generic message with `problem.detail` as the summary.
+   * `describeErrorCode` is best-effort and never throws.
    */
   private async toSubmissionError(
     err: FetchError,
     locale: Locale,
   ): Promise<TemplateApiError> {
-    // RLS's error code is in `problem.title` for problem+json responses (the full
-    // endpoint), but the temporary endpoint returns a plain-JSON body carrying it
-    // as `body.errorCode` instead — fall back to that so both go through
-    // describeErrorCode and the applicant gets the localised text, not the
-    // generic "submission failed".
+    // Both v6 endpoints carry the machine code in an `errorCode` field — the
+    // full endpoint as a problem+json extension member, the temporary endpoint
+    // in its plain-JSON body. `problem.title` must come LAST: v5 puts the code
+    // there, but on the v6 full endpoint `title` holds the operation name
+    // ("Sækja um fullnaðarskírteini"), so preferring it looks up a string that
+    // can never be in the table and the applicant loses the localised text
+    // (observed on IS-DEV 2026-08-31).
     const code =
-      err.problem?.title ??
-      (err.body as { errorCode?: string } | undefined)?.errorCode
+      (err.problem as { errorCode?: string } | undefined)?.errorCode ??
+      (err.body as { errorCode?: string } | undefined)?.errorCode ??
+      err.problem?.title
     if (code) {
       try {
         const described = await this.drivingLicenseService.describeErrorCode(

--- a/libs/application/template-api-modules/src/lib/modules/templates/transport-authority/driving-license-submission/driving-license-submission.spec.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/transport-authority/driving-license-submission/driving-license-submission.spec.ts
@@ -1538,9 +1538,11 @@ describe('DrivingLicenseSubmissionService', () => {
     let describeErrorCode: jest.Mock
 
     // A FetchError as the submission catch recognises it: name === 'FetchError'
-    // with RLS's `problem` (code in `title`) and an http `status`.
+    // with RLS's `problem` and an http `status`. v5 carries the code in `title`;
+    // the v6 full endpoint carries it in an `errorCode` extension member and
+    // uses `title` for the operation name.
     const makeFetchError = (
-      problem: { title?: string; detail?: string },
+      problem: { title?: string; detail?: string; errorCode?: string },
       status = 400,
     ) => {
       const err = new Error('rls submission failed') as Error & {
@@ -1685,6 +1687,35 @@ describe('DrivingLicenseSubmissionService', () => {
 
       expect(describeErrorCode).toHaveBeenCalledWith(
         'APPLICATION_ALREADY_EXISTS',
+      )
+      expect(getErrorReasonIfPresent(reasonOf(thrown)).summary).toBe(
+        'Umsókn er þegar til',
+      )
+    })
+
+    it('localises the code from problem.errorCode (v6 full endpoint), not the operation-name title', async () => {
+      // The v6 full endpoint's 400, exactly as observed on IS-DEV: the machine
+      // code rides in an `errorCode` extension member while `title` holds the
+      // Icelandic operation name — looking THAT up misses the table forever.
+      newDrivingLicense.mockRejectedValue(
+        makeFetchError({
+          title: 'Sækja um fullnaðarskírteini',
+          detail: 'An application already exists for this category',
+          errorCode: 'APPLICATION_ALREADY_EXISTS',
+        }),
+      )
+      describeErrorCode.mockResolvedValue({
+        is: 'Umsókn er þegar til',
+        en: 'An application already exists',
+      })
+
+      const thrown = await submitAndCatch('is')
+
+      expect(describeErrorCode).toHaveBeenCalledWith(
+        'APPLICATION_ALREADY_EXISTS',
+      )
+      expect(describeErrorCode).not.toHaveBeenCalledWith(
+        'Sækja um fullnaðarskírteini',
       )
       expect(getErrorReasonIfPresent(reasonOf(thrown)).summary).toBe(
         'Umsókn er þegar til',


### PR DESCRIPTION
## What

Reorders the error-code extraction in `toSubmissionError` so the RLS machine code is read from the `errorCode` field first, with `problem.title` as the last resort:

```ts
const code =
  err.problem?.errorCode ??   // v6 full endpoint: problem+json extension member
  err.body?.errorCode ??      // v6 temporary endpoint: plain-JSON body
  err.problem?.title          // v5 endpoints: code lives in title
```

## Why

Dev testing of the v6 `withhealthdeclaration` endpoints (merged in #23496/#23538) showed the full endpoint's 400s use `problem.title` for the **operation name** (e.g. `"Sækja um fullnaðarskírteini"`), not the error code — the code rides in an `errorCode` extension member:

```json
{ "type": "Error", "title": "Sækja um fullnaðarskírteini", "status": 400,
  "detail": "An application already exists for this category",
  "errorCode": "APPLICATION_ALREADY_EXISTS" }
```

With the previous `problem.title ?? body.errorCode` ordering, `title` is always truthy for these responses, so we looked up the operation name in the RLS error-code table — which can never match — and every full-endpoint error fell back to raw English `detail` (or the bare code) instead of the table's localised is/en text. Observed on IS-DEV 2026-08-31 for both `APPLICATION_ALREADY_EXISTS` and `INVALID_PHOTO_BIOMETRICS_ID`.

RLS is adding `APPLICATION_ALREADY_EXISTS` to the shared error-code table; with this reorder that entry localises duplicates for **both** endpoints. v5 error handling is unchanged (`title` still consulted, just last), and errors with no code at all behave as before.

Flag-gated flows only in practice (the v6 endpoints run behind `isBTempRedesignEnabled`/`isBFullRedesignEnabled`, off in prod); the extraction itself is shared but strictly widens what can be localised.

## Testing

- New spec pinning the observed v6 full-endpoint 400 shape: `describeErrorCode` is called with `APPLICATION_ALREADY_EXISTS`, never with the operation-name title, and the localised text reaches the payment screen. Negative-controlled: fails against the previous ordering, passes with this one.
- `driving-license-submission.spec.ts`: 43/43 passing (all existing v5/temp/no-code extraction tests unchanged and green).

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (n/a)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review

## AI-tools disclosure

This PR was authored with assistance from Claude Code; all changes reviewed and verified by the author.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for driving licence submissions by using the machine-readable error code when available.
  * Added support for localising errors returned by the latest submission endpoint format.
  * Preserved fallback handling for responses that do not include a machine-readable error code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->