### PR TITLE
feat(j-s): Verdict timeline information for defence users

### DIFF
--- a/apps/judicial-system/web/src/components/Cards/VerdictTimelineCard/DefenderVerdictTimelineCard.logic.spec.ts
+++ b/apps/judicial-system/web/src/components/Cards/VerdictTimelineCard/DefenderVerdictTimelineCard.logic.spec.ts
@@ -1,0 +1,103 @@
+import { createIntl } from 'react-intl'
+
+import type { Verdict } from '@island.is/judicial-system-web/src/graphql/schema'
+import {
+  ServiceRequirement,
+  VerdictAppealDecision,
+} from '@island.is/judicial-system-web/src/graphql/schema'
+
+import { getDefenderVerdictTimelineItems } from './DefenderVerdictTimelineCard.logic'
+
+describe('getDefenderVerdictTimelineItems', () => {
+  const { formatMessage } = createIntl({ locale: 'is', messages: {} })
+
+  const items = (verdict: Partial<Verdict>) =>
+    getDefenderVerdictTimelineItems(verdict as Verdict, formatMessage)
+
+  describe('service', () => {
+    it('should report the service date of a verdict that has been served', () => {
+      expect(
+        items({
+          serviceRequirement: ServiceRequirement.REQUIRED,
+          serviceDate: '2026-06-01T13:31:00.000Z',
+        }),
+      ).toEqual([{ text: 'Dómur birtur 01.06.2026' }])
+    })
+
+    it('should report the requirement while service is pending', () => {
+      expect(
+        items({ serviceRequirement: ServiceRequirement.REQUIRED }),
+      ).toEqual([{ text: 'Birta skal dómfellda dóminn' }])
+    })
+
+    it('should report that the defendant was present when no service applies', () => {
+      expect(
+        items({ serviceRequirement: ServiceRequirement.NOT_APPLICABLE }),
+      ).toEqual([{ text: 'Dómfelldi var viðstaddur dómsuppkvaðningu' }])
+    })
+
+    it('should report that no service was needed', () => {
+      expect(
+        items({ serviceRequirement: ServiceRequirement.NOT_REQUIRED }),
+      ).toEqual([{ text: 'Birting dóms ekki þörf' }])
+    })
+
+    // The public prosecution office's card always shows the requirement; the
+    // mocks for the defence card show only the date once it has been served.
+    it('should not report the requirement alongside the service date', () => {
+      expect(
+        items({
+          serviceRequirement: ServiceRequirement.REQUIRED,
+          serviceDate: '2026-06-01T13:31:00.000Z',
+        }),
+      ).toHaveLength(1)
+    })
+
+    it('should say nothing when the requirement is unknown', () => {
+      expect(items({})).toEqual([])
+    })
+  })
+
+  describe('appeal', () => {
+    const served = {
+      serviceRequirement: ServiceRequirement.REQUIRED,
+      serviceDate: '2026-06-01T13:31:00.000Z',
+    }
+
+    it('should report the stance the defendant took', () => {
+      expect(
+        items({ ...served, appealDecision: VerdictAppealDecision.POSTPONE }),
+      ).toEqual([
+        { text: 'Dómur birtur 01.06.2026' },
+        { text: 'Dómfelldi tekur áfrýjunarfrest' },
+      ])
+    })
+
+    it('should report an accepted verdict', () => {
+      expect(
+        items({ ...served, appealDecision: VerdictAppealDecision.ACCEPT }),
+      ).toEqual([
+        { text: 'Dómur birtur 01.06.2026' },
+        { text: 'Dómfelldi unir' },
+      ])
+    })
+
+    // The stance only matters while it is still open which way they will go.
+    it('should replace the stance with the appeal once appealed', () => {
+      expect(
+        items({
+          ...served,
+          appealDecision: VerdictAppealDecision.POSTPONE,
+          appealDate: '2026-06-04T13:34:00.000Z',
+        }),
+      ).toEqual([
+        { text: 'Dómur birtur 01.06.2026' },
+        { text: 'Dómfelldi áfrýjaði 04.06.2026', tone: 'critical' },
+      ])
+    })
+
+    it('should say nothing about an appeal when no stance was recorded', () => {
+      expect(items(served)).toEqual([{ text: 'Dómur birtur 01.06.2026' }])
+    })
+  })
+})

--- a/apps/judicial-system/web/src/components/Cards/VerdictTimelineCard/DefenderVerdictTimelineCard.logic.ts
+++ b/apps/judicial-system/web/src/components/Cards/VerdictTimelineCard/DefenderVerdictTimelineCard.logic.ts
@@ -1,0 +1,66 @@
+import type { IntlShape } from 'react-intl'
+
+import {
+  formatDate,
+  getDefendantVerdictAppealDecisionLabel,
+  getServiceRequirementText,
+} from '@island.is/judicial-system/formatters'
+import type { Verdict } from '@island.is/judicial-system-web/src/graphql/schema'
+import { ServiceRequirement } from '@island.is/judicial-system-web/src/graphql/schema'
+
+import type { VerdictTimelineItem } from './VerdictTimelineBody'
+import { strings } from './VerdictTimelineCard.strings'
+
+/**
+ * The bullets a defence user sees about the service and appeal of one verdict.
+ * Deliberately leaves out the appeal deadline, which defence users already get
+ * from InfoCardClosedIndictment, and everything about enforcement, which is
+ * internal to the prosecution.
+ */
+export const getDefenderVerdictTimelineItems = (
+  verdict: Verdict,
+  formatMessage: IntlShape['formatMessage'],
+): VerdictTimelineItem[] => {
+  const items: VerdictTimelineItem[] = []
+
+  // Once a verdict that had to be served has been served, the service date says
+  // all there is to say. Until then - and when no service was needed at all -
+  // the requirement itself is what the defence needs to know.
+  if (
+    verdict.serviceRequirement === ServiceRequirement.REQUIRED &&
+    verdict.serviceDate
+  ) {
+    items.push({
+      text: formatMessage(strings.defendantVerdictViewedDate, {
+        date: formatDate(verdict.serviceDate),
+      }),
+    })
+  } else if (verdict.serviceRequirement) {
+    const serviceRequirementText = getServiceRequirementText(
+      verdict.serviceRequirement,
+    )
+
+    if (serviceRequirementText) {
+      items.push({ text: serviceRequirementText })
+    }
+  }
+
+  // The stance the defendant took at service only matters while it is still open
+  // which way they will go, so an appeal takes its place in the list.
+  if (verdict.appealDate) {
+    items.push({
+      text: `Dómfelldi áfrýjaði ${formatDate(verdict.appealDate)}`,
+      tone: 'critical',
+    })
+  } else if (verdict.appealDecision) {
+    const appealDecisionLabel = getDefendantVerdictAppealDecisionLabel(
+      verdict.appealDecision,
+    )
+
+    if (appealDecisionLabel) {
+      items.push({ text: appealDecisionLabel })
+    }
+  }
+
+  return items
+}

