### PR TITLE
fix(infra): propagate enable-global-auth opt-out to Envoy HTTPRoute

### DIFF
--- a/charts/identity-server-services/identity-server/values.dev.yaml
+++ b/charts/identity-server-services/identity-server/values.dev.yaml
@@ -87,6 +87,7 @@ httpRoute:
   primary-gw:
     hostnames:
       - 'identity-server.dev01.devland.is'
+    noAuth: true
     parentRefs:
       - name: 'gateway-external'
         namespace: 'envoy-gateway-external'

--- a/charts/identity-server-services/identity-server/values.staging.yaml
+++ b/charts/identity-server-services/identity-server/values.staging.yaml
@@ -87,6 +87,7 @@ httpRoute:
   primary-gw:
     hostnames:
       - 'identity-server.staging01.devland.is'
+    noAuth: true
     parentRefs:
       - name: 'gateway-external'
         namespace: 'envoy-gateway-external'

--- a/charts/identity-server-services/services-auth-admin-api/values.dev.yaml
+++ b/charts/identity-server-services/services-auth-admin-api/values.dev.yaml
@@ -80,6 +80,7 @@ httpRoute:
   primary-gw:
     hostnames:
       - 'identity-server.dev01.devland.is'
+    noAuth: true
     parentRefs:
       - name: 'gateway-external'
         namespace: 'envoy-gateway-external'

--- a/charts/identity-server-services/services-auth-admin-api/values.prod.yaml
+++ b/charts/identity-server-services/services-auth-admin-api/values.prod.yaml
@@ -80,6 +80,7 @@ httpRoute:
   primary-gw:
     hostnames:
       - 'innskra.island.is'
+    noAuth: true
     parentRefs:
       - name: 'gateway-external'
         namespace: 'envoy-gateway-external'

--- a/charts/identity-server-services/services-auth-admin-api/values.staging.yaml
+++ b/charts/identity-server-services/services-auth-admin-api/values.staging.yaml
@@ -80,6 +80,7 @@ httpRoute:
   primary-gw:
     hostnames:
       - 'identity-server.staging01.devland.is'
+    noAuth: true
     parentRefs:
       - name: 'gateway-external'
         namespace: 'envoy-gateway-external'

--- a/charts/identity-server-services/services-auth-public-api/values.dev.yaml
+++ b/charts/identity-server-services/services-auth-public-api/values.dev.yaml
@@ -86,6 +86,7 @@ httpRoute:
   primary-gw:
     hostnames:
       - 'identity-server.dev01.devland.is'
+    noAuth: true
     parentRefs:
       - name: 'gateway-external'
         namespace: 'envoy-gateway-external'

--- a/charts/identity-server-services/services-auth-public-api/values.prod.yaml
+++ b/charts/identity-server-services/services-auth-public-api/values.prod.yaml
@@ -86,6 +86,7 @@ httpRoute:
   primary-gw:
     hostnames:
       - 'innskra.island.is'
+    noAuth: true
     parentRefs:
       - name: 'gateway-external'
         namespace: 'envoy-gateway-external'

--- a/charts/identity-server-services/services-auth-public-api/values.staging.yaml
+++ b/charts/identity-server-services/services-auth-public-api/values.staging.yaml
@@ -86,6 +86,7 @@ httpRoute:
   primary-gw:
     hostnames:
       - 'identity-server.staging01.devland.is'
+    noAuth: true
     parentRefs:
       - name: 'gateway-external'
         namespace: 'envoy-gateway-external'

--- a/charts/identity-server/values.dev.yaml
+++ b/charts/identity-server/values.dev.yaml
@@ -166,6 +166,7 @@ identity-server:
     primary-gw:
       hostnames:
         - 'identity-server.dev01.devland.is'
+      noAuth: true
       parentRefs:
         - name: 'gateway-external'
           namespace: 'envoy-gateway-external'
