### PR TITLE
feat(j-s): Court session string repository service

### DIFF
--- a/apps/judicial-system/backend/src/app/modules/court-session/courtSession.module.ts
+++ b/apps/judicial-system/backend/src/app/modules/court-session/courtSession.module.ts
@@ -1,7 +1,5 @@
 import { forwardRef, Module } from '@nestjs/common'
-import { SequelizeModule } from '@nestjs/sequelize'
 
-import { CourtSessionString } from '../repository'
 import { CaseModule, EventLogModule, FileModule, RepositoryModule } from '..'
 import { CourtDocumentController } from './courtDocument.controller'
 import { CourtDocumentService } from './courtDocument.service'
@@ -14,7 +12,6 @@ import { CourtSessionService } from './courtSession.service'
     forwardRef(() => RepositoryModule),
     forwardRef(() => FileModule),
     forwardRef(() => EventLogModule),
-    SequelizeModule.forFeature([CourtSessionString]),
   ],
   controllers: [CourtSessionController, CourtDocumentController],
   providers: [CourtSessionService, CourtDocumentService],

--- a/apps/judicial-system/backend/src/app/modules/court-session/courtSession.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/court-session/courtSession.service.ts
@@ -7,7 +7,6 @@ import {
   InternalServerErrorException,
   NotFoundException,
 } from '@nestjs/common'
-import { InjectModel } from '@nestjs/sequelize'
 
 import type { Logger } from '@island.is/logging'
 import { LOGGER_PROVIDER } from '@island.is/logging'
@@ -56,6 +55,8 @@ import {
   CourtSession,
   CourtSessionRepositoryService,
   CourtSessionString,
+  CourtSessionStringKey,
+  CourtSessionStringRepositoryService,
   UpdateCourtSession,
 } from '../repository'
 import { CourtSessionAppealDecisionDto } from './dto/courtSessionAppealDecision.dto'
@@ -88,10 +89,7 @@ export class CourtSessionService {
     private readonly appealEventLogRepositoryService: AppealEventLogRepositoryService,
     private readonly fileService: FileService,
     private readonly eventLogService: EventLogService,
-    // TODO: Move to a repository service - models should only be used in repository services
-    // It would be best to hide the details of the court session model from all but the backend
-    @InjectModel(CourtSessionString)
-    private readonly courtSessionStringModel: typeof CourtSessionString,
+    private readonly courtSessionStringRepositoryService: CourtSessionStringRepositoryService,
     @Inject(LOGGER_PROVIDER) private readonly logger: Logger,
   ) {}
 
