### PR TITLE
fix(j-s): Animate verdict timeline items that replace another

### DIFF
--- a/apps/judicial-system/web/src/components/Cards/VerdictTimelineCard/VerdictTimelineBody.logic.spec.ts
+++ b/apps/judicial-system/web/src/components/Cards/VerdictTimelineCard/VerdictTimelineBody.logic.spec.ts
@@ -1,0 +1,80 @@
+import { getEnteringItemStaggerIndices } from './VerdictTimelineBody.logic'
+
+describe('getEnteringItemStaggerIndices', () => {
+  const items = (...texts: string[]) => texts.map((text) => ({ text }))
+
+  it('should let nothing enter before the first render', () => {
+    expect(
+      getEnteringItemStaggerIndices(null, items('served', 'stance')),
+    ).toEqual([undefined, undefined])
+  })
+
+  it('should let nothing enter when the items are unchanged', () => {
+    expect(
+      getEnteringItemStaggerIndices(
+        new Set(['served', 'stance']),
+        items('served', 'stance'),
+      ),
+    ).toEqual([undefined, undefined])
+  })
+
+  it('should let an appended item enter', () => {
+    expect(
+      getEnteringItemStaggerIndices(
+        new Set(['requirement']),
+        items('requirement', 'served'),
+      ),
+    ).toEqual([undefined, 0])
+  })
+
+  it('should stagger several appended items in list order', () => {
+    expect(
+      getEnteringItemStaggerIndices(
+        new Set(['requirement']),
+        items('requirement', 'served', 'deadline'),
+      ),
+    ).toEqual([undefined, 0, 1])
+  })
+
+  it('should let an item that replaces another at the same count enter', () => {
+    expect(
+      getEnteringItemStaggerIndices(
+        new Set(['served', 'stance']),
+        items('served', 'appealed'),
+      ),
+    ).toEqual([undefined, 0])
+  })
+
+  it('should let the first item enter when it is the one replaced', () => {
+    expect(
+      getEnteringItemStaggerIndices(
+        new Set(['requirement', 'deadline']),
+        items('served', 'deadline'),
+      ),
+    ).toEqual([0, undefined])
+  })
+
+  it('should stagger entering items by their order among each other, not their position', () => {
+    expect(
+      getEnteringItemStaggerIndices(
+        new Set(['a', 'b', 'c']),
+        items('a', 'x', 'c', 'y'),
+      ),
+    ).toEqual([undefined, 0, undefined, 1])
+  })
+
+  it('should let nothing enter when items are only removed', () => {
+    expect(
+      getEnteringItemStaggerIndices(
+        new Set(['served', 'stance']),
+        items('served'),
+      ),
+    ).toEqual([undefined])
+  })
+
+  it('should let every item enter when the list was empty', () => {
+    expect(
+      getEnteringItemStaggerIndices(new Set(), items('served', 'stance')),
+    ).toEqual([0, 1])
+  })
+})

--- a/apps/judicial-system/web/src/components/Cards/VerdictTimelineCard/VerdictTimelineBody.logic.ts
+++ b/apps/judicial-system/web/src/components/Cards/VerdictTimelineCard/VerdictTimelineBody.logic.ts
@@ -1,0 +1,29 @@
+import type { VerdictTimelineItem } from './VerdictTimelineBody'
+
+/**
+ * Decides which items of a verdict timeline should animate in, and in what
+ * order, given the items the previous render showed.
+ *
+ * An item is entering when the previous render did not show it, whether it was
+ * appended or replaced another item in place - the appeal bullet taking the
+ * stance bullet's place, for instance. Entering items are staggered in the order
+ * they appear in the list.
+ *
+ * Returns one entry per item: its stagger index if it is entering, `undefined`
+ * otherwise. Nothing enters before the first render has happened, which is
+ * signalled by `previousTexts` being `null`.
+ */
+export const getEnteringItemStaggerIndices = (
+  previousTexts: ReadonlySet<string> | null,
+  items: VerdictTimelineItem[],
+): (number | undefined)[] => {
+  if (previousTexts === null) {
+    return items.map(() => undefined)
+  }
+
+  let enteringCount = 0
+
+  return items.map((item) =>
+    previousTexts.has(item.text) ? undefined : enteringCount++,
+  )
+}

