### PR TITLE
feat(user-notification): Allow users with scope internal to see all notifications that belong to the.

### DIFF
--- a/apps/services/user-notification/src/app/modules/notifications/me-notifications.controller.ts
+++ b/apps/services/user-notification/src/app/modules/notifications/me-notifications.controller.ts
@@ -56,7 +56,6 @@ export class MeNotificationsController {
       user.nationalId,
       query,
       user.scope,
-      !user.actor, // first-party only; a delegate always carries `actor`
     )
   }
 

--- a/apps/services/user-notification/src/app/modules/notifications/me-notifications.controller.ts
+++ b/apps/services/user-notification/src/app/modules/notifications/me-notifications.controller.ts
@@ -56,6 +56,7 @@ export class MeNotificationsController {
       user.nationalId,
       query,
       user.scope,
+      !user.actor, // first-party only; a delegate always carries `actor`
     )
   }
 

--- a/apps/services/user-notification/src/app/modules/notifications/notifications.service.ts
+++ b/apps/services/user-notification/src/app/modules/notifications/notifications.service.ts
@@ -40,7 +40,7 @@ import {
   GetTemplates,
   GetOrganizationByNationalId,
 } from '@island.is/clients/cms'
-import { DocumentsScope } from '@island.is/auth/scopes'
+import { ApiScope, DocumentsScope } from '@island.is/auth/scopes'
 import { Op } from 'sequelize'
 
 /**
@@ -359,6 +359,7 @@ export class NotificationsService {
     nationalId: string,
     query: ExtendedPaginationDto,
     scopes: string[],
+    isFirstParty: boolean,
   ): Promise<PaginatedNotificationDto> {
     const locale = mapToLocale(query.locale as Locale)
     const templates = await this.getTemplates(locale)
@@ -372,9 +373,17 @@ export class NotificationsService {
       orderOption: [['id', 'DESC']],
       where: {
         recipient: nationalId,
-        scope: {
-          [Op.in]: scopes || [DocumentsScope.main],
-        },
+        // A first-party caller holding @island.is/internal ("all my own data")
+        // sees every one of their own notifications. Delegates always carry an
+        // actor (isFirstParty === false) and stay constrained to the scopes
+        // their delegation granted.
+        ...(isFirstParty && scopes.includes(ApiScope.internal)
+          ? {}
+          : {
+              scope: {
+                [Op.in]: scopes || [DocumentsScope.main],
+              },
+            }),
       },
     })
 

--- a/apps/services/user-notification/src/app/modules/notifications/notifications.service.ts
+++ b/apps/services/user-notification/src/app/modules/notifications/notifications.service.ts
@@ -359,7 +359,6 @@ export class NotificationsService {
     nationalId: string,
     query: ExtendedPaginationDto,
     scopes: string[],
-    isFirstParty: boolean,
   ): Promise<PaginatedNotificationDto> {
     const locale = mapToLocale(query.locale as Locale)
     const templates = await this.getTemplates(locale)
@@ -373,11 +372,9 @@ export class NotificationsService {
       orderOption: [['id', 'DESC']],
       where: {
         recipient: nationalId,
-        // A first-party caller holding @island.is/internal ("all my own data")
-        // sees every one of their own notifications. Delegates always carry an
-        // actor (isFirstParty === false) and stay constrained to the scopes
-        // their delegation granted.
-        ...(isFirstParty && scopes.includes(ApiScope.internal)
+        // Callers with @island.is/internal see all their own notifications,
+        // regardless of scope (recipient still restricts to their own).
+        ...(scopes.includes(ApiScope.internal)
           ? {}
           : {
               scope: {


### PR DESCRIPTION
What

Users holding the @island.is/internal scope now receive all notifications that belong to them, regardless of the notification's bucket scope.

Previously the notifications list filtered on an exact scope IN (caller's scopes) match. Clients following least-privilege that request only narrow sub-scopes (e.g. @island.is/health/medicines rather than the broad @island.is/health) never matched the broad bucket scope stamped on their notifications, so those notifications silently disappeared from the list — even though they were the user's own.

Why

@island.is/internal is intended to mean "everything that belongs to the user themselves." Keying notification visibility off it lets least-privilege clients see their own notifications without having to over-request broad bucket scopes just to receive them.

The recipient = nationalId filter is always applied, so this only ever widens which of the user's own buckets are returned — it can never expose another person's notifications. Delegated access stays correctly scoped because @island.is/internal is not delegatable, so it never appears in a delegate's token.


## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved notification retrieval for internal scopes.
  - Notifications using internal access scopes are now returned correctly without requiring an additional first-party setting.
  - Existing scope filtering remains unchanged for other notification requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->