### PR TITLE
fix(web): Remove Watson chat panel from Ukrainian citizens project page

### DIFF
--- a/apps/web/screens/Project/components/ProjectChatPanel/config.ts
+++ b/apps/web/screens/Project/components/ProjectChatPanel/config.ts
@@ -19,17 +19,6 @@ export const watsonConfig: Record<
       carbonTheme: 'g10',
       namespaceKey: 'default',
     },
-
-    // Information for Ukrainian citizens
-    // https://app.contentful.com/spaces/8k0h54kbe6bj/entries/7GtuCCd7MEZhZKe0oXcHdb
-    '7GtuCCd7MEZhZKe0oXcHdb': {
-      integrationID: '89a03e83-5c73-4642-b5ba-cd3771ceca54',
-      region: 'eu-gb',
-      serviceInstanceID: 'bc3d8312-d862-4750-b8bf-529db282050a',
-      showLauncher: true,
-      carbonTheme: 'g10',
-      namespaceKey: 'ukrainian-citizens',
-    },
   },
   en: {
     // Test page for Watson chat bot
@@ -41,17 +30,6 @@ export const watsonConfig: Record<
       showLauncher: false,
       carbonTheme: 'g10',
       namespaceKey: 'default',
-    },
-
-    // Information for Ukrainian citizens
-    // https://app.contentful.com/spaces/8k0h54kbe6bj/entries/7GtuCCd7MEZhZKe0oXcHdb
-    '7GtuCCd7MEZhZKe0oXcHdb': {
-      integrationID: '9e320784-ad44-4da9-9eb3-f305057a196a',
-      region: 'eu-gb',
-      serviceInstanceID: '2529638b-503c-4374-955c-0310139ec177',
-      showLauncher: true,
-      carbonTheme: 'g10',
-      namespaceKey: 'ukrainian-citizens',
     },
   },
 }


### PR DESCRIPTION
Zendesk: https://digitaliceland.zendesk.com/agent/tickets/625438

## What

Removes the Watson chat panel from the *Information for Ukrainian citizens* project page (Contentful entry `7GtuCCd7MEZhZKe0oXcHdb`), for both the `is` and `en` locales.

`ProjectChatPanel` matches on `projectPage.id`, so with the entries gone it returns `null` and no widget is rendered on that page.

## Why

Útlendingastofnun reported that the Watson version of Askur is still showing on https://island.is/en/p/ukrainian-citizens and asked for it to be removed.

The config is a leftover from before the chat bot moved off Watson. Askur now runs through `BoostChatPanel` (`apps/web/components/WebChat/WebChat.tsx`); Watson survives only in a few hardcoded legacy configs, and this page was missed.

It was registered under both locales with separate `integrationID` / `serviceInstanceID` values, so both were removed — the `is` route serves the Ukrainian-language version of the page.

After this change `watsonConfig` contains only the two Watson test-page entries. `'ukrainian-citizens'` remains as an unused member of the namespace-key union in `apps/web/components/ChatPanel/types.ts`; left in place as it is inert, and can be dropped alongside the other Watson cleanup.

## Screenshots / Gifs

Config-only deletion, no UI to add. The effect is the absence of the chat bubble on that page.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the Watson chat configuration for the Ukrainian-citizens chat page in English and Ukrainian locales.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->