--- a/apps/judicial-system/web/src/components/Cards/VerdictTimelineCard/VerdictTimelineBody.spec.tsx
+++ b/apps/judicial-system/web/src/components/Cards/VerdictTimelineCard/VerdictTimelineBody.spec.tsx
@@ -1,0 +1,61 @@
+import { render, screen } from '@testing-library/react'
+
+import VerdictTimelineBody from './VerdictTimelineBody'
+
+/**
+ * Which items enter is decided in VerdictTimelineBody.logic.spec.ts. What is
+ * left for the rendered body is that an entering item really starts from its
+ * hidden state, and that a settled one does not.
+ */
+describe('VerdictTimelineBody', () => {
+  const item = (text: string) => ({ text })
+  const bullet = (text: string) =>
+    screen.getByText(`• ${text}`).parentElement as HTMLElement
+
+  it('should render every item settled on the first render', () => {
+    render(
+      <VerdictTimelineBody
+        eyebrow="Jón"
+        items={[item('served'), item('stance')]}
+      />,
+    )
+
+    expect(bullet('served')).not.toHaveStyle({ opacity: 0 })
+    expect(bullet('stance')).not.toHaveStyle({ opacity: 0 })
+  })
+
+  it('should let an item replacing another enter from hidden', () => {
+    const { rerender } = render(
+      <VerdictTimelineBody
+        eyebrow="Jón"
+        items={[item('served'), item('stance')]}
+      />,
+    )
+
+    rerender(
+      <VerdictTimelineBody
+        eyebrow="Jón"
+        items={[item('served'), item('appealed')]}
+      />,
+    )
+
+    expect(bullet('served')).not.toHaveStyle({ opacity: 0 })
+    expect(bullet('appealed')).toHaveStyle({ opacity: 0 })
+  })
+
+  it('should let an appended item enter from hidden', () => {
+    const { rerender } = render(
+      <VerdictTimelineBody eyebrow="Jón" items={[item('requirement')]} />,
+    )
+
+    rerender(
+      <VerdictTimelineBody
+        eyebrow="Jón"
+        items={[item('requirement'), item('served')]}
+      />,
+    )
+
+    expect(bullet('requirement')).not.toHaveStyle({ opacity: 0 })
+    expect(bullet('served')).toHaveStyle({ opacity: 0 })
+  })
+})

