### PR TITLE
feat(j-s): Event log repository service

### DIFF
--- a/apps/judicial-system/backend/src/app/modules/event-log/eventLog.module.ts
+++ b/apps/judicial-system/backend/src/app/modules/event-log/eventLog.module.ts
@@ -1,12 +1,11 @@
-import { Module } from '@nestjs/common'
-import { SequelizeModule } from '@nestjs/sequelize'
+import { forwardRef, Module } from '@nestjs/common'
 
-import { EventLog } from '../repository'
+import { RepositoryModule } from '..'
 import { EventLogController } from './eventLog.controller'
 import { EventLogService } from './eventLog.service'
 
 @Module({
-  imports: [SequelizeModule.forFeature([EventLog])],
+  imports: [forwardRef(() => RepositoryModule)],
   providers: [EventLogService],
   exports: [EventLogService],
   controllers: [EventLogController],

--- a/apps/judicial-system/backend/src/app/modules/event-log/eventLog.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/event-log/eventLog.service.ts
@@ -1,8 +1,6 @@
 import { Transaction } from 'sequelize'
-import { Sequelize } from 'sequelize-typescript'
 
 import { Inject, Injectable } from '@nestjs/common'
-import { InjectModel } from '@nestjs/sequelize'
 
 import type { Logger } from '@island.is/logging'
 import { LOGGER_PROVIDER } from '@island.is/logging'
@@ -18,7 +16,7 @@ import {
   UserDescriptor,
 } from '@island.is/judicial-system/types'
 
-import { EventLog } from '../repository'
+import { EventLogRepositoryService } from '../repository'
 import { CreateEventLogDto } from './dto/createEventLog.dto'
 
 const allowMultiple: EventType[] = [
@@ -50,8 +48,7 @@ const eventToNotificationMap: Partial<
 @Injectable()
 export class EventLogService {
   constructor(
-    @InjectModel(EventLog)
-    private readonly eventLogModel: typeof EventLog,
+    private readonly eventLogRepositoryService: EventLogRepositoryService,
     @Inject(LOGGER_PROVIDER)
     private readonly logger: Logger,
   ) {}
@@ -82,22 +79,15 @@ export class EventLogService {
   ): Promise<boolean> {
     const { eventType, caseId, userName, userRole, institutionName } = event
 
-    if (!allowMultiple.includes(event.eventType)) {
-      const where = Object.fromEntries(
-        // The user name and title do not matter when checking for duplicates
-        Object.entries({
+    if (!allowMultiple.includes(eventType)) {
+      // The user name and title do not matter when checking for duplicates
+      const eventExists =
+        await this.eventLogRepositoryService.existsForCaseAndType(
           eventType,
           caseId,
-          userRole: allowOnePerUserRole.includes(eventType)
-            ? userRole
-            : undefined,
-        }).filter(([_, value]) => value !== undefined),
-      )
-
-      const eventExists = await this.eventLogModel.findOne({
-        where,
-        transaction,
-      })
+          allowOnePerUserRole.includes(eventType) ? userRole : undefined,
+          { transaction },
+        )
 
       if (eventExists) {
         return true
@@ -105,7 +95,7 @@ export class EventLogService {
     }
 
     try {
-      await this.eventLogModel.create({ ...event }, { transaction })
+      await this.eventLogRepositoryService.create({ ...event }, { transaction })
 
       return true
     } catch (error) {
@@ -130,30 +120,15 @@ export class EventLogService {
   async loginMap(
     nationalIds: string[],
   ): Promise<Map<string, { latest: Date; count: number }>> {
-    return this.eventLogModel
-      .count({
-        group: ['nationalId', 'userRole', 'institutionName'],
-        attributes: [
-          'nationalId',
-          'userRole',
-          'institutionName',
-          [Sequelize.fn('max', Sequelize.col('created')), 'latest'],
-          [Sequelize.fn('count', Sequelize.col('national_id')), 'count'],
-        ],
-        where: {
-          eventType: ['LOGIN', 'LOGIN_BYPASS'],
-          nationalId: nationalIds,
-        },
-      })
-      .then(
-        (logs) =>
-          new Map(
-            logs.map((log) => [
-              `${log.nationalId}-${log.userRole}-${log.institutionName}`,
-              { latest: log.latest as Date, count: log.count },
-            ]),
-          ),
-      )
+    const logins =
+      await this.eventLogRepositoryService.countLoginsByNationalIds(nationalIds)
+
+    return new Map(
+      logins.map((login) => [
+        `${login.nationalId}-${login.userRole}-${login.institutionName}`,
+        { latest: login.latest, count: login.count },
+      ]),
+    )
   }
 
   // Sends events to queue for notification dispatch

--- a/apps/judicial-system/backend/src/app/modules/repository/index.ts
+++ b/apps/judicial-system/backend/src/app/modules/repository/index.ts
@@ -45,6 +45,11 @@ export {
 export { CourtDocumentRepositoryService } from './services/courtDocumentRepository.service'
 export { DefendantRepositoryService } from './services/defendantRepository.service'
 export { DefendantEventLogRepositoryService } from './services/defendantEventLogRepository.service'
+export {
+  EventLogRepositoryService,
+  CreateEventLog,
+  LoginCount,
+} from './services/eventLogRepository.service'
 export { IndictmentSubtypeRepositoryService } from './services/indictmentSubtypeRepository.service'
 export { InstitutionContactRepositoryService } from './services/institutionContactRepository.service'
 export { InstitutionRepositoryService } from './services/institutionRepository.service'

--- a/apps/judicial-system/backend/src/app/modules/repository/repository.module.ts
+++ b/apps/judicial-system/backend/src/app/modules/repository/repository.module.ts
@@ -44,6 +44,7 @@ import { CourtDocumentRepositoryService } from './services/courtDocumentReposito
 import { CourtSessionRepositoryService } from './services/courtSessionRepository.service'
 import { DefendantEventLogRepositoryService } from './services/defendantEventLogRepository.service'
 import { DefendantRepositoryService } from './services/defendantRepository.service'
+import { EventLogRepositoryService } from './services/eventLogRepository.service'
 import { IndictmentSubtypeRepositoryService } from './services/indictmentSubtypeRepository.service'
 import { InstitutionContactRepositoryService } from './services/institutionContactRepository.service'
 import { InstitutionRepositoryService } from './services/institutionRepository.service'
@@ -105,6 +106,7 @@ import { repositoryModuleConfig } from './repository.config'
     CourtDocumentRepositoryService,
     DefendantRepositoryService,
     DefendantEventLogRepositoryService,
+    EventLogRepositoryService,
     IndictmentSubtypeRepositoryService,
     InstitutionContactRepositoryService,
     InstitutionRepositoryService,
@@ -128,6 +130,7 @@ import { repositoryModuleConfig } from './repository.config'
     CourtDocumentRepositoryService,
     DefendantRepositoryService,
     DefendantEventLogRepositoryService,
+    EventLogRepositoryService,
     IndictmentSubtypeRepositoryService,
     InstitutionContactRepositoryService,
     InstitutionRepositoryService,

--- a/apps/judicial-system/backend/src/app/modules/repository/services/eventLogRepository.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/repository/services/eventLogRepository.service.ts
@@ -1,0 +1,135 @@
+import { col, fn, Transaction } from 'sequelize'
+
+import { Inject, Injectable } from '@nestjs/common'
+import { InjectModel } from '@nestjs/sequelize'
+
+import { type Logger, LOGGER_PROVIDER } from '@island.is/logging'
+
+import { EventType, UserRole } from '@island.is/judicial-system/types'
+
+import { EventLog } from '../models/eventLog.model'
+
+export type CreateEventLog = {
+  eventType: EventType
+  caseId?: string
+  nationalId?: string
+  userRole?: UserRole
+  userName?: string
+  userTitle?: string
+  institutionName?: string
+}
+
+interface EventLogTransactionOptions {
+  transaction?: Transaction
+}
+
+// One row per (national id, user role, institution) group, as counted by
+// countLoginsByNationalIds. The caller decides how to key it.
+export type LoginCount = {
+  nationalId?: string
+  userRole?: UserRole
+  institutionName?: string
+  latest: Date
+  count: number
+}
+
+@Injectable()
+export class EventLogRepositoryService {
+  constructor(
+    @InjectModel(EventLog) private readonly eventLogModel: typeof EventLog,
+    @Inject(LOGGER_PROVIDER) private readonly logger: Logger,
+  ) {}
+
+  // eventType comes first because every other part of the key is optional: an
+  // event without a case id, or one whose type does not discriminate on user
+  // role, matches on the narrower key.
+  async existsForCaseAndType(
+    eventType: EventType,
+    caseId?: string,
+    userRole?: UserRole,
+    options?: EventLogTransactionOptions,
+  ): Promise<boolean> {
+    try {
+      this.logger.debug(
+        `Checking for a ${eventType} event log for case ${caseId}`,
+      )
+
+      const eventLog = await this.eventLogModel.findOne({
+        where: {
+          eventType,
+          ...(caseId === undefined ? {} : { caseId }),
+          ...(userRole === undefined ? {} : { userRole }),
+        },
+        transaction: options?.transaction,
+      })
+
+      return Boolean(eventLog)
+    } catch (error) {
+      this.logger.error(
+        `Error checking for a ${eventType} event log for case ${caseId}:`,
+        { error },
+      )
+
+      throw error
+    }
+  }
+
+  async create(
+    event: CreateEventLog,
+    options?: EventLogTransactionOptions,
+  ): Promise<EventLog> {
+    try {
+      this.logger.debug(
+        `Creating a ${event.eventType} event log for case ${event.caseId}`,
+      )
+
+      return await this.eventLogModel.create(
+        { ...event },
+        { transaction: options?.transaction },
+      )
+    } catch (error) {
+      this.logger.error(
+        `Error creating a ${event.eventType} event log for case ${event.caseId}:`,
+        { error },
+      )
+
+      throw error
+    }
+  }
+
+  async countLoginsByNationalIds(nationalIds: string[]): Promise<LoginCount[]> {
+    try {
+      this.logger.debug(`Counting logins for ${nationalIds.length} user(s)`)
+
+      const logins = await this.eventLogModel.count({
+        group: ['nationalId', 'userRole', 'institutionName'],
+        attributes: [
+          'nationalId',
+          'userRole',
+          'institutionName',
+          [fn('max', col('created')), 'latest'],
+          [fn('count', col('national_id')), 'count'],
+        ],
+        where: {
+          eventType: [EventType.LOGIN, EventType.LOGIN_BYPASS],
+          nationalId: nationalIds,
+        },
+      })
+
+      return logins.map((login) => ({
+        nationalId: login.nationalId as string,
+        userRole: login.userRole as UserRole,
+        institutionName: login.institutionName as string,
+        latest: login.latest as Date,
+        count: login.count,
+      }))
+    } catch (error) {
+      this.logger.error(
+        `Error counting logins for ${nationalIds.length} user(s):`,
+        { error },
+      )
+
+      throw error
+    }
+  }
+}

--- a/apps/judicial-system/backend/src/app/modules/repository/test/eventLogRepository.service.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/repository/test/eventLogRepository.service.spec.ts
@@ -1,0 +1,180 @@
+import { getModelToken } from '@nestjs/sequelize'
+import { Test } from '@nestjs/testing'
+
+import { LOGGER_PROVIDER } from '@island.is/logging'
+
+import { EventType, UserRole } from '@island.is/judicial-system/types'
+
+import { EventLog } from '../models/eventLog.model'
+import { EventLogRepositoryService } from '../services/eventLogRepository.service'
+
+describe('EventLogRepositoryService', () => {
+  let service: EventLogRepositoryService
+  let model: { findOne: jest.Mock; create: jest.Mock; count: jest.Mock }
+
+  beforeEach(async () => {
+    model = {
+      findOne: jest.fn().mockResolvedValue(null),
+      create: jest.fn(),
+      count: jest.fn().mockResolvedValue([]),
+    }
+
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        {
+          provide: LOGGER_PROVIDER,
+          useValue: { debug: jest.fn(), error: jest.fn() },
+        },
+        { provide: getModelToken(EventLog), useValue: model },
+        EventLogRepositoryService,
+      ],
+    }).compile()
+
+    service = moduleRef.get(EventLogRepositoryService)
+  })
+
+  describe('existsForCaseAndType', () => {
+    it('queries on event type and case id and reports a hit', async () => {
+      model.findOne.mockResolvedValueOnce({ id: 'some-event-log-id' })
+
+      const result = await service.existsForCaseAndType(
+        EventType.INDICTMENT_CONFIRMED,
+        'some-case-id',
+      )
+
+      expect(model.findOne).toHaveBeenCalledWith({
+        where: {
+          eventType: EventType.INDICTMENT_CONFIRMED,
+          caseId: 'some-case-id',
+        },
+        transaction: undefined,
+      })
+      expect(result).toBe(true)
+    })
+
+    it('adds the user role to the query when one is given', async () => {
+      const transaction = {} as never
+
+      const result = await service.existsForCaseAndType(
+        EventType.APPEAL_RESULT_ACCESSED,
+        'some-case-id',
+        UserRole.PROSECUTOR,
+        { transaction },
+      )
+
+      expect(model.findOne).toHaveBeenCalledWith({
+        where: {
+          eventType: EventType.APPEAL_RESULT_ACCESSED,
+          caseId: 'some-case-id',
+          userRole: UserRole.PROSECUTOR,
+        },
+        transaction,
+      })
+      expect(result).toBe(false)
+    })
+
+    it('leaves out the case id when there is none', async () => {
+      await service.existsForCaseAndType(EventType.LOGIN)
+
+      expect(model.findOne).toHaveBeenCalledWith({
+        where: { eventType: EventType.LOGIN },
+        transaction: undefined,
+      })
+    })
+
+    it('rethrows when the lookup fails', async () => {
+      const error = new Error('Some error')
+      model.findOne.mockRejectedValueOnce(error)
+
+      await expect(
+        service.existsForCaseAndType(EventType.LOGIN, 'some-case-id'),
+      ).rejects.toThrow(error)
+    })
+  })
+
+  describe('create', () => {
+    it('creates the event log in the given transaction', async () => {
+      const transaction = {} as never
+      const created = { id: 'some-event-log-id' }
+      model.create.mockResolvedValueOnce(created)
+
+      const result = await service.create(
+        { eventType: EventType.LOGIN, nationalId: 'some-national-id' },
+        { transaction },
+      )
+
+      expect(model.create).toHaveBeenCalledWith(
+        { eventType: EventType.LOGIN, nationalId: 'some-national-id' },
+        { transaction },
+      )
+      expect(result).toBe(created)
+    })
+
+    it('rethrows when the creation fails', async () => {
+      const error = new Error('Some error')
+      model.create.mockRejectedValueOnce(error)
+
+      await expect(
+        service.create({ eventType: EventType.LOGIN }),
+      ).rejects.toThrow(error)
+    })
+  })
+
+  describe('countLoginsByNationalIds', () => {
+    it('groups and aggregates logins and returns typed rows', async () => {
+      const latest = new Date()
+      model.count.mockResolvedValueOnce([
+        {
+          nationalId: 'some-national-id',
+          userRole: UserRole.DISTRICT_COURT_JUDGE,
+          institutionName: 'Some institution',
+          latest,
+          count: 3,
+        },
+      ])
+
+      const result = await service.countLoginsByNationalIds([
+        'some-national-id',
+      ])
+
+      const { group, attributes, where } = model.count.mock.calls[0][0]
+
+      expect(group).toEqual(['nationalId', 'userRole', 'institutionName'])
+      expect(where).toEqual({
+        eventType: [EventType.LOGIN, EventType.LOGIN_BYPASS],
+        nationalId: ['some-national-id'],
+      })
+      expect(attributes.slice(0, 3)).toEqual([
+        'nationalId',
+        'userRole',
+        'institutionName',
+      ])
+      expect(attributes[3]).toMatchObject([
+        { fn: 'max', args: [{ col: 'created' }] },
+        'latest',
+      ])
+      expect(attributes[4]).toMatchObject([
+        { fn: 'count', args: [{ col: 'national_id' }] },
+        'count',
+      ])
+      expect(result).toEqual([
+        {
+          nationalId: 'some-national-id',
+          userRole: UserRole.DISTRICT_COURT_JUDGE,
+          institutionName: 'Some institution',
+          latest,
+          count: 3,
+        },
+      ])
+    })
+
+    it('rethrows when the count fails', async () => {
+      const error = new Error('Some error')
+      model.count.mockRejectedValueOnce(error)
+
+      await expect(
+        service.countLoginsByNationalIds(['some-national-id']),
+      ).rejects.toThrow(error)
+    })
+  })
+})


### PR DESCRIPTION
# Event log repository service

[Repository þjónusta fyrir EventLog](https://app.asana.com/1/203394141643832/project/1199153462262248/task/1218009441208542)

`EventLog` was one of nine models still reaching Sequelize directly from a business
service. This gives it a repository service and moves `EventLogService` onto it.

### The repository service

Three domain-intent methods, each wrapping its data access in the module's usual
`debug` / call / `catch` → `logger.error` → rethrow shape:

- **`existsForCaseAndType`** — the duplicate check. The `where` clause used to be built
  in `EventLogService` by `Object.entries({...}).filter(([_, v]) => v !== undefined)`;
  that composition moves inside the repository. The domain rule that decides whether
  user role participates at all — `allowOnePerUserRole.includes(eventType)` — stays with
  the service: the service decides whether to pass a `userRole`, the repository decides
  how to query for one. `eventType` leads the parameter list because every other part of
  the key is optional.
- **`create`** — rethrows. The tolerate-and-log behaviour stays in `EventLogService`,
  where it belongs: an event log that fails to write must not fail the request.
- **`countLoginsByNationalIds`** — the grouped `max(created)` / `count(national_id)`
  aggregate behind `loginMap`. It returns typed rows, so no `Sequelize.fn` / `col`
  construct leaks out of the module. The service keeps building the `Map` — that shaping
  is for the caller, not the query — and loses its `.then()` chain along the way.

### What is deliberately left

`CaseRepositoryService` and `CourtSessionRepositoryService` keep their own
`@InjectModel(EventLog)`. Both uses sit inside multi-entity orchestration (`split` in the
case aggregate), which is what the later extraction chunk exists to lift out, and the
module's convention forbids a repository service from injecting another repository
service. So this PR closes "no `EventLog` outside the repository module" — it does not
close "one injection site per model", which stays open inside the module and is tracked
as its own piece of work. That is intended, not an oversight.

`import { Transaction } from 'sequelize'` also stays in `eventLog.service.ts`:
`Transaction` is still a parameter type on `create` and `createWithUser`, whose nine
callers are out of scope here. `sequelize-typescript` is gone from the file.

### Verification

```
grep -rn "InjectModel(EventLog)\|eventLogModel" modules | grep -v modules/repository/   # no output
grep -rn -A3 "SequelizeModule.forFeature" modules/**/*.module.ts | grep EventLog        # no output
```

`tsc --noEmit` clean; `nx lint` clean (one pre-existing unrelated warning in
`updateCase.dto.ts`); `codegen/backend-schema` produces a byte-identical `openapi.yaml`
with and without these changes. Tests: 116 in `modules/(event-log|repository)/` and 8232
in `modules/(case|user|court-session|defendant|verdict)/`, all green — no consumer spec
mocked the model, so none needed rewriting.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved event logging reliability for event creation, duplicate checks, and login activity tracking.
  * Preserved transaction handling and error reporting for event log operations.

* **Refactor**
  * Centralized event log data access to improve consistency and maintainability.
  * Added support for grouped login counts by national ID, role, and institution.

* **Tests**
  * Added coverage for event existence checks, event creation, login aggregation, transactions, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->