### PR TITLE
fix(doe): Abendingar shortlist for application

### DIFF
--- a/libs/application/templates/directorate-of-equality/salary-report/src/fields/SalaryAnalysisResults/PayDispersionTable.tsx
+++ b/libs/application/templates/directorate-of-equality/salary-report/src/fields/SalaryAnalysisResults/PayDispersionTable.tsx
@@ -95,6 +95,12 @@ const formatSpreads = (value: number | null | undefined): string => {
   return `${sign}${roundedValue.toFixed(2).replace('.', ',')}`
 }
 
+// The pool figures are plain counts, but they count a whole workforce — four
+// digits on a large company — so they take the same is-IS grouping as every
+// other figure in the report rather than being interpolated raw.
+const formatCount = (value: number): string =>
+  value.toLocaleString('is-IS', { maximumFractionDigits: 0 })
+
 const blockerMessage = (
   code: PayDispersionBlocker,
   formatMessage: ReturnType<typeof useLocale>['formatMessage'],
@@ -161,20 +167,34 @@ export const PayDispersionTable = ({ payDispersion }: Props) => {
           <Text marginBottom={2} fontWeight="semiBold">
             {formatMessage(p.noObligation)}
           </Text>
-          {payDispersion.cohortResidualSpreadPercentUp != null &&
-            payDispersion.cohortResidualSpreadPercentDown != null && (
-              <Text variant="small" color="dark350" marginBottom={2}>
-                {formatMessage(p.spreadNote, {
-                  down: `${formatSignedPercentMagnitude(
-                    payDispersion.cohortResidualSpreadPercentDown,
-                  )}%`,
-                  up: `${formatSignedPercentMagnitude(
-                    payDispersion.cohortResidualSpreadPercentUp,
-                  )}%`,
-                  threshold: String(payDispersion.threshold).replace('.', ','),
-                })}
-              </Text>
-            )}
+          {/* One block, so `counts` can never be separated from `listRule` —
+              see the note on those two messages. The spread band is the only
+              line of the three that can be missing. */}
+          <Box marginBottom={2}>
+            {payDispersion.cohortResidualSpreadPercentUp != null &&
+              payDispersion.cohortResidualSpreadPercentDown != null && (
+                <Text variant="small" color="dark350">
+                  {formatMessage(p.spreadNote, {
+                    down: `${formatSignedPercentMagnitude(
+                      payDispersion.cohortResidualSpreadPercentDown,
+                    )}%`,
+                    up: `${formatSignedPercentMagnitude(
+                      payDispersion.cohortResidualSpreadPercentUp,
+                    )}%`,
+                  })}
+                </Text>
+              )}
+            <Text variant="small" color="dark350">
+              {formatMessage(p.counts, {
+                threshold: String(payDispersion.threshold).replace('.', ','),
+                below: formatCount(payDispersion.countBelowExpected),
+                above: formatCount(payDispersion.countAboveExpected),
+              })}
+            </Text>
+            <Text variant="small" color="dark350">
+              {formatMessage(p.listRule)}
+            </Text>
+          </Box>
 
           <T.Table>
             <T.Head>
@@ -194,9 +214,9 @@ export const PayDispersionTable = ({ payDispersion }: Props) => {
                   {formatMessage(o.deviationColumn)}
                 </HeadCell>
                 {/* The one column with no counterpart in the úrbótaáætlun
-                    table, and it stays: it is the figure that put the row on
-                    this list, stated in the same units as the threshold in the
-                    note above. */}
+                    table, and it stays: it is the figure that both put the row
+                    in the pool and ranked it onto this list, stated in the same
+                    units as the threshold in the note above. */}
                 <HeadCell align="right">
                   {formatMessage(p.spreadHeader)}
                 </HeadCell>

--- a/libs/application/templates/directorate-of-equality/salary-report/src/lib/messages.ts
+++ b/libs/application/templates/directorate-of-equality/salary-report/src/lib/messages.ts
@@ -1330,7 +1330,24 @@ export const messages = {
       spreadNote: {
         id: 'doe.sr.application:salaryAnalysis.payDispersion.spreadNote',
         defaultMessage:
-          'Dæmigerð dreifing um línuna hjá þessu fyrirtæki er {down} til {up}. Hér eru starfsmenn sem víkja {threshold} staðalvik eða meira frá henni.',
+          'Dæmigerð dreifing um línuna hjá þessu fyrirtæki er {down} til {up}.',
+      },
+      // `counts` states the pool the ábendingar were drawn from — everyone past
+      // the threshold — NOT the number of ábendingar. It must always be
+      // followed by `listRule`: on its own it invites the reader to add the two
+      // figures and ask where the missing rows went. It is also the only place
+      // the threshold is now stated, which is what gives the "Staðalvik frá
+      // línu" column its unit — spreadNote used to carry that and no longer
+      // can, because the list is no longer defined by the threshold alone.
+      counts: {
+        id: 'doe.sr.application:salaryAnalysis.payDispersion.counts',
+        defaultMessage:
+          'Starfsmenn sem víkja {threshold} staðalvik eða meira frá línunni: {below} niður, {above} upp.',
+      },
+      listRule: {
+        id: 'doe.sr.application:salaryAnalysis.payDispersion.listRule',
+        defaultMessage:
+          'Ábendingar eru gerðar um þá sem víkja mest í hvora átt.',
       },
       allClear: {
         id: 'doe.sr.application:salaryAnalysis.payDispersion.allClear',

--- a/libs/application/templates/directorate-of-equality/salary-report/src/utils/salaryAnalysisNavigation.spec.ts
+++ b/libs/application/templates/directorate-of-equality/salary-report/src/utils/salaryAnalysisNavigation.spec.ts
@@ -111,6 +111,8 @@ describe('salary analysis outlier navigation flags', () => {
           population: 'ALL_EMPLOYEES',
           threshold: 2,
           employees: [dispersionRow(1)],
+          countBelowExpected: 1,
+          countAboveExpected: 0,
         },
       } as Partial<SalaryAnalysisResponseDto>),
     )
@@ -126,6 +128,8 @@ describe('salary analysis outlier navigation flags', () => {
             population: 'ALL_EMPLOYEES',
             threshold: 2,
             employees: [dispersionRow(1)],
+            countBelowExpected: 1,
+            countAboveExpected: 0,
           },
         } as Partial<SalaryAnalysisResponseDto>),
         { resetReviewed: true },

--- a/libs/clients/directorate-of-equality/src/clientConfig.json
+++ b/libs/clients/directorate-of-equality/src/clientConfig.json
@@ -3766,6 +3766,19 @@
           "employees": {
             "type": "array",
             "items": { "$ref": "#/components/schemas/PayDispersionEmployeeDto" }
+          },
+          "countBelowExpected": {
+            "type": "number",
+            "description": "CONTEXT — how many employees sit more than `threshold` spreads BELOW the fitted line. This is the POOL the ábendingar were drawn from, not a count of ábendingar: the list is the most extreme few per direction, and `employees` holds all of them. Print it to show the instrument is a triage of something larger; do not present it as a number of findings. Zero when unavailable."
+          },
+          "countAboveExpected": {
+            "type": "number",
+            "description": "The same for ABOVE the fitted line — context, not a count of ábendingar. Zero when unavailable."
+          },
+          "chanceCriticalSpreads": {
+            "type": "number",
+            "nullable": true,
+            "description": "CONTEXT ONLY — never a filter. The familywise critical value z(0,05 / 2n): the distance past which chance alone would rarely put ANY of this company's employees. It grows with headcount (3,5 at 120 employees, 4,6 at 10 000) because screening more people produces more extremes, and it exists so a reader can tell a long list on a large workforce from a real finding. ⚠️ Do NOT filter rows on it: `threshold` decides membership. Null when no list could be produced."
           }
         },
         "required": [
@@ -3773,7 +3786,9 @@
           "blockers",
           "population",
           "threshold",
-          "employees"
+          "employees",
+          "countBelowExpected",
+          "countAboveExpected"
         ]
       },
       "SalaryAnalysisResponseDto": {
@@ -3925,7 +3940,11 @@
             "description": "FK to the approved EQUALITY report this salary was audited against."
           },
           "importedFromExcel": { "type": "boolean" },
