### PR TITLE
fix(j-s): Correct verdict service record for S-2595/2026

### DIFF
--- a/apps/judicial-system/backend/migrations/20260904125154-fix-verdict-service-status.js
+++ b/apps/judicial-system/backend/migrations/20260904125154-fix-verdict-service-status.js
@@ -1,0 +1,30 @@
+'use strict'
+
+// A verdict was mistakenly registered as published in Lögbirtingablaðið on
+// 10 July 2026. It was never published there — it was served in person on
+// 2 September 2026 at 09:50.
+module.exports = {
+  async up(queryInterface) {
+    return queryInterface.sequelize.transaction((transaction) =>
+      queryInterface.sequelize.query(
+        `UPDATE verdict
+         SET service_status = :serviceStatus,
+             service_date = :serviceDate,
+             served_by = :servedBy
+         WHERE id = :verdictId
+         AND service_status = 'LEGAL_PAPER'`,
+        {
+          replacements: {
+            verdictId: 'a09894a6-aaa3-4818-a0bb-7d4f81aa5d37',
+            serviceStatus: 'IN_PERSON',
+            serviceDate: '2026-09-02 09:50:00.000000+00',
+            servedBy: 'Anna Guðný Möller',
+          },
+          transaction,
+        },
+      ),
+    )
+  },
+
+  down: () => Promise.resolve(),
+}


### PR DESCRIPTION
# Correct verdict service record for S-2595/2026

Asana: https://app.asana.com/0/0/1218060241597460

## What

One-off data migration correcting the service record of a single verdict in case S-2595/2026 (Héraðsdómur Reykjavíkur):

- `service_status`: `LEGAL_PAPER` → `IN_PERSON`
- `service_date`: 10 July 2026 → 2 September 2026 09:50
- `served_by`: → `Anna Guðný Möller`

The update is guarded on the current `LEGAL_PAPER` status, so it is self-limiting and a second run matches nothing. `down` is a no-op, matching the other data-fix migrations in this directory.

## Why

The verdict was mistakenly registered as published in Lögbirtingablaðið on 10 July 2026. It was never published there — it was served in person on 2 September 2026 at 09:50. RVG therefore showed the wrong alert ("Dómur birtur í Lögbirtingablaðinu - 10.07.2026") and computed the appeal deadline from the wrong date.

There is no UI or API path to correct this: `serviceStatus` is deliberately excluded from `UpdateVerdictDto` because only the police/LÖKE integration sets it, so a migration is the established fix.

Notes from the investigation:

- This is bad data in this one case, not a systemic bug. The verdict certificate reads only `verdict.service_date` and never touches the subpoena, which has its own column. The wrong date arrived from LÖKE via the delivery callback's `PUBLISH_DATE` supplement.
- The birtingarvottorð downloaded in RVG is rendered live from the database on every request, so it is correct immediately after this migration with no user action.
- The copy previously delivered to LÖKE is a one-time snapshot gated by a `VERDICT_SERVICE_CERTIFICATE_DELIVERED_TO_POLICE` event log row. That row is deliberately left in place — the corrected certificate is uploaded to LÖKE manually rather than re-delivered by the nightly job.
- The appeal deadline is derived from `service_date`, so it now runs from 2 September 2026.

## Screenshots / Gifs

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the service status, service date, and serving official for a specific verdict record.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->