### PR TITLE
fix(j-s): use originalAncestorId when delivering verdicts to police

### DIFF
--- a/apps/judicial-system/backend/src/app/modules/verdict/test/createTestingVerdictModule.ts
+++ b/apps/judicial-system/backend/src/app/modules/verdict/test/createTestingVerdictModule.ts
@@ -22,7 +22,11 @@ import { EventLogService } from '../../event-log'
 import { FileService } from '../../file'
 import { LawyerRegistryService } from '../../lawyer-registry/lawyerRegistry.service'
 import { PoliceService } from '../../police'
-import { VerdictRepositoryService } from '../../repository'
+import {
+  Case,
+  CaseRepositoryService,
+  VerdictRepositoryService,
+} from '../../repository'
 import { UserService } from '../../user'
 import { InternalVerdictController } from '../internalVerdict.controller'
 import { VerdictController } from '../verdict.controller'
@@ -40,6 +44,7 @@ jest.mock('../../user/user.service')
 jest.mock('../../case/internalCase.service')
 jest.mock('../../lawyer-registry/lawyerRegistry.service')
 jest.mock('../../repository/services/verdictRepository.service')
+jest.mock('../../repository/services/caseRepository.service')
 
 export const createTestingVerdictModule = async () => {
   const verdictModule = await Test.createTestingModule({
@@ -72,6 +77,7 @@ export const createTestingVerdictModule = async () => {
       },
       { provide: Sequelize, useValue: { transaction: jest.fn() } },
       VerdictRepositoryService,
+      CaseRepositoryService,
       VerdictService,
       AuditTrailService,
     ],
@@ -79,6 +85,16 @@ export const createTestingVerdictModule = async () => {
 
   const verdictRepositoryService = verdictModule.get<VerdictRepositoryService>(
     VerdictRepositoryService,
+  )
+
+  const caseRepositoryService = verdictModule.get<CaseRepositoryService>(
+    CaseRepositoryService,
+  )
+
+  const mockFindOriginalAncestorId =
+    caseRepositoryService.findOriginalAncestorId as jest.Mock
+  mockFindOriginalAncestorId.mockImplementation((theCase: Case) =>
+    Promise.resolve(theCase.splitCaseId ?? theCase.id),
   )
 
   const verdictService = verdictModule.get<VerdictService>(VerdictService)
@@ -107,6 +123,7 @@ export const createTestingVerdictModule = async () => {
     eventService,
     fileService,
     verdictRepositoryService,
+    caseRepositoryService,
     sequelize,
   }
 }

--- a/apps/judicial-system/backend/src/app/modules/verdict/test/internalVerdictController/deliverVerdictToNationalCommissionersOffice.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/verdict/test/internalVerdictController/deliverVerdictToNationalCommissionersOffice.spec.ts
@@ -12,6 +12,7 @@ import { FileService } from '../../../file'
 import { PoliceService } from '../../../police'
 import { Case, Defendant, Verdict } from '../../../repository'
 import { DeliverDto } from '../../dto/deliver.dto'
+import { InternalVerdictController } from '../../internalVerdict.controller'
 import { DeliverResponse } from '../../models/deliver.response'
 
 interface Then {
@@ -19,7 +20,7 @@ interface Then {
   error: Error
 }
 
-type GivenWhenThen = () => Promise<Then>
+type GivenWhenThen = (caseToDeliver?: Case) => Promise<Then>
 
 describe('InternalVerdictController - Deliver verdict to national commissioners office', () => {
   const caseId = uuid()
@@ -52,34 +53,31 @@ describe('InternalVerdictController - Deliver verdict to national commissioners 
   let mockPoliceService: PoliceService
   let mockFileService: FileService
   let mockEventService: EventService
+  let internalVerdictController: InternalVerdictController
 
   let givenWhenThen: GivenWhenThen
 
   beforeEach(async () => {
-    const {
-      internalVerdictController,
-      policeService,
-      fileService,
-      eventService,
-    } = await createTestingVerdictModule()
+    const testingModule = await createTestingVerdictModule()
 
-    mockPoliceService = policeService
-    mockEventService = eventService
+    mockPoliceService = testingModule.policeService
+    mockEventService = testingModule.eventService
+    internalVerdictController = testingModule.internalVerdictController
     const mockCreateDocument = mockPoliceService.createDocument as jest.Mock
     mockCreateDocument.mockRejectedValue(new Error('Some error'))
 
-    mockFileService = fileService
+    mockFileService = testingModule.fileService
     const mockGetCaseFileFromS3 = mockFileService.getCaseFileFromS3 as jest.Mock
     mockGetCaseFileFromS3.mockResolvedValue(buffer)
 
-    givenWhenThen = async (): Promise<Then> => {
+    givenWhenThen = async (caseToDeliver = theCase): Promise<Then> => {
       const then = {} as Then
 
       await internalVerdictController
         .deliverVerdictToNationalCommissionersOffice(
-          caseId,
+          caseToDeliver.id,
           defendantId,
-          theCase,
+          caseToDeliver,
           defendant,
           verdict,
           dto,
@@ -121,6 +119,32 @@ describe('InternalVerdictController - Deliver verdict to national commissioners 
           { code: 'VERDICT_COURT_CASE_NUMBER', value: courtCaseNumber },
         ],
       })
+    })
+  })
+
+  describe('verdict delivered for a split case', () => {
+    const originalCaseId = uuid()
+    const createDocumentResponse = { externalPoliceDocumentId: uuid() }
+    const splitCase = {
+      ...theCase,
+      splitCaseId: originalCaseId,
+    } as Case
+
+    beforeEach(async () => {
+      const mockCreateDocument = mockPoliceService.createDocument as jest.Mock
+      mockCreateDocument.mockResolvedValue(createDocumentResponse)
+
+      await givenWhenThen(splitCase)
+    })
+
+    it('should send the original ancestor case id as RVG_CASE_ID', () => {
+      expect(mockPoliceService.createDocument).toHaveBeenCalledWith(
+        expect.objectContaining({
+          caseSupplements: expect.arrayContaining([
+            { code: 'RVG_CASE_ID', value: originalCaseId },
+          ]),
+        }),
+      )
     })
   })
 

--- a/apps/judicial-system/backend/src/app/modules/verdict/verdict.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/verdict/verdict.service.ts
@@ -33,6 +33,7 @@ import { FileService } from '../file'
 import { PoliceDocumentType, PoliceService } from '../police'
 import {
   Case,
+  CaseRepositoryService,
   Defendant,
   Verdict,
   VerdictRepositoryService,
@@ -71,6 +72,7 @@ export type VerdictServiceCertificateDelivery = {
 export class VerdictService {
   constructor(
     private readonly verdictRepositoryService: VerdictRepositoryService,
+    private readonly caseRepositoryService: CaseRepositoryService,
     private readonly pdfService: PdfService,
     @Inject(forwardRef(() => FileService))
     private readonly fileService: FileService,
@@ -322,6 +324,7 @@ export class VerdictService {
     theCase: Case,
     defendant: Defendant,
     verdict: Verdict,
+    originalAncestorCaseId: string,
   ): { code: string; value: string }[] {
     const receiverSsn = defendant.nationalId ?? ''
     const policeNumbers = theCase.policeCaseNumbers?.filter(Boolean) ?? []
@@ -334,7 +337,8 @@ export class VerdictService {
       )?.ruling ?? theCase.ruling
 
     return [
-      { code: 'RVG_CASE_ID', value: theCase.id },
+      // LÖKE only knows the original case; split cases must use the ancestor id
+      { code: 'RVG_CASE_ID', value: originalAncestorCaseId },
       { code: 'RVG_DOCUMENT_ID', value: verdict.id },
       ...(receiverSsn ? [{ code: 'RECEIVER_SSN', value: receiverSsn }] : []),
       ...(theCase.courtCaseNumber
@@ -453,6 +457,9 @@ export class VerdictService {
       // add two months because we don't want the order by date to be in the past when delivered to the police
       orderByDate.setMonth(orderByDate.getMonth() + 2)
 
+      const originalAncestorCaseId =
+        await this.caseRepositoryService.findOriginalAncestorId(theCase)
+
       // deliver the verdict by creating the document at the police
       const createdDocument = await this.policeService.createDocument({
         caseId: theCase.id,
@@ -476,6 +483,7 @@ export class VerdictService {
           theCase,
           defendant,
           verdict,
+          originalAncestorCaseId,
         ),
       })
 


### PR DESCRIPTION
[Asana](https://app.asana.com/1/203394141643832/project/1212657017130395/task/1213290103272292?focus=true)

## What

Use the original ancestor id when delivering verdicts to police. We were sending just theCase.id which would not be the correct id in split cases.

## Why

So we deliver the verdicts to LOKE for all cases.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Cursor


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected verdict delivery for split cases so the national commissioners’ office receives the original ancestor case ID.
  * Added coverage to verify that case references are mapped correctly when delivering verdicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->