### PR TITLE
fix(j-s): prevent text from overflowing in appeals

### DIFF
--- a/apps/judicial-system/web/src/routes/Shared/AppealToCourtOfAppeals/AppealCaseFiles.tsx
+++ b/apps/judicial-system/web/src/routes/Shared/AppealToCourtOfAppeals/AppealCaseFiles.tsx
@@ -172,7 +172,7 @@ const AppealFiles = () => {
           marginBottom={isProsecutionUser(user) ? 5 : 10}
         >
           <SectionHeading title="Gögn" marginBottom={1} />
-          <Text marginBottom={3} whiteSpace="pre">
+          <Text marginBottom={3} whiteSpace="preWrap">
             Ef ný gögn eiga að fylgja kærunni er hægt að hlaða þeim upp hér að
             neðan.
             {'\n'}

--- a/apps/judicial-system/web/src/routes/Shared/AppealToCourtOfAppeals/AppealToCourtOfAppeals.tsx
+++ b/apps/judicial-system/web/src/routes/Shared/AppealToCourtOfAppeals/AppealToCourtOfAppeals.tsx
@@ -196,7 +196,7 @@ const AppealToCourtOfAppeals = () => {
           marginBottom={isProsecutionUser(user) ? 5 : 10}
         >
           <SectionHeading title="Gögn" marginBottom={1} />
-          <Text marginBottom={3} whiteSpace="pre">
+          <Text marginBottom={3} whiteSpace="preWrap">
             Ef ný gögn eiga að fylgja kærunni er hægt að hlaða þeim upp hér að
             neðan.
             {'\n'}

--- a/apps/judicial-system/web/src/routes/Shared/AppealToCourtOfAppeals/Statement.tsx
+++ b/apps/judicial-system/web/src/routes/Shared/AppealToCourtOfAppeals/Statement.tsx
@@ -232,7 +232,7 @@ const Statement = () => {
               marginBottom={isProsecutionUser(user) ? 5 : 10}
             >
               <SectionHeading title="Gögn" marginBottom={1} />
-              <Text marginBottom={3} whiteSpace="pre">
+              <Text marginBottom={3} whiteSpace="preWrap">
                 Ef ný gögn eiga að fylgja greinargerðinni er hægt að hlaða þeim
                 upp hér að neðan.
                 {'\n'}


### PR DESCRIPTION
[Asana](https://app.asana.com/1/203394141643832/project/1212657017130395/task/1217826059854141?focus=true)

## What

Text was overflowing, changed whitespace="pre" to "preWrap" 

## Why

Looks bad

## Screenshots / Gifs

Before:

<img width="367" height="480" alt="image" src="https://github.com/user-attachments/assets/50096b67-7322-4afd-9a98-3c02bf8cd98f" />

After:
<img width="646" height="421" alt="image" src="https://github.com/user-attachments/assets/cad44ad4-7fbc-4ed8-b914-f5acae0ca2ca" />


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Cursor


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved text wrapping in the appeal case file upload section.
  - Long explanatory messages now wrap naturally while preserving line breaks, improving readability across screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->