### PR TITLE
chore(j-s): send email to registrar and judge if possible when file too large

### DIFF
--- a/apps/judicial-system/backend/src/app/modules/court/court.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/court/court.service.ts
@@ -140,9 +140,7 @@ export class CourtService {
     courtCaseNumber: string,
     fileName: string,
   ): Promise<void> {
-    let theCase: Awaited<
-      ReturnType<CaseRepositoryService['findById']>
-    > = null
+    let theCase: Awaited<ReturnType<CaseRepositoryService['findById']>> = null
 
     try {
       theCase = await this.caseRepositoryService.findById(caseId, {

--- a/apps/judicial-system/backend/src/app/modules/court/court.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/court/court.service.ts
@@ -140,23 +140,21 @@ export class CourtService {
     courtCaseNumber: string,
     fileName: string,
   ): Promise<void> {
-    let theCase: Awaited<
-      ReturnType<CaseRepositoryService['findById']>
-    > = null
-
-    try {
-      theCase = await this.caseRepositoryService.findById(caseId, {
+    const theCase = await this.caseRepositoryService
+      .findById(caseId, {
         include: [
           { model: UserModel, as: 'judge' },
           { model: UserModel, as: 'registrar' },
         ],
       })
-    } catch (reason) {
-      this.logger.error(
-        `Failed to look up case ${caseId} when notifying that a file was too large for the court service`,
-        { reason },
-      )
-    }
+      .catch((reason) => {
+        this.logger.error(
+          `Failed to look up case ${caseId} when notifying that a file was too large for the court service`,
+          { reason },
+        )
+
+        return null
+      })
 
     const recipients: { name: string; address: string }[] = []
 

--- a/apps/judicial-system/backend/src/app/modules/court/court.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/court/court.service.ts
@@ -34,7 +34,11 @@ import {
 } from '@island.is/judicial-system/types'
 
 import { EventService } from '../event'
-import { RobotLogRepositoryService } from '../repository'
+import {
+  CaseRepositoryService,
+  RobotLogRepositoryService,
+  User as UserModel,
+} from '../repository'
 import { courtModuleConfig } from './court.config'
 
 export enum CourtDocumentFolder {
@@ -76,6 +80,7 @@ export class CourtService {
     private readonly courtClientService: CourtClientService,
     private readonly emailService: EmailService,
     private readonly eventService: EventService,
+    private readonly caseRepositoryService: CaseRepositoryService,
     private readonly robotLogRepositoryService: RobotLogRepositoryService,
     @Inject(LOGGER_PROVIDER) private readonly logger: Logger,
     @Inject(courtModuleConfig.KEY)
@@ -130,15 +135,48 @@ export class CourtService {
   // The court service rejects files that exceed its size limit and no amount of
   // retrying will change that, so the court is asked to upload the file by hand.
   private async notifyCourtOfFileTooLarge(
+    caseId: string,
     courtId: string,
     courtCaseNumber: string,
     fileName: string,
   ): Promise<void> {
+    const theCase = await this.caseRepositoryService.findById(caseId, {
+      include: [
+        { model: UserModel, as: 'judge' },
+        { model: UserModel, as: 'registrar' },
+      ],
+    })
+
+    const recipients: { name: string; address: string }[] = []
+
     const courtEmail = this.config.courtsEmails[courtId]
 
-    if (!courtEmail) {
+    if (courtEmail) {
+      recipients.push({ name: '', address: courtEmail })
+    }
+
+    if (theCase?.judge?.email) {
+      recipients.push({
+        name: theCase.judge.name,
+        address: theCase.judge.email,
+      })
+    }
+
+    if (theCase?.registrar?.email) {
+      recipients.push({
+        name: theCase.registrar.name,
+        address: theCase.registrar.email,
+      })
+    }
+
+    const uniqueRecipients = recipients.filter(
+      (recipient, index, all) =>
+        all.findIndex((r) => r.address === recipient.address) === index,
+    )
+
+    if (uniqueRecipients.length === 0) {
       this.logger.error(
-        `No email address is registered for court ${courtId}, so it cannot be notified that a file was too large for the court service`,
+        `No email recipients are available for court ${courtId}, so it cannot be notified that a file was too large for the court service`,
       )
 
       return
@@ -148,24 +186,33 @@ export class CourtService {
       fileName,
     )} í Auði vegna stærðartakmarkana. Vinsamlegast hlaðið skjali upp handvirkt í Auði.`
 
-    try {
-      await this.emailService.sendEmail({
-        from: { name: this.config.fromName, address: this.config.fromEmail },
-        replyTo: {
-          name: this.config.replyToName,
-          address: this.config.replyToEmail,
-        },
-        to: [{ name: '', address: courtEmail }],
-        subject: `Ekki tókst að hlaða upp skjali í Auði í máli ${courtCaseNumber}`,
-        text: body,
-        html: body,
-      })
-    } catch (reason) {
-      this.logger.error(
-        `Failed to notify court ${courtId} that a file was too large for the court service`,
-        { reason },
-      )
-    }
+    const subject = `Ekki tókst að hlaða upp skjali í Auði í máli ${courtCaseNumber}`
+
+    await Promise.all(
+      uniqueRecipients.map(async (recipient) => {
+        try {
+          await this.emailService.sendEmail({
+            from: {
+              name: this.config.fromName,
+              address: this.config.fromEmail,
+            },
+            replyTo: {
+              name: this.config.replyToName,
+              address: this.config.replyToEmail,
+            },
+            to: [recipient],
+            subject,
+            text: body,
+            html: body,
+          })
+        } catch (reason) {
+          this.logger.error(
+            `Failed to notify ${recipient.address} that a file was too large for the court service`,
+            { reason },
+          )
+        }
+      }),
+    )
   }
 
   private validateCourtRobotEmailParams(
@@ -243,6 +290,7 @@ export class CourtService {
 
       if (reason instanceof PayloadTooLargeException) {
         await this.notifyCourtOfFileTooLarge(
+          caseId,
           courtId,
           courtCaseNumber,
           sanitizedFileName,
@@ -298,7 +346,12 @@ export class CourtService {
       }
 
       if (reason instanceof PayloadTooLargeException) {
-        await this.notifyCourtOfFileTooLarge(courtId, courtCaseNumber, fileName)
+        await this.notifyCourtOfFileTooLarge(
+          caseId,
+          courtId,
+          courtCaseNumber,
+          fileName,
+        )
       } else {
         this.eventService.postErrorEvent(
           'Failed to create a court record at court',

--- a/apps/judicial-system/backend/src/app/modules/court/court.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/court/court.service.ts
@@ -140,12 +140,23 @@ export class CourtService {
     courtCaseNumber: string,
     fileName: string,
   ): Promise<void> {
-    const theCase = await this.caseRepositoryService.findById(caseId, {
-      include: [
-        { model: UserModel, as: 'judge' },
-        { model: UserModel, as: 'registrar' },
-      ],
-    })
+    let theCase: Awaited<
+      ReturnType<CaseRepositoryService['findById']>
+    > = null
+
+    try {
+      theCase = await this.caseRepositoryService.findById(caseId, {
+        include: [
+          { model: UserModel, as: 'judge' },
+          { model: UserModel, as: 'registrar' },
+        ],
+      })
+    } catch (reason) {
+      this.logger.error(
+        `Failed to look up case ${caseId} when notifying that a file was too large for the court service`,
+        { reason },
+      )
+    }
 
     const recipients: { name: string; address: string }[] = []
 

--- a/apps/judicial-system/backend/src/app/modules/court/test/createDocument.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/court/test/createDocument.spec.ts
@@ -279,6 +279,44 @@ describe('CourtService - Create document', () => {
     })
   })
 
+  describe('file is too large and case lookup fails', () => {
+    const largeFileName = 'testFile.pdf'
+    let then: Then
+
+    beforeEach(async () => {
+      const mockFindById = mockCaseRepositoryService.findById as jest.Mock
+      mockFindById.mockRejectedValueOnce(new Error('Case lookup failed'))
+
+      const mockUploadStream = mockCourtClientService.uploadStream as jest.Mock
+      mockUploadStream.mockRejectedValueOnce(new PayloadTooLargeException())
+
+      then = await givenWhenThen(
+        caseId,
+        courtId,
+        courtCaseNumber,
+        caseFolder,
+        subject,
+        largeFileName,
+        fileType,
+        content,
+      )
+    })
+
+    it('should still notify the court with a masked file name', () => {
+      expect(mockEmailService.sendEmail).toHaveBeenCalledWith(
+        expect.objectContaining({
+          to: [{ name: '', address: courtEmail }],
+          subject: `Ekki tókst að hlaða upp skjali í Auði í máli ${courtCaseNumber}`,
+          text: 'Ekki tókst að hlaða upp skjali t******e.pdf í Auði vegna stærðartakmarkana. Vinsamlegast hlaðið skjali upp handvirkt í Auði.',
+        }),
+      )
+    })
+
+    it('should throw a payload too large exception', () => {
+      expect(then.error).toBeInstanceOf(PayloadTooLargeException)
+    })
+  })
+
   describe('file is too large for a court without a registered email address', () => {
     let then: Then
 

--- a/apps/judicial-system/backend/src/app/modules/court/test/createDocument.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/court/test/createDocument.spec.ts
@@ -10,6 +10,7 @@ import { User } from '@island.is/judicial-system/types'
 import { createTestingCourtModule } from './createTestingCourtModule'
 
 import { randomEnum } from '../../../test'
+import { CaseRepositoryService } from '../../repository'
 import { CourtDocumentFolder } from '../court.service'
 
 interface Then {
@@ -43,16 +44,22 @@ describe('CourtService - Create document', () => {
   const courtEmail = 'court@omnitrix.is'
   let mockCourtClientService: CourtClientService
   let mockEmailService: EmailService
+  let mockCaseRepositoryService: CaseRepositoryService
   let givenWhenThen: GivenWhenThen
 
   beforeEach(async () => {
     process.env.COURTS_EMAILS = `{"${courtId}": "${courtEmail}"}`
 
-    const { courtClientService, emailService, courtService } =
-      await createTestingCourtModule()
+    const {
+      courtClientService,
+      emailService,
+      courtService,
+      caseRepositoryService,
+    } = await createTestingCourtModule()
 
     mockEmailService = emailService
     mockCourtClientService = courtClientService
+    mockCaseRepositoryService = caseRepositoryService
     const mockUploadStream = mockCourtClientService.uploadStream as jest.Mock
     mockUploadStream.mockResolvedValue(streamId)
     const mockCreateDocument =
@@ -214,6 +221,55 @@ describe('CourtService - Create document', () => {
           to: [{ name: '', address: courtEmail }],
           subject: `Ekki tókst að hlaða upp skjali í Auði í máli ${courtCaseNumber}`,
           text: 'Ekki tókst að hlaða upp skjali t******e.pdf í Auði vegna stærðartakmarkana. Vinsamlegast hlaðið skjali upp handvirkt í Auði.',
+        }),
+      )
+    })
+
+    it('should throw a payload too large exception', () => {
+      expect(then.error).toBeInstanceOf(PayloadTooLargeException)
+    })
+  })
+
+  describe('file is too large and judge and registrar are assigned', () => {
+    const largeFileName = 'testFile.pdf'
+    const judge = { name: 'Judge One', email: 'judge@omnitrix.is' }
+    const registrar = { name: 'Registrar One', email: 'registrar@omnitrix.is' }
+    let then: Then
+
+    beforeEach(async () => {
+      const mockFindById = mockCaseRepositoryService.findById as jest.Mock
+      mockFindById.mockResolvedValueOnce({ judge, registrar })
+
+      const mockUploadStream = mockCourtClientService.uploadStream as jest.Mock
+      mockUploadStream.mockRejectedValueOnce(new PayloadTooLargeException())
+
+      then = await givenWhenThen(
+        caseId,
+        courtId,
+        courtCaseNumber,
+        caseFolder,
+        subject,
+        largeFileName,
+        fileType,
+        content,
+      )
+    })
+
+    it('should notify the court, judge and registrar', () => {
+      expect(mockEmailService.sendEmail).toHaveBeenCalledTimes(3)
+      expect(mockEmailService.sendEmail).toHaveBeenCalledWith(
+        expect.objectContaining({
+          to: [{ name: '', address: courtEmail }],
+        }),
+      )
+      expect(mockEmailService.sendEmail).toHaveBeenCalledWith(
+        expect.objectContaining({
+          to: [{ name: judge.name, address: judge.email }],
+        }),
+      )
+      expect(mockEmailService.sendEmail).toHaveBeenCalledWith(
+        expect.objectContaining({
+          to: [{ name: registrar.name, address: registrar.email }],
         }),
       )
     })

--- a/apps/judicial-system/backend/src/app/modules/court/test/createTestingCourtModule.ts
+++ b/apps/judicial-system/backend/src/app/modules/court/test/createTestingCourtModule.ts
@@ -8,7 +8,10 @@ import { ConfigModule } from '@island.is/nest/config'
 
 import { CourtClientService } from '@island.is/judicial-system/court-client'
 
-import { RobotLogRepositoryService } from '../../repository'
+import {
+  CaseRepositoryService,
+  RobotLogRepositoryService,
+} from '../../repository'
 import { courtModuleConfig } from '../court.config'
 import { CourtService } from '../court.service'
 
@@ -27,6 +30,12 @@ export const createTestingCourtModule = async () => {
           info: jest.fn(),
           warn: jest.fn(),
           error: jest.fn(),
+        },
+      },
+      {
+        provide: CaseRepositoryService,
+        useValue: {
+          findById: jest.fn().mockResolvedValue(null),
         },
       },
       {
@@ -54,7 +63,16 @@ export const createTestingCourtModule = async () => {
 
   const courtService = courtModule.get<CourtService>(CourtService)
 
+  const caseRepositoryService = courtModule.get<CaseRepositoryService>(
+    CaseRepositoryService,
+  )
+
   courtModule.close()
 
-  return { courtClientService, emailService, courtService }
+  return {
+    courtClientService,
+    emailService,
+    courtService,
+    caseRepositoryService,
+  }
 }


### PR DESCRIPTION
[Asana](https://app.asana.com/1/203394141643832/project/1212657017130395/task/1217765606004634?focus=true)

## What

Send file too large email also to judge/registrar. 

## Why

Previously we only sent to the courts general email.



## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Cursor


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Oversized file upload notifications are now sent to the court, assigned judge, and registrar.
  * Duplicate email recipients are removed, with delivery handled independently for each recipient.
  * Oversized upload errors continue to be reported correctly, even when case details cannot be loaded.

* **Tests**
  * Added coverage for oversized uploads involving assigned judges and registrars, including case lookup failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->