### PR TITLE
fix(native-app): Match web renewal states

### DIFF
--- a/apps/native/app/src/app/(auth)/(modals)/renew-prescription.tsx
+++ b/apps/native/app/src/app/(auth)/(modals)/renew-prescription.tsx
@@ -67,10 +67,8 @@ export default function RenewPrescriptionScreen() {
 
   const [postRenewal, { loading: submitting }] =
     usePostPrescriptionRenewalMutation({
-      // The backend returns nothing renewal-state-related from the mutation, so
-      // we must refetch the list to observe the new pending state. awaitRefetch
-      // keeps the submit button in its loading state until that refetch resolves
-      // — so by the time we pop back, the list is already up to date.
+      // The mutation returns no renewal state, so refetch the list to see the
+      // pending state. Await it so the list is fresh before we pop back.
       refetchQueries: ['GetDrugPrescriptions'],
       awaitRefetchQueries: true,
     })

--- a/apps/native/app/src/app/(auth)/(modals)/renew-prescription.tsx
+++ b/apps/native/app/src/app/(auth)/(modals)/renew-prescription.tsx
@@ -67,7 +67,12 @@ export default function RenewPrescriptionScreen() {
 
   const [postRenewal, { loading: submitting }] =
     usePostPrescriptionRenewalMutation({
+      // The backend returns nothing renewal-state-related from the mutation, so
+      // we must refetch the list to observe the new pending state. awaitRefetch
+      // keeps the submit button in its loading state until that refetch resolves
+      // — so by the time we pop back, the list is already up to date.
       refetchQueries: ['GetDrugPrescriptions'],
+      awaitRefetchQueries: true,
     })
 
   const noTargets = !targetsLoading && options.length === 0

--- a/apps/native/app/src/components/prescription-card.tsx
+++ b/apps/native/app/src/components/prescription-card.tsx
@@ -70,15 +70,12 @@ type PrescriptionCardProps = {
 }
 
 type BlockedReasonInfo = {
-  // The pill label to show for this blocked reason.
-  status: string
+  status: string // pill label
   description: string
-  // Whether the description should surface in the info alert box.
-  showReason: boolean
+  showReason: boolean // whether to show the description in the box
 }
 
-// Mirrors the web portal's mapBlockedStatus (libs/portals/my-pages/health):
-// same per-reason status label + showReason flag, so behaviour stays in parity.
+// Mirrors the web portal's mapBlockedStatus (libs/portals/my-pages/health).
 const getBlockedReasonInfo = (
   reason: HealthDirectoratePrescriptionRenewalBlockedReason | null | undefined,
   intl: IntlShape,
@@ -199,9 +196,7 @@ const getBlockedReasonInfo = (
   }
 }
 
-// Per-status renewal labels, mirroring the web portal's renewalStatusMessageMap
-// (libs/portals/my-pages/health) so each status reads distinctly — notably
-// Pending shows "in progress" rather than collapsing into "not available".
+// Per-status renewal labels, mirroring the web portal's renewalStatusMessageMap.
 const renewalStatusMessageMap: Record<
   HealthDirectoratePrescriptionRenewalStatus,
   string
@@ -260,12 +255,9 @@ export const PrescriptionCard = ({
   const isExpired =
     prescription.expiryDate && new Date(prescription.expiryDate) < new Date()
 
-  // Renewal presentation, mirroring the web portal (PrescriptionsTable):
-  // - the blocked reason is derived from isRenewable ALONE, independent of
-  //   renewalStatus, so its description can surface in the box even when a
-  //   status is present;
-  // - the pill label prefers renewalStatus, else the blocked reason's label;
-  // - the renew action shows only when renewable with no pending status.
+  // Renewal presentation, mirroring web (PrescriptionsTable): blocked reason is
+  // derived from isRenewable alone (so its description can show alongside a
+  // status); the pill prefers renewalStatus, else the blocked reason's label.
   const canRenew = !!prescription.isRenewable && !prescription.renewalStatus
   const blocked = !prescription.isRenewable
     ? getBlockedReasonInfo(prescription.renewalBlockedReason, intl)

--- a/apps/native/app/src/components/prescription-card.tsx
+++ b/apps/native/app/src/components/prescription-card.tsx
@@ -70,128 +70,152 @@ type PrescriptionCardProps = {
 }
 
 type BlockedReasonInfo = {
+  // The pill label to show for this blocked reason.
+  status: string
   description: string
-  // Whether the prescription itself is still valid (positive state).
-  isValid: boolean
   // Whether the description should surface in the info alert box.
   showReason: boolean
 }
 
-// Mirrors the web portal's mapBlockedStatus (libs/portals/my-pages/health).
+// Mirrors the web portal's mapBlockedStatus (libs/portals/my-pages/health):
+// same per-reason status label + showReason flag, so behaviour stays in parity.
 const getBlockedReasonInfo = (
   reason: HealthDirectoratePrescriptionRenewalBlockedReason | null | undefined,
   intl: IntlShape,
 ): BlockedReasonInfo => {
   const Reason = HealthDirectoratePrescriptionRenewalBlockedReason
   const describe = (id: string) => intl.formatMessage({ id })
+  const notAvailable = describe('health.prescriptions.renewalNotAvailable')
+  const valid = describe('health.prescriptions.renewalValid')
+  const processing = describe('health.prescriptions.renewalStatusPending')
+  const rejected = describe('health.prescriptions.renewalStatusRejected')
   switch (reason) {
     case Reason.IsRegiment:
       return {
+        status: notAvailable,
         description: describe('health.prescriptions.renewalBlockedIsRegiment'),
-        isValid: false,
         showReason: true,
       }
     case Reason.NoMedCard:
       return {
+        status: notAvailable,
         description: describe('health.prescriptions.renewalBlockedNoMedCard'),
-        isValid: false,
         showReason: true,
       }
     case Reason.NoHealthClinic:
       return {
+        status: notAvailable,
         description: describe(
           'health.prescriptions.renewalBlockedNoHealthClinic',
         ),
-        isValid: false,
         showReason: true,
       }
     case Reason.NotFullyDispensed:
       return {
+        status: valid,
         description: describe(
           'health.prescriptions.renewalBlockedNotFullyDispensed',
         ),
-        isValid: true,
         showReason: false,
       }
     case Reason.PendingRequest:
       return {
+        status: processing,
         description: describe(
           'health.prescriptions.renewalBlockedPendingRequest',
         ),
-        isValid: false,
         showReason: false,
       }
     case Reason.RejectedRequest:
       return {
+        status: rejected,
         description: describe(
           'health.prescriptions.renewalBlockedRejectedRequest',
         ),
-        isValid: false,
         showReason: false,
       }
     case Reason.DismissedRequest:
       return {
+        status: notAvailable,
         description: describe(
           'health.prescriptions.renewalBlockedDismissedRequest',
         ),
-        isValid: false,
         showReason: true,
       }
     case Reason.AlreadyRequested:
       return {
+        status: processing,
         description: describe(
           'health.prescriptions.renewalBlockedAlreadyRequested',
         ),
-        isValid: false,
         showReason: false,
       }
     case Reason.MoreRecentPrescriptionExists:
       return {
+        status: notAvailable,
         description: describe(
           'health.prescriptions.renewalBlockedMoreRecentExists',
         ),
-        isValid: false,
         showReason: true,
       }
     case Reason.SpecialistOnlyPrescription:
       return {
+        status: notAvailable,
         description: describe(
           'health.prescriptions.renewalBlockedSpecialistOnly',
         ),
-        isValid: false,
         showReason: true,
       }
     case Reason.NoRenewalTargets:
       return {
+        status: notAvailable,
         description: describe(
           'health.prescriptions.renewalBlockedNoRenewalTargets',
         ),
-        isValid: false,
         showReason: true,
       }
     case Reason.InvalidRenewalTarget:
       return {
+        status: notAvailable,
         description: describe(
           'health.prescriptions.renewalBlockedInvalidRenewalTarget',
         ),
-        isValid: false,
         showReason: true,
       }
     case Reason.RecipientExcludesAtc:
       return {
+        status: notAvailable,
         description: describe(
           'health.prescriptions.renewalBlockedRecipientExcludesAtc',
         ),
-        isValid: false,
         showReason: true,
       }
     default:
       return {
+        status: notAvailable,
         description: describe('health.prescriptions.renewalBlockedOther'),
-        isValid: false,
         showReason: true,
       }
   }
+}
+
+// Per-status renewal labels, mirroring the web portal's renewalStatusMessageMap
+// (libs/portals/my-pages/health) so each status reads distinctly — notably
+// Pending shows "in progress" rather than collapsing into "not available".
+const renewalStatusMessageMap: Record<
+  HealthDirectoratePrescriptionRenewalStatus,
+  string
+> = {
+  [HealthDirectoratePrescriptionRenewalStatus.Approved]:
+    'health.prescriptions.renewalStatusApproved',
+  [HealthDirectoratePrescriptionRenewalStatus.Pending]:
+    'health.prescriptions.renewalStatusPending',
+  [HealthDirectoratePrescriptionRenewalStatus.Rejected]:
+    'health.prescriptions.renewalStatusRejected',
+  [HealthDirectoratePrescriptionRenewalStatus.Dismissed]:
+    'health.prescriptions.renewalStatusDismissed',
+  [HealthDirectoratePrescriptionRenewalStatus.Unknown]:
+    'health.prescriptions.renewalStatusUnknown',
 }
 
 export const PrescriptionCard = ({
@@ -236,39 +260,25 @@ export const PrescriptionCard = ({
   const isExpired =
     prescription.expiryDate && new Date(prescription.expiryDate) < new Date()
 
-  // Renewal presentation, mirroring the web portal's decision order:
-  // renewalStatus wins → else renewable shows the action → else blocked reason.
+  // Renewal presentation, mirroring the web portal (PrescriptionsTable):
+  // - the blocked reason is derived from isRenewable ALONE, independent of
+  //   renewalStatus, so its description can surface in the box even when a
+  //   status is present;
+  // - the pill label prefers renewalStatus, else the blocked reason's label;
+  // - the renew action shows only when renewable with no pending status.
   const canRenew = !!prescription.isRenewable && !prescription.renewalStatus
-  const renewalInfo = ((): { statusLabel: string; alertMessage?: string } => {
-    if (prescription.renewalStatus) {
-      const isValid =
-        prescription.renewalStatus ===
-        HealthDirectoratePrescriptionRenewalStatus.Approved
-      return {
-        statusLabel: intl.formatMessage({
-          id: isValid
-            ? 'health.prescriptions.renewalValid'
-            : 'health.prescriptions.renewalNotAvailable',
-        }),
-        alertMessage: prescription.renewResponseMessage ?? undefined,
-      }
-    }
-    const blocked = getBlockedReasonInfo(
-      prescription.renewalBlockedReason,
-      intl,
-    )
-    return {
-      statusLabel: intl.formatMessage({
-        id: blocked.isValid
-          ? 'health.prescriptions.renewalValid'
-          : 'health.prescriptions.renewalNotAvailable',
-      }),
-      alertMessage:
-        blocked.showReason || prescription.renewResponseMessage
-          ? prescription.renewResponseMessage || blocked.description
-          : undefined,
-    }
-  })()
+  const blocked = !prescription.isRenewable
+    ? getBlockedReasonInfo(prescription.renewalBlockedReason, intl)
+    : null
+  const statusLabel = prescription.renewalStatus
+    ? intl.formatMessage({
+        id: renewalStatusMessageMap[prescription.renewalStatus],
+      })
+    : blocked?.status ?? ''
+  const alertMessage =
+    blocked?.showReason || prescription.renewResponseMessage
+      ? prescription.renewResponseMessage || blocked?.description
+      : undefined
 
   const attachmentRows: PrescriptionRow[] = documentsLoading
     ? [
@@ -386,7 +396,7 @@ export const PrescriptionCard = ({
     />
   ) : (
     <StatusPill>
-      <Typography variant="body3">{renewalInfo.statusLabel}</Typography>
+      <Typography variant="body3">{statusLabel}</Typography>
     </StatusPill>
   )
 
@@ -418,9 +428,9 @@ export const PrescriptionCard = ({
       footer={renewalElement}
     >
       <View style={{ width: '100%', padding: theme.spacing[2] }}>
-        {renewalInfo.alertMessage ? (
+        {alertMessage ? (
           <View style={{ marginBottom: theme.spacing[2] }}>
-            <Alert type="info" hasBorder message={renewalInfo.alertMessage} />
+            <Alert type="info" hasBorder message={alertMessage} />
           </View>
         ) : null}
         <View>

--- a/apps/native/app/src/messages/en.ts
+++ b/apps/native/app/src/messages/en.ts
@@ -1059,6 +1059,11 @@ export const en: TranslatedMessages = {
   'health.prescriptions.renewalPossible': 'Can be renewed',
   'health.prescriptions.renewalValid': 'Valid prescription',
   'health.prescriptions.renewalNotAvailable': 'Renewal not available',
+  'health.prescriptions.renewalStatusApproved': 'Renewal approved',
+  'health.prescriptions.renewalStatusPending': 'Renewal in progress',
+  'health.prescriptions.renewalStatusRejected': 'Renewal rejected',
+  'health.prescriptions.renewalStatusDismissed': 'Renewal dismissed',
+  'health.prescriptions.renewalStatusUnknown': 'Renewal status unknown',
   'health.prescriptions.renewalBlockedIsRegiment':
     'Medical treatment courses cannot be renewed here',
   'health.prescriptions.renewalBlockedNoMedCard': 'No drug card registered',

--- a/apps/native/app/src/messages/is.ts
+++ b/apps/native/app/src/messages/is.ts
@@ -1052,6 +1052,11 @@ export const is = {
   'health.prescriptions.renewalPossible': 'Hægt að endurnýja',
   'health.prescriptions.renewalValid': 'Gild lyfjaávísun',
   'health.prescriptions.renewalNotAvailable': 'Endurnýjun ekki í boði',
+  'health.prescriptions.renewalStatusApproved': 'Endurnýjun samþykkt',
+  'health.prescriptions.renewalStatusPending': 'Endurnýjun í vinnslu',
+  'health.prescriptions.renewalStatusRejected': 'Endurnýjun hafnað',
+  'health.prescriptions.renewalStatusDismissed': 'Endurnýjun vísað frá',
+  'health.prescriptions.renewalStatusUnknown': 'Staða endurnýjunar óþekkt',
   'health.prescriptions.renewalBlockedIsRegiment':
     'Ekki er hægt að endurnýja lyfjakúr',
   'health.prescriptions.renewalBlockedNoMedCard': 'Ekkert lyfjakort skráð',


### PR DESCRIPTION
## What

* Make sure to match the web for all states for the renewal process.
* Refetch prescriptions after renewal request goes through so the user sees updated info.


## Screenshots / Gifs

Shows different available states (mocked):
https://github.com/user-attachments/assets/adf646a3-e953-4c03-a767-1719d8eeb419

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prescription renewal screens now remain in a loading state until refreshed prescription information is available.
  * Renewal status labels and alerts now accurately reflect approved, pending, rejected, dismissed, unavailable, and unknown states.
  * Updated messaging prioritizes relevant renewal response details when available.

* **Documentation**
  * Added English and Icelandic translations for prescription renewal statuses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->