### PR TITLE
fix(web): show full institution name on Starfatorg vacancy detail

### DIFF
--- a/libs/api/domains/icelandic-government-institution-vacancies/src/lib/utils.spec.ts
+++ b/libs/api/domains/icelandic-government-institution-vacancies/src/lib/utils.spec.ts
@@ -1,5 +1,8 @@
+import type { Vacancy } from '@island.is/cms'
 import {
   mapIcelandicGovernmentInstitutionVacanciesFromElfur,
+  mapIcelandicGovernmentInstitutionVacancyByIdResponseFromCms,
+  mapVacancyListItemFromCms,
   sortVacancyList,
   VacancyWithCreationDate,
 } from './utils'
@@ -141,5 +144,34 @@ describe('mapIcelandicGovernmentInstitutionVacanciesFromElfur', () => {
     ])
 
     expect(result[0].fieldOfWork).toBeUndefined()
+  })
+})
+
+describe('CMS vacancy institution name', () => {
+  // Organizations may carry an abbreviation in shortTitle (e.g. "DMR" for
+  // Dómsmálaráðuneytið). The vacancy views have room for the full name, so
+  // both the list card and the detail panel must show `title`.
+  const vacancy = {
+    id: '1',
+    title: 'Tvö embætti héraðsdómara laus til umsóknar',
+    organization: {
+      id: 'org-1',
+      title: 'Dómsmálaráðuneytið',
+      shortTitle: 'DMR',
+      slug: 'domsmalaraduneytid',
+    },
+  } as Vacancy
+
+  it('should use the full organization title on the detail page', () => {
+    const result =
+      mapIcelandicGovernmentInstitutionVacancyByIdResponseFromCms(vacancy)
+
+    expect(result.institutionName).toBe('Dómsmálaráðuneytið')
+  })
+
+  it('should use the full organization title in the list', () => {
+    const result = mapVacancyListItemFromCms(vacancy)
+
+    expect(result.institutionName).toBe('Dómsmálaráðuneytið')
   })
 })

--- a/libs/api/domains/icelandic-government-institution-vacancies/src/lib/utils.ts
+++ b/libs/api/domains/icelandic-government-institution-vacancies/src/lib/utils.ts
@@ -329,8 +329,7 @@ export const mapIcelandicGovernmentInstitutionVacancyByIdResponseFromCms = (
     applicationDeadlineFrom: mapDate(vacancy.applicationDeadlineFrom),
     applicationDeadlineTo: mapDate(vacancy.applicationDeadlineTo),
     fieldOfWork: vacancy.fieldOfWork,
-    institutionName:
-      vacancy.organization?.shortTitle || vacancy.organization?.title,
+    institutionName: vacancy.organization?.title,
     institutionReferenceIdentifier: vacancy.organization?.referenceIdentifier,
     logoUrl: vacancy.organization?.logo?.url,
     locations,


### PR DESCRIPTION
Zendesk #629964

## What

On a Starfatorg vacancy detail page, the "Þjónustuaðili" card showed the organization's **abbreviation** instead of its name — `DMR` rather than `Dómsmálaráðuneytið`. The list card for the same vacancy showed the full name, so one vacancy appeared under two different institution names.

The CMS detail mapper used `organization.shortTitle || organization.title`; the list mapper used `organization.title`. This makes the detail mapper use `title` too.

Verified in production before the fix (same vacancy, both endpoints):

| endpoint | `institutionName` |
| --- | --- |
| `icelandicGovernmentInstitutionVacancies` (list) | `Dómsmálaráðuneytið` |
| `icelandicGovernmentInstitutionVacancyById` (detail) | `DMR` |

## Why

Reviewers may reasonably ask whether preferring `shortTitle` on the detail page was deliberate. The evidence says it was incidental:

1. **The two views used to agree.** Both mappers read the vacancy-specific `organization.nameInVacancyList` field until #11917 (Aug 2023) replaced it with two *different* expressions — `shortTitle || title` on detail, plain `title` on the list.
2. **#11917 was about something else.** Its description covers matching institutions via `stofnunNr` to pull logos and titles from the CMS. The `institutionName` change is not mentioned, and the checklist records no tests.
3. **The panel does not need a short name.** `InstitutionPanel` renders the name in `<Hyphen minRight={5}>` — it hyphenates and wraps long names, with no `truncate`, ellipsis or fixed height. Contrast the article page's purple `<Tag truncate>` chip, which is genuinely space-constrained and is where `shortTitle` earns its keep.
4. **The rest of the feature already shows full names.** 159 of the 165 live vacancies come from Elfur/X-Road, whose mappers use the full `orgName`/`stofnunHeiti` for *both* list and detail (spot-checked in prod: `Framhaldsskólinn í Mosfellsbæ` matches on both). The CMS path was the outlier.

**Known gap:** I could not read the historical `nameInVacancyList` values to confirm what the pre-2023 behaviour was. The field still exists on the Contentful `organization` content type but is no longer mapped into the GraphQL model, so it is not queryable via the API. If some organization does want a Starfatorg-specific short label, that dormant field is the right mechanism — not `shortTitle`, which is shared with article tag chips.

Scope: CMS-sourced vacancies only (6 of 165 live). 14 organizations currently have a `shortTitle` that differs from `title` — including Náttúruverndarstofnun (`NVS`), Umhverfis- og orkustofnun (`UOS`) and Framkvæmdasýslan – Ríkiseignir (`FSRE`) — so each would have hit this on its next vacancy.

## Screenshots / Gifs

n/a — text-only change. The "Þjónustuaðili" card now reads `Dómsmálaráðuneytið` instead of `DMR`.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code