@@ -294,6 +295,7 @@ services-auth-admin-api:
     primary-gw:
       hostnames:
         - 'identity-server.dev01.devland.is'
+      noAuth: true
       parentRefs:
         - name: 'gateway-external'
           namespace: 'envoy-gateway-external'
@@ -922,6 +924,7 @@ services-auth-public-api:
     primary-gw:
       hostnames:
         - 'identity-server.dev01.devland.is'
+      noAuth: true
       parentRefs:
         - name: 'gateway-external'
           namespace: 'envoy-gateway-external'

--- a/charts/identity-server/values.prod.yaml
+++ b/charts/identity-server/values.prod.yaml
@@ -294,6 +294,7 @@ services-auth-admin-api:
     primary-gw:
       hostnames:
         - 'innskra.island.is'
+      noAuth: true
       parentRefs:
         - name: 'gateway-external'
           namespace: 'envoy-gateway-external'
@@ -922,6 +923,7 @@ services-auth-public-api:
     primary-gw:
       hostnames:
         - 'innskra.island.is'
+      noAuth: true
       parentRefs:
         - name: 'gateway-external'
           namespace: 'envoy-gateway-external'

--- a/charts/identity-server/values.staging.yaml
+++ b/charts/identity-server/values.staging.yaml
@@ -166,6 +166,7 @@ identity-server:
     primary-gw:
       hostnames:
         - 'identity-server.staging01.devland.is'
+      noAuth: true
       parentRefs:
         - name: 'gateway-external'
           namespace: 'envoy-gateway-external'
@@ -294,6 +295,7 @@ services-auth-admin-api:
     primary-gw:
       hostnames:
         - 'identity-server.staging01.devland.is'
+      noAuth: true
       parentRefs:
         - name: 'gateway-external'
           namespace: 'envoy-gateway-external'
@@ -922,6 +924,7 @@ services-auth-public-api:
     primary-gw:
       hostnames:
         - 'identity-server.staging01.devland.is'
+      noAuth: true
       parentRefs:
         - name: 'gateway-external'
           namespace: 'envoy-gateway-external'

--- a/charts/islandis-services/air-discount-scheme-backend/values.dev.yaml
+++ b/charts/islandis-services/air-discount-scheme-backend/values.dev.yaml
@@ -66,6 +66,7 @@ httpRoute:
     hostnames:
       - 'loftbru.dev01.devland.is'
       - 'loftbru-cf.dev01.devland.is'
+    noAuth: true
     parentRefs:
       - name: 'gateway-external'
         namespace: 'envoy-gateway-external'

--- a/charts/islandis-services/air-discount-scheme-backend/values.staging.yaml
+++ b/charts/islandis-services/air-discount-scheme-backend/values.staging.yaml
@@ -66,6 +66,7 @@ httpRoute:
     hostnames:
       - 'loftbru.staging01.devland.is'
       - 'loftbru-cf.staging01.devland.is'
+    noAuth: true
     parentRefs:
       - name: 'gateway-external'
         namespace: 'envoy-gateway-external'

--- a/charts/islandis-services/download-service/values.dev.yaml
+++ b/charts/islandis-services/download-service/values.dev.yaml
@@ -86,6 +86,7 @@ httpRoute:
   primary-gw:
     hostnames:
       - 'api.dev01.devland.is'
+    noAuth: true
     parentRefs:
       - name: 'gateway-external'
         namespace: 'envoy-gateway-external'

--- a/charts/islandis-services/download-service/values.staging.yaml
+++ b/charts/islandis-services/download-service/values.staging.yaml
@@ -86,6 +86,7 @@ httpRoute:
   primary-gw:
     hostnames:
       - 'api.staging01.devland.is'
+    noAuth: true
     parentRefs:
       - name: 'gateway-external'
         namespace: 'envoy-gateway-external'

