### PR TITLE
fix(j-s): Allow skip arraignment summons on return visits to subpoena step

### DIFF
--- a/apps/judicial-system/web/src/routes/Court/Indictments/Subpoena/Subpoena.tsx
+++ b/apps/judicial-system/web/src/routes/Court/Indictments/Subpoena/Subpoena.tsx
@@ -42,7 +42,7 @@ import {
   useDefendants,
 } from '@island.is/judicial-system-web/src/utils/hooks'
 import { grid } from '@island.is/judicial-system-web/src/utils/styles/recipes.css'
-import { areAllDefendantsServedByAlternativeMeans } from '@island.is/judicial-system-web/src/utils/utils'
+import { canSkipArraignmentSummons as isArraignmentSummonsSkippable } from '@island.is/judicial-system-web/src/utils/utils'
 import { isSubpoenaStepValid } from '@island.is/judicial-system-web/src/utils/validate'
 
 import { subpoena as strings } from './Subpoena.strings'
@@ -83,15 +83,18 @@ const Subpoena: FC = () => {
   const hasArraignmentBeenSettled =
     isArraignmentScheduled || hasSkippedArraignmentSummons
 
-  // Skipping is only on the table while nobody is receiving a subpoena and no
-  // arraignment has been scheduled yet
-  const canSkipArraignmentSummons =
-    !isArraignmentScheduled &&
-    areAllDefendantsServedByAlternativeMeans(
-      // Fall back to the server's defendants for the first render, before the
-      // effect below seeds `updates`, so the step does not flash as invalid
-      updates?.defendants ?? workingCase.defendants,
-    )
+  // Skipping is only on the table while nobody is receiving a subpoena.
+  // After an arraignment has already been scheduled, it also unlocks when
+  // the court re-enters alternative service for every defendant.
+  const canSkipArraignmentSummons = isArraignmentSummonsSkippable(
+    // Fall back to the server's defendants for the first render, before the
+    // effect below seeds `updates`, so the step does not flash as invalid
+    updates?.defendants ?? workingCase.defendants,
+    {
+      isArraignmentScheduled,
+      newAlternativeServiceDefendantIds: newAlternativeServices,
+    },
+  )
   const isSkippingArraignmentSummons =
     canSkipArraignmentSummons && skipArraignmentSummons
 

--- a/apps/judicial-system/web/src/utils/utils.spec.ts
+++ b/apps/judicial-system/web/src/utils/utils.spec.ts
@@ -27,6 +27,7 @@ import {
 import * as formatters from './formatters'
 import {
   applyMergedCaseEntries,
+  canSkipArraignmentSummons,
   getAppealActorText,
   getDefaultDefendantGender,
   hasAcceptedRulingOrderInCourt,
@@ -415,6 +416,69 @@ describe('Utils', () => {
 
       // Assert
       expect(gender).toBe(Gender.MALE)
+    })
+  })
+
+  describe('canSkipArraignmentSummons', () => {
+    const alternativeDefendant = {
+      id: 'defendant-1',
+      isAlternativeService: true,
+    }
+    const subpoenaDefendant = {
+      id: 'defendant-2',
+      isAlternativeService: false,
+    }
+
+    test('should be true on first pass when all defendants are served by alternative means', () => {
+      expect(
+        canSkipArraignmentSummons([alternativeDefendant], {
+          isArraignmentScheduled: false,
+        }),
+      ).toBe(true)
+    })
+
+    test('should be false when any defendant is receiving a subpoena', () => {
+      expect(
+        canSkipArraignmentSummons(
+          [alternativeDefendant, subpoenaDefendant],
+          { isArraignmentScheduled: false },
+        ),
+      ).toBe(false)
+    })
+
+    test('should be false when arraignment is scheduled and nobody is re-entering alternative service', () => {
+      expect(
+        canSkipArraignmentSummons([alternativeDefendant], {
+          isArraignmentScheduled: true,
+          newAlternativeServiceDefendantIds: [],
+        }),
+      ).toBe(false)
+    })
+
+    test('should be true when arraignment is scheduled but every defendant is re-entering alternative service', () => {
+      expect(
+        canSkipArraignmentSummons([alternativeDefendant], {
+          isArraignmentScheduled: true,
+          newAlternativeServiceDefendantIds: [alternativeDefendant.id],
+        }),
+      ).toBe(true)
+    })
+
+    test('should be false when only some defendants are re-entering alternative service', () => {
+      const otherAlternativeDefendant = {
+        id: 'defendant-3',
+        isAlternativeService: true,
+      }
+
+      expect(
+        canSkipArraignmentSummons(
+          [alternativeDefendant, otherAlternativeDefendant],
+          {
+            isArraignmentScheduled: true,
+            newAlternativeServiceDefendantIds: [alternativeDefendant.id],
+          },
+        ),
+      ).toBe(false)
     })
   })
 

--- a/apps/judicial-system/web/src/utils/utils.spec.ts
+++ b/apps/judicial-system/web/src/utils/utils.spec.ts
@@ -439,10 +439,9 @@ describe('Utils', () => {
 
     test('should be false when any defendant is receiving a subpoena', () => {
       expect(
-        canSkipArraignmentSummons(
-          [alternativeDefendant, subpoenaDefendant],
-          { isArraignmentScheduled: false },
-        ),
+        canSkipArraignmentSummons([alternativeDefendant, subpoenaDefendant], {
+          isArraignmentScheduled: false,
+        }),
       ).toBe(false)
     })
 

--- a/apps/judicial-system/web/src/utils/utils.ts
+++ b/apps/judicial-system/web/src/utils/utils.ts
@@ -1169,6 +1169,37 @@ export const areAllDefendantsServedByAlternativeMeans = (
   (defendants?.length ?? 0) > 0 &&
   Boolean(defendants?.every((defendant) => defendant.isAlternativeService))
 
+// Skip is available on the first pass (no arraignment scheduled yet), and
+// again when the court re-enters alternative service for every defendant
+// after an arraignment was already scheduled — e.g. after splitting a
+// co-defendant and switching the remaining case to "birt með öðrum hætti".
+export const canSkipArraignmentSummons = (
+  defendants?:
+    | { id: string; isAlternativeService?: boolean | null }[]
+    | null,
+  options?: {
+    isArraignmentScheduled?: boolean
+    newAlternativeServiceDefendantIds?: string[]
+  },
+): boolean => {
+  if (!areAllDefendantsServedByAlternativeMeans(defendants)) {
+    return false
+  }
+
+  if (!options?.isArraignmentScheduled) {
+    return true
+  }
+
+  const newAlternativeServiceDefendantIds =
+    options.newAlternativeServiceDefendantIds ?? []
+
+  return Boolean(
+    defendants?.every((defendant) =>
+      newAlternativeServiceDefendantIds.includes(defendant.id),
+    ),
+  )
+}
+
 // Lets an element with role="button" be activated with the keyboard
 // (Enter or Space) the same way a native button is.
 export const onEnterOrSpace =

--- a/apps/judicial-system/web/src/utils/utils.ts
+++ b/apps/judicial-system/web/src/utils/utils.ts
@@ -1174,9 +1174,7 @@ export const areAllDefendantsServedByAlternativeMeans = (
 // after an arraignment was already scheduled — e.g. after splitting a
 // co-defendant and switching the remaining case to "birt með öðrum hætti".
 export const canSkipArraignmentSummons = (
-  defendants?:
-    | { id: string; isAlternativeService?: boolean | null }[]
-    | null,
+  defendants?: { id: string; isAlternativeService?: boolean | null }[] | null,
   options?: {
     isArraignmentScheduled?: boolean
     newAlternativeServiceDefendantIds?: string[]


### PR DESCRIPTION
Asana
[Attach a link to issue if relevant
](https://app.asana.com/1/203394141643832/project/1212657017130395/task/1214686928422248?focus=true)

## What

There was an issue when returning to this step and selecting "Birta með öðrum hætti" would not show the "Ekki boða til þinfgestingar" option due to the stored arraignment date from the first pass.


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Cursor


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved arraignment summons handling when defendants are served through alternative methods.
  * Courts can now skip summons after an arraignment is scheduled when alternative service is re-entered for every defendant.
  * Prevented summons from being skipped when alternative service is incomplete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->