### PR TITLE
feat(dsl): add rollout strategy + graceful shutdown builders

### DIFF
--- a/apps/api/infra/api.ts
+++ b/apps/api/infra/api.ts
@@ -628,14 +628,14 @@ export const serviceSetup = (services: {
       cpuAverageUtilization: 70,
     })
     .strategy({
-      // dev: fast/cheap rollout. staging/prod: zero-downtime.
+      // prod: zero-downtime. dev/staging: downtime is fine, roll faster.
       dev: {
         type: 'RollingUpdate',
         rollingUpdate: { maxSurge: '25%', maxUnavailable: '25%' },
       },
       staging: {
         type: 'RollingUpdate',
-        rollingUpdate: { maxSurge: '25%', maxUnavailable: 0 },
+        rollingUpdate: { maxSurge: '25%', maxUnavailable: '25%' },
       },
       prod: {
         type: 'RollingUpdate',
@@ -643,18 +643,18 @@ export const serviceSetup = (services: {
       },
     })
     .gracefulShutdown({
-      // Full drain in staging/prod (long XRoad/GraphQL calls); relaxed in dev.
+      // Full drain in prod (long XRoad/GraphQL calls); relaxed elsewhere.
+      // minReadySeconds kept at 0 for now — knob to tune if needed.
       dev: {
         minReadySeconds: 0,
         terminationGracePeriodSeconds: 30,
       },
       staging: {
-        minReadySeconds: 10,
-        terminationGracePeriodSeconds: 60,
-        preStopSleepSeconds: 10,
+        minReadySeconds: 0,
+        terminationGracePeriodSeconds: 30,
       },
       prod: {
-        minReadySeconds: 10,
+        minReadySeconds: 0,
         terminationGracePeriodSeconds: 60,
         preStopSleepSeconds: 10,
       },

--- a/apps/api/infra/api.ts
+++ b/apps/api/infra/api.ts
@@ -627,6 +627,38 @@ export const serviceSetup = (services: {
       min: 3,
       cpuAverageUtilization: 70,
     })
+    .strategy({
+      // dev: fast/cheap rollout. staging/prod: zero-downtime.
+      dev: {
+        type: 'RollingUpdate',
+        rollingUpdate: { maxSurge: '25%', maxUnavailable: '25%' },
+      },
+      staging: {
+        type: 'RollingUpdate',
+        rollingUpdate: { maxSurge: '25%', maxUnavailable: 0 },
+      },
+      prod: {
+        type: 'RollingUpdate',
+        rollingUpdate: { maxSurge: '25%', maxUnavailable: 0 },
+      },
+    })
+    .gracefulShutdown({
+      // Full drain in staging/prod (long XRoad/GraphQL calls); relaxed in dev.
+      dev: {
+        minReadySeconds: 0,
+        terminationGracePeriodSeconds: 30,
+      },
+      staging: {
+        minReadySeconds: 10,
+        terminationGracePeriodSeconds: 60,
+        preStopSleepSeconds: 10,
+      },
+      prod: {
+        minReadySeconds: 10,
+        terminationGracePeriodSeconds: 60,
+        preStopSleepSeconds: 10,
+      },
+    })
     .grantNamespaces(
       'nginx-ingress-external',
       'api-catalogue',

--- a/charts/islandis-services/api/values.dev.yaml
+++ b/charts/islandis-services/api/values.dev.yaml
@@ -243,6 +243,7 @@ httpRoute:
           - pathPrefix: '/api'
 image:
   repository: '821090935708.dkr.ecr.eu-west-1.amazonaws.com/api'
+minReadySeconds: 0
 namespace: 'islandis'
 podDisruptionBudget:
   minAvailable: '50%'
@@ -399,3 +400,9 @@ serviceAccount:
     eks.amazonaws.com/role-arn: 'arn:aws:iam::013313053092:role/api'
   create: true
   name: 'api'
+strategy:
+  rollingUpdate:
+    maxSurge: '25%'
+    maxUnavailable: '25%'
+  type: 'RollingUpdate'
+terminationGracePeriodSeconds: 30

--- a/charts/islandis-services/api/values.prod.yaml
+++ b/charts/islandis-services/api/values.prod.yaml
@@ -243,6 +243,14 @@ httpRoute:
           - pathPrefix: '/api'
 image:
   repository: '821090935708.dkr.ecr.eu-west-1.amazonaws.com/api'
+lifecycle:
+  preStop:
+    exec:
+      command:
+        - '/bin/sh'
+        - '-c'
+        - 'sleep 10'
+minReadySeconds: 10
 namespace: 'islandis'
 podDisruptionBudget:
   minAvailable: '50%'
@@ -399,3 +407,9 @@ serviceAccount:
     eks.amazonaws.com/role-arn: 'arn:aws:iam::251502586493:role/api'
   create: true
   name: 'api'
+strategy:
+  rollingUpdate:
+    maxSurge: '25%'
+    maxUnavailable: 0
+  type: 'RollingUpdate'
+terminationGracePeriodSeconds: 60

--- a/charts/islandis-services/api/values.prod.yaml
+++ b/charts/islandis-services/api/values.prod.yaml
@@ -250,7 +250,7 @@ lifecycle:
         - '/bin/sh'
         - '-c'
         - 'sleep 10'
-minReadySeconds: 10
+minReadySeconds: 0
 namespace: 'islandis'
 podDisruptionBudget:
   minAvailable: '50%'

--- a/charts/islandis-services/api/values.staging.yaml
+++ b/charts/islandis-services/api/values.staging.yaml
@@ -242,14 +242,7 @@ httpRoute:
           - pathPrefix: '/api'
 image:
   repository: '821090935708.dkr.ecr.eu-west-1.amazonaws.com/api'
-lifecycle:
-  preStop:
-    exec:
-      command:
-        - '/bin/sh'
-        - '-c'
-        - 'sleep 10'
-minReadySeconds: 10
+minReadySeconds: 0
 namespace: 'islandis'
 podDisruptionBudget:
   minAvailable: '50%'
@@ -409,6 +402,6 @@ serviceAccount:
 strategy:
   rollingUpdate:
     maxSurge: '25%'
-    maxUnavailable: 0
+    maxUnavailable: '25%'
   type: 'RollingUpdate'
-terminationGracePeriodSeconds: 60
+terminationGracePeriodSeconds: 30

--- a/charts/islandis-services/api/values.staging.yaml
+++ b/charts/islandis-services/api/values.staging.yaml
@@ -242,6 +242,14 @@ httpRoute:
           - pathPrefix: '/api'
 image:
   repository: '821090935708.dkr.ecr.eu-west-1.amazonaws.com/api'
+lifecycle:
+  preStop:
+    exec:
+      command:
+        - '/bin/sh'
+        - '-c'
+        - 'sleep 10'
+minReadySeconds: 10
 namespace: 'islandis'
 podDisruptionBudget:
   minAvailable: '50%'
@@ -398,3 +406,9 @@ serviceAccount:
     eks.amazonaws.com/role-arn: 'arn:aws:iam::261174024191:role/api'
   create: true
   name: 'api'
+strategy:
+  rollingUpdate:
+    maxSurge: '25%'
+    maxUnavailable: 0
+  type: 'RollingUpdate'
+terminationGracePeriodSeconds: 60

--- a/charts/islandis/values.dev.yaml
+++ b/charts/islandis/values.dev.yaml
@@ -352,6 +352,7 @@ api:
             - pathPrefix: '/api'
   image:
     repository: '821090935708.dkr.ecr.eu-west-1.amazonaws.com/api'
+  minReadySeconds: 0
   namespace: 'islandis'
   podDisruptionBudget:
     minAvailable: '50%'
@@ -508,6 +509,12 @@ api:
       eks.amazonaws.com/role-arn: 'arn:aws:iam::013313053092:role/api'
     create: true
     name: 'api'
+  strategy:
+    rollingUpdate:
+      maxSurge: '25%'
+      maxUnavailable: '25%'
+    type: 'RollingUpdate'
+  terminationGracePeriodSeconds: 30
 application-system-api:
   args:
     - 'main.cjs'

--- a/charts/islandis/values.prod.yaml
+++ b/charts/islandis/values.prod.yaml
@@ -351,6 +351,14 @@ api:
             - pathPrefix: '/api'
   image:
     repository: '821090935708.dkr.ecr.eu-west-1.amazonaws.com/api'
+  lifecycle:
+    preStop:
+      exec:
+        command:
+          - '/bin/sh'
+          - '-c'
+          - 'sleep 10'
+  minReadySeconds: 10
   namespace: 'islandis'
   podDisruptionBudget:
     minAvailable: '50%'
@@ -507,6 +515,12 @@ api:
       eks.amazonaws.com/role-arn: 'arn:aws:iam::251502586493:role/api'
     create: true
     name: 'api'
+  strategy:
+    rollingUpdate:
+      maxSurge: '25%'
+      maxUnavailable: 0
+    type: 'RollingUpdate'
+  terminationGracePeriodSeconds: 60
 application-system-api:
   args:
     - 'main.cjs'

--- a/charts/islandis/values.prod.yaml
+++ b/charts/islandis/values.prod.yaml
@@ -358,7 +358,7 @@ api:
           - '/bin/sh'
           - '-c'
           - 'sleep 10'
-  minReadySeconds: 10
+  minReadySeconds: 0
   namespace: 'islandis'
   podDisruptionBudget:
     minAvailable: '50%'

--- a/charts/islandis/values.staging.yaml
+++ b/charts/islandis/values.staging.yaml
@@ -351,6 +351,14 @@ api:
             - pathPrefix: '/api'
   image:
     repository: '821090935708.dkr.ecr.eu-west-1.amazonaws.com/api'
+  lifecycle:
+    preStop:
+      exec:
+        command:
+          - '/bin/sh'
+          - '-c'
+          - 'sleep 10'
+  minReadySeconds: 10
   namespace: 'islandis'
   podDisruptionBudget:
     minAvailable: '50%'
@@ -507,6 +515,12 @@ api:
       eks.amazonaws.com/role-arn: 'arn:aws:iam::261174024191:role/api'
     create: true
     name: 'api'
+  strategy:
+    rollingUpdate:
+      maxSurge: '25%'
+      maxUnavailable: 0
+    type: 'RollingUpdate'
+  terminationGracePeriodSeconds: 60
 application-system-api:
   args:
     - 'main.cjs'

--- a/charts/islandis/values.staging.yaml
+++ b/charts/islandis/values.staging.yaml
@@ -351,14 +351,7 @@ api:
             - pathPrefix: '/api'
   image:
     repository: '821090935708.dkr.ecr.eu-west-1.amazonaws.com/api'
-  lifecycle:
-    preStop:
-      exec:
-        command:
-          - '/bin/sh'
-          - '-c'
-          - 'sleep 10'
-  minReadySeconds: 10
+  minReadySeconds: 0
   namespace: 'islandis'
   podDisruptionBudget:
     minAvailable: '50%'
@@ -518,9 +511,9 @@ api:
   strategy:
     rollingUpdate:
       maxSurge: '25%'
-      maxUnavailable: 0
+      maxUnavailable: '25%'
     type: 'RollingUpdate'
-  terminationGracePeriodSeconds: 60
+  terminationGracePeriodSeconds: 30
 application-system-api:
   args:
     - 'main.cjs'

--- a/infra/src/dsl/dsl.ts
+++ b/infra/src/dsl/dsl.ts
@@ -21,6 +21,8 @@ import type {
   ServiceDefinition,
   XroadConfig,
   PodDisruptionBudget,
+  RolloutStrategyInput,
+  GracefulShutdownInput,
   IngressMapping,
   BffInfo,
 } from './types/input-types'
@@ -255,6 +257,26 @@ export class ServiceBuilder<ServiceType extends string> {
    */
   podDisruption(pdb: PodDisruptionBudget) {
     this.serviceDef.podDisruptionBudget = pdb
+    return this
+  }
+
+  /**
+   * Deployment rollout strategy (`Deployment.spec.strategy`). Use
+   * `maxUnavailable: 0` for zero-downtime rollouts. Accepts a flat config or a
+   * per-env map, e.g. `{ dev: {...}, prod: {...} }`.
+   */
+  strategy(strategy: RolloutStrategyInput) {
+    this.serviceDef.strategy = strategy
+    return this
+  }
+
+  /**
+   * Graceful shutdown settings; complements `strategy({ maxUnavailable: 0 })`
+   * so in-flight requests finish during a rollout. Flat or per-env. See
+   * {@link GracefulShutdown}.
+   */
+  gracefulShutdown(cfg: GracefulShutdownInput) {
+    this.serviceDef.gracefulShutdown = cfg
     return this
   }
 

--- a/infra/src/dsl/output-generators/map-to-helm-values.ts
+++ b/infra/src/dsl/output-generators/map-to-helm-values.ts
@@ -109,6 +109,36 @@ const serializeService: SerializeMethod<HelmService> = async (
   if (serviceDef.podDisruptionBudget) {
     result.podDisruptionBudget = serviceDef.podDisruptionBudget
   }
+
+  // rollout strategy
+  if (serviceDef.strategy) {
+    result.strategy = serviceDef.strategy
+  }
+
+  // graceful shutdown
+  if (serviceDef.gracefulShutdown) {
+    const {
+      minReadySeconds,
+      terminationGracePeriodSeconds,
+      preStopSleepSeconds,
+    } = serviceDef.gracefulShutdown
+    if (minReadySeconds !== undefined) {
+      result.minReadySeconds = minReadySeconds
+    }
+    if (terminationGracePeriodSeconds !== undefined) {
+      result.terminationGracePeriodSeconds = terminationGracePeriodSeconds
+    }
+    if (preStopSleepSeconds !== undefined) {
+      result.lifecycle = {
+        preStop: {
+          exec: {
+            command: ['/bin/sh', '-c', `sleep ${preStopSleepSeconds}`],
+          },
+        },
+      }
+    }
+  }
+
   // resources
   result.resources = serviceDef.resources
 

--- a/infra/src/dsl/service-to-environment/pre-process-service.ts
+++ b/infra/src/dsl/service-to-environment/pre-process-service.ts
@@ -8,6 +8,7 @@ import {
   IngressForEnv,
   localFromDev,
   MissingSetting,
+  OpsEnv,
   OpsEnvWithLocal,
   PostgresInfo,
   PostgresInfoForEnv,
@@ -118,6 +119,8 @@ export function prepareServiceForEnv(
     cmds: serviceDef.cmds,
     readiness: serviceDef.readiness,
     podDisruptionBudget: serviceDef.podDisruptionBudget,
+    strategy: resolveByEnv(serviceDef.strategy, env),
+    gracefulShutdown: resolveByEnv(serviceDef.gracefulShutdown, env),
   }
 
   if (serviceDef.postgres) {
@@ -222,6 +225,27 @@ export function prepareServiceForEnv(
   return allErrors.length === 0
     ? { type: 'success', serviceDef: result }
     : { type: 'error', errors: allErrors }
+}
+
+const OPS_ENVS: OpsEnv[] = ['dev', 'staging', 'prod']
+
+/**
+ * Resolves a flat config or a per-env map (keyed by OpsEnv) to the current
+ * env's value. Treated as per-env only when every key is an OpsEnv.
+ */
+function resolveByEnv<T extends object>(
+  value: T | Partial<Record<OpsEnv, T>> | undefined,
+  env: EnvironmentConfig,
+): T | undefined {
+  if (value === undefined) return undefined
+  const keys = Object.keys(value)
+  const isByEnv =
+    keys.length > 0 && keys.every((k) => (OPS_ENVS as string[]).includes(k))
+  if (!isByEnv) {
+    return value as T
+  }
+  const byEnv = value as Partial<Record<OpsEnv, T>>
+  return byEnv[localFromDev(env.type)]
 }
 
 export function getEnvVariables(

--- a/infra/src/dsl/strategy.spec.ts
+++ b/infra/src/dsl/strategy.spec.ts
@@ -1,0 +1,127 @@
+import { service, ServiceBuilder } from './dsl'
+import { Kubernetes } from './kubernetes-runtime'
+import { SerializeSuccess, HelmService } from './types/output-types'
+import { EnvironmentConfig } from './types/charts'
+import { renderers } from './upstream-dependencies'
+import { generateOutputOne } from './processing/rendering-pipeline'
+
+const Staging: EnvironmentConfig = {
+  auroraHost: 'a',
+  redisHost: 'b',
+  domain: 'staging01.devland.is',
+  type: 'staging',
+  featuresOn: [],
+  defaultMaxReplicas: 3,
+  defaultMinReplicas: 2,
+  releaseName: 'web',
+  awsAccountId: '111111',
+  awsAccountRegion: 'eu-west-1',
+  global: {},
+}
+
+const render = async (sut: ServiceBuilder<'api'>) => {
+  const result = (await generateOutputOne({
+    outputFormat: renderers.helm,
+    service: sut,
+    runtime: new Kubernetes(Staging),
+    env: Staging,
+  })) as SerializeSuccess<HelmService>
+  return result.serviceDef[0]
+}
+
+describe('Rollout strategy definitions', () => {
+  it('does not set a strategy by default (chart default applies)', async () => {
+    const sut: ServiceBuilder<'api'> = service('api')
+    const serviceDef = await render(sut)
+    expect(serviceDef.strategy).toBeUndefined()
+  })
+
+  it('maps a zero-downtime rollout strategy', async () => {
+    const sut: ServiceBuilder<'api'> = service('api').strategy({
+      type: 'RollingUpdate',
+      rollingUpdate: { maxSurge: '25%', maxUnavailable: 0 },
+    })
+    const serviceDef = await render(sut)
+    expect(serviceDef.strategy).toEqual({
+      type: 'RollingUpdate',
+      rollingUpdate: { maxSurge: '25%', maxUnavailable: 0 },
+    })
+  })
+
+  it('resolves a per-env strategy to the environment value (staging)', async () => {
+    const sut: ServiceBuilder<'api'> = service('api').strategy({
+      dev: {
+        type: 'RollingUpdate',
+        rollingUpdate: { maxSurge: '25%', maxUnavailable: '25%' },
+      },
+      staging: {
+        type: 'RollingUpdate',
+        rollingUpdate: { maxSurge: '25%', maxUnavailable: 0 },
+      },
+      prod: {
+        type: 'RollingUpdate',
+        rollingUpdate: { maxSurge: '25%', maxUnavailable: 0 },
+      },
+    })
+    // render() uses the Staging env
+    const serviceDef = await render(sut)
+    expect(serviceDef.strategy).toEqual({
+      type: 'RollingUpdate',
+      rollingUpdate: { maxSurge: '25%', maxUnavailable: 0 },
+    })
+  })
+})
+
+describe('Graceful shutdown definitions', () => {
+  it('does not set graceful shutdown fields by default', async () => {
+    const sut: ServiceBuilder<'api'> = service('api')
+    const serviceDef = await render(sut)
+    expect(serviceDef.minReadySeconds).toBeUndefined()
+    expect(serviceDef.terminationGracePeriodSeconds).toBeUndefined()
+    expect(serviceDef.lifecycle).toBeUndefined()
+  })
+
+  it('maps minReadySeconds and terminationGracePeriodSeconds', async () => {
+    const sut: ServiceBuilder<'api'> = service('api').gracefulShutdown({
+      minReadySeconds: 10,
+      terminationGracePeriodSeconds: 60,
+    })
+    const serviceDef = await render(sut)
+    expect(serviceDef.minReadySeconds).toEqual(10)
+    expect(serviceDef.terminationGracePeriodSeconds).toEqual(60)
+    expect(serviceDef.lifecycle).toBeUndefined()
+  })
+
+  it('maps preStopSleepSeconds to a preStop exec sleep hook', async () => {
+    const sut: ServiceBuilder<'api'> = service('api').gracefulShutdown({
+      preStopSleepSeconds: 10,
+    })
+    const serviceDef = await render(sut)
+    expect(serviceDef.lifecycle).toEqual({
+      preStop: { exec: { command: ['/bin/sh', '-c', 'sleep 10'] } },
+    })
+  })
+
+  it('resolves per-env graceful shutdown to the environment value (staging)', async () => {
+    const sut: ServiceBuilder<'api'> = service('api').gracefulShutdown({
+      dev: { minReadySeconds: 0, terminationGracePeriodSeconds: 30 },
+      staging: {
+        minReadySeconds: 10,
+        terminationGracePeriodSeconds: 60,
+        preStopSleepSeconds: 10,
+      },
+      prod: {
+        minReadySeconds: 10,
+        terminationGracePeriodSeconds: 60,
+        preStopSleepSeconds: 10,
+      },
+    })
+    // render() uses the Staging env
+    const serviceDef = await render(sut)
+    expect(serviceDef.minReadySeconds).toEqual(10)
+    expect(serviceDef.terminationGracePeriodSeconds).toEqual(60)
+    expect(serviceDef.lifecycle).toEqual({
+      preStop: { exec: { command: ['/bin/sh', '-c', 'sleep 10'] } },
+    })
+  })
+})

--- a/infra/src/dsl/types/input-types.ts
+++ b/infra/src/dsl/types/input-types.ts
@@ -139,6 +139,8 @@ export type ServiceDefinition = ServiceDefinitionCore & {
   extraAttributes?: ExtraValues
   xroadConfig: XroadConfig[]
   scheduledJob?: ScheduledJobConfig
+  strategy?: RolloutStrategyInput
+  gracefulShutdown?: GracefulShutdownInput
 }
 
 /**
@@ -152,6 +154,8 @@ export type ServiceDefinitionForEnv = ServiceDefinitionCore & {
   redis?: RedisInfoForEnv
   extraAttributes?: ExtraValuesForEnv
   scheduledJob?: ScheduledJobConfigForEnv
+  strategy?: RolloutStrategy
+  gracefulShutdown?: GracefulShutdown
 }
 
 export interface Ingress {
@@ -180,6 +184,44 @@ export type PodDisruptionBudget = {
   maxUnavailable?: number | string
   unhealthyPodEvictionPolicy?: 'IfHealthyBudget' | 'AlwaysAllow'
 }
+
+/**
+ * Deployment rollout strategy, mapped to `Deployment.spec.strategy`. Set
+ * `rollingUpdate.maxUnavailable: 0` for zero-downtime rollouts.
+ *
+ * NOTE: this is safe. Do NOT mirror `maxUnavailable: 0` onto the PDB
+ * (`.podDisruption()`) — there it blocks node drains and deadlocks.
+ */
+export type RolloutStrategy = {
+  type?: 'RollingUpdate' | 'Recreate'
+  rollingUpdate?: {
+    maxSurge?: number | string
+    maxUnavailable?: number | string
+  }
+}
+
+/** RolloutStrategy applied to all envs, or keyed per-env. */
+export type RolloutStrategyByEnv = Partial<{ [env in OpsEnv]: RolloutStrategy }>
+export type RolloutStrategyInput = RolloutStrategy | RolloutStrategyByEnv
+
+/**
+ * Graceful shutdown knobs. `maxUnavailable: 0` guarantees replica count but not
+ * that in-flight requests finish; these close that gap.
+ */
+export type GracefulShutdown = {
+  /** Time a new pod must stay Ready before it counts as available. */
+  minReadySeconds?: number
+  /** Drain window after SIGTERM before force-kill. */
+  terminationGracePeriodSeconds?: number
+  /** preStop `sleep` so the pod keeps serving while endpoints are removed. */
+  preStopSleepSeconds?: number
+}
+
+/** GracefulShutdown applied to all envs, or keyed per-env. */
+export type GracefulShutdownByEnv = Partial<{
+  [env in OpsEnv]: GracefulShutdown
+}>
+export type GracefulShutdownInput = GracefulShutdown | GracefulShutdownByEnv
 export type PersistentVolumeClaim = {
   name?: string
   size: '1Gi' | '5Gi' | '10Gi' | string

--- a/infra/src/dsl/types/output-types.ts
+++ b/infra/src/dsl/types/output-types.ts
@@ -3,6 +3,8 @@ import {
   ServiceDefinition,
   ServiceDefinitionForEnv,
   PodDisruptionBudget,
+  RolloutStrategy,
+  GracefulShutdown,
 } from './input-types'
 import { ReferenceResolver, EnvironmentConfig } from './charts'
 
@@ -125,6 +127,17 @@ export interface HelmService {
   pvcs?: OutputPersistentVolumeClaim[]
 
   podDisruptionBudget?: PodDisruptionBudget
+
+  strategy?: RolloutStrategy
+  minReadySeconds?: number
+  terminationGracePeriodSeconds?: number
+  lifecycle?: {
+    preStop?: {
+      exec: {
+        command: string[]
+      }
+    }
+  }
 
   grantNamespaces: string[]
   grantNamespacesEnabled: boolean


### PR DESCRIPTION
Add .strategy() and .gracefulShutdown(), mapping to Deployment strategy, minReadySeconds, terminationGracePeriodSeconds and a preStop sleep. Both take a flat config or a per-env map. Apply to api: zero-downtime in staging/prod, relaxed in dev. Adds strategy.spec.ts.

# ...

Attach a link to issue if relevant

## What

Specify what you're trying to achieve

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude
