### PR TITLE
fix(j-s): Show closed without enforcement defendants per defendant

### DIFF
--- a/apps/judicial-system/backend/src/app/modules/case-table/whereOptions/conditions.ts
+++ b/apps/judicial-system/backend/src/app/modules/case-table/whereOptions/conditions.ts
@@ -73,29 +73,6 @@ export const buildEventLogOrderCondition = (
     )
   `)
 
-export const buildHasEnforceableDefendantNotClosedWithoutEnforcementCondition =
-  (exists: boolean) =>
-    Sequelize.literal(`
-    ${exists ? '' : 'NOT'} EXISTS (
-      SELECT 1
-      FROM defendant
-      WHERE defendant.case_id = "Case".id
-        AND defendant.is_closed_without_enforcement IS NOT TRUE
-        -- Defendants whose indictment was cancelled or dismissed (completed for
-        -- some) never enter enforcement, so they must not keep a case out of
-        -- the closed-without-enforcement table.
-        AND NOT EXISTS (
-          SELECT 1
-          FROM defendant_event_log
-          WHERE defendant_event_log.defendant_id = defendant.id
-            AND defendant_event_log.event_type IN (
-              '${DefendantEventType.INDICTMENT_CANCELLED}',
-              '${DefendantEventType.INDICTMENT_DISMISSED}'
-            )
-        )
-    )
-  `)
-
 export const buildHasDefendantWithNullReviewDecisionCondition = (
   exists: boolean,
 ) =>

--- a/apps/judicial-system/backend/src/app/modules/case-table/whereOptions/publicProsecutionOffice.ts
+++ b/apps/judicial-system/backend/src/app/modules/case-table/whereOptions/publicProsecutionOffice.ts
@@ -9,7 +9,6 @@ import {
 
 import { CaseWhereOptions, expandCasesWithDefendants } from '../caseTable.types'
 import { publicProsecutionOfficeIndictmentsAccessWhereOptions } from './access'
-import { buildHasEnforceableDefendantNotClosedWithoutEnforcementCondition } from './conditions'
 
 // Public prosecution office indictments
 
@@ -316,16 +315,7 @@ export const publicProsecutionOfficeIndictmentsClosedWithoutEnforcementWhereOpti
         where: { is_closed_without_enforcement: true },
       },
     },
-    where: {
-      [Op.and]: [
-        publicProsecutionOfficeIndictmentsAccessWhereOptions,
-        // Only cases where every defendant that could still enter enforcement
-        // has been closed without enforcement. A case with a defendant that was
-        // sent to the prison admin, or is still in the normal flow, stays in
-        // the other tables.
-        buildHasEnforceableDefendantNotClosedWithoutEnforcementCondition(false),
-      ],
-    },
+    where: publicProsecutionOfficeIndictmentsAccessWhereOptions,
     displayCases: expandCasesWithDefendants,
   })
 


### PR DESCRIPTION
# Show closed without enforcement defendants per defendant

## What

Make the PPO "Lokið án fullnustu" case table defendant-level. A defendant closed without enforcement now gets a row in the table as soon as they are closed, instead of the case only appearing once every enforceable defendant has been closed without enforcement.

Removes the case-level `NOT EXISTS` gate from the table's where options and deletes the now-unused `buildHasEnforceableDefendantNotClosedWithoutEnforcementCondition` condition builder. The remaining defendant inner-join filter plus `expandCasesWithDefendants` already produces one row per closed defendant.

## Why

PPO case tables show one row per defendant, not per case. With the case-level gate, a defendant closed without enforcement in a multi-defendant case appeared in no PPO table at all until every other defendant was also resolved — the gate kept the case out of "Lokið án fullnustu" while the other tables already exclude closed defendants.

## Screenshots / Gifs


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Case Table**
  - Updated filtering for cases closed without enforcement.
  - Results are now determined by public prosecution office access conditions without the additional requirement that all enforceable defendants be closed without enforcement.
  - Removed the previous filtering logic that excluded defendants based on the absence of indictment cancellation or dismissal events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->