### PR TITLE
feat(merge-queue): retry infra-cancelled matrix jobs before success gate

### DIFF
--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -1,7 +1,18 @@
 name: Validate code in the merge queue (post merge)
 
 on:
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      simulate_tests:
+        description: 'CSV of TEST_CHUNKS keys to force-retry (validation only)'
+        required: false
+        type: string
+        default: ''
+      simulate_docker:
+        description: 'CSV of docker project names to force-retry (validation only)'
+        required: false
+        type: string
+        default: ''
   merge_group:
 
 defaults:
@@ -80,6 +91,8 @@ jobs:
       matrix:
         chunk: ${{ fromJson(needs.prepare.outputs.DOCKER_CHUNKS) }}
     steps:
+      - name: Job identity
+        run: echo "MQ_JOB_KEY=$(echo '${{ matrix.chunk }}' | jq -r '.projects')"
       - name: Gather apps
         id: gather
         run: |
@@ -218,6 +231,9 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJson(needs.prepare.outputs.TEST_CHUNKS) }}
     steps:
+      - name: Job identity
+        run: echo "MQ_JOB_KEY=${AFFECTED_PROJECTS}"
+
       - name: checkout
         uses: actions/checkout@v4
 
@@ -263,6 +279,244 @@ jobs:
       - name: Type checking
         run: yarn nx affected --target=typecheck
 
