### PR TITLE
feat(merge-queue): run merge_group builds on dedicated on-demand runners

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,6 +1,6 @@
 self-hosted-runner:
   # Labels of self-hosted runner in array of strings.
-  labels: [arc-shared, arc-test, ec2-runners, shared-v2]
+  labels: [arc-shared, arc-mergequeue, arc-test, ec2-runners, shared-v2]
 
 # Configuration variables in array of strings defined in your repository or
 # organization. `null` means disabling configuration variables check.

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -2,6 +2,11 @@ name: 'Run E2E tests'
 on:
   workflow_call:
     inputs:
+      runner_label:
+        description: 'Runner scale-set label to run on'
+        required: false
+        type: string
+        default: arc-shared
       e2e_build_id:
         description: 'Build ID'
         required: false
@@ -44,7 +49,7 @@ env:
 
 jobs:
   e2e:
-    runs-on: arc-shared
+    runs-on: ${{ inputs.runner_label }}
     env:
       CYPRESS_PROJECT_ID: 4q7jz8
       CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -2,6 +2,11 @@ name: 'Prep Dependencies'
 on:
   workflow_call:
     inputs:
+      runner_label:
+        description: 'Runner scale-set label to run on'
+        required: false
+        type: string
+        default: arc-shared
       force_all_to_be_affected:
         description: 'Should all be affected'
         required: false
@@ -97,7 +102,7 @@ jobs:
       NX_BASE: ${{ steps.export-sha.outputs.NX_BASE }}
       DEPLOY_FEATURE: ${{ steps.set-outputs.outputs.DEPLOY_FEATURE }}
       is-unicorn: ${{ steps.unicorn.outputs.is-unicorn }}
-    runs-on: arc-shared
+    runs-on: ${{ inputs.runner_label }}
     permissions:
       contents: 'read'
       actions: 'read'

--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -42,6 +42,8 @@ jobs:
   pre-checks:
     uses: ./.github/workflows/pre-checks.yml
     secrets: inherit
+    with:
+      runner_label: arc-mergequeue
   prepare:
     permissions:
       contents: 'read'
@@ -52,13 +54,14 @@ jobs:
       run_merge_queue: true
       force_all_to_be_affected: ${{ github.event_name == 'workflow_dispatch' }}
       main_branch: ${{ github.event.merge_group.base_ref || github.ref_name }}
+      runner_label: arc-mergequeue
     needs:
       - pre-checks
   docker-build:
     needs:
       - prepare
       - pre-checks
-    runs-on: arc-shared
+    runs-on: arc-mergequeue
     if: ${{ needs.prepare.outputs.MQ_SHOULD_RUN_BUILD == 'true' && needs.prepare.outputs.DOCKER_CHUNKS }}
     permissions:
       actions: read
@@ -200,6 +203,7 @@ jobs:
       nx_base: ${{ needs.prepare.outputs.NX_BASE }}
       nx_head: ${{ needs.prepare.outputs.NX_HEAD }}
       affected_projects: ${{ matrix.projects }}
+      runner_label: arc-mergequeue
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.prepare.outputs.E2E_CHUNKS) }}
@@ -208,7 +212,7 @@ jobs:
     needs:
       - prepare
     if: ${{ needs.prepare.outputs.TEST_CHUNKS && needs.prepare.outputs.DEPLOY_FEATURE == 'false' }}
-    runs-on: arc-shared
+    runs-on: arc-mergequeue
     timeout-minutes: 45
     env:
       AFFECTED_PROJECTS: ${{ matrix.projects }}
@@ -240,7 +244,7 @@ jobs:
       - prepare
     permissions:
       contents: 'read'
-    runs-on: arc-shared
+    runs-on: arc-mergequeue
     timeout-minutes: 35
     env:
       NODE_OPTIONS: --max-old-space-size=4096
@@ -264,7 +268,7 @@ jobs:
         run: yarn nx affected --target=typecheck
 
   success:
-    runs-on: arc-shared
+    runs-on: arc-mergequeue
     if: ${{ !cancelled() }}
     needs:
       - prepare
@@ -366,7 +370,7 @@ jobs:
   # Remove this as a required status check and switch to something more meaningful
   codeowners-check:
     name: Lint CODEOWNERS
-    runs-on: arc-shared
+    runs-on: arc-mergequeue
     env:
       CHECK: 'false'
     steps:

--- a/.github/workflows/pre-checks.yml
+++ b/.github/workflows/pre-checks.yml
@@ -2,6 +2,12 @@ name: Pre checks
 
 on:
   workflow_call:
+    inputs:
+      runner_label:
+        description: 'Runner scale-set label to run on'
+        required: false
+        type: string
+        default: arc-shared
     outputs:
       NODE_IMAGE_VERSION:
         value: ${{ jobs.should-run.outputs.NODE_IMAGE_VERSION }}
@@ -46,7 +52,7 @@ env:
 jobs:
   should-run:
     name: Check if job should run
-    runs-on: arc-shared
+    runs-on: ${{ inputs.runner_label }}
     env:
       CREATE_PATTERNS: ^release/
       PRE_RELEASE_PATTERN: ^pre-release/


### PR DESCRIPTION
Route the merge queue to the arc-mergequeue scale set (on-demand) so Spot interruptions can no longer eject PRs from the merge queue.

- thread a runner_label workflow_call input (default arc-shared) through pre-checks.yml, install.yml and e2e.yml
- merge-queue.yml passes runner_label=arc-mergequeue and sets its inline jobs (docker-build, tests, typecheck, success, codeowners-check) to it
- PR/push/test-all builds keep arc-shared via the default
- register arc-mergequeue in actionlint self-hosted labels

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable runner selection for reusable end-to-end, installation, and pre-check workflows, defaulting to the shared runner.
  * Updated merge-queue automation to run on dedicated merge-queue runners.
  * Added support for the merge-queue runner label in workflow validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->