### PR TITLE
chore(infra): Scale dev back down to norm but keep the clamp overwrite logic

### DIFF
--- a/apps/api/infra/api.ts
+++ b/apps/api/infra/api.ts
@@ -628,7 +628,6 @@ export const serviceSetup = (services: {
       max: 50,
       min: 3,
       cpuAverageUtilization: 70,
-      scaleToProdInDev: true, // TEMPORARY: load-test window
     })
     .strategy({
       // prod: zero-downtime. dev/staging: downtime is fine, roll faster.

--- a/apps/services/auth/ids-api/infra/identity-server.ts
+++ b/apps/services/auth/ids-api/infra/identity-server.ts
@@ -168,13 +168,6 @@ export const serviceSetup = (services: {
         memory: '1024Mi',
       },
     })
-    .replicaCount({
-      default: 3,
-      min: 3,
-      max: 10,
-      cpuAverageUtilization: 90,
-      scaleToProdInDev: true, // TEMPORARY: load-test window
-    })
     .healthPort(5010)
     .targetPort(5000)
     .serviceAccount('identity-server')

--- a/apps/services/auth/ids-api/infra/ids-api.ts
+++ b/apps/services/auth/ids-api/infra/ids-api.ts
@@ -145,7 +145,6 @@ export const serviceSetup = (): ServiceBuilder<'services-auth-ids-api'> => {
       default: 6,
       min: 6,
       max: 15,
-      scaleToProdInDev: true, // TEMPORARY: load-test window
     })
     .grantNamespaces('nginx-ingress-external', 'user-notification', 'datadog')
 }

--- a/apps/services/user-notification/infra/user-notification.ts
+++ b/apps/services/user-notification/infra/user-notification.ts
@@ -186,12 +186,6 @@ export const userNotificationServiceSetup = (services: {
         memory: '256Mi',
       },
     })
