### PR TITLE
fix(driving-license): don't require the driving assessment to be recent

### DIFF
--- a/libs/api/domains/driving-license/src/lib/__mock-data__/drivingAssessment.ts
+++ b/libs/api/domains/driving-license/src/lib/__mock-data__/drivingAssessment.ts
@@ -2,7 +2,10 @@ import formatISO from 'date-fns/formatISO'
 import subMonths from 'date-fns/subMonths'
 
 const getDateOfAssessment = () => {
-  const nowDate = subMonths(Date.now(), 3)
+  // Deliberately older than 6 months: an assessment does not expire, so
+  // eligibility must accept it at any age — this date pins that rule (the
+  // original template wrongly rejected assessments older than 182 days).
+  const nowDate = subMonths(Date.now(), 8)
   return formatISO(nowDate)
 }
 

--- a/libs/api/domains/driving-license/src/lib/drivingLicense.service.ts
+++ b/libs/api/domains/driving-license/src/lib/drivingLicense.service.ts
@@ -28,10 +28,7 @@ import {
   ModelsV5PostTemporaryLicenseWithHealthDeclaration as HealthDeclaration,
   DriverLicenseWithoutImages,
 } from '@island.is/clients/driving-license'
-import {
-  BLACKLISTED_JURISDICTION,
-  DRIVING_ASSESSMENT_MAX_AGE,
-} from './util/constants'
+import { BLACKLISTED_JURISDICTION } from './util/constants'
 import sortTeachers from './util/sortTeachers'
 import { StudentAssessment } from '..'
 import { FetchError } from '@island.is/clients/middlewares'
@@ -296,9 +293,12 @@ export class DrivingLicenseService {
         ? [
             {
               key: RequirementKey.drivingAssessmentMissing,
-              requirementMet:
-                (assessmentResult?.created?.getTime() ?? 0) >
-                Date.now() - DRIVING_ASSESSMENT_MAX_AGE,
+              // Only completion matters — a driving assessment does not expire
+              // (Samgongustofa, 2026-08-31), and RLS applies no age rule on its
+              // side either. The 182-day window this replaced dated from the
+              // original 2021 template and wrongly blocked applicants whose
+              // assessment was older than ~6 months.
+              requirementMet: assessmentResult != null,
             },
             {
               key: RequirementKey.drivingSchoolMissing,

--- a/libs/api/domains/driving-license/src/lib/drivingLicense.spec.ts
+++ b/libs/api/domains/driving-license/src/lib/drivingLicense.spec.ts
@@ -315,6 +315,23 @@ describe('DrivingLicenseService', () => {
       })
     })
 
+    it('accepts a driving assessment regardless of its age — only completion matters', async () => {
+      // The mock assessment is 8 months old, past the 182-day window the
+      // original template enforced. Samgongustofa confirmed (2026-08-31) an
+      // assessment does not expire, so age must not block eligibility.
+      const response = await service.getApplicationEligibility(
+        MOCK_USER,
+        MOCK_NATIONAL_ID,
+        'B-full',
+      )
+
+      expect(response.isEligible).toBe(true)
+      expect(response.requirements).toContainEqual({
+        key: 'DrivingAssessmentMissing',
+        requirementMet: true,
+      })
+    })
+
     it('all checks should pass for applicable students for temporary license', async () => {
       const response = await service.getApplicationEligibility(
         MOCK_USER,

--- a/libs/api/domains/driving-license/src/lib/util/constants.ts
+++ b/libs/api/domains/driving-license/src/lib/util/constants.ts
@@ -1,6 +1,3 @@
 export const DAYS = 24 * 3600 * 1000
 
-// TODO: max age is 6 months - eventually this should count for days of the month
-export const DRIVING_ASSESSMENT_MAX_AGE = 182 * DAYS
-
 export const BLACKLISTED_JURISDICTION = 11


### PR DESCRIPTION
## What

B-full eligibility no longer checks the *age* of the driving assessment (akstursmat) — only that one exists. Removes the `DRIVING_ASSESSMENT_MAX_AGE` (182-day) window from `getApplicationEligibility` and the now-unused constant.

## Why

Reported by Samgongustofa (Tinna, 2026-08-31): applicants whose assessment is older than ~6 months are blocked at the eligibility step on island.is, but an assessment does not expire — only its completion matters. RLS confirmed no age rule is applied on their side, so the block existed only here. The window dates from the original 2021 B-full template (#3933) and its constant carried a TODO suggesting it was never a settled rule.

Note: this gate serves the live B-full flow (not behind a redesign flag), so merging changes prod eligibility — which is the requested outcome: applicants with an older completed assessment stop being wrongly rejected.

## Testing

- Mock assessment aged to 8 months — deliberately past the removed window — so the existing B-full eligibility specs themselves pin the new rule, plus an explicitly named spec (`accepts a driving assessment regardless of its age`). Negative-controlled: 3 specs fail against the previous check, 34/34 pass with this change.
- Missing-assessment case unchanged: no assessment on record still fails the requirement.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (n/a)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review

## AI-tools disclosure

This PR was authored with assistance from Claude Code; all changes reviewed and verified by the author.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated driving licence application eligibility so assessments remain valid regardless of age.
  * Older assessments, including those over six months old, no longer incorrectly prevent eligible applications.

* **Tests**
  * Added coverage confirming that an eight-month-old assessment remains valid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->