### PR TITLE
chore(native-app): remove health scope from app

### DIFF
--- a/apps/native/app/src/config-constants.ts
+++ b/apps/native/app/src/config-constants.ts
@@ -36,7 +36,6 @@ export const config = {
     '@island.is/health/organ-donation',
     '@island.is/licenses:barcode',
     '@island.is/auth/passkeys',
-    '@island.is/health',
   ],
   cognitoUrl: 'https://cognito.shared.devland.is/login',
   cognitoClientId: 'bre6r7d5e7imkcgbt7et1kqlc',

--- a/apps/native/app/src/stores/auth-store.ts
+++ b/apps/native/app/src/stores/auth-store.ts
@@ -35,7 +35,7 @@ const INVALID_REFRESH_TOKEN_ERROR = 'invalid_grant'
 const UNAUTHORIZED_USER_INFO = 'Got 401 when fetching user info'
 
 // Optional scopes (not required for all users so we do not want to force a logout)
-const OPTIONAL_SCOPES: string[] = ['@island.is/health']
+const OPTIONAL_SCOPES: string[] = []
 
 interface UserInfo {
   sub: string


### PR DESCRIPTION
## What

Remove island.is/health scope from the native app.

## Why

Since the change to health message endpoints has been deployed to prod (that internal scope is enough to get data) the app does not need the health scope anymore.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated sign-in authorization requirements so the health access scope is now required.
  - Users without the required authorization are notified and signed out.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->