### PR TITLE
chore(application-system): fixing incorrect contentful ID

### DIFF
--- a/libs/application/templates/transport-authority/transfer-of-vehicle-ownership/src/lib/messages/information.ts
+++ b/libs/application/templates/transport-authority/transfer-of-vehicle-ownership/src/lib/messages/information.ts
@@ -260,7 +260,7 @@ export const information = {
         description: 'Main label - for main operator',
       },
       identicalError: {
-        id: 'ta.cov.application:information.labels.operator.identicalError',
+        id: 'ta.tvo.application:information.labels.operator.identicalError',
         defaultMessage: 'Það má ekki nota sömu kennitölu tvisvar',
         description: 'operator identical error',
       },


### PR DESCRIPTION
# ...

contentful id incorrectly referenced CoV application instead of TVO

## What

Specify what you're trying to achieve

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: claude


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected an internal message reference to ensure the appropriate operator labels are displayed consistently in the vehicle ownership transfer application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->