### PR TITLE
feat(old-age-pension): ask about one yearly payment before the income plan

### DIFF
--- a/libs/application/template-api-modules/src/lib/modules/templates/social-insurance-administration/social-insurance-administration-utils.spec.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/social-insurance-administration/social-insurance-administration-utils.spec.ts
@@ -3,8 +3,17 @@ import {
   RatioType,
 } from '@island.is/application/templates/social-insurance-administration/old-age-pension'
 import {
+  ApplicationWithAttachments as Application,
+  ApplicationStatus,
+  ApplicationTypes,
+  ExternalData,
+  FormValue,
+} from '@island.is/application/types'
+import { NO, YES } from '@island.is/application/core'
+import {
   getMonthNumber,
   getEmployers,
+  transformApplicationToOldAgePensionDTO,
 } from './social-insurance-administration-utils'
 
 describe('Old age pesion utils', () => {
@@ -73,5 +82,61 @@ describe('getEmployers', () => {
     const res = getEmployers(employersAnswers)
 
     expect(res).toEqual(employerInfo)
+  })
+})
+
+describe('transformApplicationToOldAgePensionDTO', () => {
+  const buildApplication = (answers: FormValue): Application => ({
+    id: '12345',
+    assignees: [],
+    applicant: '0101307789',
+    typeId: ApplicationTypes.OLD_AGE_PENSION,
+    created: new Date(),
+    modified: new Date(),
+    attachments: {},
+    applicantActors: [],
+    answers: {
+      period: { year: '2026', month: 'January' },
+      ...answers,
+    },
+    state: 'draft',
+    externalData: {} as ExternalData,
+    status: ApplicationStatus.IN_PROGRESS,
+  })
+
+  it('should omit awarenessOfIncomeDeclaration when the income plan was skipped', () => {
+    // A single yearly payment skips the income plan screens, so the applicant
+    // is never asked to declare anything about other income.
+    const application = buildApplication({
+      onePaymentPerYear: { question: YES },
+      incomePlanTable: [],
+    })
+
+    const res = transformApplicationToOldAgePensionDTO(application, [])
+
+    expect(res.hasOneTimePayment).toBe(true)
+    expect(res.incomePlan.incomeTypes).toEqual([])
+    expect(res).not.toHaveProperty('awarenessOfIncomeDeclaration')
+  })
+
+  it('should send awarenessOfIncomeDeclaration when an all-zero income plan was filled in', () => {
+    const application = buildApplication({
+      onePaymentPerYear: { question: NO },
+      incomePlanTable: [
+        {
+          incomeCategory: 'Atvinnutekjur',
+          incomeType: 'Launatekjur',
+          income: 'yearly',
+          incomePerYear: '0',
+          currency: 'ISK',
+        },
+      ],
+      incomePlan: { noOtherIncomeConfirmation: YES },
+    })
+
+    const res = transformApplicationToOldAgePensionDTO(application, [])
+
+    expect(res.hasOneTimePayment).toBe(false)
+    expect(res.awarenessOfIncomeDeclaration).toBe(true)
   })
 })

--- a/libs/application/template-api-modules/src/lib/modules/templates/social-insurance-administration/social-insurance-administration-utils.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/social-insurance-administration/social-insurance-administration-utils.ts
@@ -164,9 +164,13 @@ export const transformApplicationToOldAgePensionDTO = (
       }),
     }),
     uploads,
-    ...(incomePlanHasOnlyZeroIncome(incomePlan) && {
-      awarenessOfIncomeDeclaration: noOtherIncomeConfirmation === YES,
-    }),
+    // incomePlanHasOnlyZeroIncome is vacuously true for an empty plan, so also
+    // require rows: when the applicant asked for a single yearly payment the
+    // income plan screens are skipped and no declaration was ever made.
+    ...(incomePlan.length > 0 &&
+      incomePlanHasOnlyZeroIncome(incomePlan) && {
+        awarenessOfIncomeDeclaration: noOtherIncomeConfirmation === YES,
+      }),
   }
 
   return oldAgePensionDTO