+  retry-plan:
+    needs:
+      - prepare
+      - tests
+      - typecheck
+      - docker-build
+    if: ${{ always() && !cancelled() }}
+    # TODO: switch to arc-mergequeue (on-demand) once the scale set is deployed
+    runs-on: arc-shared
+    permissions:
+      actions: read
+      contents: read
+    outputs:
+      tests: ${{ steps.plan.outputs.tests }}
+      docker: ${{ steps.plan.outputs.docker }}
+      has_tests: ${{ steps.plan.outputs.has_tests }}
+      has_docker: ${{ steps.plan.outputs.has_docker }}
+      typecheck: ${{ steps.plan.outputs.typecheck }}
+      genuine: ${{ steps.plan.outputs.genuine }}
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+      - name: Setup yarn
+        uses: ./.github/actions/setup-yarn
+      - name: load-deps
+        uses: ./.github/actions/load-deps
+      - name: Plan retries
+        id: plan
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ORIG_TESTS: ${{ needs.prepare.outputs.TEST_CHUNKS }}
+          ORIG_DOCKER: ${{ needs.prepare.outputs.DOCKER_CHUNKS }}
+          SIMULATE_TESTS: ${{ github.event.inputs.simulate_tests }}
+          SIMULATE_DOCKER: ${{ github.event.inputs.simulate_docker }}
+        run: node scripts/ci/mq/retry-plan.mjs
+
+  tests-retry:
+    needs:
+      - prepare
+      - retry-plan
+    if: ${{ always() && !cancelled() && needs.retry-plan.outputs.has_tests == 'true' }}
+    # TODO: switch to arc-mergequeue (on-demand) once the scale set is deployed
+    runs-on: arc-shared
+    timeout-minutes: 45
+    env:
+      AFFECTED_PROJECTS: ${{ matrix.projects }}
+      NX_BASE: ${{ needs.prepare.outputs.NX_BASE }}
+      NX_HEAD: ${{ needs.prepare.outputs.NX_HEAD }}
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.retry-plan.outputs.tests) }}
+    steps:
+      - name: Job identity
+        run: echo "MQ_JOB_KEY=${AFFECTED_PROJECTS}"
+
+      - name: checkout
+        uses: actions/checkout@v4
+
+      - name: Setup yarn
+        uses: ./.github/actions/setup-yarn
+
+      - name: load-deps
+        uses: ./.github/actions/load-deps
+
+      - name: Run unit tests
+        uses: ./.github/actions/unit-test
+        with:
+          dd-api-key: '${{ secrets.DD_API_KEY }}'
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          docker-registry: 821090935708.dkr.ecr.eu-west-1.amazonaws.com/
+
+  typecheck-retry:
+    needs:
+      - prepare
+      - retry-plan
+    if: ${{ always() && !cancelled() && needs.retry-plan.outputs.typecheck == 'true' }}
+    permissions:
+      contents: 'read'
+    # TODO: switch to arc-mergequeue (on-demand) once the scale set is deployed
+    runs-on: arc-shared
+    timeout-minutes: 35
+    env:
+      NODE_OPTIONS: --max-old-space-size=4096
+      NX_BASE: ${{ needs.prepare.outputs.NX_BASE }}
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+
+      - name: Fetch NX_BASE commit
+        run: git fetch --depth=1 origin ${{ needs.prepare.outputs.NX_BASE }}
+
+      - name: Setup yarn
+        uses: ./.github/actions/setup-yarn
+
+      - name: load-deps
+        uses: ./.github/actions/load-deps
+
+      - name: Type checking
+        run: yarn nx affected --target=typecheck
+
+  docker-build-retry:
+    needs:
+      - prepare
+      - pre-checks
+      - retry-plan
+    if: ${{ always() && !cancelled() && needs.retry-plan.outputs.has_docker == 'true' }}
+    # TODO: switch to arc-mergequeue (on-demand) once the scale set is deployed
+    runs-on: arc-shared
+    permissions:
+      actions: read
+      contents: read
+    env:
+      AFFECTED_ALL: ''
+      DOCKER_TAG: ${{ needs.prepare.outputs.MQ_DOCKER_TAG}}
+      GIT_BRANCH: ${{ needs.prepare.outputs.MQ_GIT_BRANCH }}
+      GIT_COMMIT_SHA: ${{ needs.prepare.outputs.MQ_SHA }}
+      NODE_IMAGE_VERSION: ${{ needs.pre-checks.outputs.NODE_IMAGE_VERSION}}
+      PUBLISH: true
+      DISABLE_CHUNKS: true
+      MAX_JOBS: 3
+      NX_PARALLEL: 1
+    strategy:
+      fail-fast: false
+      matrix:
+        chunk: ${{ fromJson(needs.retry-plan.outputs.docker) }}
+    steps:
+      - name: Job identity
+        run: echo "MQ_JOB_KEY=$(echo '${{ matrix.chunk }}' | jq -r '.projects')"
+      - name: Gather apps
+        id: gather
+        run: |
+          set -euo pipefail
+          AFFECTED_PROJECTS="$(echo '${{ matrix.chunk }}' | jq -r '.projects')"
+          DOCKER_TYPE="$(echo '${{ matrix.chunk }}' | jq -r '.docker_type')"
+          APP_HOME="$(echo '${{ matrix.chunk }}' | jq -r '.home')"
+          APP_DIST_HOME="$(echo '${{ matrix.chunk }}' | jq -r '.dist')"
+          {
+            echo "AFFECTED_PROJECTS=$AFFECTED_PROJECTS"
+            echo "DOCKER_TYPE=$DOCKER_TYPE"
+            echo "APP_HOME=$APP_HOME"
+            echo "APP_DIST_HOME=$APP_DIST_HOME"
+          } >> "$GITHUB_ENV"
+        continue-on-error: true
+      - name: checkout
+        uses: actions/checkout@v4
+      - name: Setup yarn
+        uses: ./.github/actions/setup-yarn
+      - name: Set id for matrix
+        run: |
+          node ./scripts/ci/docker/create-id.mjs
+      - name: load-deps
+        uses: ./.github/actions/load-deps
+      - name: Docker login to ECR repo
+        if: steps.gather.outcome == 'success'
+        run: ./scripts/ci/docker-login-ecr.sh
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+      - name: Prepare Docker build arguments
+        id: dockerargs
+        if: steps.gather.outcome == 'success'
+        env:
+          DOCKER_BASE_IMAGE_REGISTRY: ${{ env.DOCKER_BASE_IMAGE_REGISTRY }}
+        run: |
+          set -x
+          # Strip protocol prefix and .git postfix
+          SERVER_URL="${{ github.server_url }}/${{ github.repository }}"
+          SERVER_URL="${SERVER_URL#*://}"
+          SERVER_URL="${SERVER_URL%.git}"
+          build_args=(
+            --build-arg="DOCKER_IMAGE_REGISTRY=${DOCKER_BASE_IMAGE_REGISTRY}"
+            --build-arg="NODE_IMAGE_VERSION=${NODE_IMAGE_VERSION}"
+            --build-arg="GIT_BRANCH=${GIT_BRANCH}"
+            --build-arg="GIT_COMMIT_SHA=${GIT_COMMIT_SHA}"
+            --build-arg="GIT_REPOSITORY_URL=${SERVER_URL}"
+            --build-arg="NX_PARALLEL=${NX_PARALLEL}"
+            --build-arg="NX_MAX_PARALLEL=${NX_MAX_PARALLEL}"
+            --build-arg="NX_TASKS_RUNNER=ci"
+          )
+          export EXTRA_DOCKER_BUILD_ARGS="${build_args[*]}"
+          echo "EXTRA_DOCKER_BUILD_ARGS=${EXTRA_DOCKER_BUILD_ARGS}" >> "${GITHUB_ENV}"
+
+          # Create a temporary file with the NX_CLOUD_ACCESS_TOKEN
+          echo "${{ secrets.NX_CLOUD_ACCESS_TOKEN }}" > nx_cloud_access_token.txt
+
+          # Add secret to EXTRA_DOCKER_BUILD_ARGS
+          echo "EXTRA_DOCKER_BUILD_ARGS=${EXTRA_DOCKER_BUILD_ARGS} --secret id=nx_cloud_access_token,src=nx_cloud_access_token.txt" >> "${GITHUB_ENV}"
+
+      - name: Check if cached buildx image exists
+        id: cache-check
+        run: |
+          if ! docker pull ${{vars.AWS_ECR_REPO_BASE}}/moby/buildkit:buildx-stable-1 ; then
+            docker pull docker.io/moby/buildkit:buildx-stable-1
+            docker tag docker.io/moby/buildkit:buildx-stable-1 ${{vars.AWS_ECR_REPO_BASE}}/moby/buildkit:buildx-stable-1
+            docker push ${{vars.AWS_ECR_REPO_BASE}}/moby/buildkit:buildx-stable-1
+          fi
+
+      - name: Building Docker images
+        continue-on-error: true
+        id: dockerbuild
+        if: steps.gather.outcome == 'success'
+        env:
+          GIT_COMMIT_SHA: ${{ github.sha }}
+          DOCKER_BASE_IMAGE_REGISTRY: ${{ env.DOCKER_BASE_IMAGE_REGISTRY }}
+          S3_DOCKER_CACHE_BUCKET: ${{ vars.S3_DOCKER_CACHE_BUCKET }}
+        run: |
+          set -x
+          echo "Node image tag is: '${NODE_IMAGE_VERSION}'"
+          echo "Docker build args are: 'EXTRA_DOCKER_BUILD_ARGS'"
+          export EXTRA_DOCKER_BUILD_ARGS
+          ./scripts/ci/run-in-parallel.sh "90_${DOCKER_TYPE}"
+
+      - name: Building Docker images Retry
+        if: steps.gather.outcome == 'success' && steps.dockerbuild.outcome == 'failure'
+        env:
+          GIT_COMMIT_SHA: ${{ github.sha }}
+          DOCKER_BASE_IMAGE_REGISTRY: ${{ env.DOCKER_BASE_IMAGE_REGISTRY }}
+          S3_DOCKER_CACHE_BUCKET: ${{ vars.S3_DOCKER_CACHE_BUCKET }}
+        run: |
+          set -x
+          echo "Node image tag is: '${NODE_IMAGE_VERSION}'"
+          echo "Docker build args are: 'EXTRA_DOCKER_BUILD_ARGS'"
+          export EXTRA_DOCKER_BUILD_ARGS
+          ./scripts/ci/run-in-parallel.sh "90_${DOCKER_TYPE}"
+      - name: Docker build output
+        uses: cloudposse/github-action-matrix-outputs-write@v1
+        with:
+          matrix-step-name: ${{ github.job }}
+          matrix-key: ${{ env.MATRIX_ID }}
+          outputs: |-
+            value: ${{ env.JSON_value }}
+            project: ${{ env.JSON_project }}
+            target: ${{ env.JSON_target }}
+            imageName: ${{ env.JSON_imageName }}
+            imageTag: ${{ env.JSON_imageTag }}
+
   success:
     runs-on: arc-shared
     if: ${{ !cancelled() }}
