### PR TITLE
feat(j-s): Civil claimant repository service

### DIFF
--- a/apps/judicial-system/backend/src/app/modules/defendant/civilClaimant.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/defendant/civilClaimant.service.ts
@@ -1,11 +1,10 @@
-import { Op, Transaction } from 'sequelize'
+import { Transaction } from 'sequelize'
 
 import {
   Inject,
   Injectable,
   InternalServerErrorException,
 } from '@nestjs/common'
-import { InjectModel } from '@nestjs/sequelize'
 
 import type { Logger } from '@island.is/logging'
 import { LOGGER_PROVIDER } from '@island.is/logging'
@@ -15,7 +14,6 @@ import {
   MessageType,
 } from '@island.is/judicial-system/message'
 import {
-  CaseState,
   CivilClaimantNotificationType,
   type User,
 } from '@island.is/judicial-system/types'
@@ -25,6 +23,7 @@ import {
   Case,
   CaseDefendantPoliceCaseNumberRepositoryService,
   CivilClaimant,
+  CivilClaimantRepositoryService,
 } from '../repository'
 import { UpdateCivilClaimantDto } from './dto/updateCivilClaimant.dto'
 import { DeliverResponse } from './models/deliver.response'
@@ -32,8 +31,7 @@ import { DeliverResponse } from './models/deliver.response'
 @Injectable()
 export class CivilClaimantService {
   constructor(
-    @InjectModel(CivilClaimant)
-    private readonly civilClaimantModel: typeof CivilClaimant,
+    private readonly civilClaimantRepositoryService: CivilClaimantRepositoryService,
     private readonly caseDefendantPoliceCaseNumberRepositoryService: CaseDefendantPoliceCaseNumberRepositoryService,
     private readonly courtService: CourtService,
     @Inject(LOGGER_PROVIDER) private readonly logger: Logger,
@@ -43,10 +41,9 @@ export class CivilClaimantService {
     theCase: Case,
     transaction: Transaction,
   ): Promise<CivilClaimant> {
-    return this.civilClaimantModel.create(
-      { caseId: theCase.id },
-      { transaction },
-    )
+    return this.civilClaimantRepositoryService.create(theCase.id, {
+      transaction,
+    })
   }
 
   private addMessagesForUpdateCivilClaimantToQueue(
@@ -130,11 +127,12 @@ export class CivilClaimantService {
       }
     }
 
-    const [numberOfAffectedRows, civilClaimants] =
-      await this.civilClaimantModel.update(effectiveUpdate, {
-        where: { id: civilClaimant.id, caseId },
-        returning: true,
-      })
+    const { numberOfAffectedRows, civilClaimants } =
+      await this.civilClaimantRepositoryService.updateByIdAndCase(
+        civilClaimant.id,
+        caseId,
+        effectiveUpdate,
+      )
 
     if (numberOfAffectedRows > 1) {
       this.logger.error(
@@ -186,12 +184,11 @@ export class CivilClaimantService {
   }
 
   async delete(caseId: string, civilClaimantId: string): Promise<boolean> {
-    const numberOfAffectedRows = await this.civilClaimantModel.destroy({
-      where: {
-        id: civilClaimantId,
+    const numberOfAffectedRows =
+      await this.civilClaimantRepositoryService.deleteByIdAndCase(
+        civilClaimantId,
         caseId,
-      },
-    })
+      )
 
     if (numberOfAffectedRows > 1) {
       // Tolerate failure, but log error
@@ -208,8 +205,7 @@ export class CivilClaimantService {
   }
 
   async deleteAll(caseId: string, transaction: Transaction): Promise<void> {
-    await this.civilClaimantModel.destroy({
-      where: { caseId },
+    await this.civilClaimantRepositoryService.deleteAllForCase(caseId, {
       transaction,
     })
   }
@@ -217,22 +213,8 @@ export class CivilClaimantService {
   findLatestClaimantBySpokespersonNationalId(
     nationalId: string,
   ): Promise<CivilClaimant | null> {
-    return this.civilClaimantModel.findOne({
-      include: [
-        {
-          model: Case,
-          as: 'case',
-          where: {
-            state: { [Op.not]: CaseState.DELETED },
-            isArchived: false,
-          },
-        },
-      ],
-      where: {
-        hasSpokesperson: true,
-        spokespersonNationalId: nationalId,
-      },
-      order: [['created', 'DESC']],
-    })
+    return this.civilClaimantRepositoryService.findLatestBySpokespersonNationalId(
+      nationalId,
+    )
   }
 }

--- a/apps/judicial-system/backend/src/app/modules/defendant/defendant.module.ts
+++ b/apps/judicial-system/backend/src/app/modules/defendant/defendant.module.ts
@@ -1,7 +1,5 @@
 import { forwardRef, Module } from '@nestjs/common'
-import { SequelizeModule } from '@nestjs/sequelize'
 
-import { CivilClaimant } from '../repository'
 import { CaseModule, CourtModule, RepositoryModule } from '..'
 import { CivilClaimantController } from './civilClaimant.controller'
 import { CivilClaimantService } from './civilClaimant.service'
@@ -16,7 +14,6 @@ import { LimitedAccessDefendantController } from './limitedAccessDefendant.contr
     forwardRef(() => CourtModule),
     forwardRef(() => CaseModule),
     forwardRef(() => RepositoryModule),
-    SequelizeModule.forFeature([CivilClaimant]),
   ],
   controllers: [
     DefendantController,

--- a/apps/judicial-system/backend/src/app/modules/defendant/test/civilClaimantController/create.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/defendant/test/civilClaimantController/create.spec.ts
@@ -64,9 +64,10 @@ describe('CivilClaimantController - Create', () => {
     })
 
     it('should create a civil claimant', () => {
-      expect(
-        mockCivilClaimantRepositoryService.create,
-      ).toHaveBeenCalledWith(caseId, { transaction })
+      expect(mockCivilClaimantRepositoryService.create).toHaveBeenCalledWith(
+        caseId,
+        { transaction },
+      )
     })
 
     it('should return the created civil claimant', () => {

--- a/apps/judicial-system/backend/src/app/modules/defendant/test/civilClaimantController/create.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/defendant/test/civilClaimantController/create.spec.ts
@@ -3,7 +3,11 @@ import { v4 as uuid } from 'uuid'
 
 import { createTestingDefendantModule } from '../createTestingDefendantModule'
 
-import { Case, CivilClaimant } from '../../../repository'
+import {
+  Case,
+  CivilClaimant,
+  CivilClaimantRepositoryService,
+} from '../../../repository'
 
 interface Then {
   result: CivilClaimant
@@ -16,20 +20,20 @@ describe('CivilClaimantController - Create', () => {
   const caseId = uuid()
   const civilClaimantId = uuid()
   const theCase = { id: caseId } as Case
-  const civilClaimantToCreate = {
-    caseId,
-  }
   const createdCivilClaimant = { id: civilClaimantId, caseId }
 
-  let mockCivilClaimantModel: typeof CivilClaimant
+  let mockCivilClaimantRepositoryService: CivilClaimantRepositoryService
   let transaction: Transaction
   let givenWhenThen: GivenWhenThen
 
   beforeEach(async () => {
-    const { sequelize, civilClaimantModel, civilClaimantController } =
-      await createTestingDefendantModule()
+    const {
+      sequelize,
+      civilClaimantRepositoryService,
+      civilClaimantController,
+    } = await createTestingDefendantModule()
 
-    mockCivilClaimantModel = civilClaimantModel
+    mockCivilClaimantRepositoryService = civilClaimantRepositoryService
 
     const mockTransaction = sequelize.transaction as jest.Mock
     transaction = {} as Transaction
@@ -37,7 +41,7 @@ describe('CivilClaimantController - Create', () => {
       (fn: (transaction: Transaction) => unknown) => fn(transaction),
     )
 
-    const mockCreate = mockCivilClaimantModel.create as jest.Mock
+    const mockCreate = mockCivilClaimantRepositoryService.create as jest.Mock
     mockCreate.mockResolvedValue(createdCivilClaimant)
 
     givenWhenThen = async () => {
@@ -60,10 +64,9 @@ describe('CivilClaimantController - Create', () => {
     })
 
     it('should create a civil claimant', () => {
-      expect(mockCivilClaimantModel.create).toHaveBeenCalledWith(
-        civilClaimantToCreate,
-        { transaction },
-      )
+      expect(
+        mockCivilClaimantRepositoryService.create,
+      ).toHaveBeenCalledWith(caseId, { transaction })
     })
 
     it('should return the created civil claimant', () => {
@@ -75,7 +78,7 @@ describe('CivilClaimantController - Create', () => {
     let then: Then
 
     beforeEach(async () => {
-      const mockCreate = mockCivilClaimantModel.create as jest.Mock
+      const mockCreate = mockCivilClaimantRepositoryService.create as jest.Mock
       mockCreate.mockRejectedValue(new Error('Test error'))
 
       then = await givenWhenThen(caseId)

--- a/apps/judicial-system/backend/src/app/modules/defendant/test/civilClaimantController/delete.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/defendant/test/civilClaimantController/delete.spec.ts
@@ -23,14 +23,13 @@ describe('CivilClaimantController - Delete', () => {
   let givenWhenThen: GivenWhenThen
 
   beforeEach(async () => {
-    const {
-      civilClaimantController,
-      civilClaimantRepositoryService,
-    } = await createTestingDefendantModule()
+    const { civilClaimantController, civilClaimantRepositoryService } =
+      await createTestingDefendantModule()
 
     mockCivilClaimantRepositoryService = civilClaimantRepositoryService
 
-    const mockDelete = mockCivilClaimantRepositoryService.deleteByIdAndCase as jest.Mock
+    const mockDelete =
+      mockCivilClaimantRepositoryService.deleteByIdAndCase as jest.Mock
     mockDelete.mockRejectedValue(new Error('Test error'))
 
     givenWhenThen = async () => {
@@ -53,7 +52,8 @@ describe('CivilClaimantController - Delete', () => {
     let then: Then
 
     beforeEach(async () => {
-      const mockDelete = mockCivilClaimantRepositoryService.deleteByIdAndCase as jest.Mock
+      const mockDelete =
+        mockCivilClaimantRepositoryService.deleteByIdAndCase as jest.Mock
       mockDelete.mockResolvedValue(1)
 
       then = await givenWhenThen(caseId, civilClaimantId)

--- a/apps/judicial-system/backend/src/app/modules/defendant/test/civilClaimantController/delete.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/defendant/test/civilClaimantController/delete.spec.ts
@@ -2,7 +2,7 @@ import { v4 as uuid } from 'uuid'
 
 import { createTestingDefendantModule } from '../createTestingDefendantModule'
 
-import { CivilClaimant } from '../../../repository'
+import { CivilClaimantRepositoryService } from '../../../repository'
 import { DeleteCivilClaimantResponse } from '../../models/deleteCivilClaimant.response'
 
 interface Then {
@@ -19,17 +19,19 @@ describe('CivilClaimantController - Delete', () => {
   const caseId = uuid()
   const civilClaimantId = uuid()
 
-  let mockCivilClaimantModel: typeof CivilClaimant
+  let mockCivilClaimantRepositoryService: CivilClaimantRepositoryService
   let givenWhenThen: GivenWhenThen
 
   beforeEach(async () => {
-    const { civilClaimantController, civilClaimantModel } =
-      await createTestingDefendantModule()
+    const {
+      civilClaimantController,
+      civilClaimantRepositoryService,
+    } = await createTestingDefendantModule()
 
-    mockCivilClaimantModel = civilClaimantModel
+    mockCivilClaimantRepositoryService = civilClaimantRepositoryService
 
-    const mockDestroy = mockCivilClaimantModel.destroy as jest.Mock
-    mockDestroy.mockRejectedValue(new Error('Test error'))
+    const mockDelete = mockCivilClaimantRepositoryService.deleteByIdAndCase as jest.Mock
+    mockDelete.mockRejectedValue(new Error('Test error'))
 
     givenWhenThen = async () => {
       const then = {} as Then
@@ -51,15 +53,15 @@ describe('CivilClaimantController - Delete', () => {
     let then: Then
 
     beforeEach(async () => {
-      const mockDestroy = mockCivilClaimantModel.destroy as jest.Mock
-      mockDestroy.mockResolvedValue(1)
+      const mockDelete = mockCivilClaimantRepositoryService.deleteByIdAndCase as jest.Mock
+      mockDelete.mockResolvedValue(1)
 
       then = await givenWhenThen(caseId, civilClaimantId)
     })
     it('should delete civil claimant', () => {
-      expect(mockCivilClaimantModel.destroy).toHaveBeenCalledWith({
-        where: { caseId, id: civilClaimantId },
-      })
+      expect(
+        mockCivilClaimantRepositoryService.deleteByIdAndCase,
+      ).toHaveBeenCalledWith(civilClaimantId, caseId)
       expect(then.result).toEqual({ deleted: true })
     })
   })

--- a/apps/judicial-system/backend/src/app/modules/defendant/test/civilClaimantController/update.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/defendant/test/civilClaimantController/update.spec.ts
@@ -50,7 +50,8 @@ describe('CivilClaimantController - Update', () => {
 
     mockQueuedMessages = queuedMessages
     mockCivilClaimantRepositoryService = civilClaimantRepositoryService
-    mockCaseDefendantPoliceCaseNumberRepositoryService = caseDefendantPoliceCaseNumberRepositoryService
+    mockCaseDefendantPoliceCaseNumberRepositoryService =
+      caseDefendantPoliceCaseNumberRepositoryService
 
     givenWhenThen = async (
       theCase: Case,
@@ -86,7 +87,8 @@ describe('CivilClaimantController - Update', () => {
     let then: Then
 
     beforeEach(async () => {
-      const mockUpdate = mockCivilClaimantRepositoryService.updateByIdAndCase as jest.Mock
+      const mockUpdate =
+        mockCivilClaimantRepositoryService.updateByIdAndCase as jest.Mock
       mockUpdate.mockResolvedValueOnce({
         numberOfAffectedRows: 1,
         civilClaimants: [updatedCivilClaimant],
@@ -119,10 +121,12 @@ describe('CivilClaimantController - Update', () => {
     }
 
     beforeEach(async () => {
-      const mockFindAssignedDefendantIds = mockCaseDefendantPoliceCaseNumberRepositoryService.findAssignedDefendantIds as jest.Mock
+      const mockFindAssignedDefendantIds =
+        mockCaseDefendantPoliceCaseNumberRepositoryService.findAssignedDefendantIds as jest.Mock
       mockFindAssignedDefendantIds.mockResolvedValueOnce(['def-b'])
 
-      const mockUpdate = mockCivilClaimantRepositoryService.updateByIdAndCase as jest.Mock
+      const mockUpdate =
+        mockCivilClaimantRepositoryService.updateByIdAndCase as jest.Mock
       mockUpdate.mockResolvedValueOnce({
         numberOfAffectedRows: 1,
         civilClaimants: [updatedCivilClaimant],
@@ -157,7 +161,8 @@ describe('CivilClaimantController - Update', () => {
     let then: Then
 
     beforeEach(async () => {
-      const mockUpdate = mockCivilClaimantRepositoryService.updateByIdAndCase as jest.Mock
+      const mockUpdate =
+        mockCivilClaimantRepositoryService.updateByIdAndCase as jest.Mock
       mockUpdate.mockResolvedValueOnce({
         numberOfAffectedRows: 1,
         civilClaimants: [updatedCivilClaimant],
@@ -186,8 +191,7 @@ describe('CivilClaimantController - Update', () => {
           user,
           elementId: civilClaimantId,
           body: {
-            type:
-              CivilClaimantNotificationType.SPOKESPERSON_COURT_DATE_FOLLOW_UP,
+            type: CivilClaimantNotificationType.SPOKESPERSON_COURT_DATE_FOLLOW_UP,
           },
         },
       ])
@@ -207,7 +211,8 @@ describe('CivilClaimantController - Update', () => {
     }
 
     beforeEach(async () => {
-      const mockUpdate = mockCivilClaimantRepositoryService.updateByIdAndCase as jest.Mock
+      const mockUpdate =
+        mockCivilClaimantRepositoryService.updateByIdAndCase as jest.Mock
       mockUpdate.mockResolvedValueOnce({
         numberOfAffectedRows: 1,
         civilClaimants: [updatedCivilClaimant],
@@ -235,7 +240,8 @@ describe('CivilClaimantController - Update', () => {
     }
 
     beforeEach(async () => {
-      const mockUpdate = mockCivilClaimantRepositoryService.updateByIdAndCase as jest.Mock
+      const mockUpdate =
+        mockCivilClaimantRepositoryService.updateByIdAndCase as jest.Mock
       mockUpdate.mockResolvedValueOnce({
         numberOfAffectedRows: 1,
         civilClaimants: [updatedCivilClaimant],
@@ -264,8 +270,7 @@ describe('CivilClaimantController - Update', () => {
           user,
           elementId: civilClaimantId,
           body: {
-            type:
-              CivilClaimantNotificationType.SPOKESPERSON_COURT_DATE_FOLLOW_UP,
+            type: CivilClaimantNotificationType.SPOKESPERSON_COURT_DATE_FOLLOW_UP,
           },
         },
       ])
@@ -282,7 +287,8 @@ describe('CivilClaimantController - Update', () => {
     const caseWithoutCourtCaseNumber = { id: caseId } as Case
 
     beforeEach(async () => {
-      const mockUpdate = mockCivilClaimantRepositoryService.updateByIdAndCase as jest.Mock
+      const mockUpdate =
+        mockCivilClaimantRepositoryService.updateByIdAndCase as jest.Mock
       mockUpdate.mockResolvedValueOnce({
         numberOfAffectedRows: 1,
         civilClaimants: [updatedCivilClaimant],
@@ -309,8 +315,7 @@ describe('CivilClaimantController - Update', () => {
           user,
           elementId: civilClaimantId,
           body: {
-            type:
-              CivilClaimantNotificationType.SPOKESPERSON_COURT_DATE_FOLLOW_UP,
+            type: CivilClaimantNotificationType.SPOKESPERSON_COURT_DATE_FOLLOW_UP,
           },
         },
       ])
@@ -321,7 +326,8 @@ describe('CivilClaimantController - Update', () => {
     let then: Then
 
     beforeEach(async () => {
-      const mockUpdate = mockCivilClaimantRepositoryService.updateByIdAndCase as jest.Mock
+      const mockUpdate =
+        mockCivilClaimantRepositoryService.updateByIdAndCase as jest.Mock
       mockUpdate.mockRejectedValue(new Error('Test error'))
 
       then = await givenWhenThen(theCase, civilClaimantId, {})

--- a/apps/judicial-system/backend/src/app/modules/defendant/test/civilClaimantController/update.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/defendant/test/civilClaimantController/update.spec.ts
@@ -12,6 +12,7 @@ import {
   Case,
   CaseDefendantPoliceCaseNumberRepositoryService,
   CivilClaimant,
+  CivilClaimantRepositoryService,
 } from '../../../repository'
 import { UpdateCivilClaimantDto } from '../../dto/updateCivilClaimant.dto'
 
@@ -35,22 +36,21 @@ describe('CivilClaimantController - Update', () => {
   const theCase = { id: caseId, courtCaseNumber } as Case
 
   let mockQueuedMessages: Message[]
-  let mockCivilClaimantModel: typeof CivilClaimant
+  let mockCivilClaimantRepositoryService: CivilClaimantRepositoryService
   let mockCaseDefendantPoliceCaseNumberRepositoryService: CaseDefendantPoliceCaseNumberRepositoryService
   let givenWhenThen: GivenWhenThen
 
   beforeEach(async () => {
     const {
       queuedMessages,
-      civilClaimantModel,
+      civilClaimantRepositoryService,
       caseDefendantPoliceCaseNumberRepositoryService,
       civilClaimantController,
     } = await createTestingDefendantModule()
 
     mockQueuedMessages = queuedMessages
-    mockCivilClaimantModel = civilClaimantModel
-    mockCaseDefendantPoliceCaseNumberRepositoryService =
-      caseDefendantPoliceCaseNumberRepositoryService
+    mockCivilClaimantRepositoryService = civilClaimantRepositoryService
+    mockCaseDefendantPoliceCaseNumberRepositoryService = caseDefendantPoliceCaseNumberRepositoryService
 
     givenWhenThen = async (
       theCase: Case,
@@ -86,20 +86,19 @@ describe('CivilClaimantController - Update', () => {
     let then: Then
 
     beforeEach(async () => {
-      const mockUpdate = mockCivilClaimantModel.update as jest.Mock
-      mockUpdate.mockResolvedValueOnce([1, [updatedCivilClaimant]])
+      const mockUpdate = mockCivilClaimantRepositoryService.updateByIdAndCase as jest.Mock
+      mockUpdate.mockResolvedValueOnce({
+        numberOfAffectedRows: 1,
+        civilClaimants: [updatedCivilClaimant],
+      })
 
       then = await givenWhenThen(theCase, civilClaimantId, civilClaimantUpdate)
     })
 
     it('should update the civil claimant', () => {
-      expect(mockCivilClaimantModel.update).toHaveBeenCalledWith(
-        civilClaimantUpdate,
-        {
-          where: { id: civilClaimantId, caseId },
-          returning: true,
-        },
-      )
+      expect(
+        mockCivilClaimantRepositoryService.updateByIdAndCase,
+      ).toHaveBeenCalledWith(civilClaimantId, caseId, civilClaimantUpdate)
       expect(mockQueuedMessages).toEqual([])
     })
 
@@ -120,12 +119,14 @@ describe('CivilClaimantController - Update', () => {
     }
 
     beforeEach(async () => {
-      const mockFindAssignedDefendantIds =
-        mockCaseDefendantPoliceCaseNumberRepositoryService.findAssignedDefendantIds as jest.Mock
+      const mockFindAssignedDefendantIds = mockCaseDefendantPoliceCaseNumberRepositoryService.findAssignedDefendantIds as jest.Mock
       mockFindAssignedDefendantIds.mockResolvedValueOnce(['def-b'])
 
-      const mockUpdate = mockCivilClaimantModel.update as jest.Mock
-      mockUpdate.mockResolvedValueOnce([1, [updatedCivilClaimant]])
+      const mockUpdate = mockCivilClaimantRepositoryService.updateByIdAndCase as jest.Mock
+      mockUpdate.mockResolvedValueOnce({
+        numberOfAffectedRows: 1,
+        civilClaimants: [updatedCivilClaimant],
+      })
 
       await givenWhenThen(theCase, civilClaimantId, civilClaimantUpdate)
     })
@@ -134,10 +135,12 @@ describe('CivilClaimantController - Update', () => {
       expect(
         mockCaseDefendantPoliceCaseNumberRepositoryService.findAssignedDefendantIds,
       ).toHaveBeenCalledWith(caseId, ['007-1', '007-2'], ['def-a', 'def-b'])
-      expect(mockCivilClaimantModel.update).toHaveBeenCalledWith(
-        { policeCaseNumbers: ['007-1', '007-2'], defendantIds: ['def-b'] },
-        { where: { id: civilClaimantId, caseId }, returning: true },
-      )
+      expect(
+        mockCivilClaimantRepositoryService.updateByIdAndCase,
+      ).toHaveBeenCalledWith(civilClaimantId, caseId, {
+        policeCaseNumbers: ['007-1', '007-2'],
+        defendantIds: ['def-b'],
+      })
     })
   })
 
@@ -154,8 +157,11 @@ describe('CivilClaimantController - Update', () => {
     let then: Then
 
     beforeEach(async () => {
-      const mockUpdate = mockCivilClaimantModel.update as jest.Mock
-      mockUpdate.mockResolvedValueOnce([1, [updatedCivilClaimant]])
+      const mockUpdate = mockCivilClaimantRepositoryService.updateByIdAndCase as jest.Mock
+      mockUpdate.mockResolvedValueOnce({
+        numberOfAffectedRows: 1,
+        civilClaimants: [updatedCivilClaimant],
+      })
 
       then = await givenWhenThen(theCase, civilClaimantId, civilClaimantUpdate)
     })
@@ -180,7 +186,8 @@ describe('CivilClaimantController - Update', () => {
           user,
           elementId: civilClaimantId,
           body: {
-            type: CivilClaimantNotificationType.SPOKESPERSON_COURT_DATE_FOLLOW_UP,
+            type:
+              CivilClaimantNotificationType.SPOKESPERSON_COURT_DATE_FOLLOW_UP,
           },
         },
       ])
@@ -200,8 +207,11 @@ describe('CivilClaimantController - Update', () => {
     }
 
     beforeEach(async () => {
-      const mockUpdate = mockCivilClaimantModel.update as jest.Mock
-      mockUpdate.mockResolvedValueOnce([1, [updatedCivilClaimant]])
+      const mockUpdate = mockCivilClaimantRepositoryService.updateByIdAndCase as jest.Mock
+      mockUpdate.mockResolvedValueOnce({
+        numberOfAffectedRows: 1,
+        civilClaimants: [updatedCivilClaimant],
+      })
 
       await givenWhenThen(theCase, civilClaimantId, civilClaimantUpdate, {
         id: civilClaimantId,
@@ -225,8 +235,11 @@ describe('CivilClaimantController - Update', () => {
     }
 
     beforeEach(async () => {
-      const mockUpdate = mockCivilClaimantModel.update as jest.Mock
-      mockUpdate.mockResolvedValueOnce([1, [updatedCivilClaimant]])
+      const mockUpdate = mockCivilClaimantRepositoryService.updateByIdAndCase as jest.Mock
+      mockUpdate.mockResolvedValueOnce({
+        numberOfAffectedRows: 1,
+        civilClaimants: [updatedCivilClaimant],
+      })
 
       await givenWhenThen(theCase, civilClaimantId, civilClaimantUpdate)
     })
@@ -251,7 +264,8 @@ describe('CivilClaimantController - Update', () => {
           user,
           elementId: civilClaimantId,
           body: {
-            type: CivilClaimantNotificationType.SPOKESPERSON_COURT_DATE_FOLLOW_UP,
+            type:
+              CivilClaimantNotificationType.SPOKESPERSON_COURT_DATE_FOLLOW_UP,
           },
         },
       ])
@@ -268,8 +282,11 @@ describe('CivilClaimantController - Update', () => {
     const caseWithoutCourtCaseNumber = { id: caseId } as Case
 
     beforeEach(async () => {
-      const mockUpdate = mockCivilClaimantModel.update as jest.Mock
-      mockUpdate.mockResolvedValueOnce([1, [updatedCivilClaimant]])
+      const mockUpdate = mockCivilClaimantRepositoryService.updateByIdAndCase as jest.Mock
+      mockUpdate.mockResolvedValueOnce({
+        numberOfAffectedRows: 1,
+        civilClaimants: [updatedCivilClaimant],
+      })
 
       await givenWhenThen(
         caseWithoutCourtCaseNumber,
@@ -292,7 +309,8 @@ describe('CivilClaimantController - Update', () => {
           user,
           elementId: civilClaimantId,
           body: {
-            type: CivilClaimantNotificationType.SPOKESPERSON_COURT_DATE_FOLLOW_UP,
+            type:
+              CivilClaimantNotificationType.SPOKESPERSON_COURT_DATE_FOLLOW_UP,
           },
         },
       ])
@@ -303,7 +321,7 @@ describe('CivilClaimantController - Update', () => {
     let then: Then
 
     beforeEach(async () => {
-      const mockUpdate = mockCivilClaimantModel.update as jest.Mock
+      const mockUpdate = mockCivilClaimantRepositoryService.updateByIdAndCase as jest.Mock
       mockUpdate.mockRejectedValue(new Error('Test error'))
 
       then = await givenWhenThen(theCase, civilClaimantId, {})

--- a/apps/judicial-system/backend/src/app/modules/defendant/test/createTestingDefendantModule.ts
+++ b/apps/judicial-system/backend/src/app/modules/defendant/test/createTestingDefendantModule.ts
@@ -1,6 +1,5 @@
 import { Sequelize } from 'sequelize-typescript'
 
-import { getModelToken } from '@nestjs/sequelize'
 import { Test } from '@nestjs/testing'
 
 import { LOGGER_PROVIDER } from '@island.is/logging'
@@ -21,7 +20,7 @@ import { CourtService } from '../../court'
 import { EventLogService } from '../../event-log'
 import {
   CaseDefendantPoliceCaseNumberRepositoryService,
-  CivilClaimant,
+  CivilClaimantRepositoryService,
   DefendantEventLogRepositoryService,
   DefendantRepositoryService,
 } from '../../repository'
@@ -75,14 +74,13 @@ export const createTestingDefendantModule = async () => {
       },
       { provide: Sequelize, useValue: { transaction: jest.fn() } },
       {
-        provide: getModelToken(CivilClaimant),
+        provide: CivilClaimantRepositoryService,
         useValue: {
-          findOne: jest.fn(),
-          findAll: jest.fn(),
           create: jest.fn(),
-          update: jest.fn(),
-          destroy: jest.fn(),
-          findByPk: jest.fn(),
+          updateByIdAndCase: jest.fn(),
+          deleteByIdAndCase: jest.fn(),
+          deleteAllForCase: jest.fn(),
+          findLatestBySpokespersonNationalId: jest.fn(),
         },
       },
       DefendantService,
@@ -98,50 +96,49 @@ export const createTestingDefendantModule = async () => {
 
   const sequelize = defendantModule.get<Sequelize>(Sequelize)
 
-  const defendantRepositoryService =
-    defendantModule.get<DefendantRepositoryService>(DefendantRepositoryService)
+  const defendantRepositoryService = defendantModule.get<DefendantRepositoryService>(
+    DefendantRepositoryService,
+  )
 
-  const defendantEventLogRepositoryService =
-    defendantModule.get<DefendantEventLogRepositoryService>(
-      DefendantEventLogRepositoryService,
-    )
+  const defendantEventLogRepositoryService = defendantModule.get<DefendantEventLogRepositoryService>(
+    DefendantEventLogRepositoryService,
+  )
 
-  const caseDefendantPoliceCaseNumberRepositoryService =
-    defendantModule.get<CaseDefendantPoliceCaseNumberRepositoryService>(
-      CaseDefendantPoliceCaseNumberRepositoryService,
-    )
+  const caseDefendantPoliceCaseNumberRepositoryService = defendantModule.get<CaseDefendantPoliceCaseNumberRepositoryService>(
+    CaseDefendantPoliceCaseNumberRepositoryService,
+  )
 
-  const defendantService =
-    defendantModule.get<DefendantService>(DefendantService)
+  const defendantService = defendantModule.get<DefendantService>(
+    DefendantService,
+  )
 
-  const defendantController =
-    defendantModule.get<DefendantController>(DefendantController)
+  const defendantController = defendantModule.get<DefendantController>(
+    DefendantController,
+  )
 
-  const internalDefendantController =
-    defendantModule.get<InternalDefendantController>(
-      InternalDefendantController,
-    )
+  const internalDefendantController = defendantModule.get<InternalDefendantController>(
+    InternalDefendantController,
+  )
 
-  const limitedAccessDefendantController =
-    defendantModule.get<LimitedAccessDefendantController>(
-      LimitedAccessDefendantController,
-    )
+  const limitedAccessDefendantController = defendantModule.get<LimitedAccessDefendantController>(
+    LimitedAccessDefendantController,
+  )
 
-  const civilClaimantModel = await defendantModule.resolve<
-    typeof CivilClaimant
-  >(getModelToken(CivilClaimant))
+  const civilClaimantRepositoryService = defendantModule.get<CivilClaimantRepositoryService>(
+    CivilClaimantRepositoryService,
+  )
 
-  const civilClaimantService =
-    defendantModule.get<CivilClaimantService>(CivilClaimantService)
+  const civilClaimantService = defendantModule.get<CivilClaimantService>(
+    CivilClaimantService,
+  )
 
   const civilClaimantController = defendantModule.get<CivilClaimantController>(
     CivilClaimantController,
   )
 
-  const internalCivilClaimantController =
-    defendantModule.get<InternalCivilClaimantController>(
-      InternalCivilClaimantController,
-    )
+  const internalCivilClaimantController = defendantModule.get<InternalCivilClaimantController>(
+    InternalCivilClaimantController,
+  )
 
   const queuedMessages: Message[] = []
   const mockAddMessageToQueue = addMessagesToQueue as jest.Mock
@@ -167,6 +164,6 @@ export const createTestingDefendantModule = async () => {
     limitedAccessDefendantController,
     civilClaimantService,
     civilClaimantController,
-    civilClaimantModel,
+    civilClaimantRepositoryService,
   }
 }

--- a/apps/judicial-system/backend/src/app/modules/defendant/test/createTestingDefendantModule.ts
+++ b/apps/judicial-system/backend/src/app/modules/defendant/test/createTestingDefendantModule.ts
@@ -96,49 +96,51 @@ export const createTestingDefendantModule = async () => {
 
   const sequelize = defendantModule.get<Sequelize>(Sequelize)
 
-  const defendantRepositoryService = defendantModule.get<DefendantRepositoryService>(
-    DefendantRepositoryService,
-  )
+  const defendantRepositoryService =
+    defendantModule.get<DefendantRepositoryService>(DefendantRepositoryService)
 
-  const defendantEventLogRepositoryService = defendantModule.get<DefendantEventLogRepositoryService>(
-    DefendantEventLogRepositoryService,
-  )
+  const defendantEventLogRepositoryService =
+    defendantModule.get<DefendantEventLogRepositoryService>(
+      DefendantEventLogRepositoryService,
+    )
 
-  const caseDefendantPoliceCaseNumberRepositoryService = defendantModule.get<CaseDefendantPoliceCaseNumberRepositoryService>(
-    CaseDefendantPoliceCaseNumberRepositoryService,
-  )
+  const caseDefendantPoliceCaseNumberRepositoryService =
+    defendantModule.get<CaseDefendantPoliceCaseNumberRepositoryService>(
+      CaseDefendantPoliceCaseNumberRepositoryService,
+    )
 
-  const defendantService = defendantModule.get<DefendantService>(
-    DefendantService,
-  )
+  const defendantService =
+    defendantModule.get<DefendantService>(DefendantService)
 
-  const defendantController = defendantModule.get<DefendantController>(
-    DefendantController,
-  )
+  const defendantController =
+    defendantModule.get<DefendantController>(DefendantController)
 
-  const internalDefendantController = defendantModule.get<InternalDefendantController>(
-    InternalDefendantController,
-  )
+  const internalDefendantController =
+    defendantModule.get<InternalDefendantController>(
+      InternalDefendantController,
+    )
 
-  const limitedAccessDefendantController = defendantModule.get<LimitedAccessDefendantController>(
-    LimitedAccessDefendantController,
-  )
+  const limitedAccessDefendantController =
+    defendantModule.get<LimitedAccessDefendantController>(
+      LimitedAccessDefendantController,
+    )
 
-  const civilClaimantRepositoryService = defendantModule.get<CivilClaimantRepositoryService>(
-    CivilClaimantRepositoryService,
-  )
+  const civilClaimantRepositoryService =
+    defendantModule.get<CivilClaimantRepositoryService>(
+      CivilClaimantRepositoryService,
+    )
 
-  const civilClaimantService = defendantModule.get<CivilClaimantService>(
-    CivilClaimantService,
-  )
+  const civilClaimantService =
+    defendantModule.get<CivilClaimantService>(CivilClaimantService)
 
   const civilClaimantController = defendantModule.get<CivilClaimantController>(
     CivilClaimantController,
   )
 
-  const internalCivilClaimantController = defendantModule.get<InternalCivilClaimantController>(
-    InternalCivilClaimantController,
-  )
+  const internalCivilClaimantController =
+    defendantModule.get<InternalCivilClaimantController>(
+      InternalCivilClaimantController,
+    )
 
   const queuedMessages: Message[] = []
   const mockAddMessageToQueue = addMessagesToQueue as jest.Mock

--- a/apps/judicial-system/backend/src/app/modules/repository/index.ts
+++ b/apps/judicial-system/backend/src/app/modules/repository/index.ts
@@ -39,6 +39,11 @@ export { CaseRepositoryService } from './services/caseRepository.service'
 export { CaseArchiveRepositoryService } from './services/caseArchiveRepository.service'
 export { CaseDefendantPoliceCaseNumberRepositoryService } from './services/caseDefendantPoliceCaseNumber.repository.service'
 export {
+  CivilClaimantRepositoryService,
+  UpdateCivilClaimant,
+  UpdatedCivilClaimants,
+} from './services/civilClaimantRepository.service'
+export {
   CourtSessionRepositoryService,
   UpdateCourtSession,
 } from './services/courtSessionRepository.service'

--- a/apps/judicial-system/backend/src/app/modules/repository/repository.module.ts
+++ b/apps/judicial-system/backend/src/app/modules/repository/repository.module.ts
@@ -40,6 +40,7 @@ import { AppealEventLogRepositoryService } from './services/appealEventLogReposi
 import { CaseArchiveRepositoryService } from './services/caseArchiveRepository.service'
 import { CaseDefendantPoliceCaseNumberRepositoryService } from './services/caseDefendantPoliceCaseNumber.repository.service'
 import { CaseRepositoryService } from './services/caseRepository.service'
+import { CivilClaimantRepositoryService } from './services/civilClaimantRepository.service'
 import { CourtDocumentRepositoryService } from './services/courtDocumentRepository.service'
 import { CourtSessionRepositoryService } from './services/courtSessionRepository.service'
 import { DefendantEventLogRepositoryService } from './services/defendantEventLogRepository.service'
@@ -103,6 +104,7 @@ import { repositoryModuleConfig } from './repository.config'
     CaseArchiveRepositoryService,
     CaseDefendantPoliceCaseNumberRepositoryService,
     CaseRepositoryService,
+    CivilClaimantRepositoryService,
     CourtSessionRepositoryService,
     CourtDocumentRepositoryService,
     DefendantRepositoryService,
@@ -128,6 +130,7 @@ import { repositoryModuleConfig } from './repository.config'
     CaseArchiveRepositoryService,
     CaseDefendantPoliceCaseNumberRepositoryService,
     CaseRepositoryService,
+    CivilClaimantRepositoryService,
     CourtSessionRepositoryService,
     CourtDocumentRepositoryService,
     DefendantRepositoryService,

--- a/apps/judicial-system/backend/src/app/modules/repository/services/civilClaimantRepository.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/repository/services/civilClaimantRepository.service.ts
@@ -1,0 +1,169 @@
+import { Op, Transaction } from 'sequelize'
+
+import { Inject, Injectable } from '@nestjs/common'
+import { InjectModel } from '@nestjs/sequelize'
+
+import { type Logger, LOGGER_PROVIDER } from '@island.is/logging'
+
+import { CaseState } from '@island.is/judicial-system/types'
+
+import { Case } from '../models/case.model'
+import { CivilClaimant } from '../models/civilClaimant.model'
+
+export type UpdateCivilClaimant = {
+  noNationalId?: boolean
+  nationalId?: string
+  name?: string
+  hasSpokesperson?: boolean
+  spokespersonIsLawyer?: boolean
+  spokespersonNationalId?: string
+  spokespersonName?: string
+  spokespersonEmail?: string
+  spokespersonPhoneNumber?: string
+  caseFilesSharedWithSpokesperson?: boolean
+  isSpokespersonConfirmed?: boolean
+  policeCaseNumbers?: string[]
+  defendantIds?: string[]
+}
+
+// Sequelize returns [affectedRows, rows] from update; naming the two halves keeps
+// the tuple from leaking to callers.
+export type UpdatedCivilClaimants = {
+  numberOfAffectedRows: number
+  civilClaimants: CivilClaimant[]
+}
+
+@Injectable()
+export class CivilClaimantRepositoryService {
+  constructor(
+    @InjectModel(CivilClaimant)
+    private readonly civilClaimantModel: typeof CivilClaimant,
+    @Inject(LOGGER_PROVIDER) private readonly logger: Logger,
+  ) {}
+
+  async create(
+    caseId: string,
+    options: { transaction: Transaction },
+  ): Promise<CivilClaimant> {
+    try {
+      this.logger.debug(`Creating a civil claimant for case ${caseId}`)
+
+      return await this.civilClaimantModel.create(
+        { caseId },
+        { transaction: options.transaction },
+      )
+    } catch (error) {
+      this.logger.error(`Error creating a civil claimant for case ${caseId}:`, {
+        error,
+      })
+
+      throw error
+    }
+  }
+
+  // A civil claimant is only addressable within its own case, so both keys are
+  // named parameters rather than a caller-supplied where clause.
+  async updateByIdAndCase(
+    civilClaimantId: string,
+    caseId: string,
+    update: UpdateCivilClaimant,
+  ): Promise<UpdatedCivilClaimants> {
+    try {
+      this.logger.debug(
+        `Updating civil claimant ${civilClaimantId} of case ${caseId}`,
+      )
+
+      const [numberOfAffectedRows, civilClaimants] =
+        await this.civilClaimantModel.update(update, {
+          where: { id: civilClaimantId, caseId },
+          returning: true,
+        })
+
+      return { numberOfAffectedRows, civilClaimants }
+    } catch (error) {
+      this.logger.error(
+        `Error updating civil claimant ${civilClaimantId} of case ${caseId}:`,
+        { error },
+      )
+
+      throw error
+    }
+  }
+
+  async deleteByIdAndCase(
+    civilClaimantId: string,
+    caseId: string,
+  ): Promise<number> {
+    try {
+      this.logger.debug(
+        `Deleting civil claimant ${civilClaimantId} of case ${caseId}`,
+      )
+
+      return await this.civilClaimantModel.destroy({
+        where: { id: civilClaimantId, caseId },
+      })
+    } catch (error) {
+      this.logger.error(
+        `Error deleting civil claimant ${civilClaimantId} of case ${caseId}:`,
+        { error },
+      )
+
+      throw error
+    }
+  }
+
+  async deleteAllForCase(
+    caseId: string,
+    options: { transaction: Transaction },
+  ): Promise<number> {
+    try {
+      this.logger.debug(`Deleting all civil claimants of case ${caseId}`)
+
+      return await this.civilClaimantModel.destroy({
+        where: { caseId },
+        transaction: options.transaction,
+      })
+    } catch (error) {
+      this.logger.error(
+        `Error deleting all civil claimants of case ${caseId}:`,
+        { error },
+      )
+
+      throw error
+    }
+  }
+
+  // Only claimants on a live case count, and "latest" is part of the operation
+  // rather than an ordering the caller gets to choose.
+  async findLatestBySpokespersonNationalId(
+    nationalId: string,
+  ): Promise<CivilClaimant | null> {
+    try {
+      this.logger.debug(
+        'Finding the latest civil claimant by spokesperson national id',
+      )
+
+      return await this.civilClaimantModel.findOne({
+        include: [
+          {
+            model: Case,
+            as: 'case',
+            where: {
+              state: { [Op.not]: CaseState.DELETED },
+              isArchived: false,
+            },
+          },
+        ],
+        where: { hasSpokesperson: true, spokespersonNationalId: nationalId },
+        order: [['created', 'DESC']],
+      })
+    } catch (error) {
+      this.logger.error(
+        'Error finding the latest civil claimant by spokesperson national id:',
+        { error },
+      )
+
+      throw error
+    }
+  }
+}

--- a/apps/judicial-system/backend/src/app/modules/repository/test/civilClaimantRepository.service.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/repository/test/civilClaimantRepository.service.spec.ts
@@ -1,0 +1,202 @@
+import { Op, Transaction } from 'sequelize'
+
+import { getModelToken } from '@nestjs/sequelize'
+import { Test } from '@nestjs/testing'
+
+import { LOGGER_PROVIDER } from '@island.is/logging'
+
+import { CaseState } from '@island.is/judicial-system/types'
+
+import { Case } from '../models/case.model'
+import { CivilClaimant } from '../models/civilClaimant.model'
+import { CivilClaimantRepositoryService } from '../services/civilClaimantRepository.service'
+
+describe('CivilClaimantRepositoryService', () => {
+  const civilClaimantId = 'some-civil-claimant-id'
+  const caseId = 'some-case-id'
+  const transaction = {} as Transaction
+
+  let service: CivilClaimantRepositoryService
+  let model: {
+    findOne: jest.Mock
+    create: jest.Mock
+    update: jest.Mock
+    destroy: jest.Mock
+  }
+
+  beforeEach(async () => {
+    model = {
+      findOne: jest.fn().mockResolvedValue(null),
+      create: jest.fn(),
+      update: jest.fn().mockResolvedValue([0, []]),
+      destroy: jest.fn().mockResolvedValue(0),
+    }
+
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        {
+          provide: LOGGER_PROVIDER,
+          useValue: { debug: jest.fn(), error: jest.fn() },
+        },
+        { provide: getModelToken(CivilClaimant), useValue: model },
+        CivilClaimantRepositoryService,
+      ],
+    }).compile()
+
+    service = moduleRef.get(CivilClaimantRepositoryService)
+  })
+
+  describe('create', () => {
+    it('creates the civil claimant against the case in the transaction', async () => {
+      const created = { id: civilClaimantId, caseId }
+      model.create.mockResolvedValueOnce(created)
+
+      const result = await service.create(caseId, { transaction })
+
+      expect(model.create).toHaveBeenCalledWith({ caseId }, { transaction })
+      expect(result).toBe(created)
+    })
+
+    it('rethrows when the creation fails', async () => {
+      const error = new Error('Some error')
+      model.create.mockRejectedValueOnce(error)
+
+      await expect(service.create(caseId, { transaction })).rejects.toThrow(
+        error,
+      )
+    })
+  })
+
+  describe('updateByIdAndCase', () => {
+    it('scopes the update to the civil claimant within its case', async () => {
+      const updated = { id: civilClaimantId, name: 'Jane Doe' }
+      model.update.mockResolvedValueOnce([1, [updated]])
+      const update = { hasSpokesperson: true, spokespersonName: 'John Doe' }
+
+      const result = await service.updateByIdAndCase(
+        civilClaimantId,
+        caseId,
+        update,
+      )
+
+      expect(model.update).toHaveBeenCalledWith(update, {
+        where: { id: civilClaimantId, caseId },
+        returning: true,
+      })
+      expect(result).toEqual({
+        numberOfAffectedRows: 1,
+        civilClaimants: [updated],
+      })
+    })
+
+    it('names both halves of the tuple, including when nothing matched', async () => {
+      model.update.mockResolvedValueOnce([0, []])
+
+      const result = await service.updateByIdAndCase(civilClaimantId, caseId, {
+        defendantIds: ['some-defendant-id'],
+      })
+
+      expect(result).toEqual({ numberOfAffectedRows: 0, civilClaimants: [] })
+    })
+
+    it('rethrows when the update fails', async () => {
+      const error = new Error('Some error')
+      model.update.mockRejectedValueOnce(error)
+
+      await expect(
+        service.updateByIdAndCase(civilClaimantId, caseId, {
+          name: 'Jane Doe',
+        }),
+      ).rejects.toThrow(error)
+    })
+  })
+
+  describe('deleteByIdAndCase', () => {
+    it('scopes the delete to the civil claimant within its case and returns the row count', async () => {
+      model.destroy.mockResolvedValueOnce(1)
+
+      const result = await service.deleteByIdAndCase(civilClaimantId, caseId)
+
+      expect(model.destroy).toHaveBeenCalledWith({
+        where: { id: civilClaimantId, caseId },
+      })
+      expect(result).toBe(1)
+    })
+
+    it('rethrows when the delete fails', async () => {
+      const error = new Error('Some error')
+      model.destroy.mockRejectedValueOnce(error)
+
+      await expect(
+        service.deleteByIdAndCase(civilClaimantId, caseId),
+      ).rejects.toThrow(error)
+    })
+  })
+
+  describe('deleteAllForCase', () => {
+    it('deletes every civil claimant of the case in the transaction', async () => {
+      model.destroy.mockResolvedValueOnce(2)
+
+      const result = await service.deleteAllForCase(caseId, { transaction })
+
+      expect(model.destroy).toHaveBeenCalledWith({
+        where: { caseId },
+        transaction,
+      })
+      expect(result).toBe(2)
+    })
+
+    it('rethrows when the delete fails', async () => {
+      const error = new Error('Some error')
+      model.destroy.mockRejectedValueOnce(error)
+
+      await expect(
+        service.deleteAllForCase(caseId, { transaction }),
+      ).rejects.toThrow(error)
+    })
+  })
+
+  describe('findLatestBySpokespersonNationalId', () => {
+    const nationalId = '0000000000'
+
+    it('looks up the most recent claimant of a live case for the spokesperson', async () => {
+      const civilClaimant = { id: civilClaimantId, caseId }
+      model.findOne.mockResolvedValueOnce(civilClaimant)
+
+      const result = await service.findLatestBySpokespersonNationalId(
+        nationalId,
+      )
+
+      expect(model.findOne).toHaveBeenCalledWith({
+        include: [
+          {
+            model: Case,
+            as: 'case',
+            where: {
+              state: { [Op.not]: CaseState.DELETED },
+              isArchived: false,
+            },
+          },
+        ],
+        where: { hasSpokesperson: true, spokespersonNationalId: nationalId },
+        order: [['created', 'DESC']],
+      })
+      expect(result).toBe(civilClaimant)
+    })
+
+    it('returns null when there is no such civil claimant', async () => {
+      expect(
+        await service.findLatestBySpokespersonNationalId(nationalId),
+      ).toBeNull()
+    })
+
+    it('rethrows when the lookup fails', async () => {
+      const error = new Error('Some error')
+      model.findOne.mockRejectedValueOnce(error)
+
+      await expect(
+        service.findLatestBySpokespersonNationalId(nationalId),
+      ).rejects.toThrow(error)
+    })
+  })
+})


### PR DESCRIPTION
# Civil claimant repository service

[Repository þjónusta fyrir CivilClaimant](https://app.asana.com/1/203394141643832/project/1199153462262248/task/1218046047762963)

Fourth chunk D satellite: `CivilClaimant` moves behind a repository service, so it is no
longer injected or registered anywhere outside `modules/repository/`.

`CivilClaimantRepositoryService` gets five intent-named methods, each wrapping its data
access per the module's error-handling convention:

- `create(caseId, { transaction })` — takes the case id rather than a `Case`.
- `updateByIdAndCase` / `deleteByIdAndCase` — name both keys instead of taking a `where`
  clause. A civil claimant is only addressable within its own case, which is a domain rule,
  not a query detail.
- `deleteAllForCase(caseId, { transaction })` — returns the row count it deletes.
- `findLatestBySpokespersonNationalId(nationalId)` — owns the whole query: the `Case`
  include that excludes deleted and archived cases, the `Op`, and the descending order.
  "Latest" is in the method name rather than in a caller-supplied `order`.

`update` returns a named `{ numberOfAffectedRows, civilClaimants }` rather than passing
Sequelize's `[count, rows]` tuple through to callers.

`CivilClaimantService` keeps every decision it made before: the row-count logging and
`InternalServerErrorException`s, the police-case-number narrowing of defendant ids, and the
spokesperson message queueing. `Op` and `CaseState` are no longer needed there. Its public
signatures are unchanged, so no caller outside the module moves.

`DefendantModule`'s `SequelizeModule.forFeature` held nothing but `CivilClaimant` (B2 removed
`CaseDefendantPoliceCaseNumber` earlier), so the whole call is gone and the module now
registers no Sequelize models at all.

`CaseRepositoryService` deliberately keeps its own `@InjectModel(CivilClaimant)`: that use sits
inside multi-entity orchestration which a later chunk lifts out, and the convention forbids a
repository service from injecting another one. So this closes **invariant 2** for
`CivilClaimant` and does not claim invariant 3.

## One deviation from the plan

The brief specified `updateByIdAndCase(..., options?: { transaction?: Transaction })`. No call
site passes a transaction to that path today, so the parameter would be dead on arrival; it is
omitted, matching `VictimRepositoryService.updateByIdAndCase`. It is one argument to add when a
caller needs it.

## Verification

Each check was dry-run on `main` first, so none of the negative ones is vacuous.

| Check | Baseline on `main` | After |
|---|---|---|
| `InjectModel(CivilClaimant)` / `civilClaimantModel` outside `modules/repository/` | 15 | 0 |
| `SequelizeModule.forFeature([… CivilClaimant …])` outside `modules/repository/` | 1 | 0 |
| `InjectModel(CivilClaimant)` inside `modules/repository/` (invariant 3, deliberately open) | 1 | 2 |
| `CivilClaimantRepositoryService` in `repository.module.ts` (import + provider + export) | 0 | 3 |

- `npx tsc --noEmit -p apps/judicial-system/backend/tsconfig.app.json` — clean.
- `yarn nx test judicial-system-backend --testPathPatterns='modules/(defendant|case|repository)/'` —
  199 suites, 8111 tests, green.
- `yarn nx lint judicial-system-backend` — no new problems.
- `openapi.yaml` unchanged after `codegen/backend-schema`.

## Tests

- New `test/civilClaimantRepository.service.spec.ts` covers each method's query shape, the
  named update result including the no-match case, and that every method rethrows.
- The defendant testing module mocks `CivilClaimantRepositoryService` in place of the model
  token, so the three `civilClaimantController` specs assert on repository calls rather than on
  Sequelize options. The `where` clauses they used to check are now the repository's own concern
  and are covered by its spec.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved the reliability and consistency of civil claimant data operations.
  * Added support for case-scoped creation, updates, deletion, bulk deletion, and latest-claimant retrieval.
  * Maintained transaction handling and exclusion of deleted or archived cases.

* **Tests**
  * Expanded coverage for civil claimant operations, error handling, filtering, and case scoping.
  * Updated controller scenarios to verify consistent data-management behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->