--- a/libs/application/templates/social-insurance-administration/old-age-pension/src/fields/Review/index.tsx
+++ b/libs/application/templates/social-insurance-administration/old-age-pension/src/fields/Review/index.tsx
@@ -30,6 +30,7 @@ import {
 import { OverviewFormField } from '@island.is/application/ui-fields'
 import { oldAgePensionFormMessage } from '../../lib/messages'
 import { ApplicationType } from '../../utils/constants'
+import { shouldShowIncomePlan } from '../../utils/conditionUtils'
 import { getApplicationAnswers } from '../../utils/oldAgePensionUtils'
 import {
   incomePlanItems,
@@ -199,21 +200,23 @@ export const Review: FC<ReviewScreenProps> = ({
           items: paymentItems,
         }}
       />
-      <OverviewFormField
-        application={application}
-        goToScreen={goToScreen}
-        field={{
-          id: 'overview.incomePlan',
-          title:
-            socialInsuranceAdministrationMessage.incomePlan.subSectionTitle,
-          backId: editable ? 'incomePlan' : undefined,
-          type: FieldTypes.OVERVIEW,
-          component: FieldComponents.OVERVIEW,
-          children: undefined,
-          tableData: incomePlanTable,
-          items: incomePlanItems,
-        }}
-      />
+      {shouldShowIncomePlan(application.answers) && (
+        <OverviewFormField
+          application={application}
+          goToScreen={goToScreen}
+          field={{
+            id: 'overview.incomePlan',
+            title:
+              socialInsuranceAdministrationMessage.incomePlan.subSectionTitle,
+            backId: editable ? 'incomePlan' : undefined,
+            type: FieldTypes.OVERVIEW,
+            component: FieldComponents.OVERVIEW,
+            children: undefined,
+            tableData: incomePlanTable,
+            items: incomePlanItems,
+          }}
+        />
+      )}
       <ResidenceHistory {...childProps} />
       {applicationType === ApplicationType.HALF_OLD_AGE_PENSION && (
         <Employers {...childProps} />

--- a/libs/application/templates/social-insurance-administration/old-age-pension/src/forms/OldAgePensionForm/generalInformationSection/incomePlanInstructionsSubSection.ts
+++ b/libs/application/templates/social-insurance-administration/old-age-pension/src/forms/OldAgePensionForm/generalInformationSection/incomePlanInstructionsSubSection.ts
@@ -4,9 +4,11 @@ import {
   buildSubSection,
 } from '@island.is/application/core'
 import { socialInsuranceAdministrationMessage } from '@island.is/application/templates/social-insurance-administration-core/lib/messages'
+import { shouldShowIncomePlan } from '../../../utils/conditionUtils'
 
 export const incomePlanInstructionsSubSection = buildSubSection({
   id: 'incomePlanInstructionsSubSection',
+  condition: (answers) => shouldShowIncomePlan(answers),
   title:
     socialInsuranceAdministrationMessage.incomePlan
       .incomePlanInstructionsSubSectionTitle,

--- a/libs/application/templates/social-insurance-administration/old-age-pension/src/forms/OldAgePensionForm/generalInformationSection/incomePlanSubSection.ts
+++ b/libs/application/templates/social-insurance-administration/old-age-pension/src/forms/OldAgePensionForm/generalInformationSection/incomePlanSubSection.ts
@@ -34,9 +34,11 @@ import { Application } from '@island.is/application/types'
 import { formatCurrencyWithoutSuffix } from '@island.is/shared/utils'
 import { RatioType } from '../../../utils/constants'
 import { getApplicationExternalData } from '../../../utils/oldAgePensionUtils'
+import { shouldShowIncomePlan } from '../../../utils/conditionUtils'
 
 export const incomePlanSubSection = buildSubSection({
   id: 'incomePlanSubSection',
+  condition: (answers) => shouldShowIncomePlan(answers),
   title: socialInsuranceAdministrationMessage.incomePlan.subSectionTitle,
   children: [
     buildMultiField({

--- a/libs/application/templates/social-insurance-administration/old-age-pension/src/forms/OldAgePensionForm/generalInformationSection/index.ts
+++ b/libs/application/templates/social-insurance-administration/old-age-pension/src/forms/OldAgePensionForm/generalInformationSection/index.ts
@@ -13,9 +13,9 @@ export const generalInformationSection = buildSection({
   children: [
     applicantInfoSubSection,
     paymentInfoSubSection,
+    onePaymentPerYearSubSection,
     incomePlanInstructionsSubSection,
     incomePlanSubSection,
-    onePaymentPerYearSubSection,
     residenceHistorySubSection,
   ],
 })

--- a/libs/application/templates/social-insurance-administration/old-age-pension/src/forms/OldAgePensionForm/generalInformationSection/onePaymentPerYearSubSection.ts
+++ b/libs/application/templates/social-insurance-administration/old-age-pension/src/forms/OldAgePensionForm/generalInformationSection/onePaymentPerYearSubSection.ts
@@ -26,6 +26,9 @@ export const onePaymentPerYearSubSection = buildSubSection({
           options: getYesNoOptions(),
           defaultValue: NO,
           width: 'half',
+          // Switching to YES skips the income plan screens, so discard anything
+          // already entered there instead of submitting it to TR.
+          clearOnChange: ['incomePlanTable', 'incomePlan'],
         }),
         buildAlertMessageField({
           id: 'onePaymentPerYear.alert',

--- a/libs/application/templates/social-insurance-administration/old-age-pension/src/utils/conditionUtils.ts
+++ b/libs/application/templates/social-insurance-administration/old-age-pension/src/utils/conditionUtils.ts
@@ -6,6 +6,7 @@ import type { Application } from '@island.is/application/types'
 import { MONTHS } from '@island.is/application/templates/social-insurance-administration-core/lib/constants'
 import addYears from 'date-fns/addYears'
 import * as kennitala from 'kennitala'
+import { YES } from '@island.is/application/core'
 import { RatioType } from './constants'
 import {
   ApplicationType,
@@ -100,6 +101,14 @@ export const isBankAccountType = (
     paymentInfo?.bankAccountType ??
     typeOfBankInfo(bankInfo, paymentInfo?.bankAccountType)
   return radio === bankAccountType
+}
+
+export const shouldShowIncomePlan = (answers: Application['answers']) => {
+  const { onePaymentPerYear } = getApplicationAnswers(answers)
+
+  // If the applicant wants a single yearly payment, TR does not need an income
+  // plan, so the income plan screens are skipped entirely.
+  return onePaymentPerYear !== YES
 }
 
 export const hasSpouse = (externalData: Application['externalData']) => {

--- a/libs/application/templates/social-insurance-administration/old-age-pension/src/utils/oldAgePensionUtils.spec.ts
+++ b/libs/application/templates/social-insurance-administration/old-age-pension/src/utils/oldAgePensionUtils.spec.ts
@@ -17,10 +17,11 @@ import {
   getApplicationExternalData,
   filterValidEmployers,
 } from './oldAgePensionUtils'
-import { isEarlyRetirement } from './conditionUtils'
+import { isEarlyRetirement, shouldShowIncomePlan } from './conditionUtils'
 import { ApplicationType } from './constants'
 import { MONTHS } from '@island.is/application/templates/social-insurance-administration-core/lib/constants'
 import * as kennitala from 'kennitala'
+import { NO, YES } from '@island.is/application/core'
 
 const buildApplication = (data?: {
   answers?: FormValue
@@ -308,5 +309,29 @@ describe('filterValidEmployers', () => {
 
     expect(employers).toEqual(filteredList)
     expect(res).toEqual(filteredList)
+  })
+})
+
+describe('shouldShowIncomePlan', () => {
+  it('should show the income plan when a single yearly payment is declined', () => {
+    const application = buildApplication({
+      answers: { onePaymentPerYear: { question: NO } },
+    })
+
+    expect(shouldShowIncomePlan(application.answers)).toBe(true)
+  })
+
+  it('should skip the income plan when a single yearly payment is requested', () => {
+    const application = buildApplication({
+      answers: { onePaymentPerYear: { question: YES } },
+    })
+
+    expect(shouldShowIncomePlan(application.answers)).toBe(false)
+  })
+
+  it('should show the income plan before the question has been answered', () => {
+    const application = buildApplication()
+
+    expect(shouldShowIncomePlan(application.answers)).toBe(true)
   })
 })


### PR DESCRIPTION
Zendesk #629183 · [SMARI-118](https://jira.tr.is/browse/SMARI-118) · [Figma: Ellilífeyrir – 2.0](https://www.figma.com/design/OH3OAHYQEfGKgkuSqnQsDd/TR---Ellil%C3%ADfeyrir?node-id=3-62&p=f&t=qi8wbMctseidybsm-0)

## What

Moves the "Ein greiðsla á ári" screen ahead of the Tekjuáætlun screens in the old-age-pension application, and skips the income plan entirely when the applicant answers **Já**.

- `Nei` → payment info → one payment per year → income plan instructions → income plan → búsetusaga
- `Já` → payment info → one payment per year → búsetusaga

Also:

- An income plan already entered before switching to **Já** is discarded via `clearOnChange`, so it is not submitted anyway.
- The income plan group is hidden in the overview when it was skipped.
- `awarenessOfIncomeDeclaration` is now only sent when the income plan actually has rows. `incomePlanHasOnlyZeroIncome` is vacuously `true` for an empty array, so the skipped path would otherwise report `awarenessOfIncomeDeclaration: false` — a declaration the applicant was never shown a screen for. There is a regression test for this; reverting just the guard makes it fail.

No dataSchema change is needed: `validateAnswers` parses with a top-level `.partial()`, so the absent `incomePlanTable` / `incomePlan` keys validate fine.

On the `Já` path the DTO now carries `incomePlan.incomeTypes: []`. `OldAgePensionDTO.incomePlan` is required in our hand-written DTO and TR's v2 spec leaves the request body untyped (`"Input for application, varies by type"`), so an empty plan is the smaller change. TR expose `GET /api/protected/v2/Application/{applicationType}/contract` for the authoritative shape — worth checking whether they would rather the field be omitted, which would mean making it optional in `libs/clients/social-insurance-administration`.

## Why

TR reported that when an applicant asks for a single yearly payment, the Tekjuáætlun they just filled in is not needed — and its presence forces TR staff to rework the application by hand in their older system (Ölmunni). Asking the question first removes the unnecessary work for both the applicant and TR.

## Screenshots / Gifs

Flow only, no visual changes to the screens themselves. The diagrams and screen-by-screen mockups are in the linked Figma file.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Income plan sections are now shown only when relevant to the applicant’s selected payment option.
  - The form displays the one-payment-per-year option before income plan details.
  - Switching to one annual payment clears previously entered income plan information.

- **Bug Fixes**
  - Prevented income declaration details from being submitted when income plan questions are skipped.
  - Correctly handles all-zero income plans and preserves the corresponding declaration status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->