@@ -271,20 +525,50 @@ jobs:
       - tests
       - typecheck
       - docker-build
+      - retry-plan
+      - tests-retry
+      - typecheck-retry
+      - docker-build-retry
     steps:
-      - name: Check prepare success
-        run: '[[ ${{ needs.prepare.result }} == "success" ]] || exit 1'
-      - name: Check tests success
-        run: '[[ ${{ needs.tests.result }} != "failure" && ${{ needs.tests.result }} != "abandoned" && ${{ needs.tests.result }} != "cancelled" ]] || exit 1'
-      - name: Check typecheck success
-        run: '[[ ${{ needs.typecheck.result }} == "success" ]] || exit 1'
-      - name: Check build success
-        run: '[[ ${{ needs.docker-build.result }} != "failure" && ${{ needs.docker-build.result }} != "abandoned" && ${{ needs.docker-build.result }} != "cancelled" ]] || exit 1'
+      - name: Gate
+        env:
+          PREPARE: ${{ needs.prepare.result }}
+          PLAN: ${{ needs.retry-plan.result }}
+          GENUINE: ${{ needs.retry-plan.outputs.genuine }}
+          TESTS: ${{ needs.tests.result }}
+          TESTS_RETRY: ${{ needs.tests-retry.result }}
+          TYPECHECK: ${{ needs.typecheck.result }}
+          TYPECHECK_RETRY: ${{ needs.typecheck-retry.result }}
+          DOCKER: ${{ needs.docker-build.result }}
+          DOCKER_RETRY: ${{ needs.docker-build-retry.result }}
+        run: |
+          fail() { echo "GATE FAIL: $1"; exit 1; }
+          # A stage is satisfied if the original passed/was empty, or its retry passed.
+          ok() { [[ "$1" == "success" || "$1" == "skipped" || "$2" == "success" ]]; }
+          [[ "$PREPARE" == "success" ]] || fail "prepare=$PREPARE"
+          [[ "$PLAN" == "success" ]] || fail "retry-plan=$PLAN"
+          [[ "$GENUINE" == "[]" ]] || fail "genuine failures present: $GENUINE"
+          ok "$TESTS" "$TESTS_RETRY" || fail "tests=$TESTS retry=$TESTS_RETRY"
+          ok "$TYPECHECK" "$TYPECHECK_RETRY" || fail "typecheck=$TYPECHECK retry=$TYPECHECK_RETRY"
+          ok "$DOCKER" "$DOCKER_RETRY" || fail "docker-build=$DOCKER retry=$DOCKER_RETRY"
+          echo "GATE PASS"
       - name: Get docker-build output
         uses: cloudposse/github-action-matrix-outputs-read@v1
         id: read
         with:
           matrix-step-name: docker-build
+      - name: Get docker-build-retry output
+        uses: cloudposse/github-action-matrix-outputs-read@v1
+        id: read_retry
+        continue-on-error: true
+        with:
+          matrix-step-name: docker-build-retry
+      - name: Merge docker outputs
+        id: merge
+        env:
+          ORIG: ${{ steps.read.outputs.result }}
+          RETRY: ${{ steps.read_retry.outputs.result }}
+        run: node scripts/ci/mq/merge-docker-outputs.mjs
       - name: checkout
         if: ${{ needs.prepare.outputs.MQ_SHOULD_RUN_BUILD == 'true' && needs.prepare.outputs.DOCKER_CHUNKS && needs.prepare.outputs.DOCKER_CHUNKS != '[]' }}
         uses: actions/checkout@v4
@@ -306,7 +590,7 @@ jobs:
       - name: Prepare artifact to be uploaded
         if: ${{ needs.prepare.outputs.MQ_SHOULD_RUN_BUILD == 'true' && needs.prepare.outputs.DOCKER_CHUNKS && needs.prepare.outputs.DOCKER_CHUNKS != '[]' }}
         env:
-          JSON_DATA: ${{ steps.read.outputs.result }}
+          JSON_DATA: ${{ steps.merge.outputs.result }}
         run: |
           node scripts/ci/docker/write-data.mjs
       - name: Get manifest data

--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -301,10 +301,10 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
-      - name: Setup yarn
-        uses: ./.github/actions/setup-yarn
-      - name: load-deps
-        uses: ./.github/actions/load-deps
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
       - name: Plan retries
         id: plan
         env:

--- a/.github/workflows/retry-selftest.yml
+++ b/.github/workflows/retry-selftest.yml
@@ -6,6 +6,7 @@ name: Retry mechanism self-test
 # No deployments, no merge queue, no Spot interruption required.
 
 on:
+  push:
   workflow_dispatch:
     inputs:
       fail_mode:
@@ -46,7 +47,7 @@ jobs:
           if [[ "${AFFECTED_PROJECTS}" != "beta" ]]; then
             echo "chunk ${AFFECTED_PROJECTS} ok"; exit 0
           fi
-          case "${{ inputs.fail_mode }}" in
+          case "${{ inputs.fail_mode || 'infra' }}" in
             infra)
               echo "The runner has received a shutdown signal"
               echo "The operation was canceled"
@@ -132,7 +133,7 @@ jobs:
     steps:
       - name: Assert gate matches expectation
         env:
-          MODE: ${{ inputs.fail_mode }}
+          MODE: ${{ inputs.fail_mode || 'infra' }}
           GATE: ${{ needs.gate.result }}
         run: |
           # genuine => gate must fail; infra/none => gate must pass.

--- a/.github/workflows/retry-selftest.yml
+++ b/.github/workflows/retry-selftest.yml
@@ -74,10 +74,10 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
-      - name: Setup yarn
-        uses: ./.github/actions/setup-yarn
-      - name: load-deps
-        uses: ./.github/actions/load-deps
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
       - name: Plan retries
         id: plan
         env:

--- a/.github/workflows/retry-selftest.yml
+++ b/.github/workflows/retry-selftest.yml
@@ -1,0 +1,144 @@
+name: Retry mechanism self-test
+
+# Deterministic harness for the merge-queue retry mechanism. Runs anywhere via
+# workflow_dispatch, fakes an infra/genuine/clean failure of one matrix chunk,
+# exercises the real scripts/ci/mq/retry-plan.mjs, and asserts the outcome.
+# No deployments, no merge queue, no Spot interruption required.
+
+on:
+  workflow_dispatch:
+    inputs:
+      fail_mode:
+        description: 'How chunk "beta" behaves on its first attempt'
+        type: choice
+        options:
+          - infra # runner-shutdown signature -> should be retried -> PASS
+          - genuine # real failure -> not retried -> gate FAIL (expected)
+          - none # nothing fails -> PASS
+        default: infra
+
+defaults:
+  run:
+    shell: bash -euxo pipefail {0}
+
+jobs:
+  prepare:
+    runs-on: arc-shared
+    outputs:
+      TEST_CHUNKS: ${{ steps.gen.outputs.chunks }}
+    steps:
+      - id: gen
+        run: echo 'chunks={"projects":["alpha","beta","gamma"]}' >> "$GITHUB_OUTPUT"
+
+  tests:
+    needs: prepare
+    runs-on: arc-shared
+    env:
+      AFFECTED_PROJECTS: ${{ matrix.projects }}
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.prepare.outputs.TEST_CHUNKS) }}
+    steps:
+      - name: Job identity
+        run: echo "MQ_JOB_KEY=${AFFECTED_PROJECTS}"
+      - name: Simulate work
+        run: |
+          if [[ "${AFFECTED_PROJECTS}" != "beta" ]]; then
+            echo "chunk ${AFFECTED_PROJECTS} ok"; exit 0
+          fi
+          case "${{ inputs.fail_mode }}" in
+            infra)
+              echo "The runner has received a shutdown signal"
+              echo "The operation was canceled"
+              exit 1 ;;
+            genuine)
+              echo "assertion failed in ${AFFECTED_PROJECTS}"; exit 1 ;;
+            none)
+              echo "chunk ${AFFECTED_PROJECTS} ok"; exit 0 ;;
+          esac
+
+  retry-plan:
+    needs:
+      - prepare
+      - tests
+    if: ${{ always() && !cancelled() }}
+    runs-on: arc-shared
+    permissions:
+      actions: read
+      contents: read
+    outputs:
+      tests: ${{ steps.plan.outputs.tests }}
+      has_tests: ${{ steps.plan.outputs.has_tests }}
+      genuine: ${{ steps.plan.outputs.genuine }}
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+      - name: Setup yarn
+        uses: ./.github/actions/setup-yarn
+      - name: load-deps
+        uses: ./.github/actions/load-deps
+      - name: Plan retries
+        id: plan
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ORIG_TESTS: ${{ needs.prepare.outputs.TEST_CHUNKS }}
+          ORIG_DOCKER: '[]'
+        run: node scripts/ci/mq/retry-plan.mjs
+
+  tests-retry:
+    needs:
+      - prepare
+      - retry-plan
+    if: ${{ always() && !cancelled() && needs.retry-plan.outputs.has_tests == 'true' }}
+    runs-on: arc-shared
+    env:
+      AFFECTED_PROJECTS: ${{ matrix.projects }}
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.retry-plan.outputs.tests) }}
+    steps:
+      - name: Job identity
+        run: echo "MQ_JOB_KEY=${AFFECTED_PROJECTS}"
+      - name: Fresh attempt (always succeeds)
+        run: echo "retry of ${AFFECTED_PROJECTS} ok"
+
+  gate:
+    needs:
+      - tests
+      - retry-plan
+      - tests-retry
+    if: ${{ !cancelled() }}
+    runs-on: arc-shared
+    steps:
+      - name: Gate
+        env:
+          PLAN: ${{ needs.retry-plan.result }}
+          GENUINE: ${{ needs.retry-plan.outputs.genuine }}
+          TESTS: ${{ needs.tests.result }}
+          TESTS_RETRY: ${{ needs.tests-retry.result }}
+        run: |
+          fail() { echo "GATE FAIL: $1"; exit 1; }
+          ok() { [[ "$1" == "success" || "$1" == "skipped" || "$2" == "success" ]]; }
+          [[ "$PLAN" == "success" ]] || fail "retry-plan=$PLAN"
+          [[ "$GENUINE" == "[]" ]] || fail "genuine failures present: $GENUINE"
+          ok "$TESTS" "$TESTS_RETRY" || fail "tests=$TESTS retry=$TESTS_RETRY"
+          echo "GATE PASS"
+
+  assert:
+    needs:
+      - gate
+    if: ${{ always() && !cancelled() }}
+    runs-on: arc-shared
+    steps:
+      - name: Assert gate matches expectation
+        env:
+          MODE: ${{ inputs.fail_mode }}
+          GATE: ${{ needs.gate.result }}
+        run: |
+          # genuine => gate must fail; infra/none => gate must pass.
+          if [[ "$MODE" == "genuine" ]]; then
+            [[ "$GATE" == "failure" ]] || { echo "EXPECTED gate failure, got $GATE"; exit 1; }
+          else
+            [[ "$GATE" == "success" ]] || { echo "EXPECTED gate success, got $GATE"; exit 1; }
+          fi
+          echo "SELF-TEST PASS (mode=$MODE, gate=$GATE)"

--- a/scripts/ci/mq/merge-docker-outputs.mjs
+++ b/scripts/ci/mq/merge-docker-outputs.mjs
@@ -12,7 +12,8 @@ const FIELDS = ['value', 'project', 'target', 'imageName', 'imageTag']
 
 function setOutput(name, value) {
   const line = `${name}=${value}\n`
-  if (process.env.GITHUB_OUTPUT) fs.appendFileSync(process.env.GITHUB_OUTPUT, line)
+  if (process.env.GITHUB_OUTPUT)
+    fs.appendFileSync(process.env.GITHUB_OUTPUT, line)
   else process.stdout.write(line)
 }
 

--- a/scripts/ci/mq/merge-docker-outputs.mjs
+++ b/scripts/ci/mq/merge-docker-outputs.mjs
@@ -1,0 +1,34 @@
+// @ts-check
+// Merges cloudposse matrix-outputs read results from the original docker-build
+// namespace and the docker-build-retry namespace. Keys (uuidv5 of the project)
+// are disjoint across namespaces: a chunk is either an original success or a
+// retry success, never both. Retry values take precedence on any collision.
+
+import core from '@actions/core'
+
+const FIELDS = ['value', 'project', 'target', 'imageName', 'imageTag']
+
+function parse(name) {
+  const raw = process.env[name]
+  if (!raw || raw.trim() === '') return {}
+  try {
+    return JSON.parse(raw)
+  } catch {
+    return {}
+  }
+}
+
+const orig = parse('ORIG')
+const retry = parse('RETRY')
+
+const merged = {}
+for (const field of FIELDS) {
+  merged[field] = { ...(orig[field] || {}), ...(retry[field] || {}) }
+}
+
+core.setOutput('result', JSON.stringify(merged))
+core.info(
+  `merge-docker-outputs: original=${Object.keys(orig.value || {}).length} ` +
+    `retry=${Object.keys(retry.value || {}).length} ` +
+    `merged=${Object.keys(merged.value).length}`,
+)

--- a/scripts/ci/mq/merge-docker-outputs.mjs
+++ b/scripts/ci/mq/merge-docker-outputs.mjs
@@ -3,10 +3,18 @@
 // namespace and the docker-build-retry namespace. Keys (uuidv5 of the project)
 // are disjoint across namespaces: a chunk is either an original success or a
 // retry success, never both. Retry values take precedence on any collision.
+//
+// Dependency-free: Node built-ins only.
 
-import core from '@actions/core'
+import fs from 'node:fs'
 
 const FIELDS = ['value', 'project', 'target', 'imageName', 'imageTag']