--- a/apps/judicial-system/web/src/components/Cards/VerdictTimelineCard/VerdictTimelineBody.spec.tsx
+++ b/apps/judicial-system/web/src/components/Cards/VerdictTimelineCard/VerdictTimelineBody.spec.tsx
@@ -12,6 +12,15 @@ describe('VerdictTimelineBody', () => {
   const bullet = (text: string) =>
     screen.getByText(`• ${text}`).parentElement as HTMLElement
 
+  // framer-motion writes an item's `initial` state as inline style on mount and
+  // never progresses the animation in jsdom, so an item that will animate in is
+  // one still sitting at opacity 0, and an item that popped straight into place
+  // is one that never was.
+  const expectToEnterAnimated = (element: HTMLElement) =>
+    expect(element).toHaveStyle({ opacity: 0 })
+  const expectToBeSettled = (element: HTMLElement) =>
+    expect(element).not.toHaveStyle({ opacity: 0 })
+
   it('should render every item settled on the first render', () => {
     render(
       <VerdictTimelineBody
@@ -20,8 +29,8 @@ describe('VerdictTimelineBody', () => {
       />,
     )
 
-    expect(bullet('served')).not.toHaveStyle({ opacity: 0 })
-    expect(bullet('stance')).not.toHaveStyle({ opacity: 0 })
+    expectToBeSettled(bullet('served'))
+    expectToBeSettled(bullet('stance'))
   })
 
   it('should let an item replacing another enter from hidden', () => {
@@ -39,8 +48,8 @@ describe('VerdictTimelineBody', () => {
       />,
     )
 
-    expect(bullet('served')).not.toHaveStyle({ opacity: 0 })
-    expect(bullet('appealed')).toHaveStyle({ opacity: 0 })
+    expectToBeSettled(bullet('served'))
+    expectToEnterAnimated(bullet('appealed'))
   })
 
   it('should let an appended item enter from hidden', () => {
@@ -55,7 +64,7 @@ describe('VerdictTimelineBody', () => {
       />,
     )
 
-    expect(bullet('requirement')).not.toHaveStyle({ opacity: 0 })
-    expect(bullet('served')).toHaveStyle({ opacity: 0 })
+    expectToBeSettled(bullet('requirement'))
+    expectToEnterAnimated(bullet('served'))
   })
 })

--- a/apps/judicial-system/web/src/components/Cards/VerdictTimelineCard/VerdictTimelineBody.tsx
+++ b/apps/judicial-system/web/src/components/Cards/VerdictTimelineCard/VerdictTimelineBody.tsx
@@ -5,6 +5,8 @@ import { AnimatePresence, motion } from 'motion/react'
 import { Box, Text } from '@island.is/island-ui/core'
 import * as styles from '@island.is/judicial-system-web/src/components/Cards/IconCard/IconCard.css'
 
+import { getEnteringItemStaggerIndices } from './VerdictTimelineBody.logic'
+
 export type VerdictTimelineItemTone = 'default' | 'critical'
 
 export interface VerdictTimelineItem {
@@ -24,27 +26,33 @@ interface Props {
  * card, which fills it with the defendant name and adds nothing.
  *
  * Items appearing after the first render animate in one after another, so a
- * newly registered date visibly lands in the list.
+ * newly registered date visibly lands in the list - whether it is appended or
+ * takes the place of another item, as the appeal bullet does the stance bullet.
+ * Which items those are is decided by getEnteringItemStaggerIndices.
  */
 const VerdictTimelineBody: FC<PropsWithChildren<Props>> = (props) => {
   const { eyebrow, items, children } = props
 
-  const hasMountedRef = useRef<boolean>(false)
-  const previousItemCountRef = useRef<number>(0)
+  // The texts shown by the previous render, or null before the first one. The
+  // text doubles as the item's identity, as it already does for its key.
+  const previousTextsRef = useRef<ReadonlySet<string> | null>(null)
 
   useEffect(() => {
-    hasMountedRef.current = true
-    previousItemCountRef.current = items.length
-  }, [items.length])
+    previousTextsRef.current = new Set(items.map((item) => item.text))
+  })
+
+  const staggerIndices = getEnteringItemStaggerIndices(
+    previousTextsRef.current,
+    items,
+  )
 
   return (
     <Box className={styles.container}>
       <Text variant="eyebrow">{eyebrow}</Text>
       <AnimatePresence initial={false}>
         {items.map((item, index) => {
-          const addedStartIndex = previousItemCountRef.current
-          const isNewItem = hasMountedRef.current && index >= addedStartIndex
-          const staggerIndex = isNewItem ? index - addedStartIndex : 0
+          const staggerIndex = staggerIndices[index]
+          const isNewItem = staggerIndex !== undefined
 
           return (
             <motion.div


### PR DESCRIPTION
# Animate verdict timeline items that replace another

[Áfrýjun - Birting dóms: hreyfing þegar punktur kemur í stað annars](https://app.asana.com/1/203394141643832/project/1199153462262248/task/1218092944257252)

Follow-up from the review of #23553.

`VerdictTimelineBody` only animated *added* items, not replacements. The entry animation keyed off `items.length` against the previous count, so an item that took another item's place at equal count was not treated as new and did not animate in. The appeal bullet replacing the stance bullet ("Dómfelldi áfrýjaði …" in place of "Dómfelldi tekur áfrýjunarfrest") is exactly that case, and it is the transition the defence card's mocks show. The behaviour was moved out of `VerdictTimelineCard` unchanged in #23546, so the public prosecution office's card shares it.

## What changed

- The decision of which items enter, and in what stagger order, is now a pure function, `getEnteringItemStaggerIndices(previousTexts, items)`, in `VerdictTimelineBody.logic.ts`. An item enters when the previous render did not show it, whether it was appended or replaced another; entering items are staggered in list order. The item text is the identity, as it already is for the element key.
- The body keeps one ref with the previous render's texts (`null` before the first render) in place of the two count/mounted refs.
- No visual change for the existing cases: first render and appended items behave as before.

## Tests

- `VerdictTimelineBody.logic.spec.ts`: nine direct cases, including replacement at equal count, replacement of the first item, mixed positions, removals only, and an empty previous list.
- `VerdictTimelineBody.spec.tsx`: three render cases asserting the entering item starts hidden and settled items do not. The replacement case was run against the previous implementation and fails there.
- Full `judicial-system-web` suite green, lint and `nx format:check` clean.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Timeline items now animate correctly when newly added or replaced, including replacements at the same position.
  * New items appear with staggered entrance animations based on their order.

* **Bug Fixes**
  * Improved detection of new timeline items so replacements no longer appear as already visible.

* **Tests**
  * Added coverage for timeline item entrance detection, replacement scenarios, and initial visibility states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->