@@ -141,30 +139,32 @@ export class CourtSessionService {
     update: CourtSessionStringDto
     transaction?: Transaction
   }): Promise<CourtSessionString> {
-    const courtSessionString = await this.courtSessionStringModel.findOne({
-      where: {
-        caseId,
-        courtSessionId,
-        mergedCaseId,
-        stringType: update.stringType,
-      },
-      transaction,
-    })
-    if (courtSessionString) {
-      const [numberOfAffectedRows, courtSessionString] =
-        await this.courtSessionStringModel.update(
+    // The same key addresses all three operations, so it is built once - the
+    // repository takes it as a typed key rather than a where clause.
+    const key: CourtSessionStringKey = {
+      caseId,
+      courtSessionId,
+      mergedCaseId,
+      stringType: update.stringType,
+    }
+
+    // Read followed by write without a lock: two concurrent requests for the
+    // same key can both miss and both insert. Carried over unchanged from the
+    // model-backed implementation - court_session_string has no unique index to
+    // upsert against, and adding one needs its own migration.
+    const existingCourtSessionString =
+      await this.courtSessionStringRepositoryService.findByKey(key, {
+        transaction,
+      })
+
+    if (existingCourtSessionString) {
+      const { numberOfAffectedRows, courtSessionStrings } =
+        await this.courtSessionStringRepositoryService.updateByKey(
+          key,
           { value: update.value },
-          {
-            where: {
-              caseId,
-              courtSessionId,
-              mergedCaseId,
-              stringType: update.stringType,
-            },
-            transaction,
-            returning: true,
-          },
+          { transaction },
         )
+
       if (numberOfAffectedRows < 1) {
         throw new InternalServerErrorException(
           `Could not update court session string for court session ${courtSessionId} of case ${caseId}`,
@@ -182,22 +182,14 @@ export class CourtSessionService {
       this.logger.debug(
         `Updated court session string for court session ${courtSessionId} of case ${caseId}`,
       )
-      return courtSessionString[0]
-    } else {
-      const courtSessionString = await this.courtSessionStringModel.create(
-        {
-          caseId,
-          courtSessionId,
-          mergedCaseId,
-          stringType: update.stringType,
-          value: update.value,
-        },
-        {
-          transaction,
-        },
-      )
-      return courtSessionString
+
+      return courtSessionStrings[0]
     }
+
+    return this.courtSessionStringRepositoryService.create(
+      { ...key, value: update.value },
+      { transaction },
+    )
   }
 
   async update(

--- a/apps/judicial-system/backend/src/app/modules/court-session/test/createTestingCourtSessionModule.ts
+++ b/apps/judicial-system/backend/src/app/modules/court-session/test/createTestingCourtSessionModule.ts
@@ -1,7 +1,6 @@
 import { mock } from 'jest-mock-extended'
 import { Sequelize } from 'sequelize-typescript'
 
-import { getModelToken } from '@nestjs/sequelize'
 import { Test } from '@nestjs/testing'
 
 import { LOGGER_PROVIDER } from '@island.is/logging'
@@ -13,7 +12,7 @@ import {
   AppealDecisionRepositoryService,
   AppealEventLogRepositoryService,
   CourtSessionRepositoryService,
-  CourtSessionString,
+  CourtSessionStringRepositoryService,
 } from '../../repository'
 import { CourtSessionController } from '../courtSession.controller'
 import { CourtSessionService } from '../courtSession.service'
@@ -41,11 +40,11 @@ export const createTestingCourtSessionModule = async () => {
         },
       },
       {
-        provide: getModelToken(CourtSessionString),
+        provide: CourtSessionStringRepositoryService,
         useValue: {
+          findByKey: jest.fn(),
+          updateByKey: jest.fn(),
           create: jest.fn(),
-          findOne: jest.fn(),
-          update: jest.fn(),
         },
       },
       { provide: Sequelize, useValue: { transaction: jest.fn() } },

--- a/apps/judicial-system/backend/src/app/modules/repository/index.ts
+++ b/apps/judicial-system/backend/src/app/modules/repository/index.ts
@@ -42,6 +42,12 @@ export {
   CourtSessionRepositoryService,
   UpdateCourtSession,
 } from './services/courtSessionRepository.service'
+export {
+  CourtSessionStringRepositoryService,
+  CourtSessionStringKey,
+  CreateCourtSessionString,
+  UpdateCourtSessionString,
+} from './services/courtSessionStringRepository.service'
 export { CourtDocumentRepositoryService } from './services/courtDocumentRepository.service'
 export { DefendantRepositoryService } from './services/defendantRepository.service'
 export { DefendantEventLogRepositoryService } from './services/defendantEventLogRepository.service'

--- a/apps/judicial-system/backend/src/app/modules/repository/repository.module.ts
+++ b/apps/judicial-system/backend/src/app/modules/repository/repository.module.ts
@@ -42,6 +42,7 @@ import { CaseDefendantPoliceCaseNumberRepositoryService } from './services/caseD
 import { CaseRepositoryService } from './services/caseRepository.service'
 import { CourtDocumentRepositoryService } from './services/courtDocumentRepository.service'
 import { CourtSessionRepositoryService } from './services/courtSessionRepository.service'
+import { CourtSessionStringRepositoryService } from './services/courtSessionStringRepository.service'
 import { DefendantEventLogRepositoryService } from './services/defendantEventLogRepository.service'
 import { DefendantRepositoryService } from './services/defendantRepository.service'
 import { IndictmentSubtypeRepositoryService } from './services/indictmentSubtypeRepository.service'
@@ -102,6 +103,7 @@ import { repositoryModuleConfig } from './repository.config'
     CaseDefendantPoliceCaseNumberRepositoryService,
     CaseRepositoryService,
     CourtSessionRepositoryService,
+    CourtSessionStringRepositoryService,
     CourtDocumentRepositoryService,
     DefendantRepositoryService,
     DefendantEventLogRepositoryService,
@@ -125,6 +127,7 @@ import { repositoryModuleConfig } from './repository.config'
     CaseDefendantPoliceCaseNumberRepositoryService,
     CaseRepositoryService,
     CourtSessionRepositoryService,
+    CourtSessionStringRepositoryService,
     CourtDocumentRepositoryService,
     DefendantRepositoryService,
     DefendantEventLogRepositoryService,

--- a/apps/judicial-system/backend/src/app/modules/repository/services/courtSessionStringRepository.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/repository/services/courtSessionStringRepository.service.ts
@@ -11,9 +11,15 @@ import { CourtSessionString } from '../models/courtSessionString.model'
 
 // A court session string is addressed by all four columns together - a merged
 // case contributes its own string of each type to a session - so the key is a
-// named type rather than a caller-supplied where clause. mergedCaseId is absent
-// for the session's own strings; stringType is optional only because the DTO the
-// only caller receives it from declares it so.
+// named type rather than a caller-supplied where clause.
+//
+// mergedCaseId and stringType are optional because CourtSessionStringDto, the
+// only source a caller gets them from, declares them so. Both are forwarded
+// verbatim: Sequelize rejects an undefined value in a where clause outright
+// ('WHERE parameter "<column>" has invalid "undefined" value'), so a partial key
+// fails at the read rather than writing a partial row. The only caller of the
+// endpoint always sends all four, so this is a latent gap in the DTO contract,
+// not a live one - tightening it is an API change, not a repository one.
 export type CourtSessionStringKey = {
   caseId: string
   courtSessionId: string

--- a/apps/judicial-system/backend/src/app/modules/repository/services/courtSessionStringRepository.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/repository/services/courtSessionStringRepository.service.ts
@@ -1,0 +1,141 @@
+import { Transaction } from 'sequelize'
+
+import { Inject, Injectable } from '@nestjs/common'
+import { InjectModel } from '@nestjs/sequelize'
+
+import { type Logger, LOGGER_PROVIDER } from '@island.is/logging'
+
+import { CourtSessionStringType } from '@island.is/judicial-system/types'
+
+import { CourtSessionString } from '../models/courtSessionString.model'
+
+// A court session string is addressed by all four columns together - a merged
+// case contributes its own string of each type to a session - so the key is a
+// named type rather than a caller-supplied where clause. mergedCaseId is absent
+// for the session's own strings; stringType is optional only because the DTO the
+// only caller receives it from declares it so.
+export type CourtSessionStringKey = {
+  caseId: string
+  courtSessionId: string
+  mergedCaseId?: string
+  stringType?: CourtSessionStringType
+}
+
+export type CreateCourtSessionString = CourtSessionStringKey & {
+  value?: string
+}
+
+export type UpdateCourtSessionString = {
+  value?: string
+}
+
+// Sequelize returns [affectedRows, rows] from update; naming the two halves
+// keeps the tuple from leaking to callers.
+export type UpdatedCourtSessionStrings = {
+  numberOfAffectedRows: number
+  courtSessionStrings: CourtSessionString[]
+}
+
+@Injectable()
+export class CourtSessionStringRepositoryService {
+  constructor(
+    @InjectModel(CourtSessionString)
+    private readonly courtSessionStringModel: typeof CourtSessionString,
+    @Inject(LOGGER_PROVIDER) private readonly logger: Logger,
+  ) {}
+
+  async findByKey(
+    key: CourtSessionStringKey,
+    options?: { transaction?: Transaction },
+  ): Promise<CourtSessionString | null> {
+    try {
+      this.logger.debug(
+        `Finding court session string of type ${key.stringType} for court session ${key.courtSessionId} of case ${key.caseId}`,
+      )
+
+      const result = await this.courtSessionStringModel.findOne({
+        where: {
+          caseId: key.caseId,
+          courtSessionId: key.courtSessionId,
+          mergedCaseId: key.mergedCaseId,
+          stringType: key.stringType,
+        },
+        transaction: options?.transaction,
+      })
+
+      this.logger.debug(
+        `Court session string of type ${key.stringType} for court session ${
+          key.courtSessionId
+        } of case ${key.caseId} ${result ? 'found' : 'not found'}`,
+      )
+
+      return result
+    } catch (error) {
+      this.logger.error(
+        `Error finding court session string of type ${key.stringType} for court session ${key.courtSessionId} of case ${key.caseId}:`,
+        { error },
+      )
+
+      throw error
+    }
+  }
+
+  // The caller decides what an unexpected row count means - a court session
+  // string carries no identity of its own beyond its key, so both halves of the
+  // count are reported rather than enforced here.
+  async updateByKey(
+    key: CourtSessionStringKey,
+    update: UpdateCourtSessionString,
+    options?: { transaction?: Transaction },
+  ): Promise<UpdatedCourtSessionStrings> {
+    try {
+      this.logger.debug(
+        `Updating court session string of type ${key.stringType} for court session ${key.courtSessionId} of case ${key.caseId} with data:`,
+        { data: Object.keys(update) },
+      )
+
+      const [numberOfAffectedRows, courtSessionStrings] =
+        await this.courtSessionStringModel.update(update, {
+          where: {
+            caseId: key.caseId,
+            courtSessionId: key.courtSessionId,
+            mergedCaseId: key.mergedCaseId,
+            stringType: key.stringType,
+          },
+          transaction: options?.transaction,
+          returning: true,
+        })
+
+      return { numberOfAffectedRows, courtSessionStrings }
+    } catch (error) {
+      this.logger.error(
+        `Error updating court session string of type ${key.stringType} for court session ${key.courtSessionId} of case ${key.caseId} with data:`,
+        { data: Object.keys(update), error },
+      )
+
+      throw error
+    }
+  }
+
+  async create(
+    courtSessionString: CreateCourtSessionString,
+    options?: { transaction?: Transaction },
+  ): Promise<CourtSessionString> {
+    try {
+      this.logger.debug(
+        `Creating a court session string of type ${courtSessionString.stringType} for court session ${courtSessionString.courtSessionId} of case ${courtSessionString.caseId}`,
+      )
+
+      return await this.courtSessionStringModel.create(courtSessionString, {
+        transaction: options?.transaction,
+      })
+    } catch (error) {
+      this.logger.error(
+        `Error creating a court session string of type ${courtSessionString.stringType} for court session ${courtSessionString.courtSessionId} of case ${courtSessionString.caseId}:`,
+        { error },
+      )
+
+      throw error
+    }
+  }
+}

--- a/apps/judicial-system/backend/src/app/modules/repository/test/courtSessionStringRepository.service.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/repository/test/courtSessionStringRepository.service.spec.ts
@@ -77,7 +77,10 @@ describe('CourtSessionStringRepositoryService', () => {
       expect(result).toBe(courtSessionString)
     })
 
-    it('passes no merged case when the string belongs to the session itself', async () => {
+    // An absent key column is forwarded as undefined rather than dropped, so
+    // Sequelize rejects the query instead of silently widening it to every
+    // merged case in the session.
+    it('forwards an absent key column rather than dropping it', async () => {
       await service.findByKey({
         caseId,
         courtSessionId,

--- a/apps/judicial-system/backend/src/app/modules/repository/test/courtSessionStringRepository.service.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/repository/test/courtSessionStringRepository.service.spec.ts
@@ -1,0 +1,184 @@
+import { Transaction } from 'sequelize'
+
+import { getModelToken } from '@nestjs/sequelize'
+import { Test } from '@nestjs/testing'
+
+import { LOGGER_PROVIDER } from '@island.is/logging'
+
+import { CourtSessionStringType } from '@island.is/judicial-system/types'
+
+import { CourtSessionString } from '../models/courtSessionString.model'
+import {
+  CourtSessionStringKey,
+  CourtSessionStringRepositoryService,
+} from '../services/courtSessionStringRepository.service'
+
+describe('CourtSessionStringRepositoryService', () => {
+  const caseId = 'some-case-id'
+  const courtSessionId = 'some-court-session-id'
+  const mergedCaseId = 'some-merged-case-id'
+  const transaction = {} as Transaction
+
+  const key: CourtSessionStringKey = {
+    caseId,
+    courtSessionId,
+    mergedCaseId,
+    stringType: CourtSessionStringType.ENTRIES,
+  }
+
+  // The typed key exists so that no caller can address a row by fewer than all
+  // four columns - assert them one by one rather than against the key object.
+  const expectedWhere = {
+    caseId,
+    courtSessionId,
+    mergedCaseId,
+    stringType: CourtSessionStringType.ENTRIES,
+  }
+
+  let service: CourtSessionStringRepositoryService
+  let model: {
+    findOne: jest.Mock
+    update: jest.Mock
+    create: jest.Mock
+  }
+
+  beforeEach(async () => {
+    model = {
+      findOne: jest.fn().mockResolvedValue(null),
+      update: jest.fn().mockResolvedValue([0, []]),
+      create: jest.fn(),
+    }
+
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        {
+          provide: LOGGER_PROVIDER,
+          useValue: { debug: jest.fn(), error: jest.fn() },
+        },
+        { provide: getModelToken(CourtSessionString), useValue: model },
+        CourtSessionStringRepositoryService,
+      ],
+    }).compile()
+
+    service = moduleRef.get(CourtSessionStringRepositoryService)
+  })
+
+  describe('findByKey', () => {
+    it('looks the string up by all four key columns', async () => {
+      const courtSessionString = { id: 'some-court-session-string-id' }
+      model.findOne.mockResolvedValueOnce(courtSessionString)
+
+      const result = await service.findByKey(key, { transaction })
+
+      expect(model.findOne).toHaveBeenCalledWith({
+        where: expectedWhere,
+        transaction,
+      })
+      expect(result).toBe(courtSessionString)
+    })
+
+    it('passes no merged case when the string belongs to the session itself', async () => {
+      await service.findByKey({
+        caseId,
+        courtSessionId,
+        stringType: CourtSessionStringType.ENTRIES,
+      })
+
+      expect(model.findOne).toHaveBeenCalledWith({
+        where: {
+          caseId,
+          courtSessionId,
+          mergedCaseId: undefined,
+          stringType: CourtSessionStringType.ENTRIES,
+        },
+        transaction: undefined,
+      })
+    })
+
+    it('returns null when there is no such string', async () => {
+      expect(await service.findByKey(key)).toBeNull()
+    })
+
+    it('rethrows when the lookup fails', async () => {
+      const error = new Error('Some error')
+      model.findOne.mockRejectedValueOnce(error)
+
+      await expect(service.findByKey(key)).rejects.toThrow(error)
+    })
+  })
+
+  describe('updateByKey', () => {
+    it('scopes the update to all four key columns and names both halves of the tuple', async () => {
+      const updated = { id: 'some-court-session-string-id' }
+      model.update.mockResolvedValueOnce([1, [updated]])
+
+      const result = await service.updateByKey(
+        key,
+        { value: 'Some value' },
+        { transaction },
+      )
+
+      expect(model.update).toHaveBeenCalledWith(
+        { value: 'Some value' },
+        { where: expectedWhere, transaction, returning: true },
+      )
+      expect(result).toEqual({
+        numberOfAffectedRows: 1,
+        courtSessionStrings: [updated],
+      })
+    })
+
+    it('reports an unexpected row count rather than enforcing one', async () => {
+      const updated = [{ id: 'one' }, { id: 'another' }]
+      model.update.mockResolvedValueOnce([2, updated])
+
+      expect(await service.updateByKey(key, { value: 'Some value' })).toEqual({
+        numberOfAffectedRows: 2,
+        courtSessionStrings: updated,
+      })
+    })
+
+    it('names both halves when nothing matched', async () => {
+      expect(await service.updateByKey(key, { value: 'Some value' })).toEqual({
+        numberOfAffectedRows: 0,
+        courtSessionStrings: [],
+      })
+    })
+
+    it('rethrows when the update fails', async () => {
+      const error = new Error('Some error')
+      model.update.mockRejectedValueOnce(error)
+
+      await expect(
+        service.updateByKey(key, { value: 'Some value' }),
+      ).rejects.toThrow(error)
+    })
+  })
+
+  describe('create', () => {
+    it('creates the string with its key columns in the caller transaction', async () => {
+      const created = { id: 'some-court-session-string-id' }
+      model.create.mockResolvedValueOnce(created)
+
+      const result = await service.create(
+        { ...key, value: 'Some value' },
+        { transaction },
+      )
+
+      expect(model.create).toHaveBeenCalledWith(
+        { ...expectedWhere, value: 'Some value' },
+        { transaction },
+      )
+      expect(result).toBe(created)
+    })
+
+    it('rethrows when the creation fails', async () => {
+      const error = new Error('Some error')
+      model.create.mockRejectedValueOnce(error)
+
+      await expect(
+        service.create({ ...key, value: 'Some value' }),
+      ).rejects.toThrow(error)
+    })
+  })
+})


### PR DESCRIPTION
# Court session string repository service

[Repository þjónusta fyrir CourtSessionString](https://app.asana.com/1/203394141643832/project/1199153462262248/task/1218039516752281)

Third satellite of the repository-pattern migration: `CourtSessionString` moves off direct model access in `CourtSessionService`.

## What changed

- **New `CourtSessionStringRepositoryService`** with three domain-intent methods — `findByKey`, `updateByKey` and `create` — registered in `RepositoryModule` and exported from `repository/index.ts`.
- The four columns that address a row (`caseId`, `courtSessionId`, `mergedCaseId`, `stringType`) become a typed **`CourtSessionStringKey`** rather than a caller-supplied `where` clause. `CourtSessionService` now builds that key once and reuses it across all three operations, instead of repeating the same four-column literal three times.
- `updateByKey` returns a named `{ numberOfAffectedRows, courtSessionStrings }` object rather than Sequelize's tuple. The `< 1` `InternalServerErrorException` and the `> 1` log stay in `CourtSessionService` — the repository reports the row count, the caller decides what it means.
- **`CourtSessionModule` no longer registers any Sequelize model.** `CourtSessionString` was the only entry in its `forFeature`, so the whole `SequelizeModule.forFeature([...])` call is gone — making it the second module in the codebase with no model registrations at all.

## Deliberately unchanged

- **The race in `createOrUpdateCourtSessionString` stays.** It is a read-then-write upsert without a lock: two concurrent requests for the same key can both miss and both insert. The module already has the right pattern (`AppealDecisionRepositoryService` uses `model.upsert` with `conflictFields`), but it cannot be applied here — `court_session_string` has no unique index to conflict against. Adding one needs a migration plus a decision about existing duplicate rows, and a repository slice should not quietly add a database constraint. The behaviour is ported faithfully, the race is now called out in a comment at the call site, and it is tracked as its own slice.
- **`CourtSessionRepositoryService` keeps its own `@InjectModel(CourtSessionString)`** (`courtSessionRepository.service.ts:69`). Repository services do not inject each other, so the aggregate cannot delegate to the new service; emptying that constructor is a separate piece of work. This PR closes the "no model access outside the repository module" invariant for `CourtSessionString`, not the "one injection site per model" one.
- `stringType` is optional on the key because `CourtSessionStringDto` — the only source callers get it from — declares it optional. Tightening that is a DTO change, not a repository one.

## Testing

- New `repository/test/courtSessionStringRepository.service.spec.ts`: asserts each key column individually (the point of the typed key is that a caller can no longer forget one), that the transaction is threaded through, that `updateByKey` maps the tuple onto the named object including the zero- and multi-row cases, and that every method rethrows.
- `court-session/test/createTestingCourtSessionModule.ts` now provides a mocked `CourtSessionStringRepositoryService` instead of the model token. No spec asserted on the model directly, so no consumer spec needed rewriting.
- `yarn nx test judicial-system-backend --testPathPatterns='modules/(court-session|repository)/'` — 46 suites, 277 tests, all green.
- `npx tsc --noEmit -p apps/judicial-system/backend/tsconfig.app.json` clean; `yarn nx lint judicial-system-backend` clean apart from one pre-existing warning in `case/dto/updateCase.dto.ts`; `openapi.yaml` unchanged after codegen.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved handling of court session strings through a centralized persistence layer.
  * Preserved transaction support, error handling, and affected-record validation during updates.
  * Improved consistency for finding, creating, and updating court session strings.

* **Tests**
  * Added coverage for court session string lookups, updates, creation, transaction forwarding, and error propagation.
  * Updated court session tests to use the new persistence service.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->