+
+function setOutput(name, value) {
+  const line = `${name}=${value}\n`
+  if (process.env.GITHUB_OUTPUT) fs.appendFileSync(process.env.GITHUB_OUTPUT, line)
+  else process.stdout.write(line)
+}
 
 function parse(name) {
   const raw = process.env[name]
@@ -26,8 +34,8 @@ for (const field of FIELDS) {
   merged[field] = { ...(orig[field] || {}), ...(retry[field] || {}) }
 }
 
-core.setOutput('result', JSON.stringify(merged))
-core.info(
+setOutput('result', JSON.stringify(merged))
+console.log(
   `merge-docker-outputs: original=${Object.keys(orig.value || {}).length} ` +
     `retry=${Object.keys(retry.value || {}).length} ` +
     `merged=${Object.keys(merged.value).length}`,

--- a/scripts/ci/mq/retry-plan.mjs
+++ b/scripts/ci/mq/retry-plan.mjs
@@ -160,9 +160,15 @@ async function main() {
       stage === 'tests'
         ? origTestKeys
         : stage === 'docker'
-          ? new Set(dockerByProject.keys())
-          : null
-    const { infra, key } = await inspectJob(token, owner, repo, job.id, knownKeys)
+        ? new Set(dockerByProject.keys())
+        : null
+    const { infra, key } = await inspectJob(
+      token,
+      owner,
+      repo,
+      job.id,
+      knownKeys,
+    )
 
     if (!infra) {
       genuine.push(name)

--- a/scripts/ci/mq/retry-plan.mjs
+++ b/scripts/ci/mq/retry-plan.mjs
@@ -97,10 +97,10 @@ async function main() {
     const stage = STAGE.tests(name)
       ? 'tests'
       : STAGE.docker(name)
-        ? 'docker'
-        : STAGE.typecheck(name)
-          ? 'typecheck'
-          : null
+      ? 'docker'
+      : STAGE.typecheck(name)
+      ? 'typecheck'
+      : null
     if (!stage) continue
     if (job.conclusion === 'success' || job.conclusion === 'skipped') continue
     if (job.status !== 'completed') {

--- a/scripts/ci/mq/retry-plan.mjs
+++ b/scripts/ci/mq/retry-plan.mjs
@@ -3,9 +3,11 @@
 // (runner/Spot shutdown) vs genuine failures, and emits targeted retry
 // matrices. Identity comes from a per-job log marker (MQ_JOB_KEY=...), never
 // from the (truncated) job name. Defaults to "genuine" on any ambiguity.
+//
+// Dependency-free: uses only Node 20 built-ins (global fetch, fs) so it runs
+// with just actions/setup-node, no yarn install / load-deps required.
 
-import core from '@actions/core'
-import github from '@actions/github'
+import fs from 'node:fs'
 
 const SHUTDOWN_SIGNATURE = 'The runner has received a shutdown signal'
 const KEY_RE = /MQ_JOB_KEY=([^\r\n']+)/
@@ -14,6 +16,12 @@ const STAGE = {
   tests: (name) => /^tests \(/.test(name),
   docker: (name) => /^docker-build \(/.test(name),
   typecheck: (name) => name === 'typecheck',
+}
+
+function setOutput(name, value) {
+  const line = `${name}=${value}\n`
+  if (process.env.GITHUB_OUTPUT) fs.appendFileSync(process.env.GITHUB_OUTPUT, line)
+  else process.stdout.write(line)
 }
 
 function parseJson(env, fallback) {
@@ -26,41 +34,57 @@ function parseJson(env, fallback) {
   }
 }
 
-async function fetchLog(octokit, owner, repo, jobId) {
+function ghHeaders(token) {
+  return {
+    Authorization: `Bearer ${token}`,
+    Accept: 'application/vnd.github+json',
+    'User-Agent': 'islandis-retry-plan',
+    'X-GitHub-Api-Version': '2022-11-28',
+  }
+}
+
+async function listJobs(token, owner, repo, runId) {
+  const jobs = []
+  for (let page = 1; ; page++) {
+    const url = `https://api.github.com/repos/${owner}/${repo}/actions/runs/${runId}/jobs?per_page=100&page=${page}`
+    const res = await fetch(url, { headers: ghHeaders(token) })
+    if (!res.ok) throw new Error(`list jobs failed: ${res.status}`)
+    const data = await res.json()
+    jobs.push(...(data.jobs || []))
+    if (!data.jobs || data.jobs.length < 100 || jobs.length >= data.total_count)
+      break
+  }
+  return jobs
+}
+
+async function fetchLog(token, owner, repo, jobId) {
+  // 302 redirects to a signed storage URL; fetch follows it and strips the
+  // Authorization header on the cross-origin hop (per spec).
   try {
-    const resp = await octokit.rest.actions.downloadJobLogsForWorkflowRun({
-      owner,
-      repo,
-      job_id: jobId,
-    })
-    if (typeof resp.data === 'string') return resp.data
-    if (resp.url) return await (await fetch(resp.url)).text()
-    if (resp.data) return Buffer.from(resp.data).toString('utf8')
+    const url = `https://api.github.com/repos/${owner}/${repo}/actions/jobs/${jobId}/logs`
+    const res = await fetch(url, { headers: ghHeaders(token) })
+    if (!res.ok) return null
+    return await res.text()
   } catch {
     return null
   }
-  return null
 }
 
 function classify(logText) {
-  // Returns { infra: boolean, key: string|null }. No log => cannot classify.
   if (logText == null) return { infra: false, key: null }
   const infra = logText.includes(SHUTDOWN_SIGNATURE)
   const m = logText.match(KEY_RE)
-  const key = m ? m[1].trim() : null
-  return { infra, key }
+  return { infra, key: m ? m[1].trim() : null }
 }
 
 async function main() {
   const token = process.env.GH_TOKEN
   if (!token) throw new Error('GH_TOKEN is required')
-  const octokit = github.getOctokit(token)
   const [owner, repo] = (process.env.GITHUB_REPOSITORY || '').split('/')
-  const runId = Number(process.env.GITHUB_RUN_ID)
+  const runId = process.env.GITHUB_RUN_ID
 
   const origTests = parseJson('ORIG_TESTS', { projects: [] })
   const origTestKeys = new Set(origTests.projects || [])
-  // DOCKER_CHUNKS is an array of stringified chunk objects.
   const origDocker = parseJson('ORIG_DOCKER', [])
   const dockerByProject = new Map()
   for (const entry of origDocker) {
@@ -72,7 +96,6 @@ async function main() {
     }
   }
 
-  // Optional simulation for workflow_dispatch validation (no real kill needed).
   const simTests = (process.env.SIMULATE_TESTS || '')
     .split(',')
     .map((s) => s.trim())
@@ -82,10 +105,7 @@ async function main() {
     .map((s) => s.trim())
     .filter(Boolean)
 
-  const jobs = await octokit.paginate(
-    octokit.rest.actions.listJobsForWorkflowRun,
-    { owner, repo, run_id: runId, per_page: 100 },
-  )
+  const jobs = await listJobs(token, owner, repo, runId)
 
   const retryTests = new Set()
   const retryDocker = new Set()
@@ -97,32 +117,31 @@ async function main() {
     const stage = STAGE.tests(name)
       ? 'tests'
       : STAGE.docker(name)
-      ? 'docker'
-      : STAGE.typecheck(name)
-      ? 'typecheck'
-      : null
+        ? 'docker'
+        : STAGE.typecheck(name)
+          ? 'typecheck'
+          : null
     if (!stage) continue
     if (job.conclusion === 'success' || job.conclusion === 'skipped') continue
     if (job.status !== 'completed') {
-      genuine.push(name) // still running/queued at plan time is unexpected
+      genuine.push(name)
       continue
     }
 
-    const log = await fetchLog(octokit, owner, repo, job.id)
+    const log = await fetchLog(token, owner, repo, job.id)
     const { infra, key } = classify(log)
 
     if (!infra) {
       genuine.push(name)
       continue
     }
-    // Infra cancellation: map back to the original matrix entry via MQ_JOB_KEY.
     if (stage === 'typecheck') {
       retryTypecheck = true
       continue
     }
     if (stage === 'tests') {
       if (key && origTestKeys.has(key)) retryTests.add(key)
-      else genuine.push(name) // could not map reliably => fail-safe
+      else genuine.push(name)
       continue
     }
     if (stage === 'docker') {
@@ -131,23 +150,20 @@ async function main() {
     }
   }
 
-  // Apply simulation overrides (workflow_dispatch only).
   for (const k of simTests) if (origTestKeys.has(k)) retryTests.add(k)
   for (const k of simDocker) if (dockerByProject.has(k)) retryDocker.add(k)
 
-  const testsOut = JSON.stringify({ projects: [...retryTests] })
-  const dockerOut = JSON.stringify(
-    [...retryDocker].map((p) => dockerByProject.get(p)),
+  setOutput('tests', JSON.stringify({ projects: [...retryTests] }))
+  setOutput(
+    'docker',
+    JSON.stringify([...retryDocker].map((p) => dockerByProject.get(p))),
   )
+  setOutput('has_tests', retryTests.size > 0 ? 'true' : 'false')
+  setOutput('has_docker', retryDocker.size > 0 ? 'true' : 'false')
+  setOutput('typecheck', retryTypecheck ? 'true' : 'false')
+  setOutput('genuine', JSON.stringify(genuine))
 
-  core.setOutput('tests', testsOut)
-  core.setOutput('docker', dockerOut)
-  core.setOutput('has_tests', retryTests.size > 0 ? 'true' : 'false')
-  core.setOutput('has_docker', retryDocker.size > 0 ? 'true' : 'false')
-  core.setOutput('typecheck', retryTypecheck ? 'true' : 'false')
-  core.setOutput('genuine', JSON.stringify(genuine))
-
-  core.info(
+  console.log(
     `retry-plan: tests=${retryTests.size} docker=${retryDocker.size} ` +
       `typecheck=${retryTypecheck} genuine=${genuine.length}`,
   )

--- a/scripts/ci/mq/retry-plan.mjs
+++ b/scripts/ci/mq/retry-plan.mjs
@@ -20,7 +20,8 @@ const STAGE = {
 
 function setOutput(name, value) {
   const line = `${name}=${value}\n`
-  if (process.env.GITHUB_OUTPUT) fs.appendFileSync(process.env.GITHUB_OUTPUT, line)
+  if (process.env.GITHUB_OUTPUT)
+    fs.appendFileSync(process.env.GITHUB_OUTPUT, line)
   else process.stdout.write(line)
 }
 
@@ -124,10 +125,10 @@ async function main() {
     const stage = STAGE.tests(name)
       ? 'tests'
       : STAGE.docker(name)
-        ? 'docker'
-        : STAGE.typecheck(name)
-          ? 'typecheck'
-          : null
+      ? 'docker'
+      : STAGE.typecheck(name)
+      ? 'typecheck'
+      : null
     if (!stage) continue
     if (job.conclusion === 'success' || job.conclusion === 'skipped') continue
     if (job.status !== 'completed') {

--- a/scripts/ci/mq/retry-plan.mjs
+++ b/scripts/ci/mq/retry-plan.mjs
@@ -10,7 +10,7 @@
 import fs from 'node:fs'
 
 const SHUTDOWN_SIGNATURE = 'The runner has received a shutdown signal'
-const KEY_RE = /MQ_JOB_KEY=([^\r\n']+)/
+const KEY_RE_G = /MQ_JOB_KEY=([^\r\n']+)/g
 
 const STAGE = {
   tests: (name) => /^tests \(/.test(name),
@@ -58,31 +58,51 @@ async function listJobs(token, owner, repo, runId) {
   return jobs
 }
 
-async function fetchLog(token, owner, repo, jobId, attempts = 6) {
+async function fetchLogOnce(token, owner, repo, jobId) {
   // 302 redirects to a signed storage URL; fetch follows it and strips the
-  // Authorization header on the cross-origin hop (per spec). Job logs can 404
-  // briefly right after completion, so retry before giving up.
-  const url = `https://api.github.com/repos/${owner}/${repo}/actions/jobs/${jobId}/logs`
-  for (let i = 0; i < attempts; i++) {
-    try {
-      const res = await fetch(url, { headers: ghHeaders(token) })
-      if (res.ok) {
-        const text = await res.text()
-        if (text && text.length > 0) return text
-      }
-    } catch {
-      /* transient network error; retry */
+  // Authorization header on the cross-origin hop (per spec).
+  try {
+    const url = `https://api.github.com/repos/${owner}/${repo}/actions/jobs/${jobId}/logs`
+    const res = await fetch(url, { headers: ghHeaders(token) })
+    if (res.ok) {
+      const text = await res.text()
+      if (text && text.length > 0) return text
     }
-    if (i < attempts - 1) await new Promise((r) => setTimeout(r, 3000))
+  } catch {
+    /* transient network error */
   }
   return null
 }
 
-function classify(logText) {
-  if (logText == null) return { infra: false, key: null }
-  const infra = logText.includes(SHUTDOWN_SIGNATURE)
-  const m = logText.match(KEY_RE)
-  return { infra, key: m ? m[1].trim() : null }
+function extractKey(log, knownKeys) {
+  // The run-script header logs the literal "MQ_JOB_KEY=${AFFECTED_PROJECTS}";
+  // only the executed output has the real value. Pick the match that validates
+  // against the known chunk set (the literal never validates).
+  const keys = [...log.matchAll(KEY_RE_G)].map((m) => m[1].trim())
+  if (!knownKeys) return null
+  return keys.find((k) => knownKeys.has(k)) ?? null
+}
+
+// Poll the job log until the shutdown signature appears (infra) or we time out
+// (treated as genuine). Handles both the post-completion log-availability race
+// and partially-flushed logs.
+async function inspectJob(
+  token,
+  owner,
+  repo,
+  jobId,
+  knownKeys,
+  attempts = 8,
+  delayMs = 3000,
+) {
+  for (let i = 0; i < attempts; i++) {
+    const log = await fetchLogOnce(token, owner, repo, jobId)
+    if (log && log.includes(SHUTDOWN_SIGNATURE)) {
+      return { infra: true, key: extractKey(log, knownKeys) }
+    }
+    if (i < attempts - 1) await new Promise((r) => setTimeout(r, delayMs))
+  }
+  return { infra: false, key: null }
 }
 
 async function main() {
@@ -136,8 +156,13 @@ async function main() {
       continue
     }
 
-    const log = await fetchLog(token, owner, repo, job.id)
-    const { infra, key } = classify(log)
+    const knownKeys =
+      stage === 'tests'
+        ? origTestKeys
+        : stage === 'docker'
+          ? new Set(dockerByProject.keys())
+          : null
+    const { infra, key } = await inspectJob(token, owner, repo, job.id, knownKeys)
 
     if (!infra) {
       genuine.push(name)
@@ -148,12 +173,12 @@ async function main() {
       continue
     }
     if (stage === 'tests') {
-      if (key && origTestKeys.has(key)) retryTests.add(key)
+      if (key) retryTests.add(key)
       else genuine.push(name)
       continue
     }
     if (stage === 'docker') {
-      if (key && dockerByProject.has(key)) retryDocker.add(key)
+      if (key) retryDocker.add(key)
       else genuine.push(name)
     }
   }

--- a/scripts/ci/mq/retry-plan.mjs
+++ b/scripts/ci/mq/retry-plan.mjs
@@ -1,0 +1,159 @@
+// @ts-check
+// Classifies non-successful merge-queue jobs as infrastructure cancellations
+// (runner/Spot shutdown) vs genuine failures, and emits targeted retry
+// matrices. Identity comes from a per-job log marker (MQ_JOB_KEY=...), never
+// from the (truncated) job name. Defaults to "genuine" on any ambiguity.
+
+import core from '@actions/core'
+import github from '@actions/github'
+
+const SHUTDOWN_SIGNATURE = 'The runner has received a shutdown signal'
+const KEY_RE = /MQ_JOB_KEY=([^\r\n']+)/
+
+const STAGE = {
+  tests: (name) => /^tests \(/.test(name),
+  docker: (name) => /^docker-build \(/.test(name),
+  typecheck: (name) => name === 'typecheck',
+}
+
+function parseJson(env, fallback) {
+  const raw = process.env[env]
+  if (!raw || raw.trim() === '') return fallback
+  try {
+    return JSON.parse(raw)
+  } catch {
+    return fallback
+  }
+}
+
+async function fetchLog(octokit, owner, repo, jobId) {
+  try {
+    const resp = await octokit.rest.actions.downloadJobLogsForWorkflowRun({
+      owner,
+      repo,
+      job_id: jobId,
+    })
+    if (typeof resp.data === 'string') return resp.data
+    if (resp.url) return await (await fetch(resp.url)).text()
+    if (resp.data) return Buffer.from(resp.data).toString('utf8')
+  } catch {
+    return null
+  }
+  return null
+}
+
+function classify(logText) {
+  // Returns { infra: boolean, key: string|null }. No log => cannot classify.
+  if (logText == null) return { infra: false, key: null }
+  const infra = logText.includes(SHUTDOWN_SIGNATURE)
+  const m = logText.match(KEY_RE)
+  const key = m ? m[1].trim() : null
+  return { infra, key }
+}
+
+async function main() {
+  const token = process.env.GH_TOKEN
+  if (!token) throw new Error('GH_TOKEN is required')
+  const octokit = github.getOctokit(token)
+  const [owner, repo] = (process.env.GITHUB_REPOSITORY || '').split('/')
+  const runId = Number(process.env.GITHUB_RUN_ID)
+
+  const origTests = parseJson('ORIG_TESTS', { projects: [] })
+  const origTestKeys = new Set(origTests.projects || [])
+  // DOCKER_CHUNKS is an array of stringified chunk objects.
+  const origDocker = parseJson('ORIG_DOCKER', [])
+  const dockerByProject = new Map()
+  for (const entry of origDocker) {
+    try {
+      const obj = typeof entry === 'string' ? JSON.parse(entry) : entry
+      dockerByProject.set(obj.projects, entry)
+    } catch {
+      /* ignore malformed entry */
+    }
+  }
+
+  // Optional simulation for workflow_dispatch validation (no real kill needed).
+  const simTests = (process.env.SIMULATE_TESTS || '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean)
+  const simDocker = (process.env.SIMULATE_DOCKER || '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean)
+
+  const jobs = await octokit.paginate(
+    octokit.rest.actions.listJobsForWorkflowRun,
+    { owner, repo, run_id: runId, per_page: 100 },
+  )
+
+  const retryTests = new Set()
+  const retryDocker = new Set()
+  let retryTypecheck = false
+  const genuine = []
+
+  for (const job of jobs) {
+    const name = job.name || ''
+    const stage = STAGE.tests(name)
+      ? 'tests'
+      : STAGE.docker(name)
+        ? 'docker'
+        : STAGE.typecheck(name)
+          ? 'typecheck'
+          : null
+    if (!stage) continue
+    if (job.conclusion === 'success' || job.conclusion === 'skipped') continue
+    if (job.status !== 'completed') {
+      genuine.push(name) // still running/queued at plan time is unexpected
+      continue
+    }
+
+    const log = await fetchLog(octokit, owner, repo, job.id)
+    const { infra, key } = classify(log)
+
+    if (!infra) {
+      genuine.push(name)
+      continue
+    }
+    // Infra cancellation: map back to the original matrix entry via MQ_JOB_KEY.
+    if (stage === 'typecheck') {
+      retryTypecheck = true
+      continue
+    }
+    if (stage === 'tests') {
+      if (key && origTestKeys.has(key)) retryTests.add(key)
+      else genuine.push(name) // could not map reliably => fail-safe
+      continue
+    }
+    if (stage === 'docker') {
+      if (key && dockerByProject.has(key)) retryDocker.add(key)
+      else genuine.push(name)
+    }
+  }
+
+  // Apply simulation overrides (workflow_dispatch only).
+  for (const k of simTests) if (origTestKeys.has(k)) retryTests.add(k)
+  for (const k of simDocker) if (dockerByProject.has(k)) retryDocker.add(k)
+
+  const testsOut = JSON.stringify({ projects: [...retryTests] })
+  const dockerOut = JSON.stringify(
+    [...retryDocker].map((p) => dockerByProject.get(p)),
+  )
+
+  core.setOutput('tests', testsOut)
+  core.setOutput('docker', dockerOut)
+  core.setOutput('has_tests', retryTests.size > 0 ? 'true' : 'false')
+  core.setOutput('has_docker', retryDocker.size > 0 ? 'true' : 'false')
+  core.setOutput('typecheck', retryTypecheck ? 'true' : 'false')
+  core.setOutput('genuine', JSON.stringify(genuine))
+
+  core.info(
+    `retry-plan: tests=${retryTests.size} docker=${retryDocker.size} ` +
+      `typecheck=${retryTypecheck} genuine=${genuine.length}`,
+  )
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/scripts/ci/mq/retry-plan.mjs
+++ b/scripts/ci/mq/retry-plan.mjs
@@ -57,17 +57,24 @@ async function listJobs(token, owner, repo, runId) {
   return jobs
 }
 
-async function fetchLog(token, owner, repo, jobId) {
+async function fetchLog(token, owner, repo, jobId, attempts = 6) {
   // 302 redirects to a signed storage URL; fetch follows it and strips the
-  // Authorization header on the cross-origin hop (per spec).
-  try {
-    const url = `https://api.github.com/repos/${owner}/${repo}/actions/jobs/${jobId}/logs`
-    const res = await fetch(url, { headers: ghHeaders(token) })
-    if (!res.ok) return null
-    return await res.text()
-  } catch {
-    return null
+  // Authorization header on the cross-origin hop (per spec). Job logs can 404
+  // briefly right after completion, so retry before giving up.
+  const url = `https://api.github.com/repos/${owner}/${repo}/actions/jobs/${jobId}/logs`
+  for (let i = 0; i < attempts; i++) {
+    try {
+      const res = await fetch(url, { headers: ghHeaders(token) })
+      if (res.ok) {
+        const text = await res.text()
+        if (text && text.length > 0) return text
+      }
+    } catch {
+      /* transient network error; retry */
+    }
+    if (i < attempts - 1) await new Promise((r) => setTimeout(r, 3000))
   }
+  return null
 }
 
 function classify(logText) {


### PR DESCRIPTION
Add a retry layer to the merge-queue workflow so Spot/runner interruptions no longer eject PRs from GitHub's native merge queue.

- retry-plan job classifies non-success jobs as infra (runner shutdown signature) vs genuine, mapping identity via an MQ_JOB_KEY log marker (keeps job names readable, avoids API name truncation)
- tests-retry / typecheck-retry / docker-build-retry re-run only the infra-cancelled chunks on fresh runners
- success gate is retry-aware and fails on any genuine failure, planner failure, or unmapped/ambiguous job (default-to-failure)
- docker outputs merged across docker-build and docker-build-retry namespaces (disjoint uuidv5 keys) so deployments include original passes and retried passes with no stale/duplicate values
- workflow_dispatch simulate_tests/simulate_docker inputs to exercise the retry path without a real merge-queue interruption

scripts/ci/mq/retry-plan.mjs, scripts/ci/mq/merge-docker-outputs.mjs

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude
