### PR TITLE
fix(driving-license): update B-temp done-screen copy to current process

### DIFF
--- a/libs/application/templates/driving-license/src/lib/messages.ts
+++ b/libs/application/templates/driving-license/src/lib/messages.ts
@@ -498,18 +498,6 @@ export const m = defineMessages({
     description:
       'Your application for a full driving license has been received. Before a full driving license can be applied for, you must bring the following to the district commissioner.',
   },
-  congratulationsTitleSuccess: {
-    id: 'dl.application:congratulationsTitleSuccess',
-    defaultMessage:
-      'Umsókn þín um fullnaðarskírteini tókst og verður tilbúið á afhendingarstað eftir 3 til 4 vikur. Skila þarf inn bráðabirgðaskírteini til sýslumanns við afhendingu fullnaðarskírteinis.',
-    description: 'Your application for full driving license was successful.',
-  },
-  congratulationsTempTitleSuccess: {
-    id: 'dl.application:congratulationsTempTitleSuccess',
-    defaultMessage:
-      'Umsókn þín um að hefja ökunám og fá bráðabirgðaskírteini hefur verið móttekin. Þegar þú hefur lokið ökunámi og staðist bæði verklegt og bóklegt ökupróf, verður skírteini þitt pantað og tilbúið til afhendingar hjá völdu sýslumannsembætti þremur vikum síðar.',
-    description: 'Your application for full driving license was successful.',
-  },
   congratulationsTitle: {
     id: 'dl.application:congratulationsTitle',
     defaultMessage: 'Til hamingju',
@@ -550,8 +538,13 @@ export const m = defineMessages({
   },
   nextStepsDescription: {
     id: 'dl.application:nextStepsDescription#markdown',
+    // Copy from Samgongustofa (2026-09-01): delivery takes ~7 days, not the
+    // 3 weeks the previous text claimed, and photo/signature can now come from
+    // the identity-documents registry during the application itself. NOTE: the
+    // live text is the Contentful entry for this id — it must be updated (and
+    // published) to match, or applicants keep seeing the old copy.
     defaultMessage:
-      'Næst þarf umsækjandi að mæta til sýslumanns með mynd og gefa rithandarsýnishorn. \n[Stafræn ökunámsbók - starfsreglur](https://island.is/stafraen-oekunamsbok/upplysingar-um-personuvernd)',
+      '* Ef ekki var hægt að velja mynd eða undirskrift úr skilríkjaskrá í umsóknarferlinu þarf að skila inn mynd og undirskrift á næstu skrifstofu sýslumanns. Þegar öllum gögnum hefur verið skilað inn er námsheimild gefin út og hægt að hefja ökunám.\n* Þegar þú hefur lokið ökunámi og staðist bæði bóklegt og verklegt ökupróf er ökuskírteinið pantað og afhent samkvæmt þeim afhendingarmáta sem þú valdir, heimsent eða sótt á valda skrifstofu sýslumanns, að jafnaði um sjö dögum síðar.\n\n[Stafræn ökunámsbók - starfsreglur](https://island.is/stafraen-oekunamsbok/upplysingar-um-personuvernd)',
     description: 'Next steps',
   },
   nextStepsDescriptionBFull: {
@@ -562,7 +555,7 @@ export const m = defineMessages({
   },
   nextStepsIntroDefault: {
     id: 'dl.application:nextStepsIntroDefault',
-    defaultMessage: 'Umsókn þín hefur verið móttekin og verður skoðuð.',
+    defaultMessage: 'Umsókn þín hefur verið móttekin og verður nú yfirfarin.',
     description: '',
   },
   nextStepsIntroBE: {


### PR DESCRIPTION
## What

Updates the B-temp done-screen next-steps copy to the text Samgongustofa provided (2026-09-01):

- `nextStepsIntroDefault`: "…og verður nú yfirfarin."
- `nextStepsDescription` (B-temp): two new bullets — photo/signature can come from the identity-documents registry during the application (visit the district commissioner only if that wasn't possible; learner's permit issued once documents are in), and the licence is delivered per the chosen delivery method in **about 7 days** (the old copy said 3 weeks). The Stafræn ökunámsbók privacy link is kept.
- Deletes `congratulationsTitleSuccess` and `congratulationsTempTitleSuccess` — unused (no references outside `messages.ts`), and both carried the same stale delivery claims ("3 til 4 vikur" / "þremur vikum").

## Why

Requested by Samgongustofa: the confirmation text described the pre-redesign process and an outdated delivery time (~7 days now, not 3 weeks).

⚠️ **The live text comes from Contentful** — the `dl.application` entries for `nextStepsDescription` and `nextStepsIntroDefault` override these defaults, so they must be updated (is + en) and published for applicants to see the change. Being handled alongside this PR.

## Testing

- `application-templates-driving-license`: 104/104 passing.
- Copy-only change; no ids renamed, no logic touched.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (n/a)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (n/a — copy only)
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review

## AI-tools disclosure

This PR was authored with assistance from Claude Code; all changes reviewed and verified by the author.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Content Updates**
  - Updated driving licence application messaging to state that delivery takes approximately 7 days.
  - Clarified that photos and signatures can be provided from the identity documents registry during the application.
  - Refined wording about reviewing the application.
  - Removed obsolete success-title messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->