--- a/charts/islandis-services/github-actions-cache/values.dev.yaml
+++ b/charts/islandis-services/github-actions-cache/values.dev.yaml
@@ -51,6 +51,7 @@ httpRoute:
   primary-gw:
     hostnames:
       - 'cache.dev01.devland.is'
+    noAuth: true
     parentRefs:
       - name: 'gateway-external'
         namespace: 'envoy-gateway-external'

--- a/charts/islandis-services/payments/values.dev.yaml
+++ b/charts/islandis-services/payments/values.dev.yaml
@@ -56,6 +56,7 @@ httpRoute:
   primary-gw:
     hostnames:
       - 'beta.dev01.devland.is'
+    noAuth: true
     parentRefs:
       - name: 'gateway-external'
         namespace: 'envoy-gateway-external'

--- a/charts/islandis-services/payments/values.staging.yaml
+++ b/charts/islandis-services/payments/values.staging.yaml
@@ -56,6 +56,7 @@ httpRoute:
   primary-gw:
     hostnames:
       - 'beta.staging01.devland.is'
+    noAuth: true
     parentRefs:
       - name: 'gateway-external'
         namespace: 'envoy-gateway-external'

--- a/charts/islandis-services/search-indexer-service/values.dev.yaml
+++ b/charts/islandis-services/search-indexer-service/values.dev.yaml
@@ -58,6 +58,7 @@ httpRoute:
   primary-gw:
     hostnames:
       - 'search-indexer-service.dev01.devland.is'
+    noAuth: true
     parentRefs:
       - name: 'gateway-external'
         namespace: 'envoy-gateway-external'

--- a/charts/islandis-services/search-indexer-service/values.staging.yaml
+++ b/charts/islandis-services/search-indexer-service/values.staging.yaml
@@ -58,6 +58,7 @@ httpRoute:
   primary-gw:
     hostnames:
       - 'search-indexer-service.staging01.devland.is'
+    noAuth: true
     parentRefs:
       - name: 'gateway-external'
         namespace: 'envoy-gateway-external'

--- a/charts/islandis-services/services-bff-portals-admin/values.dev.yaml
+++ b/charts/islandis-services/services-bff-portals-admin/values.dev.yaml
@@ -67,6 +67,7 @@ httpRoute:
   primary-gw:
     hostnames:
       - 'beta.dev01.devland.is'
+    noAuth: true
     parentRefs:
       - name: 'gateway-external'
         namespace: 'envoy-gateway-external'

--- a/charts/islandis-services/services-bff-portals-admin/values.staging.yaml
+++ b/charts/islandis-services/services-bff-portals-admin/values.staging.yaml
@@ -67,6 +67,7 @@ httpRoute:
   primary-gw:
     hostnames:
       - 'beta.staging01.devland.is'
+    noAuth: true
     parentRefs:
       - name: 'gateway-external'
         namespace: 'envoy-gateway-external'

--- a/charts/islandis-services/services-bff-portals-my-pages/values.dev.yaml
+++ b/charts/islandis-services/services-bff-portals-my-pages/values.dev.yaml
@@ -66,6 +66,7 @@ httpRoute:
   primary-gw:
     hostnames:
       - 'beta.dev01.devland.is'
+    noAuth: true
     parentRefs:
       - name: 'gateway-external'
         namespace: 'envoy-gateway-external'

--- a/charts/islandis-services/services-bff-portals-my-pages/values.staging.yaml
+++ b/charts/islandis-services/services-bff-portals-my-pages/values.staging.yaml
@@ -66,6 +66,7 @@ httpRoute:
   primary-gw:
     hostnames:
       - 'beta.staging01.devland.is'
+    noAuth: true
     parentRefs:
       - name: 'gateway-external'
         namespace: 'envoy-gateway-external'

--- a/charts/islandis/values.dev.yaml
+++ b/charts/islandis/values.dev.yaml
@@ -55,6 +55,7 @@ air-discount-scheme-backend:
       hostnames:
         - 'loftbru.dev01.devland.is'
         - 'loftbru-cf.dev01.devland.is'
+      noAuth: true
       parentRefs:
         - name: 'gateway-external'
           namespace: 'envoy-gateway-external'
@@ -1575,6 +1576,7 @@ download-service:
     primary-gw:
       hostnames:
         - 'api.dev01.devland.is'
+      noAuth: true
       parentRefs:
         - name: 'gateway-external'
           namespace: 'envoy-gateway-external'
@@ -1850,6 +1852,7 @@ github-actions-cache:
     primary-gw:
       hostnames:
         - 'cache.dev01.devland.is'
+      noAuth: true
       parentRefs:
         - name: 'gateway-external'
           namespace: 'envoy-gateway-external'
@@ -2235,6 +2238,7 @@ payments:
     primary-gw:
       hostnames:
         - 'beta.dev01.devland.is'
+      noAuth: true
       parentRefs:
         - name: 'gateway-external'
           namespace: 'envoy-gateway-external'
@@ -2506,6 +2510,7 @@ search-indexer-service:
     primary-gw:
       hostnames:
         - 'search-indexer-service.dev01.devland.is'
+      noAuth: true
       parentRefs:
         - name: 'gateway-external'
           namespace: 'envoy-gateway-external'
@@ -2856,6 +2861,7 @@ services-bff-portals-admin:
     primary-gw:
       hostnames:
         - 'beta.dev01.devland.is'
+      noAuth: true
       parentRefs:
         - name: 'gateway-external'
           namespace: 'envoy-gateway-external'
@@ -2944,6 +2950,7 @@ services-bff-portals-my-pages:
     primary-gw:
       hostnames:
         - 'beta.dev01.devland.is'
+      noAuth: true
       parentRefs:
         - name: 'gateway-external'
           namespace: 'envoy-gateway-external'

--- a/charts/islandis/values.staging.yaml
+++ b/charts/islandis/values.staging.yaml
@@ -55,6 +55,7 @@ air-discount-scheme-backend:
       hostnames:
         - 'loftbru.staging01.devland.is'
         - 'loftbru-cf.staging01.devland.is'
+      noAuth: true
       parentRefs:
         - name: 'gateway-external'
           namespace: 'envoy-gateway-external'
@@ -1377,6 +1378,7 @@ download-service:
     primary-gw:
       hostnames:
         - 'api.staging01.devland.is'
+      noAuth: true
       parentRefs:
         - name: 'gateway-external'
           namespace: 'envoy-gateway-external'
@@ -1963,6 +1965,7 @@ payments:
     primary-gw:
       hostnames:
         - 'beta.staging01.devland.is'
+      noAuth: true
       parentRefs:
         - name: 'gateway-external'
           namespace: 'envoy-gateway-external'
@@ -2234,6 +2237,7 @@ search-indexer-service:
     primary-gw:
       hostnames:
         - 'search-indexer-service.staging01.devland.is'
+      noAuth: true
       parentRefs:
         - name: 'gateway-external'
           namespace: 'envoy-gateway-external'
@@ -2584,6 +2588,7 @@ services-bff-portals-admin:
     primary-gw:
       hostnames:
         - 'beta.staging01.devland.is'
+      noAuth: true
       parentRefs:
         - name: 'gateway-external'
           namespace: 'envoy-gateway-external'
@@ -2672,6 +2677,7 @@ services-bff-portals-my-pages:
     primary-gw:
       hostnames:
         - 'beta.staging01.devland.is'
+      noAuth: true
       parentRefs:
         - name: 'gateway-external'
           namespace: 'envoy-gateway-external'

--- a/infra/src/dsl/ingress.spec.ts
+++ b/infra/src/dsl/ingress.spec.ts
@@ -49,6 +49,47 @@ describe('HTTPRoute definitions', () => {
     ])
   })
 
+  it('enable-global-auth: false propagates to httpRoute.noAuth', async () => {
+    const sut = service('api').ingress({
+      primary: {
+        host: { dev: 'a', staging: 'a', prod: 'a' },
+        paths: ['/'],
+        extraAnnotations: {
+          dev: { 'nginx.ingress.kubernetes.io/enable-global-auth': 'false' },
+          staging: {
+            'nginx.ingress.kubernetes.io/enable-global-auth': 'false',
+          },
+          prod: {},
+        },
+      },
+    })
+    const result = (await generateOutputOne({
+      outputFormat: renderers.helm,
+      service: sut,
+      runtime: new Kubernetes(Staging),
+      env: Staging,
+    })) as SerializeSuccess<HelmService>
+
+    expect(result.serviceDef[0].httpRoute!['primary-gw'].noAuth).toBe(true)
+  })
+
+  it('routes without the opt-out annotation have no noAuth flag', async () => {
+    const sut = service('api').ingress({
+      primary: {
+        host: { dev: 'a', staging: 'a', prod: 'a' },
+        paths: ['/'],
+      },
+    })
+    const result = (await generateOutputOne({
+      outputFormat: renderers.helm,
+      service: sut,
+      runtime: new Kubernetes(Staging),
+      env: Staging,
+    })) as SerializeSuccess<HelmService>
+
+    expect(result.serviceDef[0].httpRoute!['primary-gw'].noAuth).toBeUndefined()
+  })
+
   it('Internal ingress produces internal gateway HTTPRoute', async () => {
     const sut = service('api').ingress({
       primary: {

--- a/infra/src/dsl/output-generators/map-to-helm-values.ts
+++ b/infra/src/dsl/output-generators/map-to-helm-values.ts
@@ -537,6 +537,13 @@ function serializeHTTPRoute(
     ingressConf.extraAnnotations?.['nginx.ingress.kubernetes.io/rewrite-target']
   const rewritePrefix = rewriteTarget === '/$2' ? '/' : undefined
 
+  // Carry the legacy global-auth opt-out onto the route so a no-auth
+  // SecurityPolicy is rendered (Cognito wall bypass).
+  const noAuth =
+    ingressConf.extraAnnotations?.[
+      'nginx.ingress.kubernetes.io/enable-global-auth'
+    ] === 'false'
+
   return {
     parentRefs: [
       {
@@ -561,6 +568,7 @@ function serializeHTTPRoute(
         ...(rewritePrefix ? { rewritePrefix } : {}),
       },
     ],
+    ...(noAuth ? { noAuth } : {}),
   }
 }
 

--- a/infra/src/dsl/types/output-types.ts
+++ b/infra/src/dsl/types/output-types.ts
@@ -103,6 +103,8 @@ export interface HelmService {
         matches: { pathPrefix?: string; pathExact?: string }[]
         rewritePrefix?: string
       }[]
+      // Opt this route out of the gateway-wide Cognito OIDC wall.
+      noAuth?: boolean
     }
   }
 


### PR DESCRIPTION
serializeHTTPRoute only carried the rewrite-target annotation across, so the nginx `enable-global-auth: false` opt-out was silently dropped for Envoy-migrated services (ingress block no longer emitted). Those services then inherited the gateway-wide Cognito OIDC wall and returned 302 to unauthenticated callers (e.g. Contentful webhooks hitting search-indexer /sync and /delete-document).

Map the annotation to `httpRoute[*].noAuth`, which the api-template securitypolicy-noauth template renders into a per-route no-auth SecurityPolicy. Adds DSL tests for the propagation.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Individual HTTP routes can now opt out of gateway-wide authentication when configured with the supported ingress annotation.

* **Bug Fixes**
  * Preserved route-level authentication settings when converting ingress definitions into deployment configuration.

* **Tests**
  * Added coverage for routes with and without the authentication opt-out annotation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->