### PR TITLE
feat(j-s): Victim repository service

### DIFF
--- a/apps/judicial-system/backend/src/app/modules/repository/index.ts
+++ b/apps/judicial-system/backend/src/app/modules/repository/index.ts
@@ -69,6 +69,12 @@ export {
   UpdateUser,
 } from './services/userRepository.service'
 export { VerdictRepositoryService } from './services/verdictRepository.service'
+export {
+  VictimRepositoryService,
+  CreateVictim,
+  UpdateVictim,
+  UpdatedVictims,
+} from './services/victimRepository.service'
 
 export {
   caseInclude,

--- a/apps/judicial-system/backend/src/app/modules/repository/repository.module.ts
+++ b/apps/judicial-system/backend/src/app/modules/repository/repository.module.ts
@@ -55,6 +55,7 @@ import { RobotLogRepositoryService } from './services/robotLogRepository.service
 import { SubpoenaRepositoryService } from './services/subpoenaRepository.service'
 import { UserRepositoryService } from './services/userRepository.service'
 import { VerdictRepositoryService } from './services/verdictRepository.service'
+import { VictimRepositoryService } from './services/victimRepository.service'
 import { repositoryModuleConfig } from './repository.config'
 
 @Module({
@@ -116,6 +117,7 @@ import { repositoryModuleConfig } from './repository.config'
     SubpoenaRepositoryService,
     UserRepositoryService,
     VerdictRepositoryService,
+    VictimRepositoryService,
   ],
   exports: [
     AppealCaseRepositoryService,
@@ -139,6 +141,7 @@ import { repositoryModuleConfig } from './repository.config'
     SubpoenaRepositoryService,
     UserRepositoryService,
     VerdictRepositoryService,
+    VictimRepositoryService,
   ],
 })
 export class RepositoryModule {}

--- a/apps/judicial-system/backend/src/app/modules/repository/services/victimRepository.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/repository/services/victimRepository.service.ts
@@ -1,0 +1,113 @@
+import { Inject, Injectable } from '@nestjs/common'
+import { InjectModel } from '@nestjs/sequelize'
+
+import { type Logger, LOGGER_PROVIDER } from '@island.is/logging'
+
+import { RequestSharedWhen } from '@island.is/judicial-system/types'
+
+import { Victim } from '../models/victim.model'
+
+export type CreateVictim = {
+  name?: string
+  nationalId?: string
+}
+
+export type UpdateVictim = {
+  name?: string
+  hasNationalId?: boolean
+  nationalId?: string
+  hasLawyer?: boolean
+  lawyerNationalId?: string
+  lawyerName?: string
+  lawyerEmail?: string
+  lawyerPhoneNumber?: string
+  lawyerAccessToRequest?: RequestSharedWhen
+}
+
+// Sequelize returns [affectedRows, rows] from update; naming the two halves keeps
+// the tuple from leaking to callers.
+export type UpdatedVictims = {
+  numberOfAffectedRows: number
+  victims: Victim[]
+}
+
+@Injectable()
+export class VictimRepositoryService {
+  constructor(
+    @InjectModel(Victim) private readonly victimModel: typeof Victim,
+    @Inject(LOGGER_PROVIDER) private readonly logger: Logger,
+  ) {}
+
+  async findById(victimId: string): Promise<Victim | null> {
+    try {
+      this.logger.debug(`Finding victim ${victimId}`)
+
+      return await this.victimModel.findByPk(victimId)
+    } catch (error) {
+      this.logger.error(`Error finding victim ${victimId}:`, { error })
+
+      throw error
+    }
+  }
+
+  async create(caseId: string, victim: CreateVictim): Promise<Victim> {
+    try {
+      this.logger.debug(`Creating a victim for case ${caseId}`)
+
+      return await this.victimModel.create({ ...victim, caseId })
+    } catch (error) {
+      this.logger.error(`Error creating a victim for case ${caseId}:`, {
+        error,
+      })
+
+      throw error
+    }
+  }
+
+  // A victim is only addressable within its own case, so both keys are named
+  // parameters rather than a caller-supplied where clause.
+  async updateByIdAndCase(
+    victimId: string,
+    caseId: string,
+    update: UpdateVictim,
+  ): Promise<UpdatedVictims> {
+    try {
+      this.logger.debug(`Updating victim ${victimId} of case ${caseId}`)
+
+      const [numberOfAffectedRows, victims] = await this.victimModel.update(
+        update,
+        { where: { id: victimId, caseId }, returning: true },
+      )
+
+      return { numberOfAffectedRows, victims }
+    } catch (error) {
+      this.logger.error(
+        `Error updating victim ${victimId} of case ${caseId}:`,
+        {
+          error,
+        },
+      )
+
+      throw error
+    }
+  }
+
+  async deleteByIdAndCase(victimId: string, caseId: string): Promise<number> {
+    try {
+      this.logger.debug(`Deleting victim ${victimId} of case ${caseId}`)
+
+      return await this.victimModel.destroy({
+        where: { id: victimId, caseId },
+      })
+    } catch (error) {
+      this.logger.error(
+        `Error deleting victim ${victimId} of case ${caseId}:`,
+        {
+          error,
+        },
+      )
+
+      throw error
+    }
+  }
+}

