### PR TITLE
fix(parental-leave): log VMST errors instead of "[object Object]"

### DIFF
--- a/libs/application/template-api-modules/src/lib/modules/templates/parental-leave/parental-leave.service.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/parental-leave/parental-leave.service.ts
@@ -428,7 +428,7 @@ export class ParentalLeaveService extends BaseTemplateApiService {
 
       return fileContent
     } catch (e) {
-      this.logger.error('Cannot get ' + fileUpload + ' attachment', { e })
+      this.logger.error('Cannot get ' + fileUpload + ' attachment', e)
       throw new Error('Failed to get the ' + fileUpload + ' attachment')
     }
   }
@@ -1087,7 +1087,8 @@ export class ParentalLeaveService extends BaseTemplateApiService {
       return applicationInformation.periods
     } catch (e) {
       this.logger.warn(
-        `Could not fetch applicationInformation on applicationId: ${application.id} with error: ${e}`,
+        `Could not fetch applicationInformation on applicationId: ${application.id}`,
+        e,
       )
     }
 
@@ -1114,7 +1115,8 @@ export class ParentalLeaveService extends BaseTemplateApiService {
       return applicationInformation.applicationFundId || null
     } catch (e) {
       this.logger.warn(
-        `Could not fetch applicationFundId on applicationId: ${application.id} with error: ${e}`,
+        `Could not fetch applicationFundId on applicationId: ${application.id}`,
+        e,
       )
     }
 
@@ -1133,7 +1135,8 @@ export class ParentalLeaveService extends BaseTemplateApiService {
       return applicationRights
     } catch (e) {
       this.logger.warn(
-        `Could not fetch applicationRights on nationalId with error: ${e}`,
+        `Could not fetch applicationRights on applicationId: ${application.id}`,
+        e,
       )
     }
 
@@ -1152,7 +1155,8 @@ export class ParentalLeaveService extends BaseTemplateApiService {
       return { otherParentId, otherParentName }
     } catch (e) {
       this.logger.warn(
-        `Could not fetch otherParent on applicationId: ${application.id} with error: ${e}`,
+        `Could not fetch otherParent on applicationId: ${application.id}`,
+        e,
       )
     }
 


### PR DESCRIPTION
# ...

## What

Fixes five `catch` blocks in `parental-leave.service.ts` that logged the caught value in a way that threw it away.

Four of them interpolated it into the message template. A VMST error object has no useful `toString`, so what actually lands in Datadog is the literal string `[object Object]`:

```
Could not fetch applicationInformation on applicationId: <id> with error: [object Object]
```

The fifth wrapped it in an object literal (`{ e }`). `JSON.stringify` of an `Error` returns `{}`, so the attachment failure logs `{"e":{}}`.

Both now pass the value as the meta argument instead, matching what the other `catch` blocks in this file already do.

One drive-by: the `applicationRights` message said `on nationalId` but interpolated neither a national id nor an application id. It now names `applicationId`, like its three neighbours.

No behaviour outside logging changes — no control flow, no new imports, no signature changes.

## Why

We hit this triaging a support ticket where Vinnumálastofnun had lost their copy of an application (Zendesk 586167 / 625494). The question was whether re-pushing from island.is would work, and prod logs could not tell us why any given VMST call had failed — every one of these four sites reports `[object Object]`.

`libs/logging` already composes `format.errors({ stack: true, cause: true })`, so passing the value as meta gets us the message, the stack and the error's own enumerable fields (for a `FetchError`: `status`, `statusText`, `url`, `problem`). Verified against the real winston config from `libs/logging/src/lib/logging.ts`:

```
BEFORE  {"level":"warn","message":"... with error: [object Object]"}
BEFORE  {"e":{},"level":"error","message":"Cannot get attachment"}

AFTER   {"level":"warn","message":"Could not fetch applicationInformation on applicationId: <id>",
         "name":"FetchError","status":400,"statusText":"Bad Request",
         "url":"https://vmst/...","problem":{"title":"Validation failed"},
         "stack":"FetchError: Request failed with status code 400\n    at ..."}
```

National ids in log output stay masked by `maskNationalIdFormatter`, which is unchanged.

There are 9 `Could not fetch applicationInformation` warnings and 43 send failures in the last 15 days of prod logs, so these paths do fire.

## Screenshots / Gifs

n/a — log output only; the before/after JSON is above.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code

### Notes for the reviewer

- **No test added.** These are log-only lines in `catch` blocks and the service spec injects the real `logger` rather than a mock, so there is no seam to assert on without introducing one. Happy to add a mocked-logger test if you would rather have the regression pinned down.
- **Verification was partial.** Prettier and ESLint pass on the changed file (the one remaining warning, unused `params` at line 927, predates this change). I could not run the project's Jest suite or `tsc` locally — I was working in a git worktree without codegen output, and `@island.is/*` path aliases do not resolve there outside the Nx executor. CI covers both.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error and warning logging for parental leave application processing.
  * Corrected an application reference in an application-rights warning message.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->