-          "providerId": { "type": "string" },
+          "providerId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Upstream island.is application UUID, stored as the report provider_id."
+          },
           "companyAdminName": { "type": "string" },
           "companyAdminTitle": {
             "type": "string",
@@ -4011,7 +4030,11 @@
       "SubmitEqualityReportDto": {
         "type": "object",
         "properties": {
-          "providerId": { "type": "string" },
+          "providerId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Upstream island.is application UUID, stored as the report provider_id."
+          },
           "companyAdminName": { "type": "string" },
           "companyAdminTitle": {
             "type": "string",
@@ -4652,6 +4675,7 @@
           "type": { "type": "string", "enum": ["SALARY", "EQUALITY"] },
           "providerId": {
             "type": "string",
+            "format": "uuid",
             "description": "Upstream island.is application UUID, stored as the report provider_id."
           },
           "company": { "$ref": "#/components/schemas/CreateDraftCompanyDto" }


### PR DESCRIPTION
  ## What

  DMR redefined `payDispersion` for "Ábendingar um launadreifingu". The list used to be
  *every* employee past the |t| ≥ 2 threshold; it is now a triage list — the employees who
  deviate most in each direction, up to ten each way (extended to keep identical printed
  |t| together, hard-capped at 50 per direction). The threshold itself is unchanged.

  - **`messages.ts`** — `payDispersion.spreadNote` dropped its second sentence
    ("Hér eru starfsmenn sem víkja {threshold} staðalvik eða meira frá henni"), which
    defined the list by the threshold alone and is no longer what the list is.
  - **`messages.ts`** — added `payDispersion.counts` and `payDispersion.listRule`, stating
    the pool the ábendingar were drawn from and the rule by which they were selected.
  - **`PayDispersionTable.tsx`** — renders the three note lines as one block so `counts`
    can never appear without `listRule` following it. Added a `formatCount` helper using
    the file's existing `is-IS` grouping, since the pool runs to four digits on a large
    workforce.
  - **`clientConfig.json`** — regenerated. Adds `countBelowExpected` and
    `countAboveExpected` (both required) and `chanceCriticalSpreads` (nullable).
    Affects `analyzeApplicationSalaryReport`, `getApplicationDraftAnalysis` and
    `getApplicationReport`.
  - **`salaryAnalysisNavigation.spec.ts`** — fixtures updated for the two new required
    fields.

  The section now reads:

  ```
  Dæmigerð dreifing um línuna hjá þessu fyrirtæki er −16,35% til +19,55%.
  Starfsmenn sem víkja 2 staðalvik eða meira frá línunni: 12 niður, 9 upp.
  Ábendingar eru gerðar um þá sem víkja mest í hvora átt.
  ```

  ## Why

  `spreadNote` promised more than the list contains. On a workforce over ~430 employees the
  list is a subset of everyone past the threshold, so the old sentence told the applicant
  they were looking at all of them. That is the one user-visible inaccuracy this change
  fixes.

  Dropping that sentence removes the only place the threshold was stated, which would have
  left the "Staðalvik frá línu" column printing values with no stated unit or cut-off
  anywhere on the page. `counts` restores it, and `listRule` has to follow `counts` —
  on its own, the two pool figures invite the reader to add them up and ask where the
  remaining rows went.

  `countBelowExpected` / `countAboveExpected` are the **pool**, not a count of ábendingar,
  and are not presented as findings. `chanceCriticalSpreads` is not consumed: membership is
  decided by `threshold`, never by that field.

  No behavioural change to the three existing consumers — the all-clear check, the row
  rendering and the chart's ring set all treat `employees` as the list of ábendingar, which
  is still exactly what it is.

  ## Screenshots / Gifs

  <!-- Ábendingar section with rows, ideally on a company over ~430 employees so the
       pool figures exceed the number of listed rows. -->

  ## Notes for reviewers

  - Two optional parity items from DMR's handover were deliberately left out: the
    `chanceNote` sentence about `chanceCriticalSpreads`, and splitting the table under
    `Undir` / `Yfir væntanlegu tímakaupi` headings. Neither affects correctness.
  - `nx lint` cannot run in this workspace — `Failed to load plugin 'storybook'`,
    `ERR_REQUIRE_ESM`. Pre-existing and reproduces on unrelated projects.
  - Verified: `tsc -p tsconfig.spec.json` clean for this project, `nx test` 176 passed /
    16 suites. (Two pre-existing `Field[] | FormLeaf[]` errors in `reportSection.spec.ts`
    are untouched and unrelated.)
  - `extract-strings` needs running to publish the two new message ids to Contentful.

  ## Checklist:

  - [ ] I have performed a self-review of my own code
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] Formatting passes locally with my changes
  - [x] I have rebased against main before asking for a review
  - [ ] No AI tools were used in preparing this pull request
  - [x] AI tools were used in preparing this pull request
        Tools used: Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Pay dispersion results now show the number of employees below and above the expected pay range.
  - Counts use localized number formatting for improved readability.
  - Results clarify that recommendations focus on employees with the greatest deviations in each direction.
  - Spread information is displayed when relevant, with clearer threshold details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->