--- a/apps/judicial-system/backend/src/app/modules/repository/test/victimRepository.service.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/repository/test/victimRepository.service.spec.ts
@@ -1,0 +1,143 @@
+import { getModelToken } from '@nestjs/sequelize'
+import { Test } from '@nestjs/testing'
+
+import { LOGGER_PROVIDER } from '@island.is/logging'
+
+import { RequestSharedWhen } from '@island.is/judicial-system/types'
+
+import { Victim } from '../models/victim.model'
+import { VictimRepositoryService } from '../services/victimRepository.service'
+
+describe('VictimRepositoryService', () => {
+  const victimId = 'some-victim-id'
+  const caseId = 'some-case-id'
+
+  let service: VictimRepositoryService
+  let model: {
+    findByPk: jest.Mock
+    create: jest.Mock
+    update: jest.Mock
+    destroy: jest.Mock
+  }
+
+  beforeEach(async () => {
+    model = {
+      findByPk: jest.fn().mockResolvedValue(null),
+      create: jest.fn(),
+      update: jest.fn().mockResolvedValue([0, []]),
+      destroy: jest.fn().mockResolvedValue(0),
+    }
+
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        {
+          provide: LOGGER_PROVIDER,
+          useValue: { debug: jest.fn(), error: jest.fn() },
+        },
+        { provide: getModelToken(Victim), useValue: model },
+        VictimRepositoryService,
+      ],
+    }).compile()
+
+    service = moduleRef.get(VictimRepositoryService)
+  })
+
+  describe('findById', () => {
+    it('looks the victim up by primary key', async () => {
+      const victim = { id: victimId }
+      model.findByPk.mockResolvedValueOnce(victim)
+
+      const result = await service.findById(victimId)
+
+      expect(model.findByPk).toHaveBeenCalledWith(victimId)
+      expect(result).toBe(victim)
+    })
+
+    it('returns null when there is no such victim', async () => {
+      expect(await service.findById(victimId)).toBeNull()
+    })
+
+    it('rethrows when the lookup fails', async () => {
+      const error = new Error('Some error')
+      model.findByPk.mockRejectedValueOnce(error)
+
+      await expect(service.findById(victimId)).rejects.toThrow(error)
+    })
+  })
+
+  describe('create', () => {
+    it('creates the victim against the case', async () => {
+      const created = { id: victimId, caseId }
+      model.create.mockResolvedValueOnce(created)
+
+      const result = await service.create(caseId, { name: 'Jane Doe' })
+
+      expect(model.create).toHaveBeenCalledWith({ name: 'Jane Doe', caseId })
+      expect(result).toBe(created)
+    })
+
+    it('rethrows when the creation fails', async () => {
+      const error = new Error('Some error')
+      model.create.mockRejectedValueOnce(error)
+
+      await expect(service.create(caseId, {})).rejects.toThrow(error)
+    })
+  })
+
+  describe('updateByIdAndCase', () => {
+    it('scopes the update to the victim within its case', async () => {
+      const updated = { id: victimId, name: 'Jane Doe' }
+      model.update.mockResolvedValueOnce([1, [updated]])
+      const update = { hasLawyer: true, lawyerName: 'John Doe' }
+
+      const result = await service.updateByIdAndCase(victimId, caseId, update)
+
+      expect(model.update).toHaveBeenCalledWith(update, {
+        where: { id: victimId, caseId },
+        returning: true,
+      })
+      expect(result).toEqual({ numberOfAffectedRows: 1, victims: [updated] })
+    })
+
+    it('names both halves of the tuple, including when nothing matched', async () => {
+      model.update.mockResolvedValueOnce([0, []])
+
+      const result = await service.updateByIdAndCase(victimId, caseId, {
+        lawyerAccessToRequest: RequestSharedWhen.OBLIGATED,
+      })
+
+      expect(result).toEqual({ numberOfAffectedRows: 0, victims: [] })
+    })
+
+    it('rethrows when the update fails', async () => {
+      const error = new Error('Some error')
+      model.update.mockRejectedValueOnce(error)
+
+      await expect(
+        service.updateByIdAndCase(victimId, caseId, { name: 'Jane Doe' }),
+      ).rejects.toThrow(error)
+    })
+  })
+
+  describe('deleteByIdAndCase', () => {
+    it('scopes the delete to the victim within its case and returns the row count', async () => {
+      model.destroy.mockResolvedValueOnce(1)
+
+      const result = await service.deleteByIdAndCase(victimId, caseId)
+
+      expect(model.destroy).toHaveBeenCalledWith({
+        where: { id: victimId, caseId },
+      })
+      expect(result).toBe(1)
+    })
+
+    it('rethrows when the delete fails', async () => {
+      const error = new Error('Some error')
+      model.destroy.mockRejectedValueOnce(error)
+
+      await expect(service.deleteByIdAndCase(victimId, caseId)).rejects.toThrow(
+        error,
+      )
+    })
+  })
+})

