### PR TITLE
fix(my-pages): Display LSH questionnaires answers

### DIFF
--- a/libs/api/domains/questionnaires/src/lib/questionnaires.service.ts
+++ b/libs/api/domains/questionnaires/src/lib/questionnaires.service.ts
@@ -382,6 +382,8 @@ export class QuestionnairesService {
 
     const data = {
       id: LSHdata.gUID,
+      submissionId: LSHdata.gUID,
+      isDraft: false,
       title:
         LSHquestionnaire?.header ?? formatMessage(m.questionnaireWithoutTitle),
       description: LSHquestionnaire?.description ?? undefined,

--- a/libs/api/domains/questionnaires/src/lib/transform-mappers/display.mappers.spec.ts
+++ b/libs/api/domains/questionnaires/src/lib/transform-mappers/display.mappers.spec.ts
@@ -304,6 +304,42 @@ describe('display mappers', () => {
         QuestionnairesStatusEnum.notAnswered,
       )
     })
+
+    it('exposes the gUID as lastSubmissionId and a single submission when answered', () => {
+      const answerDateTime = new Date('2024-06-01T12:00:00.000Z')
+      const answered = {
+        ...baseLshItem,
+        answerDateTime,
+      } as unknown as LshQuestionnaireType
+
+      const overview = mapLshQuestionnaireOverview(answered, formatMessage)
+      expect(overview.baseInformation.status).toBe(
+        QuestionnairesStatusEnum.answered,
+      )
+      expect(overview.baseInformation.lastSubmissionId).toBe('lsh-guid-h1')
+      expect(overview.baseInformation.lastSubmitted).toEqual(answerDateTime)
+      expect(overview.submissions).toEqual([
+        {
+          id: 'lsh-guid-h1',
+          isDraft: false,
+          lastUpdated: answerDateTime,
+        },
+      ])
+
+      const listItem = mapLshQuestionnaireListItem(answered, formatMessage)
+      expect(listItem.lastSubmissionId).toBe('lsh-guid-h1')
+      expect(listItem.lastSubmitted).toEqual(answerDateTime)
+    })
+
+    it('does not set lastSubmissionId or submissions when unanswered', () => {
+      const overview = mapLshQuestionnaireOverview(baseLshItem, formatMessage)
+      expect(overview.baseInformation.lastSubmissionId).toBeUndefined()
+      expect(overview.submissions).toBeUndefined()
+      expect(
+        mapLshQuestionnaireListItem(baseLshItem, formatMessage)
+          .lastSubmissionId,
+      ).toBeUndefined()
+    })
   })
 
   describe('EL questionnaire mapping', () => {

--- a/libs/api/domains/questionnaires/src/lib/transform-mappers/lsh/display/mapQuestionnaire.ts
+++ b/libs/api/domains/questionnaires/src/lib/transform-mappers/lsh/display/mapQuestionnaire.ts
@@ -54,11 +54,25 @@ export const mapLshQuestionnaireOverview = (
     description: data.description ?? undefined,
     organization: QuestionnairesOrganizationEnum.LSH,
     department: data.department ?? undefined,
+    lastSubmitted: data.answerDateTime ?? undefined,
+    // LSH has a single answer set per questionnaire, addressed by the
+    // questionnaire gUID rather than a separate submission id
+    lastSubmissionId: data.answerDateTime ? data.gUID ?? undefined : undefined,
   },
   expirationDate: data.validToDateTime ?? undefined,
   canSubmit:
     !data.answerDateTime &&
     (data.validToDateTime == null || data.validToDateTime >= new Date()),
+  submissions:
+    data.answerDateTime && data.gUID
+      ? [
+          {
+            id: data.gUID,
+            isDraft: false,
+            lastUpdated: data.answerDateTime,
+          },
+        ]
+      : undefined,
 })
 
 export const mapLshQuestionnaireListItem = (
@@ -76,4 +90,6 @@ export const mapLshQuestionnaireListItem = (
     : data.validToDateTime != null && data.validToDateTime < new Date()
     ? QuestionnairesStatusEnum.expired
     : QuestionnairesStatusEnum.notAnswered,
+  lastSubmitted: data.answerDateTime ?? undefined,
+  lastSubmissionId: data.answerDateTime ? data.gUID ?? undefined : undefined,
 })

--- a/libs/portals/my-pages/health/src/screens/Questionnaires/AnsweredQuestionnaire.tsx
+++ b/libs/portals/my-pages/health/src/screens/Questionnaires/AnsweredQuestionnaire.tsx
@@ -78,14 +78,12 @@ const AnsweredQuestionnaire: FC = () => {
   }, [data, id, submissionId])
 
   useEffect(() => {
-    if (organization === QuestionnaireQuestionnairesOrganizationEnum.EL) {
-      getQuestionnaire({
-        variables: {
-          input: { id: id ?? '', organization: organization },
-          locale: lang,
-        },
-      })
-    }
+    getQuestionnaire({
+      variables: {
+        input: { id: id ?? '', organization: organization },
+        locale: lang,
+      },
+    })
   }, [getQuestionnaire, id, lang, organization])
 
   const isDraft = currentSubmission?.isDraft


### PR DESCRIPTION
## What

Display answers for LSH questionnaires

## Why

So users can see their answers to these questionnaires as well

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Questionnaire overviews and list items now display the latest submission date and ID.
  * Answered questionnaires include a completed submission record.
  * Questionnaire details are now available across all supported organizations.

* **Bug Fixes**
  * Corrected submission status and identifier handling for answered questionnaires.
  * Unanswered questionnaires no longer show misleading submission details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->