### PR TITLE
fix(my-pages): Health questionnaires table drafts

### DIFF
--- a/libs/api/domains/questionnaires/src/lib/questionnaires.service.ts
+++ b/libs/api/domains/questionnaires/src/lib/questionnaires.service.ts
@@ -515,9 +515,7 @@ export class QuestionnairesService {
         ? answer.toISOString().split('T')[0]
         : String(answer)
     const dateMatch = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value)
-    return dateMatch
-      ? `${dateMatch[3]}.${dateMatch[2]}.${dateMatch[1]}`
-      : value
+    return dateMatch ? `${dateMatch[3]}.${dateMatch[2]}.${dateMatch[1]}` : value
   }
 
   private formatDate(date?: Date | string | null): string | undefined {

--- a/libs/api/domains/questionnaires/src/lib/questionnaires.service.ts
+++ b/libs/api/domains/questionnaires/src/lib/questionnaires.service.ts
@@ -502,6 +502,9 @@ export class QuestionnairesService {
     }
   }
 
+  // `unknown` is deliberate: the generated EL types declare table cell
+  // answers as anyOf without a discriminator (e.g. `Date | unknown`),
+  // so this function is the runtime narrowing boundary
   private formatCellAnswer(
     answer: unknown,
     formatMessage: FormatMessage,

--- a/libs/api/domains/questionnaires/src/lib/questionnaires.service.ts
+++ b/libs/api/domains/questionnaires/src/lib/questionnaires.service.ts
@@ -482,7 +482,7 @@ export class QuestionnairesService {
         row
           .map((cell) =>
             'answer' in cell
-              ? String(cell.answer)
+              ? this.formatCellAnswer(cell.answer, formatMessage)
               : cell.values.map((v) => v.answer).join(', '),
           )
           .join(' | '),
@@ -500,6 +500,24 @@ export class QuestionnairesService {
       this.logger.warn('Unhandled reply type')
       return []
     }
+  }
+
+  private formatCellAnswer(
+    answer: unknown,
+    formatMessage: FormatMessage,
+  ): string {
+    if (answer === null || answer === undefined) return ''
+    if (answer === true) return formatMessage(m.yes)
+    if (answer === false) return formatMessage(m.no)
+
+    const value =
+      answer instanceof Date
+        ? answer.toISOString().split('T')[0]
+        : String(answer)
+    const dateMatch = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value)
+    return dateMatch
+      ? `${dateMatch[3]}.${dateMatch[2]}.${dateMatch[1]}`
+      : value
   }
 
   private formatDate(date?: Date | string | null): string | undefined {

--- a/libs/api/domains/questionnaires/src/lib/transform-mappers/el/answer/mapToELAnswer.spec.ts
+++ b/libs/api/domains/questionnaires/src/lib/transform-mappers/el/answer/mapToELAnswer.spec.ts
@@ -36,7 +36,9 @@ const entry = (
 describe('mapToElAnswer', () => {
   it('maps text answers to string replies', () => {
     const result = mapToElAnswer(
-      buildInput([entry('10', AnswerOptionType.textarea, [{ value: 'hello' }])]),
+      buildInput([
+        entry('10', AnswerOptionType.textarea, [{ value: 'hello' }]),
+      ]),
       formatMessage,
     )
     expect(result.replies).toEqual([{ questionId: '10', answer: 'hello' }])

--- a/libs/api/domains/questionnaires/src/lib/transform-mappers/el/answer/mapToELAnswer.spec.ts
+++ b/libs/api/domains/questionnaires/src/lib/transform-mappers/el/answer/mapToELAnswer.spec.ts
@@ -1,0 +1,393 @@
+import type { MessageDescriptor } from '@formatjs/intl'
+import { AnswerOptionType } from '../../../../models/question.model'
+import { QuestionnairesOrganizationEnum } from '../../../../models/questionnaires.model'
+import { QuestionnaireInput } from '../../../dto/questionnaire.input'
+import { mapToElAnswer } from './mapToELAnswer'
+
+const formatMessage = (
+  descriptor: MessageDescriptor | string,
+  _values?: Record<string, unknown>,
+): string => {
+  if (typeof descriptor === 'string') {
+    return descriptor
+  }
+  return typeof descriptor.defaultMessage === 'string'
+    ? descriptor.defaultMessage
+    : ''
+}
+
+const buildInput = (
+  entries: QuestionnaireInput['entries'],
+  saveAsDraft?: boolean,
+): QuestionnaireInput => ({
+  id: 'questionnaire-1',
+  organization: QuestionnairesOrganizationEnum.EL,
+  formId: 'form-1',
+  entries,
+  saveAsDraft,
+})
+
+const entry = (
+  entryId: string,
+  type: AnswerOptionType,
+  answers: Array<{ label?: string; value: string }>,
+) => ({ entryId, type, answers })
+
+describe('mapToElAnswer', () => {
+  it('maps text answers to string replies', () => {
+    const result = mapToElAnswer(
+      buildInput([entry('10', AnswerOptionType.textarea, [{ value: 'hello' }])]),
+      formatMessage,
+    )
+    expect(result.replies).toEqual([{ questionId: '10', answer: 'hello' }])
+  })
+
+  it('sets isDraft from saveAsDraft and defaults to false', () => {
+    expect(mapToElAnswer(buildInput([], true), formatMessage).isDraft).toBe(
+      true,
+    )
+    expect(mapToElAnswer(buildInput([]), formatMessage).isDraft).toBe(false)
+  })
+
+  it('omits entries without answers', () => {
+    const result = mapToElAnswer(
+      buildInput([entry('10', AnswerOptionType.text, [])]),
+      formatMessage,
+    )
+    expect(result.replies).toEqual([])
+  })
+
+  describe('radio', () => {
+    it('maps true/false values to boolean replies', () => {
+      const result = mapToElAnswer(
+        buildInput([
+          entry('20', AnswerOptionType.radio, [
+            { label: 'Nei', value: 'false' },
+          ]),
+        ]),
+        formatMessage,
+      )
+      expect(result.replies).toEqual([{ questionId: '20', answer: false }])
+    })
+
+    it('maps list options to a single-value list reply', () => {
+      const result = mapToElAnswer(
+        buildInput([
+          entry('50', AnswerOptionType.radio, [
+            { label: 'It is getting worse', value: '53' },
+          ]),
+        ]),
+        formatMessage,
+      )
+      expect(result.replies).toEqual([
+        {
+          questionId: '50',
+          values: [{ id: '53', answer: 'It is getting worse' }],
+        },
+      ])
+    })
+
+    it('falls back to the option value when the label is missing', () => {
+      const result = mapToElAnswer(
+        buildInput([entry('50', AnswerOptionType.radio, [{ value: '53' }])]),
+        formatMessage,
+      )
+      expect(result.replies).toEqual([
+        { questionId: '50', values: [{ id: '53', answer: '53' }] },
+      ])
+    })
+  })
+
+  describe('checkbox and slider', () => {
+    it('maps all selected options to a list reply', () => {
+      const result = mapToElAnswer(
+        buildInput([
+          entry('60', AnswerOptionType.checkbox, [
+            { label: 'Head', value: '61' },
+            { label: 'Back', value: '63' },
+          ]),
+        ]),
+        formatMessage,
+      )
+      expect(result.replies).toEqual([
+        {
+          questionId: '60',
+          values: [
+            { id: '61', answer: 'Head' },
+            { id: '63', answer: 'Back' },
+          ],
+        },
+      ])
+    })
+
+    it('maps slider selections to a list reply', () => {
+      const result = mapToElAnswer(
+        buildInput([
+          entry('65', AnswerOptionType.slider, [
+            { label: 'Medium', value: '2' },
+          ]),
+        ]),
+        formatMessage,
+      )
+      expect(result.replies).toEqual([
+        { questionId: '65', values: [{ id: '2', answer: 'Medium' }] },
+      ])
+    })
+  })
+
+  describe('date and datetime', () => {
+    it('passes date strings through', () => {
+      const result = mapToElAnswer(
+        buildInput([
+          entry('30', AnswerOptionType.date, [{ value: '2017-11-01' }]),
+        ]),
+        formatMessage,
+      )
+      expect(result.replies).toEqual([
+        { questionId: '30', answer: '2017-11-01' },
+      ])
+    })
+
+    it('omits cleared date answers instead of sending an empty string', () => {
+      const result = mapToElAnswer(
+        buildInput([entry('30', AnswerOptionType.date, [{ value: '' }])]),
+        formatMessage,
+      )
+      expect(result.replies).toEqual([])
+    })
+  })
+
+  describe('number, scale and thermometer', () => {
+    it('maps numeric strings to number replies', () => {
+      const result = mapToElAnswer(
+        buildInput([
+          entry('40', AnswerOptionType.number, [{ value: '8' }]),
+          entry('80', AnswerOptionType.scale, [{ value: '4.5' }]),
+        ]),
+        formatMessage,
+      )
+      expect(result.replies).toEqual([
+        { questionId: '40', answer: 8 },
+        { questionId: '80', answer: 4.5 },
+      ])
+    })
+
+    it('omits empty, non-numeric and partially numeric values', () => {
+      const result = mapToElAnswer(
+        buildInput([
+          entry('40', AnswerOptionType.number, [{ value: '' }]),
+          entry('41', AnswerOptionType.number, [{ value: 'wer' }]),
+          entry('42', AnswerOptionType.number, [{ value: '12abc' }]),
+        ]),
+        formatMessage,
+      )
+      expect(result.replies).toEqual([])
+    })
+  })
+
+  describe('table', () => {
+    it('respects declared column types instead of inferring from values', () => {
+      const result = mapToElAnswer(
+        buildInput([
+          entry('70', AnswerOptionType.table, [
+            { label: 'Name', value: '71:string:Lyf' },
+            { label: 'Amount', value: '72:string:234' },
+            { label: 'First taken', value: '73:date:2026-08-19' },
+          ]),
+        ]),
+        formatMessage,
+      )
+      expect(result.replies).toEqual([
+        {
+          questionId: '70',
+          rows: [
+            [
+              { questionId: '71', answer: 'Lyf' },
+              { questionId: '72', answer: '234' },
+              { questionId: '73', answer: '2026-08-19' },
+            ],
+          ],
+        },
+      ])
+    })
+
+    it('maps bool and number columns to typed answers', () => {
+      const result = mapToElAnswer(
+        buildInput([
+          entry('70', AnswerOptionType.table, [
+            { value: '74:bool:true' },
+            { value: '75:number:2.5' },
+          ]),
+        ]),
+        formatMessage,
+      )
+      expect(result.replies).toEqual([
+        {
+          questionId: '70',
+          rows: [
+            [
+              { questionId: '74', answer: true },
+              { questionId: '75', answer: 2.5 },
+            ],
+          ],
+        },
+      ])
+    })
+
+    it('groups repeated columns into separate rows', () => {
+      const result = mapToElAnswer(
+        buildInput([
+          entry('70', AnswerOptionType.table, [
+            { value: '71:string:First' },
+            { value: '72:number:1' },
+            { value: '71:string:Second' },
+            { value: '72:number:2' },
+          ]),
+        ]),
+        formatMessage,
+      )
+      expect(result.replies).toEqual([
+        {
+          questionId: '70',
+          rows: [
+            [
+              { questionId: '71', answer: 'First' },
+              { questionId: '72', answer: 1 },
+            ],
+            [
+              { questionId: '71', answer: 'Second' },
+              { questionId: '72', answer: 2 },
+            ],
+          ],
+        },
+      ])
+    })
+
+    it('skips empty non-string cells but keeps empty string cells', () => {
+      const result = mapToElAnswer(
+        buildInput([
+          entry('70', AnswerOptionType.table, [
+            { value: '71:string:' },
+            { value: '73:date:' },
+            { value: '75:number:' },
+          ]),
+        ]),
+        formatMessage,
+      )
+      expect(result.replies).toEqual([
+        {
+          questionId: '70',
+          rows: [[{ questionId: '71', answer: '' }]],
+        },
+      ])
+    })
+
+    it('skips number cells whose value is not numeric', () => {
+      const result = mapToElAnswer(
+        buildInput([
+          entry('70', AnswerOptionType.table, [
+            { value: '71:string:Lyf' },
+            { value: '75:number:abc' },
+          ]),
+        ]),
+        formatMessage,
+      )
+      expect(result.replies).toEqual([
+        {
+          questionId: '70',
+          rows: [[{ questionId: '71', answer: 'Lyf' }]],
+        },
+      ])
+    })
+
+    it('omits the table reply when no row has any valid cell', () => {
+      const result = mapToElAnswer(
+        buildInput([
+          entry('70', AnswerOptionType.table, [
+            { value: '73:date:' },
+            { value: '75:number:' },
+          ]),
+        ]),
+        formatMessage,
+      )
+      expect(result.replies).toEqual([])
+    })
+
+    it('keeps colons inside cell values intact', () => {
+      const result = mapToElAnswer(
+        buildInput([
+          entry('70', AnswerOptionType.table, [
+            { value: '71:string:10:30 daily' },
+          ]),
+        ]),
+        formatMessage,
+      )
+      expect(result.replies).toEqual([
+        {
+          questionId: '70',
+          rows: [[{ questionId: '71', answer: '10:30 daily' }]],
+        },
+      ])
+    })
+
+    it('infers types for the legacy two-part format', () => {
+      const result = mapToElAnswer(
+        buildInput([
+          entry('70', AnswerOptionType.table, [
+            { value: '71:some text' },
+            { value: '72:234' },
+            { value: '73:2026-08-05' },
+            { value: '74:true' },
+          ]),
+        ]),
+        formatMessage,
+      )
+      expect(result.replies).toEqual([
+        {
+          questionId: '70',
+          rows: [
+            [
+              { questionId: '71', answer: 'some text' },
+              { questionId: '72', answer: 234 },
+              { questionId: '73', answer: '2026-08-05' },
+              { questionId: '74', answer: true },
+            ],
+          ],
+        },
+      ])
+    })
+
+    it('does not infer a number from a legacy date value', () => {
+      const result = mapToElAnswer(
+        buildInput([
+          entry('70', AnswerOptionType.table, [{ value: '73:2026-08-05' }]),
+        ]),
+        formatMessage,
+      )
+      expect(result.replies).toEqual([
+        {
+          questionId: '70',
+          rows: [[{ questionId: '73', answer: '2026-08-05' }]],
+        },
+      ])
+    })
+  })
+
+  describe('fallback', () => {
+    it('maps true/false strings from untyped entries to boolean replies', () => {
+      const result = mapToElAnswer(
+        buildInput([entry('90', AnswerOptionType.text, [{ value: 'true' }])]),
+        formatMessage,
+      )
+      expect(result.replies).toEqual([{ questionId: '90', answer: true }])
+    })
+
+    it('defaults everything else to string replies', () => {
+      const result = mapToElAnswer(
+        buildInput([entry('91', AnswerOptionType.text, [{ value: 'plain' }])]),
+        formatMessage,
+      )
+      expect(result.replies).toEqual([{ questionId: '91', answer: 'plain' }])
+    })
+  })
+})

--- a/libs/api/domains/questionnaires/src/lib/transform-mappers/el/answer/mapToELAnswer.spec.ts
+++ b/libs/api/domains/questionnaires/src/lib/transform-mappers/el/answer/mapToELAnswer.spec.ts
@@ -300,6 +300,54 @@ describe('mapToElAnswer', () => {
       ])
     })
 
+    it('skips number cells with partially numeric values', () => {
+      const result = mapToElAnswer(
+        buildInput([
+          entry('70', AnswerOptionType.table, [
+            { value: '71:string:Lyf' },
+            { value: '75:number:12abc' },
+          ]),
+        ]),
+        formatMessage,
+      )
+      expect(result.replies).toEqual([
+        {
+          questionId: '70',
+          rows: [[{ questionId: '71', answer: 'Lyf' }]],
+        },
+      ])
+    })
+
+    it('treats a legacy value with colons as a string, not a typed cell', () => {
+      const result = mapToElAnswer(
+        buildInput([
+          entry('70', AnswerOptionType.table, [{ value: 'note:08:30' }]),
+        ]),
+        formatMessage,
+      )
+      expect(result.replies).toEqual([
+        {
+          questionId: '70',
+          rows: [[{ questionId: 'note', answer: '08:30' }]],
+        },
+      ])
+    })
+
+    it('keeps partially numeric legacy values as strings', () => {
+      const result = mapToElAnswer(
+        buildInput([
+          entry('70', AnswerOptionType.table, [{ value: '72:12abc' }]),
+        ]),
+        formatMessage,
+      )
+      expect(result.replies).toEqual([
+        {
+          questionId: '70',
+          rows: [[{ questionId: '72', answer: '12abc' }]],
+        },
+      ])
+    })
+
     it('omits the table reply when no row has any valid cell', () => {
       const result = mapToElAnswer(
         buildInput([

--- a/libs/api/domains/questionnaires/src/lib/transform-mappers/el/answer/mapToELAnswer.ts
+++ b/libs/api/domains/questionnaires/src/lib/transform-mappers/el/answer/mapToELAnswer.ts
@@ -5,6 +5,16 @@ import { QuestionnaireInput } from '../../../dto/questionnaire.input'
 import { m } from '../../../utils/messages'
 import { Reply } from '../types'
 
+// EL column types that can appear in the "columnId:type:value" encoding
+const TABLE_CELL_TYPES = [
+  'string',
+  'number',
+  'date',
+  'datetime',
+  'bool',
+  'list',
+]
+
 /**
  * Maps a QuestionnaireInput to the Health Directorate submission format
  */
@@ -103,15 +113,17 @@ export const mapToElAnswer = (
             let columnType: string | undefined
             let value = ''
 
-            if (parts.length >= 3) {
+            // Legacy "columnId:value" cells may contain ':' in the value,
+            // so only treat the middle segment as a type when it is one
+            if (parts.length >= 3 && TABLE_CELL_TYPES.includes(parts[1])) {
               // New format: "columnId:type:value"
               columnId = parts[0]
               columnType = parts[1]
               value = parts.slice(2).join(':') // In case value contains ':'
-            } else if (parts.length === 2) {
+            } else if (parts.length >= 2) {
               // Old format: "columnId:value". Keep it for backward compatibility on dev lists
               columnId = parts[0]
-              value = parts[1]
+              value = parts.slice(1).join(':')
             }
 
             if (!columnData[columnId]) {
@@ -163,11 +175,15 @@ export const mapToElAnswer = (
               })
             } else if (
               columnType === 'number' ||
-              (inferType && !isNaN(parseFloat(value)) && value.trim() !== '')
+              (inferType &&
+                value.trim() !== '' &&
+                Number.isFinite(Number(value.trim())))
             ) {
-              const numericValue = parseFloat(value)
+              // Number() rejects partial parses like "12abc" that
+              // parseFloat would accept
+              const numericValue = Number(value.trim())
 
-              if (Number.isFinite(numericValue)) {
+              if (value.trim() !== '' && Number.isFinite(numericValue)) {
                 row.push({
                   questionId: columnId,
                   answer: numericValue,

--- a/libs/api/domains/questionnaires/src/lib/transform-mappers/el/answer/mapToELAnswer.ts
+++ b/libs/api/domains/questionnaires/src/lib/transform-mappers/el/answer/mapToELAnswer.ts
@@ -135,12 +135,12 @@ export const mapToElAnswer = (
             const value = cell?.value || ''
             const columnType = cell?.type
 
-            // Use column type if available, otherwise infer from value
-            // Check in order: boolean, date, number, string (date before number to avoid year-only confusion)
+            // Only infer types for legacy untyped values; check date before
+            // number since parseFloat("2026-08-05") parses as 2026
+            const inferType = !columnType
             if (
-              columnType === 'boolean' ||
-              value === 'true' ||
-              value === 'false'
+              columnType === 'bool' ||
+              (inferType && (value === 'true' || value === 'false'))
             ) {
               row.push({
                 questionId: columnId,
@@ -148,7 +148,8 @@ export const mapToElAnswer = (
               })
             } else if (
               columnType === 'date' ||
-              /^\d{4}-\d{2}-\d{2}/.test(value)
+              columnType === 'datetime' ||
+              (inferType && /^\d{4}-\d{2}-\d{2}/.test(value))
             ) {
               row.push({
                 questionId: columnId,
@@ -156,7 +157,7 @@ export const mapToElAnswer = (
               })
             } else if (
               columnType === 'number' ||
-              (!isNaN(parseFloat(value)) && value.trim() !== '')
+              (inferType && !isNaN(parseFloat(value)) && value.trim() !== '')
             ) {
               row.push({
                 questionId: columnId,

--- a/libs/api/domains/questionnaires/src/lib/transform-mappers/el/answer/mapToELAnswer.ts
+++ b/libs/api/domains/questionnaires/src/lib/transform-mappers/el/answer/mapToELAnswer.ts
@@ -57,9 +57,13 @@ export const mapToElAnswer = (
         entry.type === AnswerOptionType.date ||
         entry.type === AnswerOptionType.datetime
       ) {
+        // A cleared date picker submits '' - omit the reply, an empty
+        // string fails EL's date validation
+        if (!answerValues[0]) return []
+
         return {
           questionId,
-          answer: answerValues[0] || '', // Should be ISO date string
+          answer: answerValues[0],
         }
       }
 
@@ -135,6 +139,8 @@ export const mapToElAnswer = (
             const value = cell?.value || ''
             const columnType = cell?.type
 
+            if (!value && columnType !== 'string') return
+
             // Only infer types for legacy untyped values; check date before
             // number since parseFloat("2026-08-05") parses as 2026
             const inferType = !columnType
@@ -159,10 +165,14 @@ export const mapToElAnswer = (
               columnType === 'number' ||
               (inferType && !isNaN(parseFloat(value)) && value.trim() !== '')
             ) {
-              row.push({
-                questionId: columnId,
-                answer: parseFloat(value),
-              })
+              const numericValue = parseFloat(value)
+
+              if (Number.isFinite(numericValue)) {
+                row.push({
+                  questionId: columnId,
+                  answer: numericValue,
+                })
+              }
             } else {
               row.push({
                 questionId: columnId,
@@ -171,8 +181,12 @@ export const mapToElAnswer = (
             }
           })
 
-          rows.push(row)
+          if (row.length) {
+            rows.push(row)
+          }
         }
+
+        if (!rows.length) return []
 
         return {
           questionId,

--- a/libs/api/domains/questionnaires/src/lib/transform-mappers/el/display/mapAnswerOptionType.ts
+++ b/libs/api/domains/questionnaires/src/lib/transform-mappers/el/display/mapAnswerOptionType.ts
@@ -20,12 +20,19 @@ export const mapAnswerOptionType = (
     case 'bool':
       // Boolean questions are typically yes/no radio buttons
       return AnswerOptionType.radio
-    case 'list':
-      return 'multiselect' in item && item.multiselect
+    case 'list': {
+      // maxSelections supersedes the deprecated multiselect flag when
+      // provided; 0 means unlimited selections
+      const multiselect =
+        'maxSelections' in item && item.maxSelections != null
+          ? item.maxSelections !== 1
+          : 'multiselect' in item && item.multiselect
+      return multiselect
         ? AnswerOptionType.checkbox
         : 'displayClass' in item && item.displayClass === 'slider'
         ? AnswerOptionType.slider
         : AnswerOptionType.radio
+    }
     case 'thermometer':
       return AnswerOptionType.thermometer
     case 'date':

--- a/libs/api/domains/questionnaires/src/lib/transform-mappers/el/draft/mapToDraft.spec.ts
+++ b/libs/api/domains/questionnaires/src/lib/transform-mappers/el/draft/mapToDraft.spec.ts
@@ -1,0 +1,234 @@
+import type { QuestionnaireDetailDto } from '@island.is/clients/health-directorate'
+import type { MessageDescriptor } from '@formatjs/intl'
+import { AnswerOptionType } from '../../../../models/question.model'
+import { mapDraftRepliesToAnswers } from './mapToDraft'
+
+const formatMessage = (
+  descriptor: MessageDescriptor | string,
+  _values?: Record<string, unknown>,
+): string => {
+  if (typeof descriptor === 'string') {
+    return descriptor
+  }
+  const translations: Record<string, string> = {
+    'sp.health:yes': 'Já',
+    'sp.health:no': 'Nei',
+  }
+  return (
+    translations[descriptor.id as string] ||
+    (typeof descriptor.defaultMessage === 'string'
+      ? descriptor.defaultMessage
+      : '')
+  )
+}
+
+const buildQuestionnaire = (
+  items: unknown[],
+  replies: unknown[],
+): QuestionnaireDetailDto =>
+  ({
+    questionnaireId: 'q-1',
+    groups: [{ items }],
+    replies,
+  } as unknown as QuestionnaireDetailDto)
+
+const tableQuestion = {
+  id: '70',
+  type: 'table',
+  label: 'Medication',
+  items: [
+    { id: '71', type: 'string', label: 'Name of drug' },
+    { id: '72', type: 'string', label: 'Amount pr. day' },
+    { id: '73', type: 'date', label: 'First taken' },
+    { id: '74', type: 'bool', label: 'Still taking' },
+    { id: '75', type: 'number', label: 'Doses' },
+  ],
+}
+
+describe('mapDraftRepliesToAnswers', () => {
+  it('returns an empty object when there are no replies', () => {
+    const result = mapDraftRepliesToAnswers(
+      buildQuestionnaire([], []),
+      formatMessage,
+    )
+    expect(result).toEqual({})
+  })
+
+  it('skips replies whose question no longer exists', () => {
+    const result = mapDraftRepliesToAnswers(
+      buildQuestionnaire(
+        [{ id: '10', type: 'string', label: 'Q' }],
+        [{ questionId: '99', answer: 'orphan' }],
+      ),
+      formatMessage,
+    )
+    expect(result).toEqual({})
+  })
+
+  it('maps string replies', () => {
+    const result = mapDraftRepliesToAnswers(
+      buildQuestionnaire(
+        [{ id: '10', type: 'string', label: 'Q' }],
+        [{ questionId: '10', answer: 'hello' }],
+      ),
+      formatMessage,
+    )
+    expect(result['10'].answers).toEqual([{ label: undefined, value: 'hello' }])
+  })
+
+  it('maps boolean replies with localized labels', () => {
+    const result = mapDraftRepliesToAnswers(
+      buildQuestionnaire(
+        [{ id: '20', type: 'bool', label: 'Q' }],
+        [{ questionId: '20', answer: false }],
+      ),
+      formatMessage,
+    )
+    expect(result['20'].answers).toEqual([{ label: 'Nei', value: 'false' }])
+    expect(result['20'].type).toBe(AnswerOptionType.radio)
+  })
+
+  it('keeps unanswered replies empty instead of stringifying null', () => {
+    const result = mapDraftRepliesToAnswers(
+      buildQuestionnaire(
+        [{ id: '10', type: 'string', label: 'Q' }],
+        [{ questionId: '10', answer: null }],
+      ),
+      formatMessage,
+    )
+    expect(result['10'].answers).toEqual([])
+  })
+
+  it('maps list replies to option ids with labels', () => {
+    const result = mapDraftRepliesToAnswers(
+      buildQuestionnaire(
+        [
+          {
+            id: '60',
+            type: 'list',
+            label: 'Q',
+            minSelections: 1,
+            maxSelections: 0,
+            values: [{ id: '63', label: 'Back' }],
+          },
+        ],
+        [{ questionId: '60', values: [{ id: '63', answer: 'Back' }] }],
+      ),
+      formatMessage,
+    )
+    expect(result['60'].answers).toEqual([{ label: 'Back', value: '63' }])
+  })
+
+  describe('table replies', () => {
+    it('tags cells with the EL column type verbatim', () => {
+      const result = mapDraftRepliesToAnswers(
+        buildQuestionnaire(
+          [tableQuestion],
+          [
+            {
+              questionId: '70',
+              rows: [
+                [
+                  { questionId: '71', answer: 'Lyf' },
+                  { questionId: '72', answer: '234' },
+                  { questionId: '73', answer: '2026-08-19' },
+                  { questionId: '74', answer: true },
+                  { questionId: '75', answer: 2 },
+                ],
+              ],
+            },
+          ],
+        ),
+        formatMessage,
+      )
+      expect(result['70'].answers.map((a) => a.value)).toEqual([
+        '71:string:Lyf',
+        '72:string:234',
+        '73:date:2026-08-19',
+        '74:bool:true',
+        '75:number:2',
+      ])
+    })
+
+    it('normalizes date cells to YYYY-MM-DD', () => {
+      const result = mapDraftRepliesToAnswers(
+        buildQuestionnaire(
+          [tableQuestion],
+          [
+            {
+              questionId: '70',
+              rows: [
+                [
+                  {
+                    questionId: '73',
+                    answer: new Date('2026-08-19T10:30:00.000Z'),
+                  },
+                ],
+              ],
+            },
+          ],
+        ),
+        formatMessage,
+      )
+      expect(result['70'].answers.map((a) => a.value)).toEqual([
+        '73:date:2026-08-19',
+      ])
+    })
+
+    it('preserves falsy-but-real cell values like false and 0', () => {
+      const result = mapDraftRepliesToAnswers(
+        buildQuestionnaire(
+          [tableQuestion],
+          [
+            {
+              questionId: '70',
+              rows: [
+                [
+                  { questionId: '74', answer: false },
+                  { questionId: '75', answer: 0 },
+                ],
+              ],
+            },
+          ],
+        ),
+        formatMessage,
+      )
+      expect(result['70'].answers.map((a) => a.value)).toEqual([
+        '74:bool:false',
+        '75:number:0',
+      ])
+    })
+
+    it('encodes empty cells with an empty value', () => {
+      const result = mapDraftRepliesToAnswers(
+        buildQuestionnaire(
+          [tableQuestion],
+          [
+            {
+              questionId: '70',
+              rows: [[{ questionId: '71', answer: null }]],
+            },
+          ],
+        ),
+        formatMessage,
+      )
+      expect(result['70'].answers.map((a) => a.value)).toEqual(['71:string:'])
+    })
+
+    it('ignores cells whose column no longer exists', () => {
+      const result = mapDraftRepliesToAnswers(
+        buildQuestionnaire(
+          [tableQuestion],
+          [
+            {
+              questionId: '70',
+              rows: [[{ questionId: '99', answer: 'orphan' }]],
+            },
+          ],
+        ),
+        formatMessage,
+      )
+      expect(result['70'].answers).toEqual([])
+    })
+  })
+})

--- a/libs/api/domains/questionnaires/src/lib/transform-mappers/el/draft/mapToDraft.ts
+++ b/libs/api/domains/questionnaires/src/lib/transform-mappers/el/draft/mapToDraft.ts
@@ -73,22 +73,16 @@ export const mapDraftRepliesToAnswers = (
           const column = columns?.find((col) => col.id === cell.questionId)
           if (!column) return
 
-          // Determine the type based on the answer value type
-          let cellType = 'string'
+          // EL column type verbatim ('bool', not 'boolean') to match the
+          // encoding the frontend Table component produces
+          const cellType = column.type
           let cellValue = ''
 
           // Handle different cell reply types based on the structure
           if ('answer' in cell) {
             const cellAnswer = cell.answer
 
-            if (typeof cellAnswer === 'boolean') {
-              cellType = 'boolean'
-              cellValue = String(cellAnswer)
-            } else if (typeof cellAnswer === 'number') {
-              cellType = 'number'
-              cellValue = String(cellAnswer)
-            } else if (column.type === 'date') {
-              cellType = 'date'
+            if (column.type === 'date') {
               // Format date as YYYY-MM-DD
               if (cellAnswer instanceof Date) {
                 cellValue = cellAnswer.toISOString().split('T')[0]
@@ -99,12 +93,11 @@ export const mapDraftRepliesToAnswers = (
                 } catch {
                   cellValue = String(cellAnswer)
                 }
-              } else {
-                cellValue = cellAnswer ? String(cellAnswer) : ''
+              } else if (cellAnswer) {
+                cellValue = String(cellAnswer)
               }
-            } else {
-              // String type
-              cellValue = cellAnswer ? String(cellAnswer) : ''
+            } else if (cellAnswer !== null && cellAnswer !== undefined) {
+              cellValue = String(cellAnswer)
             }
           }
 

--- a/libs/portals/my-pages/core/src/components/Questionnaires/Answered.tsx
+++ b/libs/portals/my-pages/core/src/components/Questionnaires/Answered.tsx
@@ -1,9 +1,14 @@
+import { QuestionnaireAnswerOptionType } from '@island.is/api/schema'
 import { Box } from '@island.is/island-ui/core'
 import { useLocale } from '@island.is/localization'
 import { FC } from 'react'
 import { m } from '../../lib/messages'
 import { QuestionAnswer } from '../../types/questionnaire'
-import { formatDateWithTime } from '../../utils/dateUtils'
+import {
+  formatDate,
+  formatDateWithTime,
+  isDateOnlyString,
+} from '../../utils/dateUtils'
 import { NestedLines } from '../NestedLines/NestedLines'
 
 interface AnsweredProps {
@@ -32,13 +37,41 @@ const isValidDate = (dateString: string): boolean => {
 
 const formatValue = (value: string): string => {
   if (isValidDate(value)) {
-    return formatDateWithTime(value)
+    return isDateOnlyString(value)
+      ? formatDate(value)
+      : formatDateWithTime(value)
   }
   return value
 }
 
 export const Answered: FC<AnsweredProps> = ({ answers }) => {
   const { formatMessage } = useLocale()
+
+  // Table cells are encoded as "columnId:type:value" (legacy: "columnId:value")
+  const formatTableCell = (cell: {
+    label?: string | undefined
+    value: string
+  }): string => {
+    const parts = cell.value.split(':')
+    const cellType = parts.length >= 3 ? parts[1] : undefined
+    const rawValue =
+      parts.length >= 3
+        ? parts.slice(2).join(':')
+        : parts.length === 2
+        ? parts[1]
+        : cell.value
+
+    let displayValue = rawValue
+    if (cellType === 'bool') {
+      displayValue =
+        rawValue === 'true' ? formatMessage(m.yes) : formatMessage(m.no)
+    } else if (rawValue && isValidDate(rawValue)) {
+      displayValue = formatDate(rawValue)
+    }
+
+    return cell.label ? `${cell.label}: ${displayValue}` : displayValue
+  }
+
   return (
     <Box>
       <NestedLines
@@ -55,7 +88,10 @@ export const Answered: FC<AnsweredProps> = ({ answers }) => {
           ...(answers?.map((answer) => {
             return {
               title: answer.question,
-              value: answer.answers.map((a) => formatValue(a.label ?? a.value)),
+              value:
+                answer.type === QuestionnaireAnswerOptionType.table
+                  ? answer.answers.map(formatTableCell)
+                  : answer.answers.map((a) => formatValue(a.label ?? a.value)),
               type: 'text' as const,
               boldValue: false,
               boldTitle: false,

--- a/libs/portals/my-pages/core/src/components/Questionnaires/Answered.tsx
+++ b/libs/portals/my-pages/core/src/components/Questionnaires/Answered.tsx
@@ -17,7 +17,14 @@ interface AnsweredProps {
 }
 
 // EL column types that can appear in the "columnId:type:value" encoding
-const TABLE_CELL_TYPES = ['string', 'number', 'date', 'datetime', 'bool', 'list']
+const TABLE_CELL_TYPES = [
+  'string',
+  'number',
+  'date',
+  'datetime',
+  'bool',
+  'list',
+]
 
 const isValidDate = (dateString: string): boolean => {
   const date = new Date(dateString)
@@ -54,8 +61,7 @@ export const Answered: FC<AnsweredProps> = ({ answers }) => {
     const columnId = parts[0] ?? ''
     // Legacy values may contain ':', so only treat the middle segment
     // as a type when it is a known column type
-    const isTyped =
-      parts.length >= 3 && TABLE_CELL_TYPES.includes(parts[1])
+    const isTyped = parts.length >= 3 && TABLE_CELL_TYPES.includes(parts[1])
     const cellType = isTyped ? parts[1] : undefined
     const rawValue = isTyped
       ? parts.slice(2).join(':')

--- a/libs/portals/my-pages/core/src/components/Questionnaires/Answered.tsx
+++ b/libs/portals/my-pages/core/src/components/Questionnaires/Answered.tsx
@@ -24,14 +24,11 @@ const isValidDate = (dateString: string): boolean => {
     return false
   }
 
-  // Match various date formats:
-  // - ISO format: 2024-04-23T07:00:58
-  // - Date string format: Tue Apr 23 2024 07:00:58 GMT+0000 (Greenwich Mean Time)
-  // - Simple date: 2024-04-23
+  // The whole value must be a date, not merely contain one - new Date()
   const hasDatePattern =
-    dateString.match(/\d{4}-\d{2}-\d{2}/) !== null || // ISO format
-    dateString.match(/^\w{3}\s\w{3}\s\d{1,2}\s\d{4}/) !== null || // Date string format
-    dateString.includes('GMT') // Contains GMT timezone info
+    isDateOnlyString(dateString) || // Simple date: 2024-04-23
+    /^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}/.test(dateString) || // ISO format: 2024-04-23T07:00:58
+    /^\w{3}\s\w{3}\s\d{1,2}\s\d{4}/.test(dateString) // Date string format: Tue Apr 23 2024 ...
 
   return hasDatePattern
 }
@@ -49,24 +46,19 @@ export const Answered: FC<AnsweredProps> = ({ answers }) => {
   const { formatMessage } = useLocale()
 
   // Table cells are encoded as "columnId:type:value" (legacy: "columnId:value")
-  const formatTableCell = (cell: {
-    label?: string | undefined
-    value: string
-  }): string => {
-    const parts = cell.value.split(':')
+  const decodeTableCell = (encoded: string) => {
+    const parts = encoded.split(':')
+    const columnId = parts[0] ?? ''
     const cellType = parts.length >= 3 ? parts[1] : undefined
     const rawValue =
       parts.length >= 3
         ? parts.slice(2).join(':')
         : parts.length === 2
         ? parts[1]
-        : cell.value
+        : encoded
 
     let displayValue = rawValue
-    if (
-      cellType === 'bool' &&
-      (rawValue === 'true' || rawValue === 'false')
-    ) {
+    if (cellType === 'bool' && (rawValue === 'true' || rawValue === 'false')) {
       displayValue =
         rawValue === 'true' ? formatMessage(m.yes) : formatMessage(m.no)
     } else if (rawValue && isDateOnlyString(rawValue)) {
@@ -75,7 +67,31 @@ export const Answered: FC<AnsweredProps> = ({ answers }) => {
       displayValue = formatDate(rawValue)
     }
 
-    return cell.label ? `${cell.label}: ${displayValue}` : displayValue
+    return { columnId, displayValue }
+  }
+
+  // One line per table row (cells joined with " | "), matching the
+  // answered-submission view. A repeated columnId marks the next row.
+  const formatTableRows = (
+    answers: Array<{ label?: string; value: string }>,
+  ): string[] => {
+    const rows: string[][] = []
+    let currentRow: string[] = []
+    let seenColumns = new Set<string>()
+
+    answers.forEach((answer) => {
+      const { columnId, displayValue } = decodeTableCell(answer.value)
+      if (seenColumns.has(columnId)) {
+        rows.push(currentRow)
+        currentRow = []
+        seenColumns = new Set()
+      }
+      seenColumns.add(columnId)
+      currentRow.push(displayValue)
+    })
+    if (currentRow.length) rows.push(currentRow)
+
+    return rows.map((row) => row.join(' | '))
   }
 
   return (
@@ -96,7 +112,7 @@ export const Answered: FC<AnsweredProps> = ({ answers }) => {
               title: answer.question,
               value:
                 answer.type === QuestionnaireAnswerOptionType.table
-                  ? answer.answers.map(formatTableCell)
+                  ? formatTableRows(answer.answers)
                   : answer.answers.map((a) => formatValue(a.label ?? a.value)),
               type: 'text' as const,
               boldValue: false,

--- a/libs/portals/my-pages/core/src/components/Questionnaires/Answered.tsx
+++ b/libs/portals/my-pages/core/src/components/Questionnaires/Answered.tsx
@@ -6,6 +6,7 @@ import { m } from '../../lib/messages'
 import { QuestionAnswer } from '../../types/questionnaire'
 import {
   formatDate,
+  formatDateOnly,
   formatDateWithTime,
   isDateOnlyString,
 } from '../../utils/dateUtils'
@@ -38,7 +39,7 @@ const isValidDate = (dateString: string): boolean => {
 const formatValue = (value: string): string => {
   if (isValidDate(value)) {
     return isDateOnlyString(value)
-      ? formatDate(value)
+      ? formatDateOnly(value)
       : formatDateWithTime(value)
   }
   return value
@@ -62,9 +63,14 @@ export const Answered: FC<AnsweredProps> = ({ answers }) => {
         : cell.value
 
     let displayValue = rawValue
-    if (cellType === 'bool') {
+    if (
+      cellType === 'bool' &&
+      (rawValue === 'true' || rawValue === 'false')
+    ) {
       displayValue =
         rawValue === 'true' ? formatMessage(m.yes) : formatMessage(m.no)
+    } else if (rawValue && isDateOnlyString(rawValue)) {
+      displayValue = formatDateOnly(rawValue)
     } else if (rawValue && isValidDate(rawValue)) {
       displayValue = formatDate(rawValue)
     }

--- a/libs/portals/my-pages/core/src/components/Questionnaires/Answered.tsx
+++ b/libs/portals/my-pages/core/src/components/Questionnaires/Answered.tsx
@@ -16,6 +16,9 @@ interface AnsweredProps {
   answers?: QuestionAnswer[]
 }
 
+// EL column types that can appear in the "columnId:type:value" encoding
+const TABLE_CELL_TYPES = ['string', 'number', 'date', 'datetime', 'bool', 'list']
+
 const isValidDate = (dateString: string): boolean => {
   const date = new Date(dateString)
 
@@ -49,13 +52,16 @@ export const Answered: FC<AnsweredProps> = ({ answers }) => {
   const decodeTableCell = (encoded: string) => {
     const parts = encoded.split(':')
     const columnId = parts[0] ?? ''
-    const cellType = parts.length >= 3 ? parts[1] : undefined
-    const rawValue =
-      parts.length >= 3
-        ? parts.slice(2).join(':')
-        : parts.length === 2
-        ? parts[1]
-        : encoded
+    // Legacy values may contain ':', so only treat the middle segment
+    // as a type when it is a known column type
+    const isTyped =
+      parts.length >= 3 && TABLE_CELL_TYPES.includes(parts[1])
+    const cellType = isTyped ? parts[1] : undefined
+    const rawValue = isTyped
+      ? parts.slice(2).join(':')
+      : parts.length >= 2
+      ? parts.slice(1).join(':')
+      : encoded
 
     let displayValue = rawValue
     if (cellType === 'bool' && (rawValue === 'true' || rawValue === 'false')) {

--- a/libs/portals/my-pages/core/src/components/Questionnaires/Answered.tsx
+++ b/libs/portals/my-pages/core/src/components/Questionnaires/Answered.tsx
@@ -63,10 +63,7 @@ export const Answered: FC<AnsweredProps> = ({ answers }) => {
         : cell.value
 
     let displayValue = rawValue
-    if (
-      cellType === 'bool' &&
-      (rawValue === 'true' || rawValue === 'false')
-    ) {
+    if (cellType === 'bool' && (rawValue === 'true' || rawValue === 'false')) {
       displayValue =
         rawValue === 'true' ? formatMessage(m.yes) : formatMessage(m.no)
     } else if (rawValue && isDateOnlyString(rawValue)) {

--- a/libs/portals/my-pages/core/src/components/Questionnaires/GenericQuestionnaire.tsx
+++ b/libs/portals/my-pages/core/src/components/Questionnaires/GenericQuestionnaire.tsx
@@ -244,6 +244,15 @@ export const GenericQuestionnaire: FC<GenericQuestionnaireProps> = ({
       }
     } else {
       setErrors(allErrors)
+
+      // Bring the first invalid question into view - it is often
+      // scrolled out of sight when the user clicks continue
+      const firstErrorId = visibleQuestions.find((q) => allErrors[q.id])?.id
+      if (firstErrorId) {
+        document
+          .getElementById(`question-${firstErrorId}`)
+          ?.scrollIntoView({ behavior: 'smooth', block: 'center' })
+      }
     }
   }
 
@@ -312,16 +321,22 @@ export const GenericQuestionnaire: FC<GenericQuestionnaireProps> = ({
                         <Stack space={4}>
                           {section.questions?.map(
                             (question: QuestionnaireQuestion) => (
-                              <QuestionRenderer
+                              <Box
                                 key={question.id}
-                                question={question}
-                                answer={answers[question.id]}
-                                onAnswerChange={handleAnswerChange}
-                                error={errors[question.id]}
-                                disabled={
-                                  question.answerOptions.formula ? true : false
-                                }
-                              />
+                                id={`question-${question.id}`}
+                              >
+                                <QuestionRenderer
+                                  question={question}
+                                  answer={answers[question.id]}
+                                  onAnswerChange={handleAnswerChange}
+                                  error={errors[question.id]}
+                                  disabled={
+                                    question.answerOptions.formula
+                                      ? true
+                                      : false
+                                  }
+                                />
+                              </Box>
                             ),
                           )}
                         </Stack>

--- a/libs/portals/my-pages/core/src/components/Questionnaires/QuestionRenderer.tsx
+++ b/libs/portals/my-pages/core/src/components/Questionnaires/QuestionRenderer.tsx
@@ -4,6 +4,7 @@ import {
   QuestionnaireQuestion,
 } from '@island.is/api/schema'
 import { Box, DatePicker, Text } from '@island.is/island-ui/core'
+import * as styles from './QuestionsTypes/QuestionTypes.css'
 import { FC } from 'react'
 import HtmlParser from 'react-html-parser'
 import { useIsMobile } from '@island.is/portals/core'
@@ -344,6 +345,12 @@ export const QuestionRenderer: FC<QuestionRendererProps> = ({
             ' - ' +
             question.answerOptions.max +
             ' '}
+        {question.required && (
+          <span aria-hidden="true" className={styles.isRequiredStar}>
+            {' '}
+            *
+          </span>
+        )}
       </Text>
       {question.sublabel && (
         <Text variant="medium" color="dark400" marginBottom={3}>

--- a/libs/portals/my-pages/core/src/components/Questionnaires/QuestionsTypes/Multiple.tsx
+++ b/libs/portals/my-pages/core/src/components/Questionnaires/QuestionsTypes/Multiple.tsx
@@ -1,5 +1,12 @@
 import React from 'react'
-import { Checkbox, Box, Stack, Inline, Text } from '@island.is/island-ui/core'
+import {
+  Checkbox,
+  Box,
+  Stack,
+  Inline,
+  InputError,
+  Text,
+} from '@island.is/island-ui/core'
 import { useLocale } from '@island.is/localization'
 import { m } from '../../../lib/messages'
 import { useIsMobile } from '@island.is/portals/core'
@@ -92,11 +99,7 @@ export const Multiple: React.FC<MultipleProps> = ({
           <Stack space={2}>{checkboxes}</Stack>
         </Box>
       )}
-      {error && (
-        <Text color="red400" variant="small" marginTop={1}>
-          {error}
-        </Text>
-      )}
+      {error && <InputError errorMessage={error} />}
     </Box>
   )
 }

--- a/libs/portals/my-pages/core/src/components/Questionnaires/QuestionsTypes/QuestionTypes.css.ts
+++ b/libs/portals/my-pages/core/src/components/Questionnaires/QuestionsTypes/QuestionTypes.css.ts
@@ -80,3 +80,7 @@ export const thermoMeterSegment = style({
   justifyContent: 'center',
   transition: 'background-color 0.2s ease',
 })
+
+export const isRequiredStar = style({
+  color: theme.color.red600,
+})

--- a/libs/portals/my-pages/core/src/components/Questionnaires/QuestionsTypes/QuestionTypes.css.ts
+++ b/libs/portals/my-pages/core/src/components/Questionnaires/QuestionsTypes/QuestionTypes.css.ts
@@ -84,3 +84,13 @@ export const thermoMeterSegment = style({
 export const isRequiredStar = style({
   color: theme.color.red600,
 })
+
+// Numeric fields hold a handful of digits - cap their width on larger
+// screens instead of letting them span the content column
+export const numberInput = style({
+  '@media': {
+    [`screen and (min-width: ${theme.breakpoints.md}px)`]: {
+      maxWidth: 300,
+    },
+  },
+})

--- a/libs/portals/my-pages/core/src/components/Questionnaires/QuestionsTypes/Radio.tsx
+++ b/libs/portals/my-pages/core/src/components/Questionnaires/QuestionsTypes/Radio.tsx
@@ -1,4 +1,10 @@
-import { Box, RadioButton, Stack, Text } from '@island.is/island-ui/core'
+import {
+  Box,
+  InputError,
+  RadioButton,
+  Stack,
+  Text,
+} from '@island.is/island-ui/core'
 import React from 'react'
 import HtmlParser from 'react-html-parser'
 
@@ -69,11 +75,7 @@ export const Radio: React.FC<RadioProps> = ({
       ) : (
         <Stack space={2}>{radioButtons}</Stack>
       )}
-      {error && (
-        <Text color="red400" variant="small" marginTop={1}>
-          {error}
-        </Text>
-      )}
+      {error && <InputError errorMessage={error} />}
     </Box>
   )
 }

--- a/libs/portals/my-pages/core/src/components/Questionnaires/QuestionsTypes/Table.tsx
+++ b/libs/portals/my-pages/core/src/components/Questionnaires/QuestionsTypes/Table.tsx
@@ -8,6 +8,7 @@ import {
   DatePicker,
   GridColumn,
   GridRow,
+  InputError,
   Table as T,
   Text,
 } from '@island.is/island-ui/core'
@@ -237,14 +238,9 @@ export const Table: React.FC<TableProps> = ({
   return (
     <Box>
       {error && (
-        <Text
-          variant="small"
-          color="red600"
-          marginBottom={2}
-          id={`${id}-error`}
-        >
-          {error}
-        </Text>
+        <Box marginBottom={2}>
+          <InputError id={`${id}-error`} errorMessage={error} />
+        </Box>
       )}
 
       {/* Always show table with headers */}

--- a/libs/portals/my-pages/core/src/components/Questionnaires/QuestionsTypes/TextInput.tsx
+++ b/libs/portals/my-pages/core/src/components/Questionnaires/QuestionsTypes/TextInput.tsx
@@ -1,6 +1,6 @@
 import { Box, Input } from '@island.is/island-ui/core'
 import React from 'react'
-import { useIsMobile } from '../../..'
+import * as styles from './QuestionTypes.css'
 
 export interface TextInputProps {
   id: string
@@ -37,7 +37,6 @@ export const TextInput: React.FC<TextInputProps> = ({
   max,
   backgroundColor = 'blue',
 }) => {
-  const isMobile = useIsMobile()
   const handleChange = (
     e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
   ) => {
@@ -80,12 +79,11 @@ export const TextInput: React.FC<TextInputProps> = ({
 
   return (
     <Box
-      width={
-        isMobile
-          ? 'full'
-          : type === 'number' || type === 'decimal'
-          ? 'half'
-          : 'full'
+      width="full"
+      className={
+        type === 'number' || type === 'decimal'
+          ? styles.numberInput
+          : undefined
       }
     >
       <Input

--- a/libs/portals/my-pages/core/src/components/Questionnaires/QuestionsTypes/TextInput.tsx
+++ b/libs/portals/my-pages/core/src/components/Questionnaires/QuestionsTypes/TextInput.tsx
@@ -81,9 +81,7 @@ export const TextInput: React.FC<TextInputProps> = ({
     <Box
       width="full"
       className={
-        type === 'number' || type === 'decimal'
-          ? styles.numberInput
-          : undefined
+        type === 'number' || type === 'decimal' ? styles.numberInput : undefined
       }
     >
       <Input

--- a/libs/portals/my-pages/core/src/components/Questionnaires/QuestionsTypes/TextInput.tsx
+++ b/libs/portals/my-pages/core/src/components/Questionnaires/QuestionsTypes/TextInput.tsx
@@ -43,7 +43,7 @@ export const TextInput: React.FC<TextInputProps> = ({
   ) => {
     let newValue = e.target.value
 
-    if (type === 'number') {
+    if (type === 'number' || type === 'decimal') {
       if (newValue === '') {
         onChange(newValue)
         return
@@ -66,7 +66,7 @@ export const TextInput: React.FC<TextInputProps> = ({
     onChange(newValue)
   }
   const handleBlur = () => {
-    if (type === 'number' && value) {
+    if ((type === 'number' || type === 'decimal') && value) {
       const numValue = parseFloat(value)
       if (!isNaN(numValue)) {
         if (min !== undefined && numValue < parseFloat(min)) {
@@ -107,7 +107,7 @@ export const TextInput: React.FC<TextInputProps> = ({
         max={max}
         textarea={multiline}
         rows={multiline ? rows : undefined}
-        type={type === 'decimal' ? 'number' : type}
+        type="text"
         inputMode={
           type === 'decimal'
             ? 'decimal'

--- a/libs/portals/my-pages/core/src/components/Questionnaires/QuestionsTypes/Thermometer.tsx
+++ b/libs/portals/my-pages/core/src/components/Questionnaires/QuestionsTypes/Thermometer.tsx
@@ -1,4 +1,4 @@
-import { Box, Text } from '@island.is/island-ui/core'
+import { Box, InputError, Text } from '@island.is/island-ui/core'
 import { theme } from '@island.is/island-ui/theme'
 import cn from 'classnames'
 import React, { FC, useCallback, useEffect, useRef, useState } from 'react'
@@ -337,11 +337,7 @@ export const Thermometer: FC<ThermometerProps> = ({
         </Box>
       </Box>
 
-      {error && (
-        <Text color="red400" variant="small" marginTop={2}>
-          {error}
-        </Text>
-      )}
+      {error && <InputError errorMessage={error} />}
     </Box>
   )
 }

--- a/libs/portals/my-pages/core/src/utils/dateUtils.spec.ts
+++ b/libs/portals/my-pages/core/src/utils/dateUtils.spec.ts
@@ -1,0 +1,37 @@
+import { formatDateOnly, isDateOnlyString } from './dateUtils'
+
+describe('isDateOnlyString', () => {
+  it('accepts date-only strings', () => {
+    expect(isDateOnlyString('2025-12-01')).toBe(true)
+    expect(isDateOnlyString('1991-01-18')).toBe(true)
+  })
+
+  it('rejects datetimes, embedded dates and other formats', () => {
+    expect(isDateOnlyString('2025-12-01T10:30:00')).toBe(false)
+    expect(isDateOnlyString('2025-12-01 10:30')).toBe(false)
+    expect(isDateOnlyString('Lyf | wer | 2026-08-19')).toBe(false)
+    expect(isDateOnlyString('2025-1-1')).toBe(false)
+    expect(isDateOnlyString('01.12.2025')).toBe(false)
+    expect(isDateOnlyString('')).toBe(false)
+  })
+})
+
+describe('formatDateOnly', () => {
+  it('formats date-only strings as local calendar dates', () => {
+    expect(formatDateOnly('2025-12-01')).toBe('01.12.2025')
+    expect(formatDateOnly('1991-01-18')).toBe('18.01.1991')
+  })
+
+  it('supports a custom format', () => {
+    expect(formatDateOnly('2025-12-01', 'yyyy')).toBe('2025')
+  })
+
+  it('returns the original value for impossible calendar dates', () => {
+    expect(formatDateOnly('2024-02-31')).toBe('2024-02-31')
+    expect(formatDateOnly('2025-13-01')).toBe('2025-13-01')
+  })
+
+  it('returns the original value for unparseable input', () => {
+    expect(formatDateOnly('not a date')).toBe('not a date')
+  })
+})

--- a/libs/portals/my-pages/core/src/utils/dateUtils.ts
+++ b/libs/portals/my-pages/core/src/utils/dateUtils.ts
@@ -1,4 +1,5 @@
 import format from 'date-fns/format'
+import parseISO from 'date-fns/parseISO'
 import is from 'date-fns/locale/is'
 import { Locale } from '@island.is/shared/types'
 
@@ -33,6 +34,9 @@ export const isDateAfterToday = (date: Date | string | undefined) => {
 // True for date-only strings like "2025-12-01" (no time component)
 export const isDateOnlyString = (value: string): boolean =>
   /^\d{4}-\d{2}-\d{2}$/.test(value)
+
+export const formatDateOnly = (value: string, dateFormat?: string) =>
+  formatDate(parseISO(value), dateFormat)
 
 // Takes in date string or date, with optional format
 export const formatDate = (

--- a/libs/portals/my-pages/core/src/utils/dateUtils.ts
+++ b/libs/portals/my-pages/core/src/utils/dateUtils.ts
@@ -30,6 +30,10 @@ export const isDateAfterToday = (date: Date | string | undefined) => {
   return argDate > new Date()
 }
 
+// True for date-only strings like "2025-12-01" (no time component)
+export const isDateOnlyString = (value: string): boolean =>
+  /^\d{4}-\d{2}-\d{2}$/.test(value)
+
 // Takes in date string or date, with optional format
 export const formatDate = (
   date?: string | Date | null,

--- a/libs/portals/my-pages/core/src/utils/dateUtils.ts
+++ b/libs/portals/my-pages/core/src/utils/dateUtils.ts
@@ -35,8 +35,10 @@ export const isDateAfterToday = (date: Date | string | undefined) => {
 export const isDateOnlyString = (value: string): boolean =>
   /^\d{4}-\d{2}-\d{2}$/.test(value)
 
-export const formatDateOnly = (value: string, dateFormat?: string) =>
-  formatDate(parseISO(value), dateFormat)
+export const formatDateOnly = (value: string, dateFormat?: string) => {
+  const parsed = parseISO(value)
+  return isNaN(parsed.getTime()) ? value : formatDate(parsed, dateFormat)
+}
 
 // Takes in date string or date, with optional format
 export const formatDate = (


### PR DESCRIPTION
## What

- Submit mapper now uses the declared table column type when building EL replies instead of guessing the type from the value.
- Draft mapper tags table cells with the EL column type
- Answers review now decodes table cells and shows label: value instead of just the column label, and date-only answers render without a redundant - 00:00. Also new shared isDateOnlyString util.

## Why

Submitting an EL questionnaire with a table failed with 400 "Invalid submission". Numeric-looking text (for ex. "234" in a string column like amount pr. day) was type guessed and sent to EL as a number, so the column received mixed number/string replies. Trusting the column type EL itself declares fixes the rejection.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved display of questionnaire table answers, including booleans, dates, date-times, labels, and empty values.
  * Preserved declared column types when mapping table responses.
  * Corrected handling of legacy and date-time column values.
  * Prevented empty or invalid table and date responses from being submitted.
  * Improved date formatting and preservation of invalid date-only values.
  * Corrected multiselect behavior based on configured selection limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->