### PR TITLE
fix(core): update and patch agentkeepalive timeout

### DIFF
--- a/.yarn/patches/agentkeepalive-npm-4.6.0-6b61ca2a37.patch
+++ b/.yarn/patches/agentkeepalive-npm-4.6.0-6b61ca2a37.patch
@@ -1,0 +1,19 @@
+diff --git a/lib/agent.js b/lib/agent.js
+index 8bd354effa05ec3d80244e9c60763dd56ed8fbd7..7438d3074342333d81ffcd86eb0f3825ea362f61 100644
+--- a/lib/agent.js
++++ b/lib/agent.js
+@@ -90,7 +90,13 @@ class Agent extends OriginalAgent {
+     this.timeoutSocketCount = 0;
+     this.timeoutSocketCountLastCheck = 0;
+ 
+-    this.on('free', socket => {
++    this.on('free', (socket, options) => {
++      // Node's listener may assign the socket to a queued request before this
++      // listener runs. Only apply the free socket timeout if it was pooled.
++      const name = this.getName(options);
++      if (!this.freeSockets[name] || this.freeSockets[name].indexOf(socket) === -1) {
++        return;
++      }
+       // https://github.com/nodejs/node/pull/32000
+       // Node.js native agent will check socket timeout eqs agent.options.timeout.
+       // Use the ttl or freeSocketTimeout to overwrite.

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "@vanilla-extract/recipes": "0.4.0",
     "@vanilla-extract/webpack-plugin": "2.1.10",
     "@xstate/react": "0.8.1",
-    "agentkeepalive": "4.2.1",
+    "agentkeepalive": "patch:agentkeepalive@npm%3A4.6.0#~/.yarn/patches/agentkeepalive-npm-4.6.0-6b61ca2a37.patch",
     "amazon-s3-uri": "0.0.3",
     "archiver": "6.0.1",
     "aws-elasticsearch-connector": "9.0.0",
@@ -539,7 +539,8 @@
     "@types/react": "19.2.17",
     "node-request-interceptor@^0.5.1": "patch:node-request-interceptor@npm%3A0.5.9#./.yarn/patches/node-request-interceptor-npm-0.5.9-77e9d9c058.patch",
     "@types/node": "22.20.1",
-    "downshift/react-is": "19.2.7"
+    "downshift/react-is": "19.2.7",
+    "agentkeepalive@npm:^4.1.3": "patch:agentkeepalive@npm%3A4.6.0#~/.yarn/patches/agentkeepalive-npm-4.6.0-6b61ca2a37.patch"
   },
   "volta": {
     "node": "22.22.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -21728,23 +21728,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"agentkeepalive@npm:4.2.1":
-  version: 4.2.1
-  resolution: "agentkeepalive@npm:4.2.1"
-  dependencies:
-    debug: "npm:^4.1.0"
-    depd: "npm:^1.1.2"
-    humanize-ms: "npm:^1.2.1"
-  checksum: 10/63961cba1afa26d708da94159f3b9428d46fdc137b783fbc399b848e750c5e28c97d96839efa8cb3c2d11ecd12dd411298c00d164600212f660e8c55369c9e55
-  languageName: node
-  linkType: hard
-
-"agentkeepalive@npm:^4.1.3":
+"agentkeepalive@npm:4.6.0":
   version: 4.6.0
   resolution: "agentkeepalive@npm:4.6.0"
   dependencies:
     humanize-ms: "npm:^1.2.1"
   checksum: 10/80c546bd88dd183376d6a29e5598f117f380b1d567feb1de184241d6ece721e2bdd38f179a1674276de01780ccae229a38c60a77317e2f5ad2f1818856445bd7
+  languageName: node
+  linkType: hard
+
+"agentkeepalive@patch:agentkeepalive@npm%3A4.6.0#~/.yarn/patches/agentkeepalive-npm-4.6.0-6b61ca2a37.patch":
+  version: 4.6.0
+  resolution: "agentkeepalive@patch:agentkeepalive@npm%3A4.6.0#~/.yarn/patches/agentkeepalive-npm-4.6.0-6b61ca2a37.patch::version=4.6.0&hash=9ca671"
+  dependencies:
+    humanize-ms: "npm:^1.2.1"
+  checksum: 10/4a75b42ea0d4a4a42c7dfaa9ad7fde0cf7a4ed7006f3db8b65322040a629944b46d259b560ba3fc921b7df1810f01b0ceb9870969fb6aa9c7af93a940b032c2b
   languageName: node
   linkType: hard
 
@@ -27883,7 +27881,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"depd@npm:^1.1.2, depd@npm:~1.1.2":
+"depd@npm:~1.1.2":
   version: 1.1.2
   resolution: "depd@npm:1.1.2"
   checksum: 10/2ed6966fc14463a9e85451db330ab8ba041efed0b9a1a472dbfc6fbf2f82bab66491915f996b25d8517dddc36c8c74e24c30879b34877f3c4410733444a51d1d
@@ -35837,7 +35835,7 @@ __metadata:
     "@vanilla-extract/webpack-plugin": "npm:2.1.10"
     "@vitejs/plugin-react": "npm:6.0.4"
     "@xstate/react": "npm:0.8.1"
-    agentkeepalive: "npm:4.2.1"
+    agentkeepalive: "patch:agentkeepalive@npm%3A4.6.0#~/.yarn/patches/agentkeepalive-npm-4.6.0-6b61ca2a37.patch"
     amazon-s3-uri: "npm:0.0.3"
     archiver: "npm:6.0.1"
     assert: "npm:2.1.0"


### PR DESCRIPTION
https://github.com/node-modules/agentkeepalive/issues/106

Upstream fix: https://github.com/node-modules/agentkeepalive/pull/123

## What

Updates the direct agentkeepalive dependency from 4.2.1 to the latest release, 4.6.0, then applies a Yarn patch against 4.6.0.

The patch checks whether a socket is actually present in the free socket pool before applying freeSocketTimeout. Both dependency paths now resolve to the same patched 4.6.0 release.

## Why

When requests queue past maxSockets, Node.js can emit the free event and immediately assign that socket to a queued request. agentkeepalive then incorrectly applies freeSocketTimeout to the now-active socket, causing ERR_SOCKET_TIMEOUT before the configured active timeout.

## Screenshots / Gifs

Not applicable.

## Verification

- Confirmed 4.6.0 is the npm latest release
- yarn install --immutable --mode=skip-build
- Ran a local reproduction with maxSockets 1, freeSocketTimeout 50 ms, timeout 1000 ms, and a queued request active for 200 ms
- Confirmed the queued request completes under the active timeout on patched agentkeepalive 4.6.0
- Confirmed yarn why agentkeepalive resolves both dependency paths to patched 4.6.0

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Codex