### PR TITLE
fix(j-s): Bump form-data from 3.0.0 to 4.0.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -206,7 +206,7 @@
     "firebase-admin": "11.5.0",
     "folder-hash": "4.0.0",
     "font-awesome": "4.7.0",
-    "form-data": "3.0.0",
+    "form-data": "4.0.6",
     "formik": "2.2.9",
     "fridagar": "^3.2.0",
     "fuse.js": "7.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -32243,17 +32243,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"form-data@npm:3.0.0":
-  version: 3.0.0
-  resolution: "form-data@npm:3.0.0"
-  dependencies:
-    asynckit: "npm:^0.4.0"
-    combined-stream: "npm:^1.0.8"
-    mime-types: "npm:^2.1.12"
-  checksum: 10/aea890ae3e8ce7eb55c6e61f84996066f450d1560c1d60f06f3c635037d4a3dce63715a1c2214c32d60737e93f4f570467dcbcade46dd4af63038af7f7a144d3
-  languageName: node
-  linkType: hard
-
 "form-data@npm:4.0.0":
   version: 4.0.0
   resolution: "form-data@npm:4.0.0"
@@ -32265,7 +32254,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"form-data@npm:4.0.5, form-data@npm:^4.0.0, form-data@npm:^4.0.4, form-data@npm:^4.0.5, form-data@npm:~4.0.4":
+"form-data@npm:4.0.5":
   version: 4.0.5
   resolution: "form-data@npm:4.0.5"
   dependencies:
@@ -32275,6 +32264,19 @@ __metadata:
     hasown: "npm:^2.0.2"
     mime-types: "npm:^2.1.12"
   checksum: 10/52ecd6e927c8c4e215e68a7ad5e0f7c1031397439672fd9741654b4a94722c4182e74cc815b225dcb5be3f4180f36428f67c6dd39eaa98af0dcfdd26c00c19cd
+  languageName: node
+  linkType: hard
+
+"form-data@npm:4.0.6, form-data@npm:^4.0.0, form-data@npm:^4.0.4, form-data@npm:^4.0.5, form-data@npm:~4.0.4":
+  version: 4.0.6
+  resolution: "form-data@npm:4.0.6"
+  dependencies:
+    asynckit: "npm:^0.4.0"
+    combined-stream: "npm:^1.0.8"
+    es-set-tostringtag: "npm:^2.1.0"
+    hasown: "npm:^2.0.4"
+    mime-types: "npm:^2.1.35"
+  checksum: 10/de6614c8537c92fa5fa3ee7e827758f98f5a9c033f348b7de81855ef36e5cb867e75d9f405d9483ab8d724a4a20d4e79926a299fa8dbba38f530eb659f0884e4
   languageName: node
   linkType: hard
 
@@ -33641,6 +33643,15 @@ __metadata:
   dependencies:
     function-bind: "npm:^1.1.2"
   checksum: 10/7898a9c1788b2862cf0f9c345a6bec77ba4a0c0983c7f19d610c382343d4f98fa260686b225dfb1f88393a66679d2ec58ee310c1d6868c081eda7918f32cc70a
+  languageName: node
+  linkType: hard
+
+"hasown@npm:^2.0.4":
+  version: 2.0.4
+  resolution: "hasown@npm:2.0.4"
+  dependencies:
+    function-bind: "npm:^1.1.2"
+  checksum: 10/13823863ae48161068b4c51606a3128451c66f14545a5169d667fe9fca168dcd38c27570c7a299e32ef844b8da3d55def7fe88602f8970d4311fb543ee88001a
   languageName: node
   linkType: hard
 
@@ -36225,7 +36236,7 @@ __metadata:
     firebase-admin: "npm:11.5.0"
     folder-hash: "npm:4.0.0"
     font-awesome: "npm:4.7.0"
-    form-data: "npm:3.0.0"
+    form-data: "npm:4.0.6"
     formik: "npm:2.2.9"
     fridagar: "npm:^3.2.0"
     fuse.js: "npm:7.0.0"


### PR DESCRIPTION
# Bump form-data from 3.0.0 to 4.0.6

## What

Bumps the root `form-data` pin from `3.0.0` to `4.0.6`, and runs `yarn dedupe form-data` so every `^4` consumer in the tree shares that single copy.

No source changes. The three call sites in the repo use only `new FormData()`, `append(field, value, options)`, `getHeaders()` and `getBuffer()`:

- `libs/judicial-system/court-client/src/lib/uploadStreamApi/uploadStreamApi.ts` (Buffer, via axios)
- `libs/dokobit-signing/src/lib/signing.service.ts` (strings, via node-fetch)
- `libs/content-search-toolkit/src/services/kibana.service.ts` (string, via node-fetch)

Two exact transitive pins cannot be deduped and stay where they are: `nx` → 4.0.5 and `ibm-cloud-sdk-core` → 4.0.0, both tooling rather than request paths. `jsdom` keeps its own 3.0.3 (test only).

## Why

**1. It was being reported as a production error.** `form-data@3.0.0` calls the deprecated `util.isArray` in `append()`, which Node 22 runtime-deprecates. Node's warning writer emits via `console.error`, and `console.error` is monkey patched to `logger.error` in `infra-nest-server`, so the DEP0044 process warning surfaced in Datadog as an application `error` on `judicial-system-backend` — once per pod, at the first court file upload (hence the case and request ids on the log line):

```
(node:1) [DEP0044] DeprecationWarning: The `util.isArray` API is deprecated. Please use `Array.isArray()` instead.
```

**2. Header escaping.** 4.0.6 escapes `\r`, `\n` and `"` in multipart `name`/`filename` parameters, so a filename can no longer break out of its `Content-Disposition` line. This is relevant to us: `sanitize()` in `judicial-system/formatters` only strips `"`, and `createCourtRecord` passes an unsanitized filename derived from `theCase.courtCaseNumber` straight into `options.filename`.

**3. CVE-2025-7783.** `form-data < 4.0.4` generates multipart boundaries with `Math.random`; 4.0.4+ uses `crypto.randomBytes`.

## Notes on behaviour changes

Verified by diffing the installed 3.0.0 against 4.0.6 rather than relying on the changelog:

- A plain court upload (Buffer + `{filename, contentType}`) produces a **byte-identical** multipart body, identical `getHeaders()` and the same `getLengthSync()`.
- `append(field, null | undefined)` no longer throws — 4.x coerces to the string `"null"`/`"undefined"`. All our appended values are typed non-nullable, so this is theoretical here.
- Confirmed axios does **not** switch to its spec-compliant-FormData path: `isSpecCompliantForm` also requires `Symbol.iterator`, which form-data has in neither version. `isFormData`, `isStream` and `isObject` all return the same values as before.
- For a filename containing `"`, the bytes on the wire do change (`%22` instead of a raw quote on the unsanitized path). That is the fix working as intended.

Not addressed here: any future `process.emitWarning` from any dependency will still land in Datadog as an `error` because of the `console.error` monkey patch. Fixing that class would mean a `process.on('warning', …)` handler in `libs/logging`, which changes log levels for every nest and next app — deliberately left out of this PR.

## Screenshots / Gifs


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated an underlying dependency to a newer version for improved compatibility and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->