### PR TITLE
chore(j-s): remove unique recipients logic from notification

### DIFF
--- a/apps/judicial-system/backend/src/app/modules/court/court.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/court/court.service.ts
@@ -178,12 +178,7 @@ export class CourtService {
       })
     }
 
-    const uniqueRecipients = recipients.filter(
-      (recipient, index, all) =>
-        all.findIndex((r) => r.address === recipient.address) === index,
-    )
-
-    if (uniqueRecipients.length === 0) {
+    if (recipients.length === 0) {
       this.logger.error(
         `No email recipients are available for court ${courtId}, so it cannot be notified that a file was too large for the court service`,
       )
@@ -198,7 +193,7 @@ export class CourtService {
     const subject = `Ekki tókst að hlaða upp skjali í Auði í máli ${courtCaseNumber}`
 
     await Promise.all(
-      uniqueRecipients.map(async (recipient) => {
+      recipients.map(async (recipient) => {
         try {
           await this.emailService.sendEmail({
             from: {


### PR DESCRIPTION
[Asana](https://app.asana.com/1/203394141643832/project/1199153462262248/task/1217765606004634?focus=true)

## What

Just send the notification to all the emails we pick up (general court email, judge and registrar) with no deduping.

## Why

Its unlikely that any of these are ever the same email in production, and it complicates testing a bit when we often have our work email listed on many different users and want to ensure we get the notification for all of them



## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Cursor


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - File-size notifications are now sent to every listed recipient, including cases where the same email address appears more than once.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->