### PR TITLE
feat(j-s): Date log repository service

### DIFF
--- a/apps/judicial-system/backend/src/app/modules/case/case.module.ts
+++ b/apps/judicial-system/backend/src/app/modules/case/case.module.ts
@@ -4,7 +4,7 @@ import { SequelizeModule } from '@nestjs/sequelize'
 import { CmsTranslationsModule } from '@island.is/cms-translations'
 import { SigningModule } from '@island.is/dokobit-signing'
 
-import { CaseString, DateLog } from '../repository'
+import { CaseString } from '../repository'
 import {
   AwsS3Module,
   CourtModule,
@@ -46,7 +46,7 @@ import { PdfService } from './pdf.service'
     forwardRef(() => PoliceModule),
     forwardRef(() => EventLogModule),
     forwardRef(() => VictimModule),
-    SequelizeModule.forFeature([DateLog, CaseString]),
+    SequelizeModule.forFeature([CaseString]),
   ],
   providers: [
     CaseService,

--- a/apps/judicial-system/backend/src/app/modules/case/case.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/case/case.service.ts
@@ -98,6 +98,7 @@ import {
   CourtDocumentRepositoryService,
   CourtSessionRepositoryService,
   DateLog,
+  DateLogRepositoryService,
   Defendant,
   DefendantEventLog,
   DefendantEventLogRepositoryService,
@@ -155,9 +156,9 @@ const APPEAL_PARTY_FILE_CATEGORIES = [
 @Injectable()
 export class CaseService {
   constructor(
-    @InjectModel(DateLog) private readonly dateLogModel: typeof DateLog,
     @InjectModel(CaseString)
     private readonly caseStringModel: typeof CaseString,
+    private readonly dateLogRepositoryService: DateLogRepositoryService,
     @Inject(caseModuleConfig.KEY)
     private readonly config: ConfigType<typeof caseModuleConfig>,
     @Inject(forwardRef(() => DefendantService))
@@ -1416,30 +1417,32 @@ export class CaseService {
       if (updateDateLog !== undefined) {
         const dateType = dateLogTypes[dateKey]
 
-        const dateLog = await this.dateLogModel.findOne({
-          where: { caseId: theCase.id, dateType },
-          transaction,
-        })
+        const dateLog = await this.dateLogRepositoryService.findByCaseAndType(
+          theCase.id,
+          dateType,
+          { transaction },
+        )
 
         if (dateLog) {
           if (updateDateLog === null) {
-            await this.dateLogModel.destroy({
-              where: { caseId: theCase.id, dateType },
-              transaction,
-            })
+            await this.dateLogRepositoryService.deleteByCaseAndType(
+              theCase.id,
+              dateType,
+              { transaction },
+            )
           } else {
-            await this.dateLogModel.update(updateDateLog, {
-              where: { caseId: theCase.id, dateType },
-              transaction,
-            })
+            await this.dateLogRepositoryService.updateByCaseAndType(
+              theCase.id,
+              dateType,
+              updateDateLog,
+              { transaction },
+            )
           }
         } else if (updateDateLog !== null) {
-          await this.dateLogModel.create(
-            {
-              caseId: theCase.id,
-              dateType,
-              ...updateDateLog,
-            },
+          await this.dateLogRepositoryService.createForCase(
+            theCase.id,
+            dateType,
+            updateDateLog,
             { transaction },
           )
         }

--- a/apps/judicial-system/backend/src/app/modules/case/test/caseController/update.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/case/test/caseController/update.spec.ts
@@ -46,7 +46,7 @@ import {
   Case,
   CaseRepositoryService,
   CaseString,
-  DateLog,
+  DateLogRepositoryService,
   DefendantEventLogRepositoryService,
   Verdict,
 } from '../../../repository'
@@ -99,7 +99,7 @@ describe('CaseController - Update', () => {
   let mockDefendantEventLogRepositoryService: DefendantEventLogRepositoryService
   let mockDefendantService: DefendantService
   let mockVerdictService: VerdictService
-  let mockDateLogModel: typeof DateLog
+  let mockDateLogRepositoryService: DateLogRepositoryService
   let mockCaseStringModel: typeof CaseString
   let givenWhenThen: GivenWhenThen
 
@@ -114,7 +114,7 @@ describe('CaseController - Update', () => {
       defendantEventLogRepositoryService,
       defendantService,
       verdictService,
-      dateLogModel,
+      dateLogRepositoryService,
       caseStringModel,
       caseController,
     } = await createTestingCaseModule()
@@ -127,7 +127,7 @@ describe('CaseController - Update', () => {
     mockDefendantEventLogRepositoryService = defendantEventLogRepositoryService
     mockDefendantService = defendantService
     mockVerdictService = verdictService
-    mockDateLogModel = dateLogModel
+    mockDateLogRepositoryService = dateLogRepositoryService
     mockCaseStringModel = caseStringModel
 
     const mockTransaction = sequelize.transaction as jest.Mock
@@ -1195,9 +1195,13 @@ describe('CaseController - Update', () => {
     })
 
     it('should update case', () => {
-      expect(mockDateLogModel.create).toHaveBeenCalledWith(
-        { dateType: DateType.ARRAIGNMENT_DATE, caseId, ...arraignmentDate },
-        { transaction },
+      expect(mockDateLogRepositoryService.createForCase).toHaveBeenCalledWith(
+        caseId,
+        DateType.ARRAIGNMENT_DATE,
+        arraignmentDate,
+        {
+          transaction,
+        },
       )
     })
 
@@ -1270,9 +1274,13 @@ describe('CaseController - Update', () => {
     })
 
     it('should update case', () => {
-      expect(mockDateLogModel.create).toHaveBeenCalledWith(
-        { dateType: DateType.ARRAIGNMENT_DATE, caseId, ...arraignmentDate },
-        { transaction },
+      expect(mockDateLogRepositoryService.createForCase).toHaveBeenCalledWith(
+        caseId,
+        DateType.ARRAIGNMENT_DATE,
+        arraignmentDate,
+        {
+          transaction,
+        },
       )
       expect(mockEventLogService.createWithUser).toHaveBeenCalledWith(
         EventType.COURT_DATE_SCHEDULED,
@@ -1409,9 +1417,13 @@ describe('CaseController - Update', () => {
     })
 
     it('should update case', () => {
-      expect(mockDateLogModel.create).toHaveBeenCalledWith(
-        { dateType: DateType.COURT_DATE, caseId, ...courtDate },
-        { transaction },
+      expect(mockDateLogRepositoryService.createForCase).toHaveBeenCalledWith(
+        caseId,
+        DateType.COURT_DATE,
+        courtDate,
+        {
+          transaction,
+        },
       )
       expect(mockEventLogService.createWithUser).toHaveBeenCalledWith(
         EventType.COURT_DATE_SCHEDULED,

--- a/apps/judicial-system/backend/src/app/modules/case/test/createTestingCaseModule.ts
+++ b/apps/judicial-system/backend/src/app/modules/case/test/createTestingCaseModule.ts
@@ -33,7 +33,7 @@ import {
   CaseArchiveRepositoryService,
   CaseRepositoryService,
   CaseString,
-  DateLog,
+  DateLogRepositoryService,
   DefendantEventLogRepositoryService,
   DefendantRepositoryService,
   PoliceDigitalCaseFileRepositoryService,
@@ -75,6 +75,7 @@ jest.mock('../../repository/services/appealDecisionRepository.service')
 jest.mock('../../repository/services/appealEventLogRepository.service')
 jest.mock('../../repository/services/caseRepository.service')
 jest.mock('../../repository/services/caseArchiveRepository.service')
+jest.mock('../../repository/services/dateLogRepository.service')
 jest.mock('../../repository/services/defendantRepository.service')
 jest.mock('../../repository/services/defendantEventLogRepository.service')
 jest.mock('../../repository/services/policeDigitalCaseFileRepository.service')
@@ -111,6 +112,7 @@ export const createTestingCaseModule = async () => {
       AppealEventLogRepositoryService,
       CaseRepositoryService,
       CaseArchiveRepositoryService,
+      DateLogRepositoryService,
       DefendantRepositoryService,
       DefendantEventLogRepositoryService,
       PoliceDigitalCaseFileRepositoryService,
@@ -135,13 +137,6 @@ export const createTestingCaseModule = async () => {
         },
       },
       { provide: Sequelize, useValue: { transaction: jest.fn() } },
-      {
-        provide: getModelToken(DateLog),
-        useValue: {
-          create: jest.fn(),
-          findOne: jest.fn(),
-        },
-      },
       {
         provide: getModelToken(CaseString),
         useValue: {
@@ -236,7 +231,9 @@ export const createTestingCaseModule = async () => {
 
   const sequelize = caseModule.get<Sequelize>(Sequelize)
 
-  const dateLogModel = caseModule.get<typeof DateLog>(getModelToken(DateLog))
+  const dateLogRepositoryService = caseModule.get<DateLogRepositoryService>(
+    DateLogRepositoryService,
+  )
 
   const caseStringModel = caseModule.get<typeof CaseString>(
     getModelToken(CaseString),
@@ -296,7 +293,7 @@ export const createTestingCaseModule = async () => {
     policeDigitalCaseFileRepositoryService,
     logger,
     sequelize,
-    dateLogModel,
+    dateLogRepositoryService,
     caseStringModel,
     caseConfig,
     caseService,

--- a/apps/judicial-system/backend/src/app/modules/repository/index.ts
+++ b/apps/judicial-system/backend/src/app/modules/repository/index.ts
@@ -49,6 +49,11 @@ export {
   UpdateCourtSessionString,
 } from './services/courtSessionStringRepository.service'
 export { CourtDocumentRepositoryService } from './services/courtDocumentRepository.service'
+export {
+  DateLogRepositoryService,
+  CreateDateLog,
+  UpdateDateLog,
+} from './services/dateLogRepository.service'
 export { DefendantRepositoryService } from './services/defendantRepository.service'
 export { DefendantEventLogRepositoryService } from './services/defendantEventLogRepository.service'
 export {

--- a/apps/judicial-system/backend/src/app/modules/repository/repository.module.ts
+++ b/apps/judicial-system/backend/src/app/modules/repository/repository.module.ts
@@ -43,6 +43,7 @@ import { CaseRepositoryService } from './services/caseRepository.service'
 import { CourtDocumentRepositoryService } from './services/courtDocumentRepository.service'
 import { CourtSessionRepositoryService } from './services/courtSessionRepository.service'
 import { CourtSessionStringRepositoryService } from './services/courtSessionStringRepository.service'
+import { DateLogRepositoryService } from './services/dateLogRepository.service'
 import { DefendantEventLogRepositoryService } from './services/defendantEventLogRepository.service'
 import { DefendantRepositoryService } from './services/defendantRepository.service'
 import { EventLogRepositoryService } from './services/eventLogRepository.service'
@@ -107,6 +108,7 @@ import { repositoryModuleConfig } from './repository.config'
     CourtSessionRepositoryService,
     CourtSessionStringRepositoryService,
     CourtDocumentRepositoryService,
+    DateLogRepositoryService,
     DefendantRepositoryService,
     DefendantEventLogRepositoryService,
     EventLogRepositoryService,
@@ -133,6 +135,7 @@ import { repositoryModuleConfig } from './repository.config'
     CourtSessionRepositoryService,
     CourtSessionStringRepositoryService,
     CourtDocumentRepositoryService,
+    DateLogRepositoryService,
     DefendantRepositoryService,
     DefendantEventLogRepositoryService,
     EventLogRepositoryService,

--- a/apps/judicial-system/backend/src/app/modules/repository/services/dateLogRepository.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/repository/services/dateLogRepository.service.ts
@@ -1,0 +1,142 @@
+import { Transaction } from 'sequelize'
+
+import { Inject, Injectable } from '@nestjs/common'
+import { InjectModel } from '@nestjs/sequelize'
+
+import { type Logger, LOGGER_PROVIDER } from '@island.is/logging'
+
+import { DateType } from '@island.is/judicial-system/types'
+
+import { DateLog } from '../models/dateLog.model'
+
+// A date log is addressed by (caseId, dateType) - the table has a composite
+// UNIQUE on the pair (unique_date_log_case_id_date_type) - so both key columns
+// are named parameters rather than a caller-supplied where clause.
+//
+// The two value columns are optional because UpdateCaseDto declares them so.
+// Create and update take the same shape, since the caller forwards the same
+// nested DTO object on both paths; they are named separately so that tightening
+// one (date is NOT NULL in the table) does not have to rename the other.
+export type UpdateDateLog = {
+  date?: Date
+  location?: string
+}
+
+export type CreateDateLog = UpdateDateLog
+
+@Injectable()
+export class DateLogRepositoryService {
+  constructor(
+    @InjectModel(DateLog) private readonly dateLogModel: typeof DateLog,
+    @Inject(LOGGER_PROVIDER) private readonly logger: Logger,
+  ) {}
+
+  async findByCaseAndType(
+    caseId: string,
+    dateType: DateType,
+    options: { transaction: Transaction },
+  ): Promise<DateLog | null> {
+    try {
+      this.logger.debug(
+        `Finding date log of type ${dateType} for case ${caseId}`,
+      )
+
+      const result = await this.dateLogModel.findOne({
+        where: { caseId, dateType },
+        transaction: options.transaction,
+      })
+
+      this.logger.debug(
+        `Date log of type ${dateType} for case ${caseId} ${
+          result ? 'found' : 'not found'
+        }`,
+      )
+
+      return result
+    } catch (error) {
+      this.logger.error(
+        `Error finding date log of type ${dateType} for case ${caseId}:`,
+        { error },
+      )
+
+      throw error
+    }
+  }
+
+  async createForCase(
+    caseId: string,
+    dateType: DateType,
+    dateLog: CreateDateLog,
+    options: { transaction: Transaction },
+  ): Promise<DateLog> {
+    try {
+      this.logger.debug(
+        `Creating a date log of type ${dateType} for case ${caseId}`,
+      )
+
+      return await this.dateLogModel.create(
+        { caseId, dateType, ...dateLog },
+        { transaction: options.transaction },
+      )
+    } catch (error) {
+      this.logger.error(
+        `Error creating a date log of type ${dateType} for case ${caseId}:`,
+        { error },
+      )
+
+      throw error
+    }
+  }
+
+  // The row count is not reported: the key identifies at most one row, and the
+  // only caller has just read it. Add a result when a caller needs one.
+  async updateByCaseAndType(
+    caseId: string,
+    dateType: DateType,
+    update: UpdateDateLog,
+    options: { transaction: Transaction },
+  ): Promise<void> {
+    try {
+      this.logger.debug(
+        `Updating date log of type ${dateType} for case ${caseId} with data:`,
+        { data: Object.keys(update) },
+      )
+
+      await this.dateLogModel.update(update, {
+        where: { caseId, dateType },
+        transaction: options.transaction,
+      })
+    } catch (error) {
+      this.logger.error(
+        `Error updating date log of type ${dateType} for case ${caseId} with data:`,
+        { data: Object.keys(update), error },
+      )
+
+      throw error
+    }
+  }
+
+  async deleteByCaseAndType(
+    caseId: string,
+    dateType: DateType,
+    options: { transaction: Transaction },
+  ): Promise<number> {
+    try {
+      this.logger.debug(
+        `Deleting date log of type ${dateType} for case ${caseId}`,
+      )
+
+      return await this.dateLogModel.destroy({
+        where: { caseId, dateType },
+        transaction: options.transaction,
+      })
+    } catch (error) {
+      this.logger.error(
+        `Error deleting date log of type ${dateType} for case ${caseId}:`,
+        { error },
+      )
+
+      throw error
+    }
+  }
+}

--- a/apps/judicial-system/backend/src/app/modules/repository/test/dateLogRepository.service.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/repository/test/dateLogRepository.service.spec.ts
@@ -1,0 +1,166 @@
+import { Transaction } from 'sequelize'
+
+import { getModelToken } from '@nestjs/sequelize'
+import { Test } from '@nestjs/testing'
+
+import { LOGGER_PROVIDER } from '@island.is/logging'
+
+import { DateType } from '@island.is/judicial-system/types'
+
+import { DateLog } from '../models/dateLog.model'
+import { DateLogRepositoryService } from '../services/dateLogRepository.service'
+
+describe('DateLogRepositoryService', () => {
+  const caseId = 'some-case-id'
+  const dateType = DateType.ARRAIGNMENT_DATE
+  const transaction = {} as Transaction
+
+  // The table has a composite UNIQUE on (case_id, date_type), so every method
+  // must address the row by both columns - assert them one by one rather than
+  // against a shared object that could hide a dropped key.
+  const expectedWhere = { caseId, dateType }
+
+  let service: DateLogRepositoryService
+  let model: {
+    findOne: jest.Mock
+    create: jest.Mock
+    update: jest.Mock
+    destroy: jest.Mock
+  }
+
+  beforeEach(async () => {
+    model = {
+      findOne: jest.fn().mockResolvedValue(null),
+      create: jest.fn(),
+      update: jest.fn().mockResolvedValue([0]),
+      destroy: jest.fn().mockResolvedValue(0),
+    }
+
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        {
+          provide: LOGGER_PROVIDER,
+          useValue: { debug: jest.fn(), error: jest.fn() },
+        },
+        { provide: getModelToken(DateLog), useValue: model },
+        DateLogRepositoryService,
+      ],
+    }).compile()
+
+    service = moduleRef.get(DateLogRepositoryService)
+  })
+
+  describe('findByCaseAndType', () => {
+    it('looks the date log up by both key columns in the caller transaction', async () => {
+      const dateLog = { id: 'some-date-log-id' }
+      model.findOne.mockResolvedValueOnce(dateLog)
+
+      const result = await service.findByCaseAndType(caseId, dateType, {
+        transaction,
+      })
+
+      expect(model.findOne).toHaveBeenCalledWith({
+        where: expectedWhere,
+        transaction,
+      })
+      expect(result).toBe(dateLog)
+    })
+
+    it('returns null when there is no such date log', async () => {
+      expect(
+        await service.findByCaseAndType(caseId, dateType, { transaction }),
+      ).toBeNull()
+    })
+
+    it('rethrows when the lookup fails', async () => {
+      const error = new Error('Some error')
+      model.findOne.mockRejectedValueOnce(error)
+
+      await expect(
+        service.findByCaseAndType(caseId, dateType, { transaction }),
+      ).rejects.toThrow(error)
+    })
+  })
+
+  describe('createForCase', () => {
+    it('creates the date log with both key columns in the caller transaction', async () => {
+      const date = new Date()
+      const created = { id: 'some-date-log-id' }
+      model.create.mockResolvedValueOnce(created)
+
+      const result = await service.createForCase(
+        caseId,
+        dateType,
+        { date, location: 'Some location' },
+        { transaction },
+      )
+
+      expect(model.create).toHaveBeenCalledWith(
+        { ...expectedWhere, date, location: 'Some location' },
+        { transaction },
+      )
+      expect(result).toBe(created)
+    })
+
+    it('rethrows when the creation fails', async () => {
+      const error = new Error('Some error')
+      model.create.mockRejectedValueOnce(error)
+
+      await expect(
+        service.createForCase(caseId, dateType, {}, { transaction }),
+      ).rejects.toThrow(error)
+    })
+  })
+
+  describe('updateByCaseAndType', () => {
+    it('scopes the update to both key columns in the caller transaction', async () => {
+      const date = new Date()
+
+      await service.updateByCaseAndType(
+        caseId,
+        dateType,
+        { date, location: 'Some location' },
+        { transaction },
+      )
+
+      expect(model.update).toHaveBeenCalledWith(
+        { date, location: 'Some location' },
+        { where: expectedWhere, transaction },
+      )
+    })
+
+    it('rethrows when the update fails', async () => {
+      const error = new Error('Some error')
+      model.update.mockRejectedValueOnce(error)
+
+      await expect(
+        service.updateByCaseAndType(caseId, dateType, {}, { transaction }),
+      ).rejects.toThrow(error)
+    })
+  })
+
+  describe('deleteByCaseAndType', () => {
+    it('scopes the delete to both key columns in the caller transaction and reports the row count', async () => {
+      model.destroy.mockResolvedValueOnce(1)
+
+      const result = await service.deleteByCaseAndType(caseId, dateType, {
+        transaction,
+      })
+
+      expect(model.destroy).toHaveBeenCalledWith({
+        where: expectedWhere,
+        transaction,
+      })
+      expect(result).toBe(1)
+    })
+
+    it('rethrows when the delete fails', async () => {
+      const error = new Error('Some error')
+      model.destroy.mockRejectedValueOnce(error)
+
+      await expect(
+        service.deleteByCaseAndType(caseId, dateType, { transaction }),
+      ).rejects.toThrow(error)
+    })
+  })
+})

--- a/apps/judicial-system/backend/src/app/modules/repository/types/caseRepository.types.ts
+++ b/apps/judicial-system/backend/src/app/modules/repository/types/caseRepository.types.ts
@@ -42,6 +42,7 @@ import { Subpoena } from '../models/subpoena.model'
 import { User } from '../models/user.model'
 import { Verdict } from '../models/verdict.model'
 import { Victim } from '../models/victim.model'
+import { UpdateDateLog } from '../services/dateLogRepository.service'
 
 export const caseInclude: Includeable[] = [
   { model: Institution, as: 'prosecutorsOffice' },
@@ -527,11 +528,6 @@ export const caseInclude: Includeable[] = [
     separate: true,
   },
 ]
-
-interface UpdateDateLog {
-  date?: Date
-  location?: string
-}
 
 export interface UpdateCaseDefendantEventLogDecision {
   defendantId: string


### PR DESCRIPTION
# Date log repository service

[Repository þjónusta fyrir DateLog](https://app.asana.com/1/203394141643832/project/1199153462262248/task/1218056737269579)

Chunk D of the repository-pattern migration: `DateLog` is the fifth satellite model to
get its own repository service, and `CaseService` stops touching the Sequelize model.

## What moves

`DateLogRepositoryService` gets four methods, all keyed on `(caseId, dateType)` — the
pair the table has a composite `UNIQUE` on (`unique_date_log_case_id_date_type`, added in
`20240422124352-update-events-dates.js`). That means no caller can address a date log by
fewer than both columns, and the read-then-write flow below cannot duplicate rows: a
concurrent double-create fails on the constraint rather than silently writing a second row.

| Method | Replaces |
|---|---|
| `findByCaseAndType` | `dateLogModel.findOne` |
| `createForCase` | `dateLogModel.create` |
| `updateByCaseAndType` | `dateLogModel.update` |
| `deleteByCaseAndType` | `dateLogModel.destroy` |

`CaseService.handleDateLogUpdates` keeps everything that is business logic: the
`dateKey` → `dateType` mapping, the null/exists branching (`destroy` when the update is
`null`, `update` when the row exists, `create` when it does not), and the
"a real arraignment date always wins over a skipped summons" rule. Only the four
Sequelize calls move. The branching is ported as-is — the `destroy`-on-`null` branch means
a plain `upsert` could not replace it.

`UpdateDateLog` moves out of `caseRepository.types.ts`, where it was declared privately
for `UpdateCase`'s nested `arraignmentDate` / `courtDate`, into the repository service
that owns the row. `CreateDateLog` aliases it: both paths receive the same nested DTO
object, and they are named separately so tightening one later does not rename the other.

`DateLog` is still imported into `case.service.ts` for its `arraignmentDate` /
`courtDate` static helpers, which search an already-loaded array rather than the database.

## Two deviations from the brief

- **The `transaction` option is required, not optional.** All four call sites run inside
  `handleDateLogUpdates`, which takes a non-optional `Transaction`, so an optional
  parameter would have been dead — and would invite a later caller to write outside the
  case update transaction. Same reasoning as the `options` parameter dropped in #23564.
- **`caseRepository.types.ts` is touched** (7 lines) to delete the duplicate
  `UpdateDateLog` rather than ship a second copy of it in the new service.

## Deliberately out of scope

- **`caseRepository.service.ts` keeps its own `@InjectModel(DateLog)`** — per decision D2
  (consumer-only chunk D slices), since `CaseRepositoryService` may not inject another
  repository service. Emptying that constructor is chunk E's job, after `split` and
  `duplicateIndictmentToDraft` move out. So this closes **invariant 2** for `DateLog`
  (nothing outside the repository module) but not invariant 3.
- **`CaseString`** — same file, same `forFeature` line, but it has a second consumer in
  `internalCase.service.ts` and its own upsert semantics. Separate slice; the
  `SequelizeModule.forFeature` call in `case.module.ts` stays, holding `CaseString` alone.
- No migration and no behaviour change: the unique constraint already exists.

## Verification

Each check dry-run on `main` first, so none of the negative results is vacuous:

| Check | On `main` | After |
|---|---|---|
| `InjectModel(DateLog)` / `dateLogModel` outside the repository module | 9 | **0** |
| `SequelizeModule.forFeature([… DateLog …])` outside it | 1 | **0** |
| `InjectModel(DateLog)` inside it (1 deferred + 1 new) | 1 | **2** |
| `DateLogRepositoryService` in `repository.module.ts` | 0 | **3** |

- `npx tsc --noEmit -p apps/judicial-system/backend/tsconfig.app.json` — clean
- `yarn nx test judicial-system-backend --testPathPatterns='modules/(case|repository)/'` —
  159 suites / 7,972 tests green
- `yarn nx lint judicial-system-backend` — clean apart from one pre-existing warning in
  `updateCase.dto.ts`
- `yarn nx run judicial-system-backend:codegen/backend-schema` — `openapi.yaml` byte-identical

## Tests

- **New:** `test/dateLogRepository.service.spec.ts` — 9 tests. Every method's `where`
  carries both key columns, `findByCaseAndType` returns `null` when there is no row, the
  caller's transaction is forwarded, and each method rethrows.
- **Reworked:** `case/test/createTestingCaseModule.ts` provides the repository service
  (auto-mocked) instead of the `DateLog` model token, and `caseController/update.spec.ts`
  moves its three `create` assertions onto `createForCase`. The `where` clauses those
  assertions used to check are now covered by the repository's own spec. The
  `mockCaseStringModel` assertions in that file are untouched.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added centralized date-log repository operations for finding, creating, updating, and deleting case date records.
  - Added transactional handling and consistent error reporting for date-log updates.

- **Bug Fixes**
  - Improved case date and arraignment updates by routing them through the shared repository layer.

- **Tests**
  - Added coverage for date-log repository operations, transaction handling, and error propagation.
  - Updated case controller tests for the revised date-log workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->