### PR TITLE
feat(j-s): revoke previous subpoena when issuing a new one

### DIFF
--- a/apps/judicial-system/backend/src/app/modules/subpoena/subpoena.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/subpoena/subpoena.service.ts
@@ -32,6 +32,7 @@ import {
   type User as TUser,
 } from '@island.is/judicial-system/types'
 
+import { nowFactory } from '../../factories'
 import { getCaseFileHash } from '../../formatters'
 import { PdfService } from '../case/pdf.service'
 import {
@@ -193,6 +194,8 @@ export class SubpoenaService {
       }
     }
 
+    this.queueSubpoenaRevocationMessages(theCase, defendantsToProcess, user)
+
     // Queue messages for delivering subpoenas to court and national commissioners office
     await this.queueSubpoenaDeliveryMessages(
       theCase,
@@ -208,6 +211,44 @@ export class SubpoenaService {
     })
 
     return subpoenas
+  }
+
+  private shouldRevokeSubpoena(subpoena: Subpoena, now: Date): boolean {
+    if (!subpoena.policeSubpoenaId) {
+      return false
+    }
+
+    if (isSuccessfulServiceStatus(subpoena.serviceStatus)) {
+      return false
+    }
+
+    return subpoena.arraignmentDate.getTime() > now.getTime()
+  }
+
+  private queueSubpoenaRevocationMessages(
+    theCase: Case,
+    defendants: Defendant[],
+    user: TUser,
+  ): void {
+    const now = nowFactory()
+    const messages = []
+
+    for (const defendant of defendants) {
+      for (const subpoena of defendant.subpoenas ?? []) {
+        if (this.shouldRevokeSubpoena(subpoena, now)) {
+          messages.push({
+            type: MessageType.DELIVERY_TO_NATIONAL_COMMISSIONERS_OFFICE_SUBPOENA_REVOCATION,
+            user,
+            caseId: theCase.id,
+            elementId: [defendant.id, subpoena.id],
+          })
+        }
+      }
+    }
+
+    if (messages.length > 0) {
+      addMessagesToQueue(...messages)
+    }
   }
 
   private async queueSubpoenaDeliveryMessages(

--- a/apps/judicial-system/backend/src/app/modules/subpoena/test/subpoenaController/createSubpoenas.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/subpoena/test/subpoenaController/createSubpoenas.spec.ts
@@ -8,6 +8,7 @@ import {
   CaseOrigin,
   CaseType,
   CourtDocumentType,
+  ServiceStatus,
   SubpoenaType,
   User,
 } from '@island.is/judicial-system/types'
@@ -362,6 +363,204 @@ describe('SubpoenaController - Create subpoenas', () => {
       expect(mockQueuedMessages).toEqual([])
 
       expect(then.result).toEqual([])
+      expect(then.error).toBeUndefined()
+    })
+  })
+
+  describe('previous subpoenas revoked when reissued', () => {
+    const futureArraignmentDate = new Date(Date.now() + 24 * 60 * 60 * 1000)
+    const pastArraignmentDate = new Date(Date.now() - 24 * 60 * 60 * 1000)
+    const oldSubpoenaId = uuid()
+    const policeSubpoenaId = uuid()
+
+    beforeEach(() => {
+      const mockCreate = mockSubpoenaRepositoryService.create as jest.Mock
+      mockCreate.mockResolvedValueOnce(subpoena1)
+    })
+
+    it('should revoke previous undelivered subpoenas with a future arraignment date', async () => {
+      const defendantWithPreviousSubpoena = {
+        ...defendant1,
+        subpoenas: [
+          {
+            id: oldSubpoenaId,
+            policeSubpoenaId,
+            arraignmentDate: futureArraignmentDate,
+          },
+        ],
+      } as Defendant
+
+      const theCase = {
+        id: caseId,
+        type: CaseType.INDICTMENT,
+        origin: CaseOrigin.RVG,
+        defendants: [defendantWithPreviousSubpoena],
+        withCourtSessions: false,
+      } as Case
+
+      const createSubpoenasDto: CreateSubpoenasDto = {
+        defendantIds: [defendantId1],
+        arraignmentDate,
+        location,
+      }
+
+      const then = await givenWhenThen(caseId, theCase, createSubpoenasDto)
+
+      expect(mockQueuedMessages).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: MessageType.DELIVERY_TO_NATIONAL_COMMISSIONERS_OFFICE_SUBPOENA_REVOCATION,
+            caseId: theCase.id,
+            elementId: [defendantId1, oldSubpoenaId],
+          }),
+          expect.objectContaining({
+            type: MessageType.DELIVERY_TO_NATIONAL_COMMISSIONERS_OFFICE_SUBPOENA,
+            caseId: theCase.id,
+            elementId: [defendantId1, subpoenaId1],
+          }),
+          expect.objectContaining({
+            type: MessageType.DELIVERY_TO_COURT_SUBPOENA,
+            caseId: theCase.id,
+            elementId: [defendantId1, subpoenaId1],
+          }),
+        ]),
+      )
+      expect(mockQueuedMessages).toHaveLength(3)
+
+      expect(then.result).toEqual([subpoena1])
+      expect(then.error).toBeUndefined()
+    })
+
+    it('should not revoke previous subpoenas with a past arraignment date', async () => {
+      const defendantWithPreviousSubpoena = {
+        ...defendant1,
+        subpoenas: [
+          {
+            id: oldSubpoenaId,
+            policeSubpoenaId,
+            arraignmentDate: pastArraignmentDate,
+          },
+        ],
+      } as Defendant
+
+      const theCase = {
+        id: caseId,
+        type: CaseType.INDICTMENT,
+        origin: CaseOrigin.RVG,
+        defendants: [defendantWithPreviousSubpoena],
+        withCourtSessions: false,
+      } as Case
+
+      const createSubpoenasDto: CreateSubpoenasDto = {
+        defendantIds: [defendantId1],
+        arraignmentDate,
+        location,
+      }
+
+      const then = await givenWhenThen(caseId, theCase, createSubpoenasDto)
+
+      expect(mockQueuedMessages).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: MessageType.DELIVERY_TO_NATIONAL_COMMISSIONERS_OFFICE_SUBPOENA,
+          }),
+          expect.objectContaining({
+            type: MessageType.DELIVERY_TO_COURT_SUBPOENA,
+          }),
+        ]),
+      )
+      expect(
+        mockQueuedMessages.some(
+          (message) =>
+            message.type ===
+            MessageType.DELIVERY_TO_NATIONAL_COMMISSIONERS_OFFICE_SUBPOENA_REVOCATION,
+        ),
+      ).toBe(false)
+      expect(mockQueuedMessages).toHaveLength(2)
+
+      expect(then.result).toEqual([subpoena1])
+      expect(then.error).toBeUndefined()
+    })
+
+    it('should not revoke previous subpoenas that were successfully served', async () => {
+      const defendantWithPreviousSubpoena = {
+        ...defendant1,
+        subpoenas: [
+          {
+            id: oldSubpoenaId,
+            policeSubpoenaId,
+            arraignmentDate: futureArraignmentDate,
+            serviceStatus: ServiceStatus.ELECTRONICALLY,
+          },
+        ],
+      } as Defendant
+
+      const theCase = {
+        id: caseId,
+        type: CaseType.INDICTMENT,
+        origin: CaseOrigin.RVG,
+        defendants: [defendantWithPreviousSubpoena],
+        withCourtSessions: false,
+      } as Case
+
+      const createSubpoenasDto: CreateSubpoenasDto = {
+        defendantIds: [defendantId1],
+        arraignmentDate,
+        location,
+      }
+
+      const then = await givenWhenThen(caseId, theCase, createSubpoenasDto)
+
+      expect(
+        mockQueuedMessages.some(
+          (message) =>
+            message.type ===
+            MessageType.DELIVERY_TO_NATIONAL_COMMISSIONERS_OFFICE_SUBPOENA_REVOCATION,
+        ),
+      ).toBe(false)
+      expect(mockQueuedMessages).toHaveLength(2)
+
+      expect(then.result).toEqual([subpoena1])
+      expect(then.error).toBeUndefined()
+    })
+
+    it('should not revoke previous subpoenas that were never delivered to police', async () => {
+      const defendantWithPreviousSubpoena = {
+        ...defendant1,
+        subpoenas: [
+          {
+            id: oldSubpoenaId,
+            arraignmentDate: futureArraignmentDate,
+          },
+        ],
+      } as Defendant
+
+      const theCase = {
+        id: caseId,
+        type: CaseType.INDICTMENT,
+        origin: CaseOrigin.RVG,
+        defendants: [defendantWithPreviousSubpoena],
+        withCourtSessions: false,
+      } as Case
+
+      const createSubpoenasDto: CreateSubpoenasDto = {
+        defendantIds: [defendantId1],
+        arraignmentDate,
+        location,
+      }
+
+      const then = await givenWhenThen(caseId, theCase, createSubpoenasDto)
+
+      expect(
+        mockQueuedMessages.some(
+          (message) =>
+            message.type ===
+            MessageType.DELIVERY_TO_NATIONAL_COMMISSIONERS_OFFICE_SUBPOENA_REVOCATION,
+        ),
+      ).toBe(false)
+      expect(mockQueuedMessages).toHaveLength(2)
+
+      expect(then.result).toEqual([subpoena1])
       expect(then.error).toBeUndefined()
     })
   })


### PR DESCRIPTION
[Asana](https://app.asana.com/1/203394141643832/project/1199153462262248/task/1209678203415009?focus=true)

## What

Invalidate prior subpoena when issueing a new one in the same case.

## Why

So we don't have two active subpoenas for the same defendant/case

## Screenshots / Gifs

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Cursor


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatically queues revocation notifications when eligible subpoenas are reissued.
  * Prevents outdated, undelivered subpoenas from remaining active when a new subpoena is created.

* **Bug Fixes**
  * Improved handling of previously issued subpoenas based on delivery status and arraignment dates.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->