### PR TITLE
feat(j-s): add Datadog browser error logging to web

### DIFF
--- a/apps/judicial-system/web/environments/runtimeEnvironment.ts
+++ b/apps/judicial-system/web/environments/runtimeEnvironment.ts
@@ -19,6 +19,9 @@ export const buildPublicRuntimeEnv = () => ({
   apiUrl: apiPath,
   graphqlEndpoint: graphqlPath,
   supportEmail: process.env.SUPPORT_EMAIL ?? 'ben10@omnitrix.is',
+  ddLogsClientToken: process.env.DD_LOGS_CLIENT_TOKEN,
+  environment: process.env.ENVIRONMENT,
+  appVersion: process.env.APP_VERSION,
 })
 
 /**

--- a/apps/judicial-system/web/graphql/errorLink.ts
+++ b/apps/judicial-system/web/graphql/errorLink.ts
@@ -4,31 +4,41 @@ import { onError } from '@apollo/client/link/error'
 import { userRef } from '@island.is/judicial-system-web/src/components'
 import { api } from '@island.is/judicial-system-web/src/services'
 
-export default onError(({ graphQLErrors, networkError }: ErrorResponse) => {
-  if (networkError) {
-    return
-  }
+export default onError(
+  ({ graphQLErrors, networkError, operation }: ErrorResponse) => {
+    if (networkError) {
+      // Forwarded to Datadog by the browser-logs SDK
+      console.error(
+        `Network error in operation ${operation.operationName}: ${networkError.message}`,
+      )
+      return
+    }
 
-  if (graphQLErrors) {
-    graphQLErrors.forEach(async (err) => {
-      switch (err.extensions?.code) {
-        case 'UNAUTHENTICATED':
-          {
-            const userId = userRef.current?.id ? `/${userRef.current.id}` : ''
-            const userNationalId =
-              userRef.authBypass && userRef.current?.nationalId
-                ? `nationalId=${userRef.current.nationalId}&`
-                : ''
-            window.location.assign(
-              `${api.apiUrl}/api/auth/login${userId}?${userNationalId}redirectRoute=${window.location.pathname}`,
+    if (graphQLErrors) {
+      graphQLErrors.forEach(async (err) => {
+        switch (err.extensions?.code) {
+          case 'UNAUTHENTICATED':
+            {
+              const userId = userRef.current?.id ? `/${userRef.current.id}` : ''
+              const userNationalId =
+                userRef.authBypass && userRef.current?.nationalId
+                  ? `nationalId=${userRef.current.nationalId}&`
+                  : ''
+              window.location.assign(
+                `${api.apiUrl}/api/auth/login${userId}?${userNationalId}redirectRoute=${window.location.pathname}`,
+              )
+            }
+            return
+          default:
+            // Forwarded to Datadog by the browser-logs SDK
+            console.error(
+              `GraphQL error in operation ${operation.operationName}: ${
+                err.message
+              } (code: ${err.extensions?.code}, path: ${err.path?.join('.')})`,
             )
-          }
-          return
-        case 'FORBIDDEN':
-          return
-        default:
-          return
-      }
-    })
-  }
-})
+            return
+        }
+      })
+    }
+  },
+)

--- a/apps/judicial-system/web/infra/judicial-system-web.ts
+++ b/apps/judicial-system/web/infra/judicial-system-web.ts
@@ -13,8 +13,10 @@ export const serviceSetup = (services: {
         prod: 'https://rettarvorslugatt.island.is',
       },
       INTERNAL_API_URL: ref((h) => `http://${h.svc(services.api)}`),
+      ENVIRONMENT: ref((h) => h.env.type),
     })
     .secrets({
+      DD_LOGS_CLIENT_TOKEN: '/k8s/DD_LOGS_CLIENT_TOKEN',
       NATIONAL_REGISTRY_API_KEY:
         '/k8s/judicial-system/NATIONAL_REGISTRY_API_KEY',
       LAWYERS_ICELAND_API_KEY: '/k8s/judicial-system/LAWYERS_ICELAND_API_KEY',

--- a/apps/judicial-system/web/pages/_app.tsx
+++ b/apps/judicial-system/web/pages/_app.tsx
@@ -27,7 +27,7 @@ if (typeof window !== 'undefined') {
       service: 'judicial-system-web',
       clientToken: ddLogsClientToken,
       env: environment || 'local',
-      version: appVersion || 'local',
+      version: appVersion || 'unknown',
     })
   }
 }

--- a/apps/judicial-system/web/pages/_app.tsx
+++ b/apps/judicial-system/web/pages/_app.tsx
@@ -5,6 +5,7 @@ import { ApolloProvider } from '@apollo/client'
 
 import type { Query, QueryGetTranslationsArgs } from '@island.is/api/schema'
 import { Box, ToastContainer } from '@island.is/island-ui/core'
+import { getPublicRuntimeEnv } from '@island.is/judicial-system-web/environments/runtimeEnvironment'
 import client from '@island.is/judicial-system-web/graphql/client'
 import {
   FeatureProvider,
@@ -16,6 +17,20 @@ import {
   ViewportProvider,
 } from '@island.is/judicial-system-web/src/components'
 import { GET_TRANSLATIONS, LocaleProvider } from '@island.is/localization'
+import { userMonitoring } from '@island.is/user-monitoring'
+
+if (typeof window !== 'undefined') {
+  const { ddLogsClientToken, environment, appVersion } = getPublicRuntimeEnv()
+
+  if (ddLogsClientToken) {
+    userMonitoring.initDdLogs({
+      service: 'judicial-system-web',
+      clientToken: ddLogsClientToken,
+      env: environment || 'local',
+      version: appVersion || 'local',
+    })
+  }
+}
 
 const getTranslationStrings = (apolloClient: typeof client) => {
   if (!apolloClient) {

--- a/charts/judicial-system-services/judicial-system-web/values.dev.yaml
+++ b/charts/judicial-system-services/judicial-system-web/values.dev.yaml
@@ -21,6 +21,7 @@ enabled: true
 env:
   API_URL: 'https://judicial-system.dev01.devland.is'
   DD_TRACE_DISABLED_INSTRUMENTATIONS: 'fetch'
+  ENVIRONMENT: 'dev'
   INTERNAL_API_URL: 'http://web-judicial-system-api'
   LOG_LEVEL: 'info'
   NODE_OPTIONS: '--max-old-space-size=460 --enable-source-maps -r dd-trace/init'
@@ -76,6 +77,7 @@ resources:
     memory: '256Mi'
 secrets:
   CONFIGCAT_SDK_KEY: '/k8s/configcat/CONFIGCAT_SDK_KEY'
+  DD_LOGS_CLIENT_TOKEN: '/k8s/DD_LOGS_CLIENT_TOKEN'
   LAWYERS_ICELAND_API_KEY: '/k8s/judicial-system/LAWYERS_ICELAND_API_KEY'
   NATIONAL_REGISTRY_API_KEY: '/k8s/judicial-system/NATIONAL_REGISTRY_API_KEY'
   SUPPORT_EMAIL: '/k8s/judicial-system/SUPPORT_EMAIL'

--- a/charts/judicial-system-services/judicial-system-web/values.prod.yaml
+++ b/charts/judicial-system-services/judicial-system-web/values.prod.yaml
@@ -21,6 +21,7 @@ enabled: true
 env:
   API_URL: 'https://rettarvorslugatt.island.is'
   DD_TRACE_DISABLED_INSTRUMENTATIONS: 'fetch'
+  ENVIRONMENT: 'prod'
   INTERNAL_API_URL: 'http://web-judicial-system-api'
   LOG_LEVEL: 'info'
   NODE_OPTIONS: '--max-old-space-size=460 --enable-source-maps -r dd-trace/init'
@@ -76,6 +77,7 @@ resources:
     memory: '256Mi'
 secrets:
   CONFIGCAT_SDK_KEY: '/k8s/configcat/CONFIGCAT_SDK_KEY'
+  DD_LOGS_CLIENT_TOKEN: '/k8s/DD_LOGS_CLIENT_TOKEN'
   LAWYERS_ICELAND_API_KEY: '/k8s/judicial-system/LAWYERS_ICELAND_API_KEY'
   NATIONAL_REGISTRY_API_KEY: '/k8s/judicial-system/NATIONAL_REGISTRY_API_KEY'
   SUPPORT_EMAIL: '/k8s/judicial-system/SUPPORT_EMAIL'

--- a/charts/judicial-system-services/judicial-system-web/values.staging.yaml
+++ b/charts/judicial-system-services/judicial-system-web/values.staging.yaml
@@ -21,6 +21,7 @@ enabled: true
 env:
   API_URL: 'https://judicial-system.staging01.devland.is'
   DD_TRACE_DISABLED_INSTRUMENTATIONS: 'fetch'
+  ENVIRONMENT: 'staging'
   INTERNAL_API_URL: 'http://web-judicial-system-api'
   LOG_LEVEL: 'info'
   NODE_OPTIONS: '--max-old-space-size=460 --enable-source-maps -r dd-trace/init'
@@ -76,6 +77,7 @@ resources:
     memory: '256Mi'
 secrets:
   CONFIGCAT_SDK_KEY: '/k8s/configcat/CONFIGCAT_SDK_KEY'
+  DD_LOGS_CLIENT_TOKEN: '/k8s/DD_LOGS_CLIENT_TOKEN'
   LAWYERS_ICELAND_API_KEY: '/k8s/judicial-system/LAWYERS_ICELAND_API_KEY'
   NATIONAL_REGISTRY_API_KEY: '/k8s/judicial-system/NATIONAL_REGISTRY_API_KEY'
   SUPPORT_EMAIL: '/k8s/judicial-system/SUPPORT_EMAIL'

--- a/charts/judicial-system/values.dev.yaml
+++ b/charts/judicial-system/values.dev.yaml
@@ -475,6 +475,7 @@ judicial-system-web:
   env:
     API_URL: 'https://judicial-system.dev01.devland.is'
     DD_TRACE_DISABLED_INSTRUMENTATIONS: 'fetch'
+    ENVIRONMENT: 'dev'
     INTERNAL_API_URL: 'http://web-judicial-system-api'
     LOG_LEVEL: 'info'
     NODE_OPTIONS: '--max-old-space-size=460 --enable-source-maps -r dd-trace/init'
@@ -530,6 +531,7 @@ judicial-system-web:
       memory: '256Mi'
   secrets:
     CONFIGCAT_SDK_KEY: '/k8s/configcat/CONFIGCAT_SDK_KEY'
+    DD_LOGS_CLIENT_TOKEN: '/k8s/DD_LOGS_CLIENT_TOKEN'
     LAWYERS_ICELAND_API_KEY: '/k8s/judicial-system/LAWYERS_ICELAND_API_KEY'
     NATIONAL_REGISTRY_API_KEY: '/k8s/judicial-system/NATIONAL_REGISTRY_API_KEY'
     SUPPORT_EMAIL: '/k8s/judicial-system/SUPPORT_EMAIL'

--- a/charts/judicial-system/values.prod.yaml
+++ b/charts/judicial-system/values.prod.yaml
@@ -475,6 +475,7 @@ judicial-system-web:
   env:
     API_URL: 'https://rettarvorslugatt.island.is'
     DD_TRACE_DISABLED_INSTRUMENTATIONS: 'fetch'
+    ENVIRONMENT: 'prod'
     INTERNAL_API_URL: 'http://web-judicial-system-api'
     LOG_LEVEL: 'info'
     NODE_OPTIONS: '--max-old-space-size=460 --enable-source-maps -r dd-trace/init'
@@ -530,6 +531,7 @@ judicial-system-web:
       memory: '256Mi'
   secrets:
     CONFIGCAT_SDK_KEY: '/k8s/configcat/CONFIGCAT_SDK_KEY'
+    DD_LOGS_CLIENT_TOKEN: '/k8s/DD_LOGS_CLIENT_TOKEN'
     LAWYERS_ICELAND_API_KEY: '/k8s/judicial-system/LAWYERS_ICELAND_API_KEY'
     NATIONAL_REGISTRY_API_KEY: '/k8s/judicial-system/NATIONAL_REGISTRY_API_KEY'
     SUPPORT_EMAIL: '/k8s/judicial-system/SUPPORT_EMAIL'

--- a/charts/judicial-system/values.staging.yaml
+++ b/charts/judicial-system/values.staging.yaml
@@ -475,6 +475,7 @@ judicial-system-web:
   env:
     API_URL: 'https://judicial-system.staging01.devland.is'
     DD_TRACE_DISABLED_INSTRUMENTATIONS: 'fetch'
+    ENVIRONMENT: 'staging'
     INTERNAL_API_URL: 'http://web-judicial-system-api'
     LOG_LEVEL: 'info'
     NODE_OPTIONS: '--max-old-space-size=460 --enable-source-maps -r dd-trace/init'
@@ -530,6 +531,7 @@ judicial-system-web:
       memory: '256Mi'
   secrets:
     CONFIGCAT_SDK_KEY: '/k8s/configcat/CONFIGCAT_SDK_KEY'
+    DD_LOGS_CLIENT_TOKEN: '/k8s/DD_LOGS_CLIENT_TOKEN'
     LAWYERS_ICELAND_API_KEY: '/k8s/judicial-system/LAWYERS_ICELAND_API_KEY'
     NATIONAL_REGISTRY_API_KEY: '/k8s/judicial-system/NATIONAL_REGISTRY_API_KEY'
     SUPPORT_EMAIL: '/k8s/judicial-system/SUPPORT_EMAIL'


### PR DESCRIPTION
## What
Give judicial-system-web frontend error reporting via Datadog browser logs:

1. **Initialize Datadog browser-logs error tracking** (`@datadog/browser-logs` via `@island.is/user-monitoring`):
   - Call `userMonitoring.initDdLogs` in `_app.tsx` (browser only, service `judicial-system-web`), guarded on the client token being present. With `forwardErrorsToLogs` this captures uncaught exceptions, unhandled promise rejections, failed fetch/XHR, and `console.error` calls.
   - Expose `ddLogsClientToken`, `environment`, and `appVersion` in `buildPublicRuntimeEnv` so the browser receives them via the existing runtime-env script tag.
   - Infra DSL: add the shared `DD_LOGS_CLIENT_TOKEN` secret (`/k8s/DD_LOGS_CLIENT_TOKEN`, same key as other frontends) and set `ENVIRONMENT` from the env type. Charts regenerated with `yarn charts`.
2. **Stop swallowing errors in the Apollo error link**: `errorLink.ts` previously returned silently on network errors and on all GraphQL errors except `UNAUTHENTICATED`. It now logs network errors and GraphQL errors (message, code, path, operation name) via `console.error`, which the SDK forwards to Datadog. GraphQL variables are deliberately not logged. The `UNAUTHENTICATED` redirect-to-login flow is unchanged and stays silent.

## Why
judicial-system-web has had no frontend error reporting since RUM was removed repo-wide in #18119 — client-side crashes, unhandled rejections, and network failures were invisible, and the Apollo error link dropped GraphQL errors before anyone could see them (users only saw toasts). This restores error signal using the same error-tracking-only setup (no RUM/session tracking) as the other island.is frontends. Errors will appear in Datadog under `service:judicial-system-web`, `source:browser`.

## Screenshots / Gifs
Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code
- [ ] No AI tools were used in preparing this pull request