--- a/apps/judicial-system/web/src/components/Cards/VerdictTimelineCard/DefenderVerdictTimelineCard.spec.tsx
+++ b/apps/judicial-system/web/src/components/Cards/VerdictTimelineCard/DefenderVerdictTimelineCard.spec.tsx
@@ -1,0 +1,121 @@
+import { render, screen } from '@testing-library/react'
+
+import type { Defendant } from '@island.is/judicial-system-web/src/graphql/schema'
+import {
+  ServiceRequirement,
+  VerdictAppealDecision,
+} from '@island.is/judicial-system-web/src/graphql/schema'
+import { IntlProviderWrapper } from '@island.is/judicial-system-web/src/utils/testHelpers'
+
+import DefenderVerdictTimelineCard from './DefenderVerdictTimelineCard'
+
+describe('DefenderVerdictTimelineCard', () => {
+  const name = 'Jón Sigurður Jónsson'
+
+  const renderComponent = (defendant: Defendant) =>
+    render(
+      <IntlProviderWrapper>
+        <DefenderVerdictTimelineCard defendant={defendant} />
+      </IntlProviderWrapper>,
+    )
+
+  const servedDefendant = {
+    id: 'defendant_id',
+    name,
+    verdict: {
+      serviceRequirement: ServiceRequirement.REQUIRED,
+      serviceDate: '2026-06-01T13:31:00.000Z',
+      appealDecision: VerdictAppealDecision.POSTPONE,
+    },
+  } as Defendant
+
+  it('renders nothing when the defendant has no verdict', () => {
+    const { container } = renderComponent({
+      id: 'defendant_id',
+      name,
+    } as Defendant)
+
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('shows the service date and the stance the defendant took', async () => {
+    renderComponent(servedDefendant)
+
+    expect(await screen.findByText('Birting dóms')).toBeInTheDocument()
+    expect(screen.getByText(name)).toBeInTheDocument()
+    expect(screen.getByText('• Dómur birtur 01.06.2026')).toBeInTheDocument()
+    expect(
+      screen.getByText('• Dómfelldi tekur áfrýjunarfrest'),
+    ).toBeInTheDocument()
+  })
+
+  it('shows that the verdict has to be served while service is pending', async () => {
+    renderComponent({
+      ...servedDefendant,
+      verdict: { serviceRequirement: ServiceRequirement.REQUIRED },
+    } as Defendant)
+
+    expect(
+      await screen.findByText('• Birta skal dómfellda dóminn'),
+    ).toBeInTheDocument()
+  })
+
+  it('shows that the defendant was present when no service was needed', async () => {
+    renderComponent({
+      ...servedDefendant,
+      verdict: { serviceRequirement: ServiceRequirement.NOT_APPLICABLE },
+    } as Defendant)
+
+    expect(
+      await screen.findByText('• Dómfelldi var viðstaddur dómsuppkvaðningu'),
+    ).toBeInTheDocument()
+  })
+
+  it('replaces the stance with the appeal once the verdict has been appealed', async () => {
+    renderComponent({
+      ...servedDefendant,
+      verdict: {
+        ...servedDefendant.verdict,
+        appealDate: '2026-06-04T13:34:00.000Z',
+      },
+    } as Defendant)
+
+    const appealItem = await screen.findByText(
+      '• Dómfelldi áfrýjaði 04.06.2026',
+    )
+
+    expect(appealItem).toBeInTheDocument()
+    // The appeal stands out from the rest of the timeline, see the design
+    expect(appealItem.className).toMatch(/red600/)
+    expect(
+      screen.queryByText('• Dómfelldi tekur áfrýjunarfrest'),
+    ).not.toBeInTheDocument()
+  })
+
+  // The appeal deadline is already on InfoCardClosedIndictment for defence
+  // users, and enforcement is internal to the prosecution.
+  it('leaves out the lines that belong to the public prosecution office', async () => {
+    renderComponent({
+      ...servedDefendant,
+      verdictAppealDeadline: '2026-06-29T23:59:59.999Z',
+      isSentToPrisonAdmin: true,
+      sentToPrisonAdminDate: '2026-06-10T13:31:00.000Z',
+      isClosedWithoutEnforcement: true,
+      closedWithoutEnforcementDate: '2026-06-11T13:31:00.000Z',
+      publicProsecutorIsRegisteredInPoliceSystem: true,
+    } as Defendant)
+
+    expect(await screen.findByText('Birting dóms')).toBeInTheDocument()
+    expect(screen.queryByText(/Áfrýjunarfrestur/)).not.toBeInTheDocument()
+    expect(screen.queryByText(/Sent til fullnustu/)).not.toBeInTheDocument()
+    expect(
+      screen.queryByText(/Máli lokið án fullnustu/),
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByText('Afstaða dómfellda til dóms'),
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: `Valmynd fyrir ${name}` }),
+    ).not.toBeInTheDocument()
+  })
+})

--- a/apps/judicial-system/web/src/components/Cards/VerdictTimelineCard/DefenderVerdictTimelineCard.spec.tsx
+++ b/apps/judicial-system/web/src/components/Cards/VerdictTimelineCard/DefenderVerdictTimelineCard.spec.tsx
@@ -9,6 +9,12 @@ import { IntlProviderWrapper } from '@island.is/judicial-system-web/src/utils/te
 
 import DefenderVerdictTimelineCard from './DefenderVerdictTimelineCard'
 
+/**
+ * Which bullets a verdict comes to is covered directly in
+ * DefenderVerdictTimelineCard.logic.spec.ts. What is left for the rendered card
+ * is that they reach the page, that the tone survives, and that nothing the
+ * public prosecution office keeps to itself appears.
+ */
 describe('DefenderVerdictTimelineCard', () => {
   const name = 'Jón Sigurður Jónsson'
 
@@ -38,7 +44,7 @@ describe('DefenderVerdictTimelineCard', () => {
     expect(container).toBeEmptyDOMElement()
   })
 
-  it('shows the service date and the stance the defendant took', async () => {
+  it('renders the heading, the defendant and the bullets', async () => {
     renderComponent(servedDefendant)
 
     expect(await screen.findByText('Birting dóms')).toBeInTheDocument()
@@ -49,29 +55,7 @@ describe('DefenderVerdictTimelineCard', () => {
     ).toBeInTheDocument()
   })
 
-  it('shows that the verdict has to be served while service is pending', async () => {
-    renderComponent({
-      ...servedDefendant,
-      verdict: { serviceRequirement: ServiceRequirement.REQUIRED },
-    } as Defendant)
-
-    expect(
-      await screen.findByText('• Birta skal dómfellda dóminn'),
-    ).toBeInTheDocument()
-  })
-
-  it('shows that the defendant was present when no service was needed', async () => {
-    renderComponent({
-      ...servedDefendant,
-      verdict: { serviceRequirement: ServiceRequirement.NOT_APPLICABLE },
-    } as Defendant)
-
-    expect(
-      await screen.findByText('• Dómfelldi var viðstaddur dómsuppkvaðningu'),
-    ).toBeInTheDocument()
-  })
-
-  it('replaces the stance with the appeal once the verdict has been appealed', async () => {
+  it('renders the appeal in a tone of its own', async () => {
     renderComponent({
       ...servedDefendant,
       verdict: {
@@ -84,12 +68,8 @@ describe('DefenderVerdictTimelineCard', () => {
       '• Dómfelldi áfrýjaði 04.06.2026',
     )
 
-    expect(appealItem).toBeInTheDocument()
     // The appeal stands out from the rest of the timeline, see the design
     expect(appealItem.className).toMatch(/red600/)
-    expect(
-      screen.queryByText('• Dómfelldi tekur áfrýjunarfrest'),
-    ).not.toBeInTheDocument()
   })
 
   // The appeal deadline is already on InfoCardClosedIndictment for defence

--- a/apps/judicial-system/web/src/components/Cards/VerdictTimelineCard/DefenderVerdictTimelineCard.tsx
+++ b/apps/judicial-system/web/src/components/Cards/VerdictTimelineCard/DefenderVerdictTimelineCard.tsx
@@ -1,20 +1,12 @@
 import type { FC } from 'react'
-import { useMemo } from 'react'
 import { useIntl } from 'react-intl'
 
-import {
-  formatDate,
-  getDefendantVerdictAppealDecisionLabel,
-  getServiceRequirementText,
-} from '@island.is/judicial-system/formatters'
 import BlueBox from '@island.is/judicial-system-web/src/components/BlueBox/BlueBox'
 import SectionHeading from '@island.is/judicial-system-web/src/components/SectionHeading/SectionHeading'
 import type { Defendant } from '@island.is/judicial-system-web/src/graphql/schema'
-import { ServiceRequirement } from '@island.is/judicial-system-web/src/graphql/schema'
 
-import type { VerdictTimelineItem } from './VerdictTimelineBody'
+import { getDefenderVerdictTimelineItems } from './DefenderVerdictTimelineCard.logic'
 import VerdictTimelineBody from './VerdictTimelineBody'
-import { strings } from './VerdictTimelineCard.strings'
 
 interface Props {
   defendant: Defendant
@@ -23,63 +15,13 @@ interface Props {
 /**
  * The defence view of a defendant's verdict timeline: the same service and
  * appeal information the public prosecution office has, without the actions it
- * can take. It deliberately leaves out the appeal deadline, which defence users
- * already get from InfoCardClosedIndictment, and everything about enforcement,
- * which is internal to the prosecution.
+ * can take. Which bullets that comes to is decided by
+ * getDefenderVerdictTimelineItems.
  */
 const DefenderVerdictTimelineCard: FC<Props> = (props) => {
   const { defendant } = props
   const { verdict } = defendant
   const { formatMessage } = useIntl()
-
-  const textItems = useMemo(() => {
-    const items: VerdictTimelineItem[] = []
-
-    if (!verdict) {
-      return items
-    }
-
-    // Once a verdict that had to be served has been served, the service date
-    // says all there is to say. Until then - and when no service was needed at
-    // all - the requirement itself is what the defence needs to know.
-    if (
-      verdict.serviceRequirement === ServiceRequirement.REQUIRED &&
-      verdict.serviceDate
-    ) {
-      items.push({
-        text: formatMessage(strings.defendantVerdictViewedDate, {
-          date: formatDate(verdict.serviceDate),
-        }),
-      })
-    } else if (verdict.serviceRequirement) {
-      const serviceRequirementText = getServiceRequirementText(
-        verdict.serviceRequirement,
-      )
-
-      if (serviceRequirementText) {
-        items.push({ text: serviceRequirementText })
-      }
-    }
-
-    // The stance the defendant took at service only matters while it is still
-    // open which way they will go, so an appeal takes its place in the list.
-    if (verdict.appealDate) {
-      items.push({
-        text: `Dómfelldi áfrýjaði ${formatDate(verdict.appealDate)}`,
-        tone: 'critical',
-      })
-    } else if (verdict.appealDecision) {
-      const appealDecisionLabel = getDefendantVerdictAppealDecisionLabel(
-        verdict.appealDecision,
-      )
-
-      if (appealDecisionLabel) {
-        items.push({ text: appealDecisionLabel })
-      }
-    }
-
-    return items
-  }, [formatMessage, verdict])
 
   if (!verdict) {
     return null
@@ -88,7 +30,10 @@ const DefenderVerdictTimelineCard: FC<Props> = (props) => {
   return (
     <BlueBox>
       <SectionHeading title="Birting dóms" heading="h4" marginBottom={2} />
-      <VerdictTimelineBody eyebrow={defendant.name ?? ''} items={textItems} />
+      <VerdictTimelineBody
+        eyebrow={defendant.name ?? ''}
+        items={getDefenderVerdictTimelineItems(verdict, formatMessage)}
+      />
     </BlueBox>
   )
 }

--- a/apps/judicial-system/web/src/components/Cards/VerdictTimelineCard/DefenderVerdictTimelineCard.tsx
+++ b/apps/judicial-system/web/src/components/Cards/VerdictTimelineCard/DefenderVerdictTimelineCard.tsx
@@ -1,0 +1,96 @@
+import type { FC } from 'react'
+import { useMemo } from 'react'
+import { useIntl } from 'react-intl'
+
+import {
+  formatDate,
+  getDefendantVerdictAppealDecisionLabel,
+  getServiceRequirementText,
+} from '@island.is/judicial-system/formatters'
+import BlueBox from '@island.is/judicial-system-web/src/components/BlueBox/BlueBox'
+import SectionHeading from '@island.is/judicial-system-web/src/components/SectionHeading/SectionHeading'
+import type { Defendant } from '@island.is/judicial-system-web/src/graphql/schema'
+import { ServiceRequirement } from '@island.is/judicial-system-web/src/graphql/schema'
+
+import type { VerdictTimelineItem } from './VerdictTimelineBody'
+import VerdictTimelineBody from './VerdictTimelineBody'
+import { strings } from './VerdictTimelineCard.strings'
+
+interface Props {
+  defendant: Defendant
+}
+
+/**
+ * The defence view of a defendant's verdict timeline: the same service and
+ * appeal information the public prosecution office has, without the actions it
+ * can take. It deliberately leaves out the appeal deadline, which defence users
+ * already get from InfoCardClosedIndictment, and everything about enforcement,
+ * which is internal to the prosecution.
+ */
+const DefenderVerdictTimelineCard: FC<Props> = (props) => {
+  const { defendant } = props
+  const { verdict } = defendant
+  const { formatMessage } = useIntl()
+
+  const textItems = useMemo(() => {
+    const items: VerdictTimelineItem[] = []
+
+    if (!verdict) {
+      return items
+    }
+
+    // Once a verdict that had to be served has been served, the service date
+    // says all there is to say. Until then - and when no service was needed at
+    // all - the requirement itself is what the defence needs to know.
+    if (
+      verdict.serviceRequirement === ServiceRequirement.REQUIRED &&
+      verdict.serviceDate
+    ) {
+      items.push({
+        text: formatMessage(strings.defendantVerdictViewedDate, {
+          date: formatDate(verdict.serviceDate),
+        }),
+      })
+    } else if (verdict.serviceRequirement) {
+      const serviceRequirementText = getServiceRequirementText(
+        verdict.serviceRequirement,
+      )
+
+      if (serviceRequirementText) {
+        items.push({ text: serviceRequirementText })
+      }
+    }
+
+    // The stance the defendant took at service only matters while it is still
+    // open which way they will go, so an appeal takes its place in the list.
+    if (verdict.appealDate) {
+      items.push({
+        text: `Dómfelldi áfrýjaði ${formatDate(verdict.appealDate)}`,
+        tone: 'critical',
+      })
+    } else if (verdict.appealDecision) {
+      const appealDecisionLabel = getDefendantVerdictAppealDecisionLabel(
+        verdict.appealDecision,
+      )
+
+      if (appealDecisionLabel) {
+        items.push({ text: appealDecisionLabel })
+      }
+    }
+
+    return items
+  }, [formatMessage, verdict])
+
+  if (!verdict) {
+    return null
+  }
+
+  return (
+    <BlueBox>
+      <SectionHeading title="Birting dóms" heading="h4" marginBottom={2} />
+      <VerdictTimelineBody eyebrow={defendant.name ?? ''} items={textItems} />
+    </BlueBox>
+  )
+}
+
+export default DefenderVerdictTimelineCard

--- a/apps/judicial-system/web/src/components/Cards/VerdictTimelineCard/VerdictTimelineBody.tsx
+++ b/apps/judicial-system/web/src/components/Cards/VerdictTimelineCard/VerdictTimelineBody.tsx
@@ -1,0 +1,84 @@
+import type { FC, PropsWithChildren } from 'react'
+import { useEffect, useRef } from 'react'
+import { AnimatePresence, motion } from 'motion/react'
+
+import { Box, Text } from '@island.is/island-ui/core'
+import * as styles from '@island.is/judicial-system-web/src/components/Cards/IconCard/IconCard.css'
+
+export type VerdictTimelineItemTone = 'default' | 'critical'
+
+export interface VerdictTimelineItem {
+  text: string
+  tone?: VerdictTimelineItemTone
+}
+
+interface Props {
+  eyebrow: string
+  items: VerdictTimelineItem[]
+}
+
+/**
+ * The read-only body of a verdict timeline card: an eyebrow above a bullet
+ * list. Shared by the public prosecution office card, which fills the eyebrow
+ * with the kind of ruling and adds date pickers below the list, and the defence
+ * card, which fills it with the defendant name and adds nothing.
+ *
+ * Items appearing after the first render animate in one after another, so a
+ * newly registered date visibly lands in the list.
+ */
+const VerdictTimelineBody: FC<PropsWithChildren<Props>> = (props) => {
+  const { eyebrow, items, children } = props
+
+  const hasMountedRef = useRef<boolean>(false)
+  const previousItemCountRef = useRef<number>(0)
+
+  useEffect(() => {
+    hasMountedRef.current = true
+    previousItemCountRef.current = items.length
+  }, [items.length])
+
+  return (
+    <Box className={styles.container}>
+      <Text variant="eyebrow">{eyebrow}</Text>
+      <AnimatePresence initial={false}>
+        {items.map((item, index) => {
+          const addedStartIndex = previousItemCountRef.current
+          const isNewItem = hasMountedRef.current && index >= addedStartIndex
+          const staggerIndex = isNewItem ? index - addedStartIndex : 0
+
+          return (
+            <motion.div
+              key={item.text}
+              initial={
+                isNewItem
+                  ? {
+                      opacity: 0,
+                      y: 20,
+                      height: 0,
+                    }
+                  : false
+              }
+              animate={{
+                opacity: 1,
+                y: 0,
+                height: 'auto',
+              }}
+              exit={{ opacity: 0, y: 20, height: 0 }}
+              transition={{
+                delay: isNewItem ? staggerIndex * 0.2 : 0,
+                duration: 0.3,
+              }}
+            >
+              <Text color={item.tone === 'critical' ? 'red600' : undefined}>
+                {`• ${item.text}`}
+              </Text>
+            </motion.div>
+          )
+        })}
+      </AnimatePresence>
+      {children}
+    </Box>
+  )
+}
+
+export default VerdictTimelineBody

--- a/apps/judicial-system/web/src/components/Cards/VerdictTimelineCard/VerdictTimelineCard.tsx
+++ b/apps/judicial-system/web/src/components/Cards/VerdictTimelineCard/VerdictTimelineCard.tsx
@@ -1,5 +1,5 @@
 import type { FC } from 'react'
-import { useContext, useEffect, useMemo, useRef, useState } from 'react'
+import { useContext, useEffect, useMemo, useState } from 'react'
 import { useIntl } from 'react-intl'
 import { AnimatePresence, motion } from 'motion/react'
 import { useRouter } from 'next/router'
@@ -32,6 +32,8 @@ import {
 import useVerdict from '@island.is/judicial-system-web/src/utils/hooks/useVerdict'
 import { grid } from '@island.is/judicial-system-web/src/utils/styles/recipes.css'
 
+import type { VerdictTimelineItem } from './VerdictTimelineBody'
+import VerdictTimelineBody from './VerdictTimelineBody'
 import { strings } from './VerdictTimelineCard.strings'
 
 interface Props {
@@ -62,9 +64,6 @@ const VerdictTimelineCard: FC<Props> = (props) => {
   const { setAndSendDefendantToServer, updateDefendant, isUpdatingDefendant } =
     useDefendants()
   const { setAndSendVerdictToServer } = useVerdict()
-
-  const hasMountedRef = useRef<boolean>(false)
-  const previousTextCountRef = useRef<number>(0)
 
   const [modalVisible, setModalVisible] = useState<VisibleModal>()
   const [pendingServiceDate, setPendingServiceDate] = useState<Date>()
@@ -139,23 +138,23 @@ const VerdictTimelineCard: FC<Props> = (props) => {
   )
 
   const textItems = useMemo(() => {
-    const texts: string[] = []
+    const items: VerdictTimelineItem[] = []
 
     const pushIf = (condition: boolean, message: string | null) => {
       if (condition && message) {
-        texts.push(message)
+        items.push({ text: message })
       }
     }
 
     pushIf(!!serviceRequirementText, serviceRequirementText)
 
     if (isFine) {
-      texts.push(
-        formatMessage(strings.fineAppealDeadline, {
+      items.push({
+        text: formatMessage(strings.fineAppealDeadline, {
           appealDeadlineIsInThePast: defendant.isVerdictAppealDeadlineExpired,
           appealDeadline: formatDate(defendant.verdictAppealDeadline),
         }),
-      )
+      })
     } else if (verdict?.serviceDate) {
       pushIf(
         !!isServiceRequired,
@@ -164,14 +163,14 @@ const VerdictTimelineCard: FC<Props> = (props) => {
         }),
       )
 
-      texts.push(
-        formatMessage(appealExpirationInfo.message, {
+      items.push({
+        text: formatMessage(appealExpirationInfo.message, {
           appealExpirationDate: appealExpirationInfo.date,
           deadlineType: verdict?.isDefaultJudgement
             ? 'Endurupptökufrestur'
             : 'Áfrýjunarfrestur',
         }),
-      )
+      })
 
       pushIf(
         !!verdict?.appealDate,
@@ -198,7 +197,7 @@ const VerdictTimelineCard: FC<Props> = (props) => {
       )}`,
     )
 
-    return texts
+    return items
   }, [
     appealExpirationInfo.date,
     appealExpirationInfo.message,
@@ -288,11 +287,6 @@ const VerdictTimelineCard: FC<Props> = (props) => {
       setWorkingCase,
     )
   }
-
-  useEffect(() => {
-    hasMountedRef.current = true
-    previousTextCountRef.current = textItems.length
-  }, [textItems.length])
 
   useEffect(() => {
     if (isServiceDatePickerClosing && verdict?.serviceDate) {
@@ -462,45 +456,10 @@ const VerdictTimelineCard: FC<Props> = (props) => {
             : []),
         ]}
       >
-        <Box className={styles.container}>
-          <Text variant="eyebrow">
-            {isFine ? 'Viðurlagaákvörðun' : 'Birting dóms'}
-          </Text>
-          <AnimatePresence initial={false}>
-            {textItems.map((text, index) => {
-              const addedStartIndex = previousTextCountRef.current
-              const isNewItem =
-                hasMountedRef.current && index >= addedStartIndex
-              const staggerIndex = isNewItem ? index - addedStartIndex : 0
-
-              return (
-                <motion.div
-                  key={`${defendant.id}-${text}`}
-                  initial={
-                    isNewItem
-                      ? {
-                          opacity: 0,
-                          y: 20,
-                          height: 0,
-                        }
-                      : false
-                  }
-                  animate={{
-                    opacity: 1,
-                    y: 0,
-                    height: 'auto',
-                  }}
-                  exit={{ opacity: 0, y: 20, height: 0 }}
-                  transition={{
-                    delay: isNewItem ? staggerIndex * 0.2 : 0,
-                    duration: 0.3,
-                  }}
-                >
-                  <Text>{`• ${text}`}</Text>
-                </motion.div>
-              )
-            })}
-          </AnimatePresence>
+        <VerdictTimelineBody
+          eyebrow={isFine ? 'Viðurlagaákvörðun' : 'Birting dóms'}
+          items={textItems}
+        >
           {showDatePickers && (
             <AnimatePresence
               onExitComplete={() => {
@@ -621,7 +580,7 @@ const VerdictTimelineCard: FC<Props> = (props) => {
               />
             </motion.div>
           )}
-        </Box>
+        </VerdictTimelineBody>
       </ContextMenuCard>
       {modalVisible?.type === 'REVOKE_SEND_TO_PRISON_ADMIN' && (
         <Modal

--- a/apps/judicial-system/web/src/components/index.ts
+++ b/apps/judicial-system/web/src/components/index.ts
@@ -3,6 +3,7 @@ export { default as AccordionListItem } from './AccordionListItem/AccordionListI
 export { default as BaseSelect } from './BaseSelect/BaseSelect'
 export { default as BlueBox } from './BlueBox/BlueBox'
 export { default as VerdictTimelineCard } from './Cards/VerdictTimelineCard/VerdictTimelineCard'
+export { default as DefenderVerdictTimelineCard } from './Cards/VerdictTimelineCard/DefenderVerdictTimelineCard'
 export { default as CaseDates } from './CaseDates/CaseDates'
 export { default as CaseFile } from './CaseFile/CaseFile'
 export { default as CaseFileList } from './CaseFileList/CaseFileList'

--- a/apps/judicial-system/web/src/routes/Defender/IndictmentCase/IndictmentOverview.spec.tsx
+++ b/apps/judicial-system/web/src/routes/Defender/IndictmentCase/IndictmentOverview.spec.tsx
@@ -1,0 +1,137 @@
+import { MockedProvider } from '@apollo/client/testing'
+import { render, screen, within } from '@testing-library/react'
+
+import type { Case } from '@island.is/judicial-system-web/src/graphql/schema'
+import {
+  CaseIndictmentRulingDecision,
+  CaseState,
+  CaseType,
+  ServiceRequirement,
+  UserRole,
+  VerdictAppealDecision,
+} from '@island.is/judicial-system-web/src/graphql/schema'
+import { mockCase } from '@island.is/judicial-system-web/src/utils/mocks'
+import {
+  FormContextWrapper,
+  IntlProviderWrapper,
+  UserContextWrapper,
+} from '@island.is/judicial-system-web/src/utils/testHelpers'
+
+import IndictmentOverview from './IndictmentOverview'
+
+jest.mock('next/router', () => ({
+  useRouter() {
+    return {
+      pathname: '',
+      push: jest.fn(),
+    }
+  },
+}))
+
+window.scrollTo = jest.fn()
+
+const defenderNationalId = '1111111111'
+
+const completedCase = (
+  indictmentRulingDecision: CaseIndictmentRulingDecision,
+): Case => ({
+  ...mockCase(CaseType.INDICTMENT),
+  state: CaseState.COMPLETED,
+  indictmentRulingDecision,
+  defendants: [
+    {
+      id: 'own_client_id',
+      created: '2020-09-16T19:50:08.033Z',
+      modified: '2020-09-16T19:51:39.466Z',
+      caseId: 'test_id',
+      name: 'Eigin sakborningur',
+      defenderNationalId,
+      verdict: {
+        id: 'own_client_verdict_id',
+        serviceRequirement: ServiceRequirement.REQUIRED,
+        serviceDate: '2026-06-01T13:31:00.000Z',
+        appealDecision: VerdictAppealDecision.POSTPONE,
+      },
+    },
+    {
+      id: 'other_client_id',
+      created: '2020-09-16T19:50:08.033Z',
+      modified: '2020-09-16T19:51:39.466Z',
+      caseId: 'test_id',
+      name: 'Annar sakborningur',
+      defenderNationalId: '2222222222',
+      verdict: {
+        id: 'other_client_verdict_id',
+        serviceRequirement: ServiceRequirement.REQUIRED,
+        serviceDate: '2026-06-02T13:31:00.000Z',
+        appealDecision: VerdictAppealDecision.ACCEPT,
+      },
+    },
+  ],
+})
+
+const renderOverview = (theCase: Case) =>
+  render(
+    <MockedProvider mocks={[]} addTypename={false}>
+      <UserContextWrapper
+        userRole={UserRole.DEFENDER}
+        nationalId={defenderNationalId}
+      >
+        <IntlProviderWrapper>
+          <FormContextWrapper theCase={theCase}>
+            <IndictmentOverview />
+          </FormContextWrapper>
+        </IntlProviderWrapper>
+      </UserContextWrapper>
+    </MockedProvider>,
+  )
+
+describe('Defender IndictmentOverview', () => {
+  // The verdict information is read only, so it is shown for every defendant on
+  // the case - the same way InfoCardClosedIndictment lists them all - not only
+  // for the defendants this defender represents.
+  it('renders a verdict timeline card for every defendant on the case', async () => {
+    renderOverview(completedCase(CaseIndictmentRulingDecision.RULING))
+
+    const timelineCards = await screen.findAllByTestId(
+      'defenderVerdictTimelineCard',
+    )
+
+    expect(timelineCards).toHaveLength(2)
+    expect(
+      within(timelineCards[0]).getByText('Eigin sakborningur'),
+    ).toBeInTheDocument()
+    expect(
+      within(timelineCards[0]).getByText('• Dómur birtur 01.06.2026'),
+    ).toBeInTheDocument()
+    expect(
+      within(timelineCards[1]).getByText('Annar sakborningur'),
+    ).toBeInTheDocument()
+    expect(
+      within(timelineCards[1]).getByText('• Dómfelldi unir'),
+    ).toBeInTheDocument()
+  })
+
+  it('renders no verdict timeline card when the case did not end in a verdict', async () => {
+    renderOverview(completedCase(CaseIndictmentRulingDecision.FINE))
+
+    expect(
+      await screen.findByRole('heading', { name: 'Máli lokið' }),
+    ).toBeInTheDocument()
+    expect(screen.queryAllByTestId('defenderVerdictTimelineCard')).toHaveLength(
+      0,
+    )
+  })
+
+  it('renders no verdict timeline card while the case is still open', async () => {
+    renderOverview({
+      ...completedCase(CaseIndictmentRulingDecision.RULING),
+      state: CaseState.RECEIVED,
+    })
+
+    expect(await screen.findByText('Yfirlit ákæru')).toBeInTheDocument()
+    expect(screen.queryAllByTestId('defenderVerdictTimelineCard')).toHaveLength(
+      0,
+    )
+  })
+})

--- a/apps/judicial-system/web/src/routes/Defender/IndictmentCase/IndictmentOverview.tsx
+++ b/apps/judicial-system/web/src/routes/Defender/IndictmentCase/IndictmentOverview.tsx
@@ -21,6 +21,7 @@ import {
   AppealRulingModifiedAlert,
   Conclusion,
   CourtCaseInfo,
+  DefenderVerdictTimelineCard,
   FormContentContainer,
   FormContext,
   FormFooter,
@@ -125,6 +126,13 @@ const IndictmentOverview: FC = () => {
     (isCaseDefendantDefender(user, workingCase) ||
       isCaseCivilClaimantSpokesperson(user, workingCase))
 
+  // Defence users get the same verdict service and appeal information the
+  // public prosecution office has, but only on a case that ended in a verdict -
+  // there is no verdict timeline to show for a fine or a dismissal.
+  const displayVerdictTimeline =
+    caseIsClosed &&
+    workingCase.indictmentRulingDecision === CaseIndictmentRulingDecision.RULING
+
   const shouldDisplayAppealBanner =
     workingCase.indictmentRulingDecision ===
       CaseIndictmentRulingDecision.DISMISSAL &&
@@ -187,6 +195,19 @@ const IndictmentOverview: FC = () => {
                 </Box>
               ),
           )}
+          {displayVerdictTimeline &&
+            workingCase.defendants?.map(
+              (defendant) =>
+                defendant.verdict && (
+                  <Box
+                    key={`${defendant.id}${defendant.verdict.id}-timeline`}
+                    marginBottom={2}
+                    dataTestId="defenderVerdictTimelineCard"
+                  >
+                    <DefenderVerdictTimelineCard defendant={defendant} />
+                  </Box>
+                ),
+            )}
           {workingCase.defendants?.map((defendant) => (
             <Fragment key={defendant.id}>
               {defendant.alternativeServiceDescription && (

--- a/apps/judicial-system/web/src/routes/PublicProsecutor/Indictments/Overview/Overview.tsx
+++ b/apps/judicial-system/web/src/routes/PublicProsecutor/Indictments/Overview/Overview.tsx
@@ -5,7 +5,10 @@ import { useRouter } from 'next/router'
 import type { Option } from '@island.is/island-ui/core'
 import { Box } from '@island.is/island-ui/core'
 import { getStandardUserDashboardRoute } from '@island.is/judicial-system/consts'
-import { isRulingOrDismissalCase } from '@island.is/judicial-system/types'
+import {
+  canDefendantAppealVerdict,
+  isRulingOrDismissalCase,
+} from '@island.is/judicial-system/types'
 import { core, titles } from '@island.is/judicial-system-web/messages'
 import {
   AllIndictmentCaseFiles,
@@ -29,7 +32,6 @@ import VerdictStatusAlert from '@island.is/judicial-system-web/src/components/Ve
 import {
   AppealCaseState,
   CaseIndictmentRulingDecision,
-  ServiceRequirement,
 } from '@island.is/judicial-system-web/src/graphql/schema'
 import type { ModalId } from '@island.is/judicial-system-web/src/routes/PublicProsecutor/components/utils'
 import {
@@ -101,18 +103,7 @@ export const Overview = () => {
 
         const { verdict } = defendant
 
-        const isServiceRequired =
-          verdict?.serviceRequirement === ServiceRequirement.REQUIRED
-
-        const isServiceNotApplicable =
-          verdict?.serviceRequirement === ServiceRequirement.NOT_APPLICABLE
-
-        const canDefendantAppealVerdict = !!(
-          verdict &&
-          !verdict.isDefaultJudgement &&
-          (isServiceNotApplicable ||
-            (isServiceRequired && !!verdict.serviceDate))
-        )
+        const canAppealVerdict = canDefendantAppealVerdict(verdict)
 
         // Service and appeal alerts are noise for defendants whose case was
         // closed without enforcement.
@@ -133,7 +124,7 @@ export const Overview = () => {
           >
             <VerdictTimelineCard
               defendant={defendant}
-              canDefendantAppealVerdict={canDefendantAppealVerdict}
+              canDefendantAppealVerdict={canAppealVerdict}
             />
           </Box>,
         )

--- a/libs/judicial-system/types/src/index.ts
+++ b/libs/judicial-system/types/src/index.ts
@@ -20,6 +20,7 @@ export {
   InformationForDefendant,
   informationForDefendantMap,
   mapPoliceVerdictDeliveryStatus,
+  canDefendantAppealVerdict,
 } from './lib/verdict'
 
 export { CourtSessionStringType } from './lib/courtSessionString'

--- a/libs/judicial-system/types/src/lib/verdict.spec.ts
+++ b/libs/judicial-system/types/src/lib/verdict.spec.ts
@@ -1,0 +1,51 @@
+import { canDefendantAppealVerdict, ServiceRequirement } from './verdict'
+
+describe('canDefendantAppealVerdict', () => {
+  it('should not allow an appeal when there is no verdict', () => {
+    expect(canDefendantAppealVerdict()).toBe(false)
+    expect(canDefendantAppealVerdict(null)).toBe(false)
+  })
+
+  it('should not allow an appeal of a default judgement', () => {
+    expect(
+      canDefendantAppealVerdict({
+        isDefaultJudgement: true,
+        serviceRequirement: ServiceRequirement.NOT_APPLICABLE,
+      }),
+    ).toBe(false)
+  })
+
+  it('should allow an appeal when the defendant was present in court', () => {
+    expect(
+      canDefendantAppealVerdict({
+        serviceRequirement: ServiceRequirement.NOT_APPLICABLE,
+      }),
+    ).toBe(true)
+  })
+
+  it('should allow an appeal when a required service has taken place', () => {
+    expect(
+      canDefendantAppealVerdict({
+        serviceRequirement: ServiceRequirement.REQUIRED,
+        serviceDate: '2026-06-01T00:00:00.000Z',
+      }),
+    ).toBe(true)
+  })
+
+  it('should not allow an appeal while a required service is pending', () => {
+    expect(
+      canDefendantAppealVerdict({
+        serviceRequirement: ServiceRequirement.REQUIRED,
+      }),
+    ).toBe(false)
+  })
+
+  it('should not allow an appeal when service is not required', () => {
+    expect(
+      canDefendantAppealVerdict({
+        serviceRequirement: ServiceRequirement.NOT_REQUIRED,
+        serviceDate: '2026-06-01T00:00:00.000Z',
+      }),
+    ).toBe(false)
+  })
+})

--- a/libs/judicial-system/types/src/lib/verdict.ts
+++ b/libs/judicial-system/types/src/lib/verdict.ts
@@ -20,6 +20,30 @@ export enum VerdictAppealDecision {
   POSTPONE = 'POSTPONE', // Taka áfrýjunarfrest
 }
 
+// A defendant can appeal a verdict once they have been made aware of it -
+// either it was served on them, or they were present when it was delivered.
+// Default judgements are reopened rather than appealed.
+export const canDefendantAppealVerdict = (
+  verdict?: {
+    isDefaultJudgement?: boolean | null
+    serviceRequirement?: ServiceRequirement | null
+    serviceDate?: unknown
+  } | null,
+): boolean => {
+  if (!verdict || verdict.isDefaultJudgement) {
+    return false
+  }
+
+  if (verdict.serviceRequirement === ServiceRequirement.NOT_APPLICABLE) {
+    return true
+  }
+
+  return (
+    verdict.serviceRequirement === ServiceRequirement.REQUIRED &&
+    Boolean(verdict.serviceDate)
+  )
+}
+
 export enum InformationForDefendant {
   INSTRUCTIONS_ON_REOPENING_OUT_OF_COURT_CASES = 'INSTRUCTIONS_ON_REOPENING_OUT_OF_COURT_CASES',
   INFORMATION_ON_APPEAL_TO_COURT_OF_APPEALS = 'INFORMATION_ON_APPEAL_TO_COURT_OF_APPEALS',


### PR DESCRIPTION
# Upplýsingar um birtingu dóms hjá verjanda

[Áfrýjun - Fasi 1: upplýsingakort um birtingu dóms hjá verjanda](https://app.asana.com/1/203394141643832/project/1199153462262248/task/1218009121593688)

Fyrsti fasi af tveimur á [Áfrýjun - verjandi á máli áfrýjar dómi í RVG](https://app.asana.com/1/203394141643832/project/1199153462262248/task/1217777694501261). Þessi fasi er eingöngu **upplýsingar** — engar aðgerðir, ekkert feature hiding. Áfrýjunaraðgerðin sjálf (context menu, áfrýjunaryfirlýsing, `AppealCase`) kemur í fasa 2 og verður feature hidden.

Verjandi sem skoðar mál sem lokið er með dómi sér nú sömu upplýsingar um birtingu dóms og skrifstofa ríkissaksóknara hefur, eitt kort fyrir hvern dómfelldan á málinu.

## Það sem breytist

`VerdictTimelineCard` var `ContextMenuCard` sem blandaði saman lestrarupplýsingum og aðgerðum sem eingöngu ríkissaksóknari hefur (dagsetningarval, LÖKE, fullnusta, afstöðuval). Framsetningarhlutinn er dreginn út í nýjan `VerdictTimelineBody`: eyebrow, hreyfður punktalisti þar sem hver lína getur haft `tone`, og `children` fyrir það sem hjúpurinn setur fyrir neðan listann. Kort ríkissaksóknara heldur dagsetningarvalinu og afstöðuvalinu í þeim slot; nýja `DefenderVerdictTimelineCard` setur ekkert þar.

Kortin eru spegilmyndir samkvæmt hönnun: hjá verjanda er "Birting dóms" fyrirsögnin og nafn dómfellda eyebrow, öfugt við kort ríkissaksóknara.

Verjandi sér **ekki** línur sem tilheyra ákæruvaldinu — fullnustu, skráningu í LÖKE, mál lokið án fullnustu — og ekki áfrýjunarfrestinn, sem `InfoCardClosedIndictment` birtir þegar fyrir verjendum. Afstaða dómfellda til dóms er punktur í listanum í stað valmöguleika, og áfrýjun tekur sæti hennar í listanum, í rauðu.

Kortið birtist fyrir **hvern dómfelldan á málinu**, ekki bara þá sem notandinn er verjandi fyrir — sama og `InfoCardClosedIndictment` gerir í dag fyrir mál sem er lokið. Það er lesaðgangur eingöngu; í fasa 2 verður áfrýjunaraðgerðin bundin við eigin umbjóðendur. Engin bakendabreyting þurfti: `defendants` include í `limitedAccessCase.service.ts` er ekki filteraður á `defenderNationalId`.

`canDefendantAppealVerdict` fer úr `PublicProsecutor/Indictments/Overview/Overview.tsx` í `libs/judicial-system/types` (með prófum) þar sem fasi 2 kemst í hana.

Kortið birtist aðeins þegar máli er lokið með dómi (`RULING`) — viðurlagaákvörðun fær ekkert kort, þar er kærufresturinn ríkissaksóknara.

## Prófanir

- `DefenderVerdictTimelineCard.spec.tsx`: engin verdict, birt + afstaða, birting í bið, viðstaddur dómsuppkvaðningu, áfrýjun leysir afstöðu af í rauðu, línur ríkissaksóknara fjarverandi.
- `Defender/IndictmentCase/IndictmentOverview.spec.tsx`: kort fyrir alla dómfellda þar með þann sem verjandinn er ekki verjandi fyrir, ekkert kort fyrir viðurlagaákvörðun, ekkert kort á opnu máli.
- `libs/judicial-system/types/src/lib/verdict.spec.ts` fyrir `canDefendantAppealVerdict`.
- Öll `judicial-system-web` prófin: 96 suites / 839 próf í lagi. Lint og `nx format:check` í lagi.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a defence-focused verdict timeline to closed indictment cases with ruling outcomes.
  * Timeline displays service requirements, service dates, appeal information, and relevant status updates.
  * Added animated timeline entries with visual emphasis for critical information.
  * Standardized appeal eligibility checks across verdict views.

* **Tests**
  * Added coverage for verdict timelines, appeal scenarios, service states, and cases where timelines should not appear.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->