### PR TITLE
fix(j-s): Equalize spacing around defendant info in indictment pdf

### DIFF
--- a/apps/judicial-system/backend/src/app/formatters/generatedPdfs/indictmentPdf.ts
+++ b/apps/judicial-system/backend/src/app/formatters/generatedPdfs/indictmentPdf.ts
@@ -109,7 +109,10 @@ export const createIndictment = async (
   addNormalPlusText(doc, ' ')
   setLineCap(2)
   addNormalPlusText(doc, theCase.indictmentIntroduction ?? '')
-  addEmptyLines(doc)
+
+  if (theCase.indictmentIntroduction) {
+    addEmptyLines(doc)
+  }
 
   const hasManyCounts =
     theCase.indictmentCounts && theCase.indictmentCounts.length > 1

--- a/apps/judicial-system/backend/src/app/formatters/generatedPdfs/indictmentPdf.ts
+++ b/apps/judicial-system/backend/src/app/formatters/generatedPdfs/indictmentPdf.ts
@@ -109,6 +109,7 @@ export const createIndictment = async (
   addNormalPlusText(doc, ' ')
   setLineCap(2)
   addNormalPlusText(doc, theCase.indictmentIntroduction ?? '')
+  addEmptyLines(doc)
 
   const hasManyCounts =
     theCase.indictmentCounts && theCase.indictmentCounts.length > 1


### PR DESCRIPTION
# Equalize spacing around defendant info in indictment pdf

## What

Add one extra empty line between the indictment introduction and the first indictment count in the generated indictment pdf.

## Why

A prosecutor reported that the space below the defendant's address was smaller than the space above the defendant's name. The autofilled introduction ends with the defendant's name and address and has two blank lines above the name, but only one blank line was rendered below the address before the first count. Adding the fix in the pdf formatter also corrects the spacing for existing cases with an already stored introduction.

## Screenshots / Gifs

| Before | After |
| --- | --- |
| ![Before](https://gist.githubusercontent.com/oddsson/54d1a975e737e79ea6fbab992c24f276/raw/before.png) | ![After](https://gist.githubusercontent.com/oddsson/54d1a975e737e79ea6fbab992c24f276/raw/after.png) |

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved indictment PDF formatting by removing an unnecessary blank line when no indictment introduction is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->