--- a/apps/judicial-system/backend/src/app/modules/victim/test/create.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/victim/test/create.spec.ts
@@ -2,7 +2,7 @@ import { v4 as uuid } from 'uuid'
 
 import { createTestingVictimModule } from './createTestingVictimModule'
 
-import { Case, Victim } from '../../repository'
+import { Case, Victim, VictimRepositoryService } from '../../repository'
 
 interface Then {
   result: Victim
@@ -20,15 +20,16 @@ describe('VictimController - Create', () => {
   const victimId = uuid()
   const createdVictim = { id: victimId, caseId }
 
-  let mockVictimModel: typeof Victim
+  let mockVictimRepositoryService: VictimRepositoryService
   let givenWhenThen: GivenWhenThen
 
   beforeEach(async () => {
-    const { victimController, victimModel } = await createTestingVictimModule()
+    const { victimController, victimRepositoryService } =
+      await createTestingVictimModule()
 
-    mockVictimModel = victimModel
+    mockVictimRepositoryService = victimRepositoryService
 
-    const mockCreate = mockVictimModel.create as jest.Mock
+    const mockCreate = mockVictimRepositoryService.create as jest.Mock
     mockCreate.mockResolvedValue(createdVictim)
 
     givenWhenThen = async () => {
@@ -51,10 +52,10 @@ describe('VictimController - Create', () => {
     })
 
     it('should create a victim', () => {
-      expect(mockVictimModel.create).toHaveBeenCalledWith({
-        ...victimToCreate,
+      expect(mockVictimRepositoryService.create).toHaveBeenCalledWith(
         caseId,
-      })
+        victimToCreate,
+      )
     })
 
     it('should return victim', () => {
@@ -66,7 +67,7 @@ describe('VictimController - Create', () => {
     let then: Then
 
     beforeEach(async () => {
-      const mockCreate = mockVictimModel.create as jest.Mock
+      const mockCreate = mockVictimRepositoryService.create as jest.Mock
       mockCreate.mockRejectedValueOnce(new Error('Some error'))
 
       then = await givenWhenThen()

--- a/apps/judicial-system/backend/src/app/modules/victim/test/createTestingVictimModule.ts
+++ b/apps/judicial-system/backend/src/app/modules/victim/test/createTestingVictimModule.ts
@@ -1,6 +1,5 @@
 import { Sequelize } from 'sequelize-typescript'
 
-import { getModelToken } from '@nestjs/sequelize'
 import { Test } from '@nestjs/testing'
 
 import { LOGGER_PROVIDER } from '@island.is/logging'
@@ -12,7 +11,7 @@ import {
 } from '@island.is/judicial-system/auth'
 
 import { CaseService } from '../../case'
-import { Victim } from '../../repository'
+import { VictimRepositoryService } from '../../repository'
 import { VictimController } from '../victim.controller'
 import { VictimService } from '../victim.service'
 
@@ -38,14 +37,12 @@ export const createTestingVictimModule = async () => {
         },
       },
       {
-        provide: getModelToken(Victim),
+        provide: VictimRepositoryService,
         useValue: {
-          findOne: jest.fn(),
-          findAll: jest.fn(),
+          findById: jest.fn(),
           create: jest.fn(),
-          update: jest.fn(),
-          destroy: jest.fn(),
-          findByPk: jest.fn(),
+          updateByIdAndCase: jest.fn(),
+          deleteByIdAndCase: jest.fn(),
         },
       },
       VictimService,
@@ -53,8 +50,8 @@ export const createTestingVictimModule = async () => {
     ],
   }).compile()
 
-  const victimModel = await victimModule.resolve<typeof Victim>(
-    getModelToken(Victim),
+  const victimRepositoryService = victimModule.get<VictimRepositoryService>(
+    VictimRepositoryService,
   )
 
   const victimController = victimModule.get<VictimController>(VictimController)
@@ -63,6 +60,6 @@ export const createTestingVictimModule = async () => {
 
   return {
     victimController,
-    victimModel,
+    victimRepositoryService,
   }
 }

--- a/apps/judicial-system/backend/src/app/modules/victim/test/delete.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/victim/test/delete.spec.ts
@@ -2,7 +2,7 @@ import { v4 as uuid } from 'uuid'
 
 import { createTestingVictimModule } from './createTestingVictimModule'
 
-import { Case, Victim } from '../../repository'
+import { Case, Victim, VictimRepositoryService } from '../../repository'
 import { DeleteVictimResponse } from '../models/deleteVictim.response'
 
 interface Then {
@@ -16,16 +16,18 @@ describe('VictimController - Delete', () => {
   const caseId = uuid()
   const victimId = uuid()
 
-  let mockVictimModel: typeof Victim
+  let mockVictimRepositoryService: VictimRepositoryService
   let givenWhenThen: GivenWhenThen
 
   beforeEach(async () => {
-    const { victimController, victimModel } = await createTestingVictimModule()
+    const { victimController, victimRepositoryService } =
+      await createTestingVictimModule()
 
-    mockVictimModel = victimModel
+    mockVictimRepositoryService = victimRepositoryService
 
-    const mockDestroy = mockVictimModel.destroy as jest.Mock
-    mockDestroy.mockRejectedValue(new Error('Some error'))
+    const mockDelete =
+      mockVictimRepositoryService.deleteByIdAndCase as jest.Mock
+    mockDelete.mockRejectedValue(new Error('Some error'))
 
     givenWhenThen = async () => {
       const then = {} as Then
@@ -51,16 +53,17 @@ describe('VictimController - Delete', () => {
     let then: Then
 
     beforeEach(async () => {
-      const mockDestroy = mockVictimModel.destroy as jest.Mock
-      mockDestroy.mockResolvedValue(1)
+      const mockDelete =
+        mockVictimRepositoryService.deleteByIdAndCase as jest.Mock
+      mockDelete.mockResolvedValue(1)
 
       then = await givenWhenThen()
     })
 
     it('should delete the victim', () => {
-      expect(mockVictimModel.destroy).toHaveBeenCalledWith({
-        where: { id: victimId, caseId },
-      })
+      expect(
+        mockVictimRepositoryService.deleteByIdAndCase,
+      ).toHaveBeenCalledWith(victimId, caseId)
       expect(then.result).toEqual({ deleted: true })
     })
   })

--- a/apps/judicial-system/backend/src/app/modules/victim/test/update.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/victim/test/update.spec.ts
@@ -2,7 +2,7 @@ import { v4 as uuid } from 'uuid'
 
 import { createTestingVictimModule } from './createTestingVictimModule'
 
-import { Case, Victim } from '../../repository'
+import { Case, Victim, VictimRepositoryService } from '../../repository'
 import { UpdateVictimDto } from '../dto/updateVictim.dto'
 
 interface Then {
@@ -21,15 +21,17 @@ describe('VictimController - Update', () => {
     name: 'Jane Doe',
   } as Victim
 
-  let mockVictimModel: typeof Victim
+  let mockVictimRepositoryService: VictimRepositoryService
   let givenWhenThen: GivenWhenThen
 
   beforeEach(async () => {
-    const { victimController, victimModel } = await createTestingVictimModule()
+    const { victimController, victimRepositoryService } =
+      await createTestingVictimModule()
 
-    mockVictimModel = victimModel
+    mockVictimRepositoryService = victimRepositoryService
 
-    const mockUpdate = mockVictimModel.update as jest.Mock
+    const mockUpdate =
+      mockVictimRepositoryService.updateByIdAndCase as jest.Mock
     mockUpdate.mockRejectedValue(new Error('Some error'))
 
     givenWhenThen = async (victimUpdate) => {
@@ -50,16 +52,19 @@ describe('VictimController - Update', () => {
     let then: Then
 
     beforeEach(async () => {
-      const mockUpdate = mockVictimModel.update as jest.Mock
-      mockUpdate.mockResolvedValueOnce([1, [updatedVictim]])
+      const mockUpdate =
+        mockVictimRepositoryService.updateByIdAndCase as jest.Mock
+      mockUpdate.mockResolvedValueOnce({
+        numberOfAffectedRows: 1,
+        victims: [updatedVictim],
+      })
       then = await givenWhenThen(victimUpdate)
     })
 
     it('should update the victim ', () => {
-      expect(mockVictimModel.update).toHaveBeenCalledWith(victimUpdate, {
-        where: { id: victimId, caseId },
-        returning: true,
-      })
+      expect(
+        mockVictimRepositoryService.updateByIdAndCase,
+      ).toHaveBeenCalledWith(victimId, caseId, victimUpdate)
       expect(then.result).toBe(updatedVictim)
     })
   })

--- a/apps/judicial-system/backend/src/app/modules/victim/victim.module.ts
+++ b/apps/judicial-system/backend/src/app/modules/victim/victim.module.ts
@@ -1,13 +1,11 @@
 import { forwardRef, Module } from '@nestjs/common'
-import { SequelizeModule } from '@nestjs/sequelize'
 
-import { Victim } from '../repository'
-import { CaseModule } from '..'
+import { CaseModule, RepositoryModule } from '..'
 import { VictimController } from './victim.controller'
 import { VictimService } from './victim.service'
 
 @Module({
-  imports: [forwardRef(() => CaseModule), SequelizeModule.forFeature([Victim])],
+  imports: [forwardRef(() => CaseModule), forwardRef(() => RepositoryModule)],
   controllers: [VictimController],
   providers: [VictimService],
   exports: [VictimService],

--- a/apps/judicial-system/backend/src/app/modules/victim/victim.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/victim/victim.service.ts
@@ -4,26 +4,24 @@ import {
   InternalServerErrorException,
   NotFoundException,
 } from '@nestjs/common'
-import { InjectModel } from '@nestjs/sequelize'
 
 import type { Logger } from '@island.is/logging'
 import { LOGGER_PROVIDER } from '@island.is/logging'
 
-import { Victim } from '../repository'
+import { Victim, VictimRepositoryService } from '../repository'
 import { CreateVictimDto } from './dto/createVictim.dto'
 import { UpdateVictimDto } from './dto/updateVictim.dto'
 
 @Injectable()
 export class VictimService {
   constructor(
-    @InjectModel(Victim)
-    private readonly victimModel: typeof Victim,
+    private readonly victimRepositoryService: VictimRepositoryService,
     @Inject(LOGGER_PROVIDER)
     private readonly logger: Logger,
   ) {}
 
   async findById(victimId: string): Promise<Victim> {
-    const victim = await this.victimModel.findByPk(victimId)
+    const victim = await this.victimRepositoryService.findById(victimId)
 
     if (!victim) {
       throw new NotFoundException(`Victim ${victimId} not found`)
@@ -33,10 +31,7 @@ export class VictimService {
   }
 
   async create(caseId: string, dto: CreateVictimDto): Promise<Victim> {
-    return this.victimModel.create({
-      ...dto,
-      caseId,
-    })
+    return this.victimRepositoryService.create(caseId, dto)
   }
 
   async update(
@@ -44,11 +39,12 @@ export class VictimService {
     victimId: string,
     update: UpdateVictimDto,
   ): Promise<Victim> {
-    const [numberOfAffectedRows, updatedVictims] =
-      await this.victimModel.update(update, {
-        where: { id: victimId, caseId },
-        returning: true,
-      })
+    const { numberOfAffectedRows, victims: updatedVictims } =
+      await this.victimRepositoryService.updateByIdAndCase(
+        victimId,
+        caseId,
+        update,
+      )
 
     if (numberOfAffectedRows > 1) {
       this.logger.error(
@@ -64,9 +60,8 @@ export class VictimService {
   }
 
   async delete(caseId: string, victimId: string): Promise<boolean> {
-    const numberOfAffectedRows = await this.victimModel.destroy({
-      where: { id: victimId, caseId },
-    })
+    const numberOfAffectedRows =
+      await this.victimRepositoryService.deleteByIdAndCase(victimId, caseId)
 
     if (numberOfAffectedRows > 1) {
       this.logger.error(


### PR DESCRIPTION
# Victim repository service

[Repository þjónusta fyrir Victim](https://app.asana.com/1/203394141643832/project/1199153462262248/task/1218022287005969)

Second of the models still reaching Sequelize directly from a business service. Same
shape as #23543 (`EventLog`), and independent of it — the two share only the two
alphabetised lists in `repository.module.ts` / `index.ts`, and sort far apart in both.

### The repository service

Four intent-named methods, each wrapping its data access in the module's usual
`debug` / call / `catch` → `logger.error` → rethrow shape:

- **`findById`** — returns `Victim | null`. The `NotFoundException` stays in
  `VictimService`; deciding that a missing victim is a 404 is the caller's judgement.
- **`create(caseId, victim)`** — the case id is its own argument rather than something
  the caller folds into the payload.
- **`updateByIdAndCase` / `deleteByIdAndCase`** — both keys are named parameters instead
  of a caller-supplied `where`. A victim is only addressable within its own case; that is
  a domain rule, not a query detail. The `> 1` row-count logging and the `< 1`
  `InternalServerErrorException` stay in `VictimService` — the repository reports what
  happened, the service decides what it means.

`updateByIdAndCase` returns a named `{ numberOfAffectedRows, victims }` rather than
passing Sequelize's `[count, rows]` tuple through to callers.

### Tests

The victim testing module now mocks `VictimRepositoryService` in place of the model
token, so `create.spec.ts`, `update.spec.ts` and `delete.spec.ts` assert on repository
calls rather than on Sequelize options. The `where: { id, caseId }` clauses they used to
check are now the repository's own concern, covered by its spec — which also tests the
tuple-to-object mapping and that all four methods rethrow.
`victimControllerGuards.spec.ts` and `victimControllerRolesRules.spec.ts` are untouched.

### What is deliberately left

`caseRepository.service.ts:128` keeps its own `@InjectModel(Victim)`. That use sits
inside multi-entity orchestration which a later chunk lifts out, and the module's
convention forbids a repository service from injecting another repository service. So
this PR closes "no `Victim` outside the repository module" — it does not close "one
injection site per model", which stays open inside the module and is tracked as its own
piece of work. Intended, not an oversight.

### Verification

Each check was dry-run on `main` first, so the numbers below are movements from a
recorded baseline rather than greps that were vacuous all along:

| check | on `main` | here |
|---|---|---|
| `InjectModel(Victim)\|victimModel` outside the repository module | 14 | 0 |
| `forFeature([… Victim …])` outside `RepositoryModule` | 1 | 0 |
| `InjectModel(Victim)` inside the repository module | 1 | 2 (expected — see above) |
| `VictimRepositoryService` in `repository.module.ts` | 0 | 3 (import, provider, export) |

`tsc --noEmit` clean; `nx lint` clean (one pre-existing unrelated warning in
`updateCase.dto.ts`); `codegen/backend-schema` produces a byte-identical `openapi.yaml`
against a `main` baseline. Tests: 22 suites / 143 tests in `modules/(victim|repository)/`,
all green.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Centralized victim record operations for more consistent creation, lookup, updates, and deletion.
  - Victim management now applies case-scoped data handling consistently across supported actions.
  - Existing validation and error handling remain in place.

- **Tests**
  - Added coverage for victim record persistence operations, including successful, empty-result, and error scenarios.
  - Updated victim management tests to reflect the new data access flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->