### PR TITLE
feat(j-s): Indictment count and offense repository services

### DIFF
--- a/apps/judicial-system/backend/src/app/modules/indictment-count/indictmentCount.module.ts
+++ b/apps/judicial-system/backend/src/app/modules/indictment-count/indictmentCount.module.ts
@@ -1,16 +1,11 @@
 import { forwardRef, Module } from '@nestjs/common'
-import { SequelizeModule } from '@nestjs/sequelize'
 
-import { IndictmentCount, Offense } from '../repository'
-import { CaseModule } from '..'
+import { CaseModule, RepositoryModule } from '..'
 import { IndictmentCountController } from './indictmentCount.controller'
 import { IndictmentCountService } from './indictmentCount.service'
 
 @Module({
-  imports: [
-    forwardRef(() => CaseModule),
-    SequelizeModule.forFeature([IndictmentCount, Offense]),
-  ],
+  imports: [forwardRef(() => CaseModule), forwardRef(() => RepositoryModule)],
   controllers: [IndictmentCountController],
   providers: [IndictmentCountService],
   exports: [IndictmentCountService],

--- a/apps/judicial-system/backend/src/app/modules/indictment-count/indictmentCount.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/indictment-count/indictmentCount.service.ts
@@ -6,7 +6,6 @@ import {
   InternalServerErrorException,
   NotFoundException,
 } from '@nestjs/common'
-import { InjectModel } from '@nestjs/sequelize'
 
 import type { Logger } from '@island.is/logging'
 import { LOGGER_PROVIDER } from '@island.is/logging'
@@ -16,34 +15,28 @@ import {
   isTrafficViolationIndictmentCount,
 } from '@island.is/judicial-system/types'
 
-import { IndictmentCount, Offense } from '../repository'
+import {
+  IndictmentCount,
+  IndictmentCountRepositoryService,
+  Offense,
+  OffenseRepositoryService,
+} from '../repository'
 import { UpdateIndictmentCountDto } from './dto/updateIndictmentCount.dto'
 import { UpdateOffenseDto } from './dto/updateOffense.dto'
 
 @Injectable()
 export class IndictmentCountService {
   constructor(
-    @InjectModel(IndictmentCount)
-    private readonly indictmentCountModel: typeof IndictmentCount,
-    @InjectModel(Offense) private readonly offenseModel: typeof Offense,
+    private readonly indictmentCountRepositoryService: IndictmentCountRepositoryService,
+    private readonly offenseRepositoryService: OffenseRepositoryService,
     @Inject(LOGGER_PROVIDER) private readonly logger: Logger,
   ) {}
 
   async findById(indictmentCountId: string): Promise<IndictmentCount> {
-    const indictmentCount = await this.indictmentCountModel.findByPk(
-      indictmentCountId,
-      {
-        include: [
-          {
-            model: Offense,
-            as: 'offenses',
-            required: false,
-            separate: true,
-            order: [['created', 'ASC']],
-          },
-        ],
-      },
-    )
+    const indictmentCount =
+      await this.indictmentCountRepositoryService.findByIdWithOffenses(
+        indictmentCountId,
+      )
 
     if (!indictmentCount) {
       throw new NotFoundException(
@@ -58,15 +51,13 @@ export class IndictmentCountService {
     caseId: string,
     transaction: Transaction,
   ): Promise<number> {
-    const maxDisplayOrder = await this.indictmentCountModel.max(
-      'displayOrder',
-      {
-        where: { caseId },
-        transaction,
-      },
-    )
+    const maxDisplayOrder =
+      await this.indictmentCountRepositoryService.getMaxDisplayOrderForCase(
+        caseId,
+        { transaction },
+      )
 
-    return typeof maxDisplayOrder === 'number' ? maxDisplayOrder : -1
+    return maxDisplayOrder ?? -1
   }
 
   async reorder(
@@ -75,23 +66,21 @@ export class IndictmentCountService {
     transaction: Transaction,
   ): Promise<IndictmentCount[]> {
     const updates = counts.map(async ({ id, displayOrder }) => {
-      const [numberOfAffectedRows, updatedIndictmentCounts] =
-        await this.indictmentCountModel.update(
+      const { numberOfAffectedRows, indictmentCounts } =
+        await this.indictmentCountRepositoryService.updateByIdAndCase(
+          id,
+          caseId,
           { displayOrder },
-          {
-            where: { id, caseId },
-            returning: true,
-            transaction,
-          },
+          { transaction },
         )
 
-      if (numberOfAffectedRows !== 1 || !updatedIndictmentCounts[0]) {
+      if (numberOfAffectedRows !== 1 || !indictmentCounts[0]) {
         throw new NotFoundException(
           `IndictmentCount ${id} not found for case ${caseId}`,
         )
       }
 
-      return updatedIndictmentCounts[0]
+      return indictmentCounts[0]
     })
 
     return Promise.all(updates)
@@ -101,14 +90,11 @@ export class IndictmentCountService {
     caseId: string,
     transaction: Transaction,
   ): Promise<void> {
-    const counts = await this.indictmentCountModel.findAll({
-      where: { caseId },
-      order: [
-        ['displayOrder', 'ASC'],
-        ['created', 'ASC'],
-      ],
-      transaction,
-    })
+    const counts =
+      await this.indictmentCountRepositoryService.findAllForCaseOrdered(
+        caseId,
+        { transaction },
+      )
 
     if (counts.length === 0) {
       return
@@ -128,8 +114,9 @@ export class IndictmentCountService {
     const displayOrder =
       (await this.getMaxDisplayOrder(caseId, transaction)) + 1
 
-    return this.indictmentCountModel.create(
-      { caseId, displayOrder },
+    return this.indictmentCountRepositoryService.create(
+      caseId,
+      { displayOrder },
       { transaction },
     )
   }
@@ -142,8 +129,9 @@ export class IndictmentCountService {
     const displayOrder =
       (await this.getMaxDisplayOrder(caseId, transaction)) + 1
 
-    return this.indictmentCountModel.create(
-      { caseId, policeCaseNumber, displayOrder },
+    return this.indictmentCountRepositoryService.create(
+      caseId,
+      { policeCaseNumber, displayOrder },
       { transaction },
     )
   }
@@ -158,11 +146,12 @@ export class IndictmentCountService {
       const policeCaseNumberSubtypes = update.policeCaseNumberSubtypes
       const updatedSubtypes = update.indictmentCountSubtypes
       if (!policeCaseNumberSubtypes || !updatedSubtypes) {
-        return this.indictmentCountModel.update(update, {
-          where: { id: indictmentCountId, caseId },
-          returning: true,
-          transaction,
-        })
+        return this.indictmentCountRepositoryService.updateByIdAndCase(
+          indictmentCountId,
+          caseId,
+          update,
+          { transaction },
+        )
       }
 
       const isTrafficViolation = isTrafficViolationIndictmentCount(
@@ -186,20 +175,21 @@ export class IndictmentCountService {
       if (!isTrafficViolation) {
         // currently offenses only exist for traffic violation indictment subtype.
         // if we support other offenses per subtype in the future we have to take the subtype into account
-        await this.offenseModel.destroy({
-          where: { indictmentCountId },
-          transaction,
-        })
+        await this.offenseRepositoryService.deleteAllForIndictmentCount(
+          indictmentCountId,
+          { transaction },
+        )
       }
 
-      return this.indictmentCountModel.update(updatedIndictmentCount, {
-        where: { id: indictmentCountId, caseId },
-        returning: true,
-        transaction,
-      })
+      return this.indictmentCountRepositoryService.updateByIdAndCase(
+        indictmentCountId,
+        caseId,
+        updatedIndictmentCount,
+        { transaction },
+      )
     }
 
-    const [numberOfAffectedRows, updatedIndictmentCounts] =
+    const { numberOfAffectedRows, indictmentCounts } =
       await updateIndictmentCount()
 
     if (numberOfAffectedRows > 1) {
@@ -213,7 +203,7 @@ export class IndictmentCountService {
       )
     }
 
-    return updatedIndictmentCounts[0]
+    return indictmentCounts[0]
   }
 
   async delete(
@@ -221,15 +211,17 @@ export class IndictmentCountService {
     indictmentCountId: string,
     transaction: Transaction,
   ): Promise<boolean> {
-    await this.offenseModel.destroy({
-      where: { indictmentCountId },
-      transaction,
-    })
+    await this.offenseRepositoryService.deleteAllForIndictmentCount(
+      indictmentCountId,
+      { transaction },
+    )
 
-    const numberOfAffectedRows = await this.indictmentCountModel.destroy({
-      where: { id: indictmentCountId, caseId },
-      transaction,
-    })
+    const numberOfAffectedRows =
+      await this.indictmentCountRepositoryService.deleteByIdAndCase(
+        indictmentCountId,
+        caseId,
+        { transaction },
+      )
 
     if (numberOfAffectedRows > 1) {
       // Tolerate failure, but log error
@@ -251,7 +243,7 @@ export class IndictmentCountService {
     indictmentCountId: string,
     offense: IndictmentCountOffense,
   ): Promise<Offense> {
-    return this.offenseModel.create({ indictmentCountId, offense })
+    return this.offenseRepositoryService.create(indictmentCountId, offense)
   }
 
   async updateOffense(
@@ -259,13 +251,12 @@ export class IndictmentCountService {
     offenseId: string,
     update: UpdateOffenseDto,
   ): Promise<Offense> {
-    const [numberOfAffectedRows, offenses] = await this.offenseModel.update(
-      update,
-      {
-        where: { id: offenseId, indictmentCountId },
-        returning: true,
-      },
-    )
+    const { numberOfAffectedRows, offenses } =
+      await this.offenseRepositoryService.updateByIdAndIndictmentCount(
+        offenseId,
+        indictmentCountId,
+        update,
+      )
 
     if (numberOfAffectedRows > 1) {
       // Tolerate failure, but log error
@@ -285,9 +276,11 @@ export class IndictmentCountService {
     indictmentCountId: string,
     offenseId: string,
   ): Promise<boolean> {
-    const numberOfAffectedRows = await this.offenseModel.destroy({
-      where: { id: offenseId, indictmentCountId },
-    })
+    const numberOfAffectedRows =
+      await this.offenseRepositoryService.deleteByIdAndIndictmentCount(
+        offenseId,
+        indictmentCountId,
+      )
 
     if (numberOfAffectedRows > 1) {
       // Tolerate failure, but log error

--- a/apps/judicial-system/backend/src/app/modules/indictment-count/test/create.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/indictment-count/test/create.spec.ts
@@ -3,7 +3,10 @@ import { v4 as uuid } from 'uuid'
 
 import { createTestingIndictmentCountModule } from './createTestingIndictmentCountModule'
 
-import { IndictmentCount } from '../../repository'
+import {
+  IndictmentCount,
+  IndictmentCountRepositoryService,
+} from '../../repository'
 
 interface Then {
   result: IndictmentCount
@@ -13,15 +16,18 @@ interface Then {
 type GivenWhenThen = (caseId: string) => Promise<Then>
 
 describe('IndictmentCountController - Create', () => {
-  let mockIndictmentCountModel: typeof IndictmentCount
+  let mockIndictmentCountRepositoryService: IndictmentCountRepositoryService
   let givenWhenThen: GivenWhenThen
   let transaction: Transaction
 
   beforeEach(async () => {
-    const { indictmentCountModel, indictmentCountController, sequelize } =
-      await createTestingIndictmentCountModule()
+    const {
+      indictmentCountRepositoryService,
+      indictmentCountController,
+      sequelize,
+    } = await createTestingIndictmentCountModule()
 
-    mockIndictmentCountModel = indictmentCountModel
+    mockIndictmentCountRepositoryService = indictmentCountRepositoryService
     const mockTransaction = sequelize.transaction as jest.Mock
     transaction = {} as Transaction
     mockTransaction.mockImplementationOnce(
@@ -41,34 +47,57 @@ describe('IndictmentCountController - Create', () => {
     }
   })
 
-  describe('indictment count created', () => {
+  describe('first indictment count created', () => {
     const caseId = uuid()
     const createdIndictmentCount = { id: uuid() }
     let then: Then
 
     beforeEach(async () => {
-      const mockMax = mockIndictmentCountModel.max as jest.Mock
-      mockMax.mockResolvedValueOnce(-1)
+      const mockGetMaxDisplayOrderForCase =
+        mockIndictmentCountRepositoryService.getMaxDisplayOrderForCase as jest.Mock
+      mockGetMaxDisplayOrderForCase.mockResolvedValueOnce(null)
 
-      const mockCreate = mockIndictmentCountModel.create as jest.Mock
+      const mockCreate =
+        mockIndictmentCountRepositoryService.create as jest.Mock
       mockCreate.mockResolvedValueOnce(createdIndictmentCount)
 
       then = await givenWhenThen(caseId)
     })
 
-    it('should create an indictment count', () => {
-      expect(mockIndictmentCountModel.max).toHaveBeenCalledWith(
-        'displayOrder',
-        {
-          where: { caseId },
-          transaction,
-        },
+    it('should create an indictment count at display order 0', () => {
+      expect(
+        mockIndictmentCountRepositoryService.getMaxDisplayOrderForCase,
+      ).toHaveBeenCalledWith(caseId, { transaction })
+      expect(mockIndictmentCountRepositoryService.create).toHaveBeenCalledWith(
+        caseId,
+        { displayOrder: 0 },
+        { transaction },
       )
-      expect(mockIndictmentCountModel.create).toHaveBeenCalledWith(
-        {
-          caseId,
-          displayOrder: 0,
-        },
+      expect(then.result).toBe(createdIndictmentCount)
+    })
+  })
+
+  describe('further indictment count created', () => {
+    const caseId = uuid()
+    const createdIndictmentCount = { id: uuid() }
+    let then: Then
+
+    beforeEach(async () => {
+      const mockGetMaxDisplayOrderForCase =
+        mockIndictmentCountRepositoryService.getMaxDisplayOrderForCase as jest.Mock
+      mockGetMaxDisplayOrderForCase.mockResolvedValueOnce(2)
+
+      const mockCreate =
+        mockIndictmentCountRepositoryService.create as jest.Mock
+      mockCreate.mockResolvedValueOnce(createdIndictmentCount)
+
+      then = await givenWhenThen(caseId)
+    })
+
+    it('should create an indictment count after the last one', () => {
+      expect(mockIndictmentCountRepositoryService.create).toHaveBeenCalledWith(
+        caseId,
+        { displayOrder: 3 },
         { transaction },
       )
       expect(then.result).toBe(createdIndictmentCount)
@@ -80,7 +109,8 @@ describe('IndictmentCountController - Create', () => {
     let then: Then
 
     beforeEach(async () => {
-      const mockCreate = mockIndictmentCountModel.create as jest.Mock
+      const mockCreate =
+        mockIndictmentCountRepositoryService.create as jest.Mock
       mockCreate.mockRejectedValueOnce(new Error('Some error'))
 
       then = await givenWhenThen(caseId)

--- a/apps/judicial-system/backend/src/app/modules/indictment-count/test/createOffense.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/indictment-count/test/createOffense.spec.ts
@@ -4,7 +4,7 @@ import { IndictmentCountOffense } from '@island.is/judicial-system/types'
 
 import { createTestingIndictmentCountModule } from './createTestingIndictmentCountModule'
 
-import { Offense } from '../../repository'
+import { Offense, OffenseRepositoryService } from '../../repository'
 
 interface Then {
   result: Offense
@@ -18,14 +18,14 @@ type GivenWhenThen = (
 ) => Promise<Then>
 
 describe('IndictmentCountController - Create offense', () => {
-  let mockOffenseModel: typeof Offense
+  let mockOffenseRepositoryService: OffenseRepositoryService
   let givenWhenThen: GivenWhenThen
 
   beforeEach(async () => {
-    const { offenseModel, indictmentCountController } =
+    const { offenseRepositoryService, indictmentCountController } =
       await createTestingIndictmentCountModule()
 
-    mockOffenseModel = offenseModel
+    mockOffenseRepositoryService = offenseRepositoryService
 
     givenWhenThen = async (
       caseId: string,
@@ -56,17 +56,17 @@ describe('IndictmentCountController - Create offense', () => {
     let then: Then
 
     beforeEach(async () => {
-      const mockCreate = mockOffenseModel.create as jest.Mock
+      const mockCreate = mockOffenseRepositoryService.create as jest.Mock
       mockCreate.mockResolvedValueOnce(createdOffense)
 
       then = await givenWhenThen(caseId, indictmentCountId, offense)
     })
 
     it('should create an offense', () => {
-      expect(mockOffenseModel.create).toHaveBeenCalledWith({
+      expect(mockOffenseRepositoryService.create).toHaveBeenCalledWith(
         indictmentCountId,
         offense,
-      })
+      )
       expect(then.result).toBe(createdOffense)
     })
   })
@@ -79,7 +79,7 @@ describe('IndictmentCountController - Create offense', () => {
     let then: Then
 
     beforeEach(async () => {
-      const mockCreate = mockOffenseModel.create as jest.Mock
+      const mockCreate = mockOffenseRepositoryService.create as jest.Mock
       mockCreate.mockRejectedValueOnce(new Error('Some error'))
 
       then = await givenWhenThen(caseId, indictmentCountId, offense)

--- a/apps/judicial-system/backend/src/app/modules/indictment-count/test/createTestingIndictmentCountModule.ts
+++ b/apps/judicial-system/backend/src/app/modules/indictment-count/test/createTestingIndictmentCountModule.ts
@@ -1,6 +1,5 @@
 import { Sequelize } from 'sequelize-typescript'
 
-import { getModelToken } from '@nestjs/sequelize'
 import { Test } from '@nestjs/testing'
 
 import { LOGGER_PROVIDER } from '@island.is/logging'
@@ -12,12 +11,17 @@ import {
 } from '@island.is/judicial-system/auth'
 
 import { CaseService } from '../../case'
-import { IndictmentCount, Offense } from '../../repository'
+import {
+  IndictmentCountRepositoryService,
+  OffenseRepositoryService,
+} from '../../repository'
 import { IndictmentCountController } from '../indictmentCount.controller'
 import { IndictmentCountService } from '../indictmentCount.service'
 
 jest.mock('@island.is/judicial-system/message')
 jest.mock('../../case/case.service')
+jest.mock('../../repository/services/indictmentCountRepository.service')
+jest.mock('../../repository/services/offenseRepository.service')
 
 export const createTestingIndictmentCountModule = async () => {
   const indictmentCountModule = await Test.createTestingModule({
@@ -35,37 +39,21 @@ export const createTestingIndictmentCountModule = async () => {
         },
       },
       { provide: Sequelize, useValue: { transaction: jest.fn() } },
-      {
-        provide: getModelToken(IndictmentCount),
-        useValue: {
-          findOne: jest.fn(),
-          findAll: jest.fn(),
-          create: jest.fn(),
-          update: jest.fn(),
-          destroy: jest.fn(),
-          findByPk: jest.fn(),
-          max: jest.fn(),
-        },
-      },
-      {
-        provide: getModelToken(Offense),
-        useValue: {
-          create: jest.fn(),
-          update: jest.fn(),
-          destroy: jest.fn(),
-        },
-      },
+      IndictmentCountRepositoryService,
+      OffenseRepositoryService,
       IndictmentCountService,
     ],
   }).compile()
 
-  const indictmentCountModel = await indictmentCountModule.resolve<
-    typeof IndictmentCount
-  >(getModelToken(IndictmentCount))
+  const indictmentCountRepositoryService =
+    indictmentCountModule.get<IndictmentCountRepositoryService>(
+      IndictmentCountRepositoryService,
+    )
 
-  const offenseModel = await indictmentCountModule.resolve<typeof Offense>(
-    getModelToken(Offense),
-  )
+  const offenseRepositoryService =
+    indictmentCountModule.get<OffenseRepositoryService>(
+      OffenseRepositoryService,
+    )
 
   const sequelize = indictmentCountModule.get<Sequelize>(Sequelize)
 
@@ -81,8 +69,8 @@ export const createTestingIndictmentCountModule = async () => {
 
   return {
     sequelize,
-    offenseModel,
-    indictmentCountModel,
+    indictmentCountRepositoryService,
+    offenseRepositoryService,
     indictmentCountService,
     indictmentCountController,
   }

--- a/apps/judicial-system/backend/src/app/modules/indictment-count/test/delete.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/indictment-count/test/delete.spec.ts
@@ -3,7 +3,10 @@ import { v4 as uuid } from 'uuid'
 
 import { createTestingIndictmentCountModule } from './createTestingIndictmentCountModule'
 
-import { IndictmentCount, Offense } from '../../repository'
+import {
+  IndictmentCountRepositoryService,
+  OffenseRepositoryService,
+} from '../../repository'
 import { DeleteResponse } from '../models/delete.response'
 
 interface Then {
@@ -17,22 +20,22 @@ type GivenWhenThen = (
 ) => Promise<Then>
 
 describe('IndictmentCountController - Delete', () => {
-  let mockIndictmentCountModel: typeof IndictmentCount
-  let mockOffenseModel: typeof Offense
+  let mockIndictmentCountRepositoryService: IndictmentCountRepositoryService
+  let mockOffenseRepositoryService: OffenseRepositoryService
 
   let transaction: Transaction
   let givenWhenThen: GivenWhenThen
 
   beforeEach(async () => {
     const {
-      indictmentCountModel,
-      offenseModel,
+      indictmentCountRepositoryService,
+      offenseRepositoryService,
       indictmentCountController,
       sequelize,
     } = await createTestingIndictmentCountModule()
 
-    mockIndictmentCountModel = indictmentCountModel
-    mockOffenseModel = offenseModel
+    mockIndictmentCountRepositoryService = indictmentCountRepositoryService
+    mockOffenseRepositoryService = offenseRepositoryService
 
     const mockTransaction = sequelize.transaction as jest.Mock
     transaction = {} as Transaction
@@ -62,24 +65,76 @@ describe('IndictmentCountController - Delete', () => {
     let then: Then
 
     beforeEach(async () => {
-      const mockDestroy = mockIndictmentCountModel.destroy as jest.Mock
-      mockDestroy.mockResolvedValueOnce(1)
+      const mockDeleteByIdAndCase =
+        mockIndictmentCountRepositoryService.deleteByIdAndCase as jest.Mock
+      mockDeleteByIdAndCase.mockResolvedValueOnce(1)
 
-      const mockFindAll = mockIndictmentCountModel.findAll as jest.Mock
-      mockFindAll.mockResolvedValueOnce([])
+      const mockFindAllForCaseOrdered =
+        mockIndictmentCountRepositoryService.findAllForCaseOrdered as jest.Mock
+      mockFindAllForCaseOrdered.mockResolvedValueOnce([])
 
       then = await givenWhenThen(caseId, indictmentCountId)
     })
 
     it('should delete the indictment count and related offenses', () => {
-      expect(mockOffenseModel.destroy).toHaveBeenCalledWith({
-        transaction,
-        where: { indictmentCountId },
+      expect(
+        mockOffenseRepositoryService.deleteAllForIndictmentCount,
+      ).toHaveBeenCalledWith(indictmentCountId, { transaction })
+      expect(
+        mockIndictmentCountRepositoryService.deleteByIdAndCase,
+      ).toHaveBeenCalledWith(indictmentCountId, caseId, { transaction })
+      expect(then.result).toEqual({ deleted: true })
+    })
+  })
+
+  describe('remaining indictment counts renormalized', () => {
+    const caseId = uuid()
+    const indictmentCountId = uuid()
+    const remainingIndictmentCounts = [
+      { id: uuid(), displayOrder: 2 },
+      { id: uuid(), displayOrder: 5 },
+    ]
+    let then: Then
+
+    beforeEach(async () => {
+      const mockDeleteByIdAndCase =
+        mockIndictmentCountRepositoryService.deleteByIdAndCase as jest.Mock
+      mockDeleteByIdAndCase.mockResolvedValueOnce(1)
+
+      const mockFindAllForCaseOrdered =
+        mockIndictmentCountRepositoryService.findAllForCaseOrdered as jest.Mock
+      mockFindAllForCaseOrdered.mockResolvedValueOnce(remainingIndictmentCounts)
+
+      const mockUpdateByIdAndCase =
+        mockIndictmentCountRepositoryService.updateByIdAndCase as jest.Mock
+      mockUpdateByIdAndCase.mockResolvedValue({
+        numberOfAffectedRows: 1,
+        indictmentCounts: [{}],
       })
-      expect(mockIndictmentCountModel.destroy).toHaveBeenCalledWith({
-        transaction,
-        where: { id: indictmentCountId, caseId },
-      })
+
+      then = await givenWhenThen(caseId, indictmentCountId)
+    })
+
+    it('should close the gap in the display order', () => {
+      expect(
+        mockIndictmentCountRepositoryService.findAllForCaseOrdered,
+      ).toHaveBeenCalledWith(caseId, { transaction })
+      expect(
+        mockIndictmentCountRepositoryService.updateByIdAndCase,
+      ).toHaveBeenCalledWith(
+        remainingIndictmentCounts[0].id,
+        caseId,
+        { displayOrder: 0 },
+        { transaction },
+      )
+      expect(
+        mockIndictmentCountRepositoryService.updateByIdAndCase,
+      ).toHaveBeenCalledWith(
+        remainingIndictmentCounts[1].id,
+        caseId,
+        { displayOrder: 1 },
+        { transaction },
+      )
       expect(then.result).toEqual({ deleted: true })
     })
   })
@@ -90,8 +145,9 @@ describe('IndictmentCountController - Delete', () => {
     let then: Then
 
     beforeEach(async () => {
-      const mockDestroy = mockIndictmentCountModel.destroy as jest.Mock
-      mockDestroy.mockRejectedValueOnce(new Error('Some error'))
+      const mockDeleteByIdAndCase =
+        mockIndictmentCountRepositoryService.deleteByIdAndCase as jest.Mock
+      mockDeleteByIdAndCase.mockRejectedValueOnce(new Error('Some error'))
 
       then = await givenWhenThen(caseId, indictmentCountId)
     })

--- a/apps/judicial-system/backend/src/app/modules/indictment-count/test/deleteOffense.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/indictment-count/test/deleteOffense.spec.ts
@@ -2,7 +2,7 @@ import { v4 as uuid } from 'uuid'
 
 import { createTestingIndictmentCountModule } from './createTestingIndictmentCountModule'
 
-import { Offense } from '../../repository'
+import { OffenseRepositoryService } from '../../repository'
 import { DeleteResponse } from '../models/delete.response'
 
 interface Then {
@@ -17,14 +17,14 @@ type GivenWhenThen = (
 ) => Promise<Then>
 
 describe('IndictmentCountController - Delete offense', () => {
-  let mockOffenseModel: typeof Offense
+  let mockOffenseRepositoryService: OffenseRepositoryService
   let givenWhenThen: GivenWhenThen
 
   beforeEach(async () => {
-    const { offenseModel, indictmentCountController } =
+    const { offenseRepositoryService, indictmentCountController } =
       await createTestingIndictmentCountModule()
 
-    mockOffenseModel = offenseModel
+    mockOffenseRepositoryService = offenseRepositoryService
 
     givenWhenThen = async (
       caseId: string,
@@ -54,16 +54,17 @@ describe('IndictmentCountController - Delete offense', () => {
     let then: Then
 
     beforeEach(async () => {
-      const mockDestroy = mockOffenseModel.destroy as jest.Mock
-      mockDestroy.mockResolvedValueOnce(1)
+      const mockDeleteByIdAndIndictmentCount =
+        mockOffenseRepositoryService.deleteByIdAndIndictmentCount as jest.Mock
+      mockDeleteByIdAndIndictmentCount.mockResolvedValueOnce(1)
 
       then = await givenWhenThen(caseId, indictmentCountId, offenseId)
     })
 
     it('should delete the offense', () => {
-      expect(mockOffenseModel.destroy).toHaveBeenCalledWith({
-        where: { id: offenseId, indictmentCountId },
-      })
+      expect(
+        mockOffenseRepositoryService.deleteByIdAndIndictmentCount,
+      ).toHaveBeenCalledWith(offenseId, indictmentCountId)
       expect(then.result).toEqual({ deleted: true })
     })
   })
@@ -75,8 +76,11 @@ describe('IndictmentCountController - Delete offense', () => {
     let then: Then
 
     beforeEach(async () => {
-      const mockDestroy = mockOffenseModel.destroy as jest.Mock
-      mockDestroy.mockRejectedValueOnce(new Error('Some error'))
+      const mockDeleteByIdAndIndictmentCount =
+        mockOffenseRepositoryService.deleteByIdAndIndictmentCount as jest.Mock
+      mockDeleteByIdAndIndictmentCount.mockRejectedValueOnce(
+        new Error('Some error'),
+      )
 
       then = await givenWhenThen(caseId, indictmentCountId, offenseId)
     })

--- a/apps/judicial-system/backend/src/app/modules/indictment-count/test/reorder.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/indictment-count/test/reorder.spec.ts
@@ -5,7 +5,10 @@ import { NotFoundException } from '@nestjs/common'
 
 import { createTestingIndictmentCountModule } from './createTestingIndictmentCountModule'
 
-import { IndictmentCount } from '../../repository'
+import {
+  IndictmentCount,
+  IndictmentCountRepositoryService,
+} from '../../repository'
 import { ReorderIndictmentCountsDto } from '../dto/reorderIndictmentCounts.dto'
 
 interface Then {
@@ -19,15 +22,18 @@ type GivenWhenThen = (
 ) => Promise<Then>
 
 describe('IndictmentCountController - Reorder', () => {
-  let mockIndictmentCountModel: typeof IndictmentCount
+  let mockIndictmentCountRepositoryService: IndictmentCountRepositoryService
   let givenWhenThen: GivenWhenThen
   let transaction: Transaction
 
   beforeEach(async () => {
-    const { indictmentCountModel, indictmentCountController, sequelize } =
-      await createTestingIndictmentCountModule()
+    const {
+      indictmentCountRepositoryService,
+      indictmentCountController,
+      sequelize,
+    } = await createTestingIndictmentCountModule()
 
-    mockIndictmentCountModel = indictmentCountModel
+    mockIndictmentCountRepositoryService = indictmentCountRepositoryService
     const mockTransaction = sequelize.transaction as jest.Mock
     transaction = {} as Transaction
     mockTransaction.mockImplementationOnce(
@@ -75,8 +81,12 @@ describe('IndictmentCountController - Reorder', () => {
 
     let then: Then
     beforeEach(async () => {
-      const mockUpdate = mockIndictmentCountModel.update as jest.Mock
-      mockUpdate.mockResolvedValue([1, [{}] as IndictmentCount[]])
+      const mockUpdateByIdAndCase =
+        mockIndictmentCountRepositoryService.updateByIdAndCase as jest.Mock
+      mockUpdateByIdAndCase.mockResolvedValue({
+        numberOfAffectedRows: 1,
+        indictmentCounts: [{}] as IndictmentCount[],
+      })
       then = await givenWhenThen(caseId, body)
     })
 
@@ -85,14 +95,16 @@ describe('IndictmentCountController - Reorder', () => {
     })
 
     it('should update each count in the case', () => {
-      expect(mockIndictmentCountModel.update).toHaveBeenCalledTimes(3)
-      expect(mockIndictmentCountModel.update).toHaveBeenCalledWith(
+      expect(
+        mockIndictmentCountRepositoryService.updateByIdAndCase,
+      ).toHaveBeenCalledTimes(3)
+      expect(
+        mockIndictmentCountRepositoryService.updateByIdAndCase,
+      ).toHaveBeenCalledWith(
+        countUpdates[0].id,
+        caseId,
         { displayOrder: countUpdates[0].displayOrder },
-        {
-          where: { id: countUpdates[0].id, caseId },
-          returning: true,
-          transaction,
-        },
+        { transaction },
       )
     })
   })
@@ -104,8 +116,12 @@ describe('IndictmentCountController - Reorder', () => {
 
     let then: Then
     beforeEach(async () => {
-      const mockUpdate = mockIndictmentCountModel.update as jest.Mock
-      mockUpdate.mockResolvedValue([0, [] as IndictmentCount[]])
+      const mockUpdateByIdAndCase =
+        mockIndictmentCountRepositoryService.updateByIdAndCase as jest.Mock
+      mockUpdateByIdAndCase.mockResolvedValue({
+        numberOfAffectedRows: 0,
+        indictmentCounts: [] as IndictmentCount[],
+      })
       then = await givenWhenThen(caseId, body)
     })
 
@@ -125,8 +141,9 @@ describe('IndictmentCountController - Reorder', () => {
 
     let then: Then
     beforeEach(async () => {
-      const mockUpdate = mockIndictmentCountModel.update as jest.Mock
-      mockUpdate.mockRejectedValueOnce(new Error('Some error'))
+      const mockUpdateByIdAndCase =
+        mockIndictmentCountRepositoryService.updateByIdAndCase as jest.Mock
+      mockUpdateByIdAndCase.mockRejectedValueOnce(new Error('Some error'))
       then = await givenWhenThen(caseId, body)
     })
 

--- a/apps/judicial-system/backend/src/app/modules/indictment-count/test/update.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/indictment-count/test/update.spec.ts
@@ -1,9 +1,15 @@
 import { Transaction } from 'sequelize'
 import { v4 as uuid } from 'uuid'
 
+import { IndictmentSubtype } from '@island.is/judicial-system/types'
+
 import { createTestingIndictmentCountModule } from './createTestingIndictmentCountModule'
 
-import { IndictmentCount } from '../../repository'
+import {
+  IndictmentCount,
+  IndictmentCountRepositoryService,
+  OffenseRepositoryService,
+} from '../../repository'
 import { UpdateIndictmentCountDto } from '../dto/updateIndictmentCount.dto'
 
 interface Then {
@@ -23,15 +29,21 @@ describe('IndictmentCountController - Update', () => {
   const policeCaseNumber = uuid()
   const indictmentCountToUpdate = { policeCaseNumber }
 
-  let mockIndictmentCountModel: typeof IndictmentCount
+  let mockIndictmentCountRepositoryService: IndictmentCountRepositoryService
+  let mockOffenseRepositoryService: OffenseRepositoryService
   let transaction: Transaction
   let givenWhenThen: GivenWhenThen
 
   beforeEach(async () => {
-    const { indictmentCountModel, indictmentCountController, sequelize } =
-      await createTestingIndictmentCountModule()
+    const {
+      indictmentCountRepositoryService,
+      offenseRepositoryService,
+      indictmentCountController,
+      sequelize,
+    } = await createTestingIndictmentCountModule()
 
-    mockIndictmentCountModel = indictmentCountModel
+    mockIndictmentCountRepositoryService = indictmentCountRepositoryService
+    mockOffenseRepositoryService = offenseRepositoryService
 
     const mockTransaction = sequelize.transaction as jest.Mock
     transaction = {} as Transaction
@@ -69,11 +81,12 @@ describe('IndictmentCountController - Update', () => {
     let then: Then
 
     beforeEach(async () => {
-      const mockUpdate = mockIndictmentCountModel.update as jest.Mock
-      mockUpdate.mockResolvedValueOnce([1, [updatedIndictmentCount]])
-
-      const mockFindOne = mockIndictmentCountModel.findOne as jest.Mock
-      mockFindOne.mockResolvedValueOnce(updatedIndictmentCount)
+      const mockUpdateByIdAndCase =
+        mockIndictmentCountRepositoryService.updateByIdAndCase as jest.Mock
+      mockUpdateByIdAndCase.mockResolvedValueOnce({
+        numberOfAffectedRows: 1,
+        indictmentCounts: [updatedIndictmentCount],
+      })
 
       then = await givenWhenThen(
         caseId,
@@ -83,13 +96,106 @@ describe('IndictmentCountController - Update', () => {
     })
 
     it('should update the indictment count', () => {
-      expect(mockIndictmentCountModel.update).toHaveBeenCalledWith(
+      expect(
+        mockIndictmentCountRepositoryService.updateByIdAndCase,
+      ).toHaveBeenCalledWith(
+        indictmentCountId,
+        caseId,
         indictmentCountToUpdate,
+        { transaction },
+      )
+      expect(
+        mockOffenseRepositoryService.deleteAllForIndictmentCount,
+      ).not.toHaveBeenCalled()
+      expect(then.result).toBe(updatedIndictmentCount)
+    })
+  })
+
+  describe('indictment count updated to a traffic violation', () => {
+    const trafficViolationUpdate: UpdateIndictmentCountDto = {
+      policeCaseNumberSubtypes: [IndictmentSubtype.TRAFFIC_VIOLATION],
+      indictmentCountSubtypes: [IndictmentSubtype.TRAFFIC_VIOLATION],
+      vehicleRegistrationNumber: 'AB123',
+    }
+    const updatedIndictmentCount = { id: indictmentCountId, caseId }
+    let then: Then
+
+    beforeEach(async () => {
+      const mockUpdateByIdAndCase =
+        mockIndictmentCountRepositoryService.updateByIdAndCase as jest.Mock
+      mockUpdateByIdAndCase.mockResolvedValueOnce({
+        numberOfAffectedRows: 1,
+        indictmentCounts: [updatedIndictmentCount],
+      })
+
+      then = await givenWhenThen(
+        caseId,
+        indictmentCountId,
+        trafficViolationUpdate,
+      )
+    })
+
+    it('should update the indictment count and keep its offenses', () => {
+      expect(
+        mockIndictmentCountRepositoryService.updateByIdAndCase,
+      ).toHaveBeenCalledWith(
+        indictmentCountId,
+        caseId,
+        trafficViolationUpdate,
+        { transaction },
+      )
+      expect(
+        mockOffenseRepositoryService.deleteAllForIndictmentCount,
+      ).not.toHaveBeenCalled()
+      expect(then.result).toBe(updatedIndictmentCount)
+    })
+  })
+
+  describe('indictment count updated away from a traffic violation', () => {
+    const nonTrafficViolationUpdate: UpdateIndictmentCountDto = {
+      policeCaseNumberSubtypes: [
+        IndictmentSubtype.TRAFFIC_VIOLATION,
+        IndictmentSubtype.THEFT,
+      ],
+      indictmentCountSubtypes: [IndictmentSubtype.THEFT],
+      vehicleRegistrationNumber: 'AB123',
+    }
+    const updatedIndictmentCount = { id: indictmentCountId, caseId }
+    let then: Then
+
+    beforeEach(async () => {
+      const mockUpdateByIdAndCase =
+        mockIndictmentCountRepositoryService.updateByIdAndCase as jest.Mock
+      mockUpdateByIdAndCase.mockResolvedValueOnce({
+        numberOfAffectedRows: 1,
+        indictmentCounts: [updatedIndictmentCount],
+      })
+
+      then = await givenWhenThen(
+        caseId,
+        indictmentCountId,
+        nonTrafficViolationUpdate,
+      )
+    })
+
+    it('should clear the traffic violation fields and delete the offenses', () => {
+      expect(
+        mockOffenseRepositoryService.deleteAllForIndictmentCount,
+      ).toHaveBeenCalledWith(indictmentCountId, { transaction })
+      expect(
+        mockIndictmentCountRepositoryService.updateByIdAndCase,
+      ).toHaveBeenCalledWith(
+        indictmentCountId,
+        caseId,
         {
-          where: { id: indictmentCountId, caseId },
-          returning: true,
-          transaction,
+          ...nonTrafficViolationUpdate,
+          vehicleRegistrationNumber: null,
+          recordedSpeed: null,
+          speedLimit: null,
+          lawsBroken: [],
+          legalArguments: '',
         },
+        { transaction },
       )
       expect(then.result).toBe(updatedIndictmentCount)
     })
@@ -99,8 +205,9 @@ describe('IndictmentCountController - Update', () => {
     let then: Then
 
     beforeEach(async () => {
-      const mockUpdate = mockIndictmentCountModel.update as jest.Mock
-      mockUpdate.mockRejectedValueOnce(new Error('Some error'))
+      const mockUpdateByIdAndCase =
+        mockIndictmentCountRepositoryService.updateByIdAndCase as jest.Mock
+      mockUpdateByIdAndCase.mockRejectedValueOnce(new Error('Some error'))
 
       then = await givenWhenThen(
         caseId,

--- a/apps/judicial-system/backend/src/app/modules/indictment-count/test/updateOffense.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/indictment-count/test/updateOffense.spec.ts
@@ -4,7 +4,7 @@ import { IndictmentCountOffense } from '@island.is/judicial-system/types'
 
 import { createTestingIndictmentCountModule } from './createTestingIndictmentCountModule'
 
-import { Offense } from '../../repository'
+import { Offense, OffenseRepositoryService } from '../../repository'
 import { UpdateOffenseDto } from '../dto/updateOffense.dto'
 
 interface Then {
@@ -28,14 +28,14 @@ describe('IndictmentCountController - Update offense', () => {
     substances: { ALCOHOL: '0,10' },
   }
 
-  let mockOffenseModel: typeof Offense
+  let mockOffenseRepositoryService: OffenseRepositoryService
   let givenWhenThen: GivenWhenThen
 
   beforeEach(async () => {
-    const { offenseModel, indictmentCountController } =
+    const { offenseRepositoryService, indictmentCountController } =
       await createTestingIndictmentCountModule()
 
-    mockOffenseModel = offenseModel
+    mockOffenseRepositoryService = offenseRepositoryService
 
     givenWhenThen = async (
       caseId: string,
@@ -68,8 +68,12 @@ describe('IndictmentCountController - Update offense', () => {
     let then: Then
 
     beforeEach(async () => {
-      const mockUpdate = mockOffenseModel.update as jest.Mock
-      mockUpdate.mockResolvedValueOnce([1, [updatedOffense]])
+      const mockUpdateByIdAndIndictmentCount =
+        mockOffenseRepositoryService.updateByIdAndIndictmentCount as jest.Mock
+      mockUpdateByIdAndIndictmentCount.mockResolvedValueOnce({
+        numberOfAffectedRows: 1,
+        offenses: [updatedOffense],
+      })
 
       then = await givenWhenThen(
         caseId,
@@ -80,10 +84,9 @@ describe('IndictmentCountController - Update offense', () => {
     })
 
     it('should update the offense', () => {
-      expect(mockOffenseModel.update).toHaveBeenCalledWith(offenseToUpdate, {
-        where: { id: offenseId, indictmentCountId },
-        returning: true,
-      })
+      expect(
+        mockOffenseRepositoryService.updateByIdAndIndictmentCount,
+      ).toHaveBeenCalledWith(offenseId, indictmentCountId, offenseToUpdate)
       expect(then.result).toBe(updatedOffense)
     })
   })
@@ -92,8 +95,11 @@ describe('IndictmentCountController - Update offense', () => {
     let then: Then
 
     beforeEach(async () => {
-      const mockUpdate = mockOffenseModel.update as jest.Mock
-      mockUpdate.mockRejectedValueOnce(new Error('Some error'))
+      const mockUpdateByIdAndIndictmentCount =
+        mockOffenseRepositoryService.updateByIdAndIndictmentCount as jest.Mock
+      mockUpdateByIdAndIndictmentCount.mockRejectedValueOnce(
+        new Error('Some error'),
+      )
 
       then = await givenWhenThen(
         caseId,

--- a/apps/judicial-system/backend/src/app/modules/repository/index.ts
+++ b/apps/judicial-system/backend/src/app/modules/repository/index.ts
@@ -56,6 +56,12 @@ export {
   CreateEventLog,
   LoginCount,
 } from './services/eventLogRepository.service'
+export {
+  IndictmentCountRepositoryService,
+  CreateIndictmentCount,
+  UpdateIndictmentCount,
+  UpdatedIndictmentCounts,
+} from './services/indictmentCountRepository.service'
 export { IndictmentSubtypeRepositoryService } from './services/indictmentSubtypeRepository.service'
 export { InstitutionContactRepositoryService } from './services/institutionContactRepository.service'
 export { InstitutionRepositoryService } from './services/institutionRepository.service'
@@ -68,6 +74,11 @@ export {
   NotificationRepositoryService,
   CreateNotification,
 } from './services/notificationRepository.service'
+export {
+  OffenseRepositoryService,
+  UpdateOffense,
+  UpdatedOffenses,
+} from './services/offenseRepository.service'
 export { PoliceDigitalCaseFileRepositoryService } from './services/policeDigitalCaseFileRepository.service'
 export {
   RobotLogRepositoryService,

--- a/apps/judicial-system/backend/src/app/modules/repository/repository.module.ts
+++ b/apps/judicial-system/backend/src/app/modules/repository/repository.module.ts
@@ -46,12 +46,14 @@ import { CourtSessionStringRepositoryService } from './services/courtSessionStri
 import { DefendantEventLogRepositoryService } from './services/defendantEventLogRepository.service'
 import { DefendantRepositoryService } from './services/defendantRepository.service'
 import { EventLogRepositoryService } from './services/eventLogRepository.service'
+import { IndictmentCountRepositoryService } from './services/indictmentCountRepository.service'
 import { IndictmentSubtypeRepositoryService } from './services/indictmentSubtypeRepository.service'
 import { InstitutionContactRepositoryService } from './services/institutionContactRepository.service'
 import { InstitutionRepositoryService } from './services/institutionRepository.service'
 import { LawyerRegistryRepositoryService } from './services/lawyerRegistryRepository.service'
 import { MessageSuspensionRepositoryService } from './services/messageSuspensionRepository.service'
 import { NotificationRepositoryService } from './services/notificationRepository.service'
+import { OffenseRepositoryService } from './services/offenseRepository.service'
 import { PoliceDigitalCaseFileRepositoryService } from './services/policeDigitalCaseFileRepository.service'
 import { RobotLogRepositoryService } from './services/robotLogRepository.service'
 import { SubpoenaRepositoryService } from './services/subpoenaRepository.service'
@@ -110,12 +112,14 @@ import { repositoryModuleConfig } from './repository.config'
     DefendantRepositoryService,
     DefendantEventLogRepositoryService,
     EventLogRepositoryService,
+    IndictmentCountRepositoryService,
     IndictmentSubtypeRepositoryService,
     InstitutionContactRepositoryService,
     InstitutionRepositoryService,
     LawyerRegistryRepositoryService,
     MessageSuspensionRepositoryService,
     NotificationRepositoryService,
+    OffenseRepositoryService,
     PoliceDigitalCaseFileRepositoryService,
     RobotLogRepositoryService,
     SubpoenaRepositoryService,
@@ -136,12 +140,14 @@ import { repositoryModuleConfig } from './repository.config'
     DefendantRepositoryService,
     DefendantEventLogRepositoryService,
     EventLogRepositoryService,
+    IndictmentCountRepositoryService,
     IndictmentSubtypeRepositoryService,
     InstitutionContactRepositoryService,
     InstitutionRepositoryService,
     LawyerRegistryRepositoryService,
     MessageSuspensionRepositoryService,
     NotificationRepositoryService,
+    OffenseRepositoryService,
     PoliceDigitalCaseFileRepositoryService,
     RobotLogRepositoryService,
     SubpoenaRepositoryService,

--- a/apps/judicial-system/backend/src/app/modules/repository/services/indictmentCountRepository.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/repository/services/indictmentCountRepository.service.ts
@@ -1,0 +1,224 @@
+import { Transaction } from 'sequelize'
+
+import { Inject, Injectable } from '@nestjs/common'
+import { InjectModel } from '@nestjs/sequelize'
+
+import { type Logger, LOGGER_PROVIDER } from '@island.is/logging'
+
+import { IndictmentSubtype } from '@island.is/judicial-system/types'
+
+import { IndictmentCount } from '../models/indictmentCount.model'
+import { Offense } from '../models/offense.model'
+
+// The display order is computed by the caller from the case's current maximum;
+// the police case number is set only when a count is created for one of the
+// case's police case numbers.
+export type CreateIndictmentCount = {
+  displayOrder: number
+  policeCaseNumber?: string
+}
+
+// Typed by the columns, not by the DTO that usually feeds it: every column but
+// displayOrder is nullable, and both the traffic-violation cascade and the
+// archive path clear columns with null. Keys that are not columns (the DTO's
+// policeCaseNumberSubtypes) are dropped by Sequelize before the UPDATE.
+export type UpdateIndictmentCount = {
+  displayOrder?: number
+  policeCaseNumber?: string | null
+  vehicleRegistrationNumber?: string | null
+  lawsBroken?: [number, number][] | null
+  incidentDescription?: string | null
+  legalArguments?: string | null
+  indictmentCountSubtypes?: IndictmentSubtype[] | null
+  recordedSpeed?: number | null
+  speedLimit?: number | null
+}
+
+// Sequelize returns [affectedRows, rows] from update; naming the two halves keeps
+// the tuple from leaking to callers.
+export type UpdatedIndictmentCounts = {
+  numberOfAffectedRows: number
+  indictmentCounts: IndictmentCount[]
+}
+
+@Injectable()
+export class IndictmentCountRepositoryService {
+  constructor(
+    @InjectModel(IndictmentCount)
+    private readonly indictmentCountModel: typeof IndictmentCount,
+    @Inject(LOGGER_PROVIDER) private readonly logger: Logger,
+  ) {}
+
+  // The offenses ride along in creation order, loaded as a separate query so
+  // the count itself stays a single row.
+  async findByIdWithOffenses(
+    indictmentCountId: string,
+  ): Promise<IndictmentCount | null> {
+    try {
+      this.logger.debug(
+        `Finding indictment count ${indictmentCountId} with its offenses`,
+      )
+
+      const result = await this.indictmentCountModel.findByPk(
+        indictmentCountId,
+        {
+          include: [
+            {
+              model: Offense,
+              as: 'offenses',
+              required: false,
+              separate: true,
+              order: [['created', 'ASC']],
+            },
+          ],
+        },
+      )
+
+      this.logger.debug(
+        `Indictment count ${indictmentCountId} ${
+          result ? 'found' : 'not found'
+        }`,
+      )
+
+      return result
+    } catch (error) {
+      this.logger.error(
+        `Error finding indictment count ${indictmentCountId} with its offenses:`,
+        { error },
+      )
+
+      throw error
+    }
+  }
+
+  // Null when the case has no indictment counts yet; the caller picks the
+  // fallback.
+  async getMaxDisplayOrderForCase(
+    caseId: string,
+    options: { transaction: Transaction },
+  ): Promise<number | null> {
+    try {
+      this.logger.debug(
+        `Finding the highest indictment count display order of case ${caseId}`,
+      )
+
+      const maxDisplayOrder = await this.indictmentCountModel.max(
+        'displayOrder',
+        { where: { caseId }, transaction: options.transaction },
+      )
+
+      return typeof maxDisplayOrder === 'number' ? maxDisplayOrder : null
+    } catch (error) {
+      this.logger.error(
+        `Error finding the highest indictment count display order of case ${caseId}:`,
+        { error },
+      )
+
+      throw error
+    }
+  }
+
+  // Display order first, creation time as the tie-breaker.
+  async findAllForCaseOrdered(
+    caseId: string,
+    options: { transaction: Transaction },
+  ): Promise<IndictmentCount[]> {
+    try {
+      this.logger.debug(`Finding all indictment counts of case ${caseId}`)
+
+      return await this.indictmentCountModel.findAll({
+        where: { caseId },
+        order: [
+          ['displayOrder', 'ASC'],
+          ['created', 'ASC'],
+        ],
+        transaction: options.transaction,
+      })
+    } catch (error) {
+      this.logger.error(
+        `Error finding all indictment counts of case ${caseId}:`,
+        { error },
+      )
+
+      throw error
+    }
+  }
+
+  async create(
+    caseId: string,
+    indictmentCount: CreateIndictmentCount,
+    options: { transaction: Transaction },
+  ): Promise<IndictmentCount> {
+    try {
+      this.logger.debug(`Creating an indictment count for case ${caseId}`)
+
+      return await this.indictmentCountModel.create(
+        { caseId, ...indictmentCount },
+        { transaction: options.transaction },
+      )
+    } catch (error) {
+      this.logger.error(
+        `Error creating an indictment count for case ${caseId}:`,
+        { error },
+      )
+
+      throw error
+    }
+  }
+
+  // An indictment count is only addressable within its own case, so both keys
+  // are named parameters rather than a caller-supplied where clause.
+  async updateByIdAndCase(
+    indictmentCountId: string,
+    caseId: string,
+    update: UpdateIndictmentCount,
+    options: { transaction: Transaction },
+  ): Promise<UpdatedIndictmentCounts> {
+    try {
+      this.logger.debug(
+        `Updating indictment count ${indictmentCountId} of case ${caseId} with data:`,
+        { data: Object.keys(update) },
+      )
+
+      const [numberOfAffectedRows, indictmentCounts] =
+        await this.indictmentCountModel.update(update, {
+          where: { id: indictmentCountId, caseId },
+          returning: true,
+          transaction: options.transaction,
+        })
+
+      return { numberOfAffectedRows, indictmentCounts }
+    } catch (error) {
+      this.logger.error(
+        `Error updating indictment count ${indictmentCountId} of case ${caseId} with data:`,
+        { data: Object.keys(update), error },
+      )
+
+      throw error
+    }
+  }
+
+  async deleteByIdAndCase(
+    indictmentCountId: string,
+    caseId: string,
+    options: { transaction: Transaction },
+  ): Promise<number> {
+    try {
+      this.logger.debug(
+        `Deleting indictment count ${indictmentCountId} of case ${caseId}`,
+      )
+
+      return await this.indictmentCountModel.destroy({
+        where: { id: indictmentCountId, caseId },
+        transaction: options.transaction,
+      })
+    } catch (error) {
+      this.logger.error(
+        `Error deleting indictment count ${indictmentCountId} of case ${caseId}:`,
+        { error },
+      )
+
+      throw error
+    }
+  }
+}

--- a/apps/judicial-system/backend/src/app/modules/repository/services/offenseRepository.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/repository/services/offenseRepository.service.ts
@@ -1,0 +1,128 @@
+import { Transaction } from 'sequelize'
+
+import { Inject, Injectable } from '@nestjs/common'
+import { InjectModel } from '@nestjs/sequelize'
+
+import { type Logger, LOGGER_PROVIDER } from '@island.is/logging'
+
+import {
+  IndictmentCountOffense,
+  type SubstanceMap,
+} from '@island.is/judicial-system/types'
+
+import { Offense } from '../models/offense.model'
+
+// The only updatable column; nullable in the table.
+export type UpdateOffense = {
+  substances?: SubstanceMap | null
+}
+
+// Sequelize returns [affectedRows, rows] from update; naming the two halves keeps
+// the tuple from leaking to callers.
+export type UpdatedOffenses = {
+  numberOfAffectedRows: number
+  offenses: Offense[]
+}
+
+// Offenses exist only under an indictment count, so every method addresses them
+// through the count. The single-offense endpoints run untransacted today, so
+// only the cascade method - whose callers all hold one - takes a transaction.
+@Injectable()
+export class OffenseRepositoryService {
+  constructor(
+    @InjectModel(Offense) private readonly offenseModel: typeof Offense,
+    @Inject(LOGGER_PROVIDER) private readonly logger: Logger,
+  ) {}
+
+  async create(
+    indictmentCountId: string,
+    offense: IndictmentCountOffense,
+  ): Promise<Offense> {
+    try {
+      this.logger.debug(
+        `Creating an offense for indictment count ${indictmentCountId}`,
+      )
+
+      return await this.offenseModel.create({ indictmentCountId, offense })
+    } catch (error) {
+      this.logger.error(
+        `Error creating an offense for indictment count ${indictmentCountId}:`,
+        { error },
+      )
+
+      throw error
+    }
+  }
+
+  async updateByIdAndIndictmentCount(
+    offenseId: string,
+    indictmentCountId: string,
+    update: UpdateOffense,
+  ): Promise<UpdatedOffenses> {
+    try {
+      this.logger.debug(
+        `Updating offense ${offenseId} of indictment count ${indictmentCountId} with data:`,
+        { data: Object.keys(update) },
+      )
+
+      const [numberOfAffectedRows, offenses] = await this.offenseModel.update(
+        update,
+        { where: { id: offenseId, indictmentCountId }, returning: true },
+      )
+
+      return { numberOfAffectedRows, offenses }
+    } catch (error) {
+      this.logger.error(
+        `Error updating offense ${offenseId} of indictment count ${indictmentCountId} with data:`,
+        { data: Object.keys(update), error },
+      )
+
+      throw error
+    }
+  }
+
+  async deleteByIdAndIndictmentCount(
+    offenseId: string,
+    indictmentCountId: string,
+  ): Promise<number> {
+    try {
+      this.logger.debug(
+        `Deleting offense ${offenseId} of indictment count ${indictmentCountId}`,
+      )
+
+      return await this.offenseModel.destroy({
+        where: { id: offenseId, indictmentCountId },
+      })
+    } catch (error) {
+      this.logger.error(
+        `Error deleting offense ${offenseId} of indictment count ${indictmentCountId}:`,
+        { error },
+      )
+
+      throw error
+    }
+  }
+
+  async deleteAllForIndictmentCount(
+    indictmentCountId: string,
+    options: { transaction: Transaction },
+  ): Promise<number> {
+    try {
+      this.logger.debug(
+        `Deleting all offenses of indictment count ${indictmentCountId}`,
+      )
+
+      return await this.offenseModel.destroy({
+        where: { indictmentCountId },
+        transaction: options.transaction,
+      })
+    } catch (error) {
+      this.logger.error(
+        `Error deleting all offenses of indictment count ${indictmentCountId}:`,
+        { error },
+      )
+
+      throw error
+    }
+  }
+}

--- a/apps/judicial-system/backend/src/app/modules/repository/test/indictmentCountRepository.service.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/repository/test/indictmentCountRepository.service.spec.ts
@@ -1,0 +1,276 @@
+import { Transaction } from 'sequelize'
+
+import { getModelToken } from '@nestjs/sequelize'
+import { Test } from '@nestjs/testing'
+
+import { LOGGER_PROVIDER } from '@island.is/logging'
+
+import { IndictmentCount } from '../models/indictmentCount.model'
+import { Offense } from '../models/offense.model'
+import { IndictmentCountRepositoryService } from '../services/indictmentCountRepository.service'
+
+describe('IndictmentCountRepositoryService', () => {
+  const caseId = 'some-case-id'
+  const indictmentCountId = 'some-indictment-count-id'
+  const transaction = {} as Transaction
+
+  // An indictment count is only addressable within its own case, so the
+  // by-id methods must carry both keys.
+  const expectedWhere = { id: indictmentCountId, caseId }
+
+  let service: IndictmentCountRepositoryService
+  let model: {
+    findByPk: jest.Mock
+    max: jest.Mock
+    findAll: jest.Mock
+    create: jest.Mock
+    update: jest.Mock
+    destroy: jest.Mock
+  }
+
+  beforeEach(async () => {
+    model = {
+      findByPk: jest.fn().mockResolvedValue(null),
+      max: jest.fn().mockResolvedValue(null),
+      findAll: jest.fn().mockResolvedValue([]),
+      create: jest.fn(),
+      update: jest.fn().mockResolvedValue([0, []]),
+      destroy: jest.fn().mockResolvedValue(0),
+    }
+
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        {
+          provide: LOGGER_PROVIDER,
+          useValue: { debug: jest.fn(), error: jest.fn() },
+        },
+        { provide: getModelToken(IndictmentCount), useValue: model },
+        IndictmentCountRepositoryService,
+      ],
+    }).compile()
+
+    service = moduleRef.get(IndictmentCountRepositoryService)
+  })
+
+  describe('findByIdWithOffenses', () => {
+    it('loads the count by primary key with its offenses in creation order', async () => {
+      const indictmentCount = { id: indictmentCountId }
+      model.findByPk.mockResolvedValueOnce(indictmentCount)
+
+      const result = await service.findByIdWithOffenses(indictmentCountId)
+
+      expect(model.findByPk).toHaveBeenCalledWith(indictmentCountId, {
+        include: [
+          {
+            model: Offense,
+            as: 'offenses',
+            required: false,
+            separate: true,
+            order: [['created', 'ASC']],
+          },
+        ],
+      })
+      expect(result).toBe(indictmentCount)
+    })
+
+    it('returns null when there is no such count', async () => {
+      expect(await service.findByIdWithOffenses(indictmentCountId)).toBeNull()
+    })
+
+    it('rethrows when the lookup fails', async () => {
+      const error = new Error('Some error')
+      model.findByPk.mockRejectedValueOnce(error)
+
+      await expect(
+        service.findByIdWithOffenses(indictmentCountId),
+      ).rejects.toThrow(error)
+    })
+  })
+
+  describe('getMaxDisplayOrderForCase', () => {
+    it('reads the maximum display order of the case in the caller transaction', async () => {
+      model.max.mockResolvedValueOnce(4)
+
+      const result = await service.getMaxDisplayOrderForCase(caseId, {
+        transaction,
+      })
+
+      expect(model.max).toHaveBeenCalledWith('displayOrder', {
+        where: { caseId },
+        transaction,
+      })
+      expect(result).toBe(4)
+    })
+
+    it('returns zero as a number, not as a missing value', async () => {
+      model.max.mockResolvedValueOnce(0)
+
+      expect(
+        await service.getMaxDisplayOrderForCase(caseId, { transaction }),
+      ).toBe(0)
+    })
+
+    it('returns null when the case has no counts', async () => {
+      expect(
+        await service.getMaxDisplayOrderForCase(caseId, { transaction }),
+      ).toBeNull()
+    })
+
+    it('rethrows when the aggregate fails', async () => {
+      const error = new Error('Some error')
+      model.max.mockRejectedValueOnce(error)
+
+      await expect(
+        service.getMaxDisplayOrderForCase(caseId, { transaction }),
+      ).rejects.toThrow(error)
+    })
+  })
+
+  describe('findAllForCaseOrdered', () => {
+    it('lists the counts of the case by display order, then creation, in the caller transaction', async () => {
+      const indictmentCounts = [{ id: indictmentCountId }]
+      model.findAll.mockResolvedValueOnce(indictmentCounts)
+
+      const result = await service.findAllForCaseOrdered(caseId, {
+        transaction,
+      })
+
+      expect(model.findAll).toHaveBeenCalledWith({
+        where: { caseId },
+        order: [
+          ['displayOrder', 'ASC'],
+          ['created', 'ASC'],
+        ],
+        transaction,
+      })
+      expect(result).toBe(indictmentCounts)
+    })
+
+    it('rethrows when the lookup fails', async () => {
+      const error = new Error('Some error')
+      model.findAll.mockRejectedValueOnce(error)
+
+      await expect(
+        service.findAllForCaseOrdered(caseId, { transaction }),
+      ).rejects.toThrow(error)
+    })
+  })
+
+  describe('create', () => {
+    it('creates the count against the case in the caller transaction', async () => {
+      const created = { id: indictmentCountId, caseId }
+      model.create.mockResolvedValueOnce(created)
+
+      const result = await service.create(
+        caseId,
+        { displayOrder: 3 },
+        { transaction },
+      )
+
+      expect(model.create).toHaveBeenCalledWith(
+        { caseId, displayOrder: 3 },
+        { transaction },
+      )
+      expect(result).toBe(created)
+    })
+
+    it('carries an optional police case number', async () => {
+      await service.create(
+        caseId,
+        { displayOrder: 0, policeCaseNumber: '007-2024-1' },
+        { transaction },
+      )
+
+      expect(model.create).toHaveBeenCalledWith(
+        { caseId, displayOrder: 0, policeCaseNumber: '007-2024-1' },
+        { transaction },
+      )
+    })
+
+    it('rethrows when the creation fails', async () => {
+      const error = new Error('Some error')
+      model.create.mockRejectedValueOnce(error)
+
+      await expect(
+        service.create(caseId, { displayOrder: 0 }, { transaction }),
+      ).rejects.toThrow(error)
+    })
+  })
+
+  describe('updateByIdAndCase', () => {
+    it('scopes the update to the row id and the case, returning the rows, in the caller transaction', async () => {
+      const indictmentCount = { id: indictmentCountId, displayOrder: 1 }
+      model.update.mockResolvedValueOnce([1, [indictmentCount]])
+
+      const result = await service.updateByIdAndCase(
+        indictmentCountId,
+        caseId,
+        { displayOrder: 1 },
+        { transaction },
+      )
+
+      expect(model.update).toHaveBeenCalledWith(
+        { displayOrder: 1 },
+        { where: expectedWhere, returning: true, transaction },
+      )
+      expect(result).toEqual({
+        numberOfAffectedRows: 1,
+        indictmentCounts: [indictmentCount],
+      })
+    })
+
+    it('reports zero rows when nothing matched', async () => {
+      const result = await service.updateByIdAndCase(
+        indictmentCountId,
+        caseId,
+        { policeCaseNumber: null },
+        { transaction },
+      )
+
+      expect(result).toEqual({ numberOfAffectedRows: 0, indictmentCounts: [] })
+    })
+
+    it('rethrows when the update fails', async () => {
+      const error = new Error('Some error')
+      model.update.mockRejectedValueOnce(error)
+
+      await expect(
+        service.updateByIdAndCase(
+          indictmentCountId,
+          caseId,
+          {},
+          { transaction },
+        ),
+      ).rejects.toThrow(error)
+    })
+  })
+
+  describe('deleteByIdAndCase', () => {
+    it('scopes the delete to the row id and the case in the caller transaction and reports the row count', async () => {
+      model.destroy.mockResolvedValueOnce(1)
+
+      const result = await service.deleteByIdAndCase(
+        indictmentCountId,
+        caseId,
+        {
+          transaction,
+        },
+      )
+
+      expect(model.destroy).toHaveBeenCalledWith({
+        where: expectedWhere,
+        transaction,
+      })
+      expect(result).toBe(1)
+    })
+
+    it('rethrows when the delete fails', async () => {
+      const error = new Error('Some error')
+      model.destroy.mockRejectedValueOnce(error)
+
+      await expect(
+        service.deleteByIdAndCase(indictmentCountId, caseId, { transaction }),
+      ).rejects.toThrow(error)
+    })
+  })
+})

--- a/apps/judicial-system/backend/src/app/modules/repository/test/offenseRepository.service.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/repository/test/offenseRepository.service.spec.ts
@@ -1,0 +1,163 @@
+import { Transaction } from 'sequelize'
+
+import { getModelToken } from '@nestjs/sequelize'
+import { Test } from '@nestjs/testing'
+
+import { LOGGER_PROVIDER } from '@island.is/logging'
+
+import { IndictmentCountOffense } from '@island.is/judicial-system/types'
+
+import { Offense } from '../models/offense.model'
+import { OffenseRepositoryService } from '../services/offenseRepository.service'
+
+describe('OffenseRepositoryService', () => {
+  const indictmentCountId = 'some-indictment-count-id'
+  const offenseId = 'some-offense-id'
+  const transaction = {} as Transaction
+
+  // An offense is only addressable within its own indictment count, so the
+  // by-id methods must carry both keys.
+  const expectedWhere = { id: offenseId, indictmentCountId }
+
+  let service: OffenseRepositoryService
+  let model: {
+    create: jest.Mock
+    update: jest.Mock
+    destroy: jest.Mock
+  }
+
+  beforeEach(async () => {
+    model = {
+      create: jest.fn(),
+      update: jest.fn().mockResolvedValue([0, []]),
+      destroy: jest.fn().mockResolvedValue(0),
+    }
+
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        {
+          provide: LOGGER_PROVIDER,
+          useValue: { debug: jest.fn(), error: jest.fn() },
+        },
+        { provide: getModelToken(Offense), useValue: model },
+        OffenseRepositoryService,
+      ],
+    }).compile()
+
+    service = moduleRef.get(OffenseRepositoryService)
+  })
+
+  describe('create', () => {
+    it('creates the offense against the indictment count', async () => {
+      const created = { id: offenseId, indictmentCountId }
+      model.create.mockResolvedValueOnce(created)
+
+      const result = await service.create(
+        indictmentCountId,
+        IndictmentCountOffense.DRUNK_DRIVING,
+      )
+
+      expect(model.create).toHaveBeenCalledWith({
+        indictmentCountId,
+        offense: IndictmentCountOffense.DRUNK_DRIVING,
+      })
+      expect(result).toBe(created)
+    })
+
+    it('rethrows when the creation fails', async () => {
+      const error = new Error('Some error')
+      model.create.mockRejectedValueOnce(error)
+
+      await expect(
+        service.create(indictmentCountId, IndictmentCountOffense.DRUNK_DRIVING),
+      ).rejects.toThrow(error)
+    })
+  })
+
+  describe('updateByIdAndIndictmentCount', () => {
+    it('scopes the update to the row id and the indictment count and returns the rows', async () => {
+      const offense = { id: offenseId, substances: { ALCOHOL: '0,10' } }
+      model.update.mockResolvedValueOnce([1, [offense]])
+
+      const result = await service.updateByIdAndIndictmentCount(
+        offenseId,
+        indictmentCountId,
+        { substances: { ALCOHOL: '0,10' } },
+      )
+
+      expect(model.update).toHaveBeenCalledWith(
+        { substances: { ALCOHOL: '0,10' } },
+        { where: expectedWhere, returning: true },
+      )
+      expect(result).toEqual({ numberOfAffectedRows: 1, offenses: [offense] })
+    })
+
+    it('reports zero rows when nothing matched', async () => {
+      const result = await service.updateByIdAndIndictmentCount(
+        offenseId,
+        indictmentCountId,
+        { substances: null },
+      )
+
+      expect(result).toEqual({ numberOfAffectedRows: 0, offenses: [] })
+    })
+
+    it('rethrows when the update fails', async () => {
+      const error = new Error('Some error')
+      model.update.mockRejectedValueOnce(error)
+
+      await expect(
+        service.updateByIdAndIndictmentCount(offenseId, indictmentCountId, {}),
+      ).rejects.toThrow(error)
+    })
+  })
+
+  describe('deleteByIdAndIndictmentCount', () => {
+    it('scopes the delete to the row id and the indictment count and reports the row count', async () => {
+      model.destroy.mockResolvedValueOnce(1)
+
+      const result = await service.deleteByIdAndIndictmentCount(
+        offenseId,
+        indictmentCountId,
+      )
+
+      expect(model.destroy).toHaveBeenCalledWith({ where: expectedWhere })
+      expect(result).toBe(1)
+    })
+
+    it('rethrows when the delete fails', async () => {
+      const error = new Error('Some error')
+      model.destroy.mockRejectedValueOnce(error)
+
+      await expect(
+        service.deleteByIdAndIndictmentCount(offenseId, indictmentCountId),
+      ).rejects.toThrow(error)
+    })
+  })
+
+  describe('deleteAllForIndictmentCount', () => {
+    it('deletes every offense of the indictment count in the caller transaction and reports the row count', async () => {
+      model.destroy.mockResolvedValueOnce(3)
+
+      const result = await service.deleteAllForIndictmentCount(
+        indictmentCountId,
+        { transaction },
+      )
+
+      expect(model.destroy).toHaveBeenCalledWith({
+        where: { indictmentCountId },
+        transaction,
+      })
+      expect(result).toBe(3)
+    })
+
+    it('rethrows when the delete fails', async () => {
+      const error = new Error('Some error')
+      model.destroy.mockRejectedValueOnce(error)
+
+      await expect(
+        service.deleteAllForIndictmentCount(indictmentCountId, { transaction }),
+      ).rejects.toThrow(error)
+    })
+  })
+})


### PR DESCRIPTION
# Indictment count and offense repository services

[Repository þjónustur fyrir IndictmentCount og Offense](https://app.asana.com/1/203394141643832/project/1199153462262248/task/1218131150614732)

Chunk D of the repository-pattern migration: `IndictmentCount` and `Offense` get their own repository services and `IndictmentCountService` stops injecting the two models. This is the one slice the plan carries as a pair in a single PR: an offense exists only under an indictment count, both were injected in the same single consumer, and deleting a count cascades to its offenses.

**Two new services**, one model each:

- `IndictmentCountRepositoryService` — `findByIdWithOffenses`, `getMaxDisplayOrderForCase`, `findAllForCaseOrdered`, `create`, `updateByIdAndCase`, `deleteByIdAndCase`. Every method takes the caller's transaction except `findByIdWithOffenses`, whose only caller is untransacted.
- `OffenseRepositoryService` — `create`, `updateByIdAndIndictmentCount`, `deleteByIdAndIndictmentCount`, `deleteAllForIndictmentCount`. The single-offense endpoints run untransacted today, so only the cascade method takes a transaction (both of its callers hold one). Signatures are derived from the call sites they replace.

**What stays in the service:** the traffic-violation cascade (deciding `isTrafficViolation`, clearing the traffic fields, destroying offenses first), the delete cascade (offenses, then the count, then `renormalizeDisplayOrder`), the display-order arithmetic (`+1`, the `-1` fallback for an empty case, the `!== 1` not-found check), and all `numberOfAffectedRows` handling and exceptions. The repositories supply plain named operations; the service orchestrates them.

`IndictmentCountModule` now registers no Sequelize models at all. `UpdateIndictmentCount` is typed by the columns (all nullable but `displayOrder`), so both the cascade's explicit `null`s and the archive path's generic payload fit without a cast.

**Deliberately left, per the plan's D2 decision:** `CaseRepositoryService` keeps its own `@InjectModel` for both models until chunk E lifts `split` / `duplicateIndictmentToDraft` out of it. This slice closes invariant 2 (no `@InjectModel` and no `forFeature` outside the repository module) for both models; it does not claim invariant 3.

## Verification

| Check | Before | After |
|---|---|---|
| `InjectModel(IndictmentCount\|Offense)` / model handles outside `modules/repository/` | 37 | 0 |
| `forFeature([… IndictmentCount, Offense …])` outside `modules/repository/` | 1 | 0 |
| `InjectModel(IndictmentCount\|Offense)` inside `modules/repository/` | 2 | 4 (aggregate + new services) |
| `IndictmentCountRepositoryService` / `OffenseRepositoryService` in `repository.module.ts` | 0 / 0 | 3 / 3 |

- `npx tsc --noEmit -p apps/judicial-system/backend/tsconfig.app.json` clean
- `yarn nx test judicial-system-backend --testPathPatterns='app/modules/(indictment-count|repository)/'` — 32 suites, 224 tests, all green
- `yarn nx lint judicial-system-backend` clean bar the pre-existing `CaseAppealDecision` warning
- `yarn nx run judicial-system-backend:codegen/backend-schema` boots the app; `openapi.yaml` byte-identical

## Tests

- Two new repository specs (`indictmentCountRepository.service.spec.ts`, `offenseRepository.service.spec.ts`): every `where` carries its full key, the include shape on `findByIdWithOffenses`, `0` as a real max display order, tuples mapped to named objects, transaction pass-through, rethrow on failure.
- Seven consumer specs moved from model-token mocks to repository-service mocks. `update.spec.ts` gains both traffic-violation branches (offenses kept vs. cleared); `delete.spec.ts` gains a display-order renormalization row.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added repository-backed handling for indictment counts and offenses, including creation, updates, deletion, ordering, and bulk offense removal.
  * Added case-scoped operations to help ensure records are updated and deleted within the correct case.
* **Bug Fixes**
  * Updating an indictment count away from a traffic violation now removes associated offenses and clears related traffic-violation details.
* **Tests**
  * Expanded coverage for ordering, cascading updates, deletions, error handling, and repository operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->