-    .replicaCount({
-      default: 3,
-      min: 3,
-      max: 10,
-      scaleToProdInDev: true, // TEMPORARY: load-test window
-    })
     .grantNamespaces(
       'nginx-ingress-internal',
       'islandis',

--- a/apps/services/user-profile/infra/service-portal-api.ts
+++ b/apps/services/user-profile/infra/service-portal-api.ts
@@ -77,7 +77,6 @@ export const serviceSetup = (): ServiceBuilder<typeof serviceId> =>
       default: 2,
       max: 30,
       min: 2,
-      scaleToProdInDev: true, // TEMPORARY: load-test window
     })
     .ingress({
       internal: {

--- a/apps/web/infra/web.ts
+++ b/apps/web/infra/web.ts
@@ -83,7 +83,6 @@ export const serviceSetup = (services: {
       max: 50,
       min: 3,
       cpuAverageUtilization: 70,
-      scaleToProdInDev: true, // TEMPORARY: load-test window
     })
     .extraAttributes({
       dev: {},

--- a/charts/identity-server-services/identity-server/values.dev.yaml
+++ b/charts/identity-server-services/identity-server/values.dev.yaml
@@ -81,8 +81,8 @@ hpa:
       cpuAverageUtilization: 90
       nginxRequestsIrate: 5
     replicas:
-      max: 10
-      min: 3
+      max: 2
+      min: 1
 httpRoute:
   primary-gw:
     hostnames:
@@ -109,9 +109,9 @@ pvcs:
     storageClass: 'efs-csi'
     useExisting: false
 replicaCount:
-  default: 3
-  max: 10
-  min: 3
+  default: 1
+  max: 2
+  min: 1
 resources:
   limits:
     cpu: '4000m'

--- a/charts/identity-server-services/identity-server/values.staging.yaml
+++ b/charts/identity-server-services/identity-server/values.staging.yaml
@@ -81,8 +81,8 @@ hpa:
       cpuAverageUtilization: 90
       nginxRequestsIrate: 5
     replicas:
-      max: 10
-      min: 3
+      max: 2
+      min: 1
 httpRoute:
   primary-gw:
     hostnames:
@@ -109,9 +109,9 @@ pvcs:
     storageClass: 'efs-csi'
     useExisting: false
 replicaCount:
-  default: 3
-  max: 10
-  min: 3
+  default: 1
+  max: 2
+  min: 1
 resources:
   limits:
     cpu: '4000m'

--- a/charts/identity-server-services/services-auth-ids-api/values.dev.yaml
+++ b/charts/identity-server-services/services-auth-ids-api/values.dev.yaml
@@ -83,8 +83,8 @@ hpa:
       cpuAverageUtilization: 90
       nginxRequestsIrate: 5
     replicas:
-      max: 15
-      min: 6
+      max: 2
+      min: 1
 image:
   repository: '821090935708.dkr.ecr.eu-west-1.amazonaws.com/services-auth-ids-api'
 initContainer:
@@ -132,9 +132,9 @@ podSecurityContext:
   fsGroup: 65534
 pvcs: []
 replicaCount:
-  default: 6
-  max: 15
-  min: 6
+  default: 1
+  max: 2
+  min: 1
 resources:
   limits:
     cpu: '800m'

--- a/charts/identity-server-services/services-auth-ids-api/values.staging.yaml
+++ b/charts/identity-server-services/services-auth-ids-api/values.staging.yaml
@@ -83,8 +83,8 @@ hpa:
       cpuAverageUtilization: 90
       nginxRequestsIrate: 5
     replicas:
-      max: 15
-      min: 6
+      max: 2
+      min: 1
 image:
   repository: '821090935708.dkr.ecr.eu-west-1.amazonaws.com/services-auth-ids-api'
 initContainer:
@@ -132,9 +132,9 @@ podSecurityContext:
   fsGroup: 65534
 pvcs: []
 replicaCount:
-  default: 6
-  max: 15
-  min: 6
+  default: 1
+  max: 2
+  min: 1
 resources:
   limits:
     cpu: '800m'

--- a/charts/identity-server/values.dev.yaml
+++ b/charts/identity-server/values.dev.yaml
@@ -160,8 +160,8 @@ identity-server:
         cpuAverageUtilization: 90
         nginxRequestsIrate: 5
       replicas:
-        max: 10
-        min: 3
+        max: 2
+        min: 1
   httpRoute:
     primary-gw:
       hostnames:
@@ -188,9 +188,9 @@ identity-server:
       storageClass: 'efs-csi'
       useExisting: false
   replicaCount:
-    default: 3
-    max: 10
-    min: 3
+    default: 1
+    max: 2
+    min: 1
   resources:
     limits:
       cpu: '4000m'
@@ -523,8 +523,8 @@ services-auth-ids-api:
         cpuAverageUtilization: 90
         nginxRequestsIrate: 5
       replicas:
-        max: 15
-        min: 6
+        max: 2
+        min: 1
   image:
     repository: '821090935708.dkr.ecr.eu-west-1.amazonaws.com/services-auth-ids-api'
   initContainer:
@@ -572,9 +572,9 @@ services-auth-ids-api:
     fsGroup: 65534
   pvcs: []
   replicaCount:
-    default: 6
-    max: 15
-    min: 6
+    default: 1
+    max: 2
+    min: 1
   resources:
     limits:
       cpu: '800m'

--- a/charts/identity-server/values.staging.yaml
+++ b/charts/identity-server/values.staging.yaml
@@ -160,8 +160,8 @@ identity-server:
         cpuAverageUtilization: 90
         nginxRequestsIrate: 5
       replicas:
-        max: 10
-        min: 3
+        max: 2
+        min: 1
   httpRoute:
     primary-gw:
       hostnames:
@@ -188,9 +188,9 @@ identity-server:
       storageClass: 'efs-csi'
       useExisting: false
   replicaCount:
-    default: 3
-    max: 10
-    min: 3
+    default: 1
+    max: 2
+    min: 1
   resources:
     limits:
       cpu: '4000m'
@@ -523,8 +523,8 @@ services-auth-ids-api:
         cpuAverageUtilization: 90
         nginxRequestsIrate: 5
       replicas:
-        max: 15
-        min: 6
+        max: 2
+        min: 1
   image:
     repository: '821090935708.dkr.ecr.eu-west-1.amazonaws.com/services-auth-ids-api'
   initContainer:
@@ -572,9 +572,9 @@ services-auth-ids-api:
     fsGroup: 65534
   pvcs: []
   replicaCount:
-    default: 6
-    max: 15
-    min: 6
+    default: 1
+    max: 2
+    min: 1
   resources:
     limits:
       cpu: '800m'

--- a/charts/islandis-services/api/values.dev.yaml
+++ b/charts/islandis-services/api/values.dev.yaml
@@ -230,8 +230,8 @@ hpa:
       cpuAverageUtilization: 70
       nginxRequestsIrate: 5
     replicas:
-      max: 50
-      min: 3
+      max: 2
+      min: 1
 httpRoute:
   primary-gw:
     hostnames:
@@ -254,9 +254,9 @@ podSecurityContext:
   fsGroup: 65534
 pvcs: []
 replicaCount:
-  default: 3
-  max: 50
-  min: 3
+  default: 1
+  max: 2
+  min: 1
 resources:
   limits:
     cpu: '3000m'

--- a/charts/islandis-services/api/values.staging.yaml
+++ b/charts/islandis-services/api/values.staging.yaml
@@ -230,8 +230,8 @@ hpa:
       cpuAverageUtilization: 70
       nginxRequestsIrate: 5
     replicas:
-      max: 50
-      min: 3
+      max: 2
+      min: 1
 httpRoute:
   primary-gw:
     hostnames:
@@ -253,9 +253,9 @@ podSecurityContext:
   fsGroup: 65534
 pvcs: []
 replicaCount:
-  default: 3
-  max: 50
-  min: 3
+  default: 1
+  max: 2
+  min: 1
 resources:
   limits:
     cpu: '3000m'

--- a/charts/islandis-services/service-portal-api/values.dev.yaml
+++ b/charts/islandis-services/service-portal-api/values.dev.yaml
@@ -68,8 +68,8 @@ hpa:
       cpuAverageUtilization: 90
       nginxRequestsIrate: 5
     replicas:
-      max: 30
-      min: 2
+      max: 2
+      min: 1
 httpRoute:
   internal-gw:
     hostnames:
@@ -113,9 +113,9 @@ podSecurityContext:
   fsGroup: 65534
 pvcs: []
 replicaCount:
-  default: 2
-  max: 30
-  min: 2
+  default: 1
+  max: 2
+  min: 1
 resources:
   limits:
     cpu: '800m'

--- a/charts/islandis-services/service-portal-api/values.staging.yaml
+++ b/charts/islandis-services/service-portal-api/values.staging.yaml
@@ -68,8 +68,8 @@ hpa:
       cpuAverageUtilization: 90
       nginxRequestsIrate: 5
     replicas:
-      max: 30
-      min: 2
+      max: 2
+      min: 1
 httpRoute:
   internal-gw:
     hostnames:
@@ -113,9 +113,9 @@ podSecurityContext:
   fsGroup: 65534
 pvcs: []
 replicaCount:
-  default: 2
-  max: 30
-  min: 2
+  default: 1
+  max: 2
+  min: 1
 resources:
   limits:
     cpu: '800m'

--- a/charts/islandis-services/user-notification/values.dev.yaml
+++ b/charts/islandis-services/user-notification/values.dev.yaml
@@ -85,8 +85,8 @@ hpa:
       cpuAverageUtilization: 90
       nginxRequestsIrate: 5
     replicas:
-      max: 10
-      min: 3
+      max: 2
+      min: 1
 httpRoute:
   internal-gw:
     hostnames:
@@ -116,9 +116,9 @@ podSecurityContext:
   fsGroup: 65534
 pvcs: []
 replicaCount:
-  default: 3
-  max: 10
-  min: 3
+  default: 1
+  max: 2
+  min: 1
 resources:
   limits:
     cpu: '400m'

--- a/charts/islandis-services/user-notification/values.staging.yaml
+++ b/charts/islandis-services/user-notification/values.staging.yaml
@@ -85,8 +85,8 @@ hpa:
       cpuAverageUtilization: 90
       nginxRequestsIrate: 5
     replicas:
-      max: 10
-      min: 3
+      max: 2
+      min: 1
 httpRoute:
   internal-gw:
     hostnames:
@@ -116,9 +116,9 @@ podSecurityContext:
   fsGroup: 65534
 pvcs: []
 replicaCount:
-  default: 3
-  max: 10
-  min: 3
+  default: 1
+  max: 2
+  min: 1
 resources:
   limits:
     cpu: '400m'

--- a/charts/islandis-services/web/values.dev.yaml
+++ b/charts/islandis-services/web/values.dev.yaml
@@ -56,8 +56,8 @@ hpa:
       cpuAverageUtilization: 70
       nginxRequestsIrate: 5
     replicas:
-      max: 50
-      min: 3
+      max: 2
+      min: 1
 httpRoute:
   primary-gw:
     hostnames:
@@ -78,9 +78,9 @@ podSecurityContext:
   fsGroup: 65534
 pvcs: []
 replicaCount:
-  default: 3
-  max: 50
-  min: 3
+  default: 1
+  max: 2
+  min: 1
 resources:
   limits:
     cpu: '3000m'

--- a/charts/islandis-services/web/values.staging.yaml
+++ b/charts/islandis-services/web/values.staging.yaml
@@ -57,8 +57,8 @@ hpa:
       cpuAverageUtilization: 70
       nginxRequestsIrate: 5
     replicas:
-      max: 50
-      min: 3
+      max: 2
+      min: 1
 httpRoute:
   primary-gw:
     hostnames:
@@ -79,9 +79,9 @@ podSecurityContext:
   fsGroup: 65534
 pvcs: []
 replicaCount:
-  default: 3
-  max: 50
-  min: 3
+  default: 1
+  max: 2
+  min: 1
 resources:
   limits:
     cpu: '3000m'

--- a/charts/islandis/values.dev.yaml
+++ b/charts/islandis/values.dev.yaml
@@ -339,8 +339,8 @@ api:
         cpuAverageUtilization: 70
         nginxRequestsIrate: 5
       replicas:
-        max: 50
-        min: 3
+        max: 2
+        min: 1
   httpRoute:
     primary-gw:
       hostnames:
@@ -363,9 +363,9 @@ api:
     fsGroup: 65534
   pvcs: []
   replicaCount:
-    default: 3
-    max: 50
-    min: 3
+    default: 1
+    max: 2
+    min: 1
   resources:
     limits:
       cpu: '3000m'
@@ -2729,8 +2729,8 @@ service-portal-api:
         cpuAverageUtilization: 90
         nginxRequestsIrate: 5
       replicas:
-        max: 30
-        min: 2
+        max: 2
+        min: 1
   httpRoute:
     internal-gw:
       hostnames:
@@ -2774,9 +2774,9 @@ service-portal-api:
     fsGroup: 65534
   pvcs: []
   replicaCount:
-    default: 2
-    max: 30
-    min: 2
+    default: 1
+    max: 2
+    min: 1
   resources:
     limits:
       cpu: '800m'
@@ -4328,8 +4328,8 @@ user-notification:
         cpuAverageUtilization: 90
         nginxRequestsIrate: 5
       replicas:
-        max: 10
-        min: 3
+        max: 2
+        min: 1
   httpRoute:
     internal-gw:
       hostnames:
@@ -4359,9 +4359,9 @@ user-notification:
     fsGroup: 65534
   pvcs: []
   replicaCount:
-    default: 3
-    max: 10
-    min: 3
+    default: 1
+    max: 2
+    min: 1
   resources:
     limits:
       cpu: '400m'
@@ -4779,8 +4779,8 @@ web:
         cpuAverageUtilization: 70
         nginxRequestsIrate: 5
       replicas:
-        max: 50
-        min: 3
+        max: 2
+        min: 1
   httpRoute:
     primary-gw:
       hostnames:
@@ -4801,9 +4801,9 @@ web:
     fsGroup: 65534
   pvcs: []
   replicaCount:
-    default: 3
-    max: 50
-    min: 3
+    default: 1
+    max: 2
+    min: 1
   resources:
     limits:
       cpu: '3000m'

--- a/charts/islandis/values.staging.yaml
+++ b/charts/islandis/values.staging.yaml
@@ -339,8 +339,8 @@ api:
         cpuAverageUtilization: 70
         nginxRequestsIrate: 5
       replicas:
-        max: 50
-        min: 3
+        max: 2
+        min: 1
   httpRoute:
     primary-gw:
       hostnames:
@@ -362,9 +362,9 @@ api:
     fsGroup: 65534
   pvcs: []
   replicaCount:
-    default: 3
-    max: 50
-    min: 3
+    default: 1
+    max: 2
+    min: 1
   resources:
     limits:
       cpu: '3000m'
@@ -2457,8 +2457,8 @@ service-portal-api:
         cpuAverageUtilization: 90
         nginxRequestsIrate: 5
       replicas:
-        max: 30
-        min: 2
+        max: 2
+        min: 1
   httpRoute:
     internal-gw:
       hostnames:
@@ -2502,9 +2502,9 @@ service-portal-api:
     fsGroup: 65534
   pvcs: []
   replicaCount:
-    default: 2
-    max: 30
-    min: 2
+    default: 1
+    max: 2
+    min: 1
   resources:
     limits:
       cpu: '800m'
@@ -4056,8 +4056,8 @@ user-notification:
         cpuAverageUtilization: 90
         nginxRequestsIrate: 5
       replicas:
-        max: 10
-        min: 3
+        max: 2
+        min: 1
   httpRoute:
     internal-gw:
       hostnames:
@@ -4087,9 +4087,9 @@ user-notification:
     fsGroup: 65534
   pvcs: []
   replicaCount:
-    default: 3
-    max: 10
-    min: 3
+    default: 1
+    max: 2
+    min: 1
   resources:
     limits:
       cpu: '400m'
@@ -4508,8 +4508,8 @@ web:
         cpuAverageUtilization: 70
         nginxRequestsIrate: 5
       replicas:
-        max: 50
-        min: 3
+        max: 2
+        min: 1
   httpRoute:
     primary-gw:
       hostnames:
@@ -4530,9 +4530,9 @@ web:
     fsGroup: 65534
   pvcs: []
   replicaCount:
-    default: 3
-    max: 50
-    min: 3
+    default: 1
+    max: 2
+    min: 1
   resources:
     limits:
       cpu: '3000m'

--- a/infra/src/dsl/output-generators/map-to-helm-values.ts
+++ b/infra/src/dsl/output-generators/map-to-helm-values.ts
@@ -146,9 +146,8 @@ const serializeService: SerializeMethod<HelmService> = async (
   if (
     (env1.type == 'staging' || env1.type == 'dev') &&
     service.name.indexOf('search-indexer') == -1 &&
-    // TEMPORARY (load-test window): services with scaleToProdInDev opt out of
-    // the dev/staging replica clamp and use their explicit replicaCount instead.
-    !serviceDef.replicaCount?.scaleToProdInDev
+    // bypassReplicaClamp services keep their explicit replicaCount in dev/staging.
+    !serviceDef.replicaCount?.bypassReplicaClamp
   ) {
     result.replicaCount = {
       min: 1,

--- a/infra/src/dsl/types/input-types.ts
+++ b/infra/src/dsl/types/input-types.ts
@@ -257,12 +257,10 @@ export type ReplicaCount = {
   scalingMagicNumber?: number
   cpuAverageUtilization?: number
   /**
-   * TEMPORARY (load-test window): opt this service out of the dev/staging
-   * `min: 1, max: 2, default: 1` clamp so its explicit min/max/default and
-   * cpuAverageUtilization are used in dev/staging too. Leave unset for normal
-   * cost-saving behaviour. Remove once the load test is over.
+   * Opt this service out of the dev/staging `min:1, max:2` cost-saving clamp
+   * so its explicit `replicaCount` applies there too (e.g. for load testing).
    */
-  scaleToProdInDev?: boolean
+  bypassReplicaClamp?: boolean
 }
 
 type Container = {


### PR DESCRIPTION

This reverts commit f96d61b35073b56bcffb087a7f3b6599664c78b2.

# ...

Attach a link to issue if relevant

## What

Specify what you're trying to achieve

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: GPT


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Development and staging deployments now use standard configured replica counts instead of temporarily scaling to production levels.
  * Default scaling behavior is restored for API, web, authentication, notification, and profile services.
  * Removed the temporary replica-scaling option from service configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->