### PR TITLE
fix(my-pages): show every ÍSAT classification on the company page

### DIFF
--- a/libs/portals/my-pages/information/src/screens/Company/CompanyInfo.tsx
+++ b/libs/portals/my-pages/information/src/screens/Company/CompanyInfo.tsx
@@ -2,7 +2,7 @@ import format from 'date-fns/format'
 import React from 'react'
 import { defineMessage } from 'react-intl'
 
-import { Divider, Stack } from '@island.is/island-ui/core'
+import { Box, Divider, Stack, Text } from '@island.is/island-ui/core'
 import { useLocale, useNamespaces } from '@island.is/localization'
 import {
   FootNote,
@@ -47,13 +47,19 @@ const CompanyInfo = () => {
       : ''
 
   const vatDisplay = companyInfo?.vat.filter(
-    (item) => item.dateOfDeregistration === null,
+    (item) => !item.dateOfDeregistration,
   )
-  const vatClassification =
-    vatDisplay?.[0]?.classification?.[0]?.number &&
-    vatDisplay?.[0]?.classification?.[0]?.name
-      ? `${vatDisplay?.[0]?.classification?.[0]?.number} ${vatDisplay?.[0]?.classification?.[0]?.name}`
-      : ''
+
+  // A company can be registered for several ISAT activities (one main number
+  // and any number of secondary ones), so every classification on the active
+  // VAT registrations is listed, not just the first one.
+  const vatClassifications = (vatDisplay ?? [])
+    .flatMap((item) => item.classification ?? [])
+    .filter((item) => item.number && item.name)
+    .filter(
+      (item, index, all) =>
+        all.findIndex((other) => other.number === item.number) === index,
+    )
 
   const emptyData = data?.companyRegistryCompany === null
 
@@ -132,7 +138,19 @@ const CompanyInfo = () => {
           <Divider />
           <UserInfoLine
             label={formatMessage(mCompany.industryClass)}
-            content={vatClassification}
+            content={
+              vatClassifications.length ? (
+                <Box>
+                  {vatClassifications.map((item) => (
+                    <Text key={item.number} variant="default">
+                      {`${item.number} ${item.name}`}
+                    </Text>
+                  ))}
+                </Box>
+              ) : (
+                ''
+              )
+            }
             loading={loading}
           />
           <Divider />


### PR DESCRIPTION
Zendesk 629202

## What

On Mínar síður → Fyrirtæki → Upplýsingar, the "ÍSAT Atvinnugreinaflokkun" line rendered only `vat[0].classification[0]`. A company registered for more than one ÍSAT activity — one main number ("Aðal") plus any number of secondary ones ("Aukanúmer") — had every entry after the first silently dropped.

Now every classification on the active VAT registrations is listed, one per line, deduplicated by number. Also relaxed the "active registration" test from `dateOfDeregistration === null` to `!dateOfDeregistration`, so an absent date counts as active regardless of whether it arrives as `null` or `undefined`.

## Why

Reported via Zendesk: a company had two activities registered at Skatturinn but only one showed on Ísland.is, which caused them bookkeeping trouble. The data was already reaching the frontend in full — `libs/clients/rsk/company-registry` maps the whole `flokkun` array and the GraphQL query selects it — so this was purely the screen discarding it.

One thing this does **not** change, worth knowing for follow-up tickets: the numbers on this line come from the **VAT register** (`companyInfo.vat[].classification[]`), not the company register. RSK's `ft-v1` API has no company-level classification field at all — `flokkun` exists only nested under `virdisaukaskattur[]`, confirmed in both the committed `clientConfig.json` (`company_item`) and the generated `CompanyItem`. So where Skatturinn's own two registers disagree on the main number for a company, Ísland.is will keep showing the VAT-register value. That gap is in their data, not in our rendering.

## Screenshots / Gifs

No visual change for the common single-activity case. For a company with a main plus a secondary activity, the line goes from one row to one row per code, e.g.:

```
before:  ÍSAT Atvinnugreinaflokkun    79.90.0 Önnur bókunarþjónusta og önnur starfsemi tengd ferðaþjónustu

after:   ÍSAT Atvinnugreinaflokkun    79.90.0 Önnur bókunarþjónusta og önnur starfsemi tengd ferðaþjónustu
                                      77.11.0 Leiga á bifreiðum og léttum vélknúnum ökutækjum
```

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - VAT classifications now include information from all active VAT registrations with valid details.
  - Duplicate classifications are removed based on registration number.
  - Industry classifications are displayed as separate lines for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->