### PR TITLE
fix(form-system): stop persisting priceAmount. also logging

### DIFF
--- a/apps/form-system/web/src/components/Footer/Footer.tsx
+++ b/apps/form-system/web/src/components/Footer/Footer.tsx
@@ -1,8 +1,13 @@
-import { useMutation } from '@apollo/client'
-import { FormSystemField, FormSystemSection } from '@island.is/api/schema'
+import { useLazyQuery, useMutation } from '@apollo/client'
+import {
+  FormSystemField,
+  FormSystemSection,
+  PaymentCatalogItem,
+} from '@island.is/api/schema'
 import { NotificationCommands } from '@island.is/form-system/enums'
 import {
   CREATE_PAYMENT,
+  GET_PAYMENT_CATALOG,
   NOTIFY_EXTERNAL_SERVICE,
   SAVE_SCREEN,
   SUBMIT_APPLICATION,
@@ -86,6 +91,13 @@ export const Footer = ({ externalDataAgreement }: Props) => {
   )
   const [createPayment, { loading: paymentLoading }] =
     useMutation(CREATE_PAYMENT)
+  const [getPaymentCatalog, { loading: paymentCatalogLoading }] = useLazyQuery(
+    GET_PAYMENT_CATALOG,
+    {
+      fetchPolicy: 'network-only',
+    },
+  )
+  const isPaymentLoading = paymentLoading || paymentCatalogLoading
 
   const [submitApplication, { loading: submitLoading }] = useMutation(
     SUBMIT_APPLICATION,
@@ -222,7 +234,7 @@ export const Footer = ({ externalDataAgreement }: Props) => {
   }
 
   const handleIncrement = async () => {
-    if (paymentLoading) return
+    if (isPaymentLoading) return
     const isValid = await validate()
     dispatch({ type: 'SET_VALIDITY', payload: { isValid } })
 
@@ -238,6 +250,17 @@ export const Footer = ({ externalDataAgreement }: Props) => {
     }
 
     if (shouldShowPay) {
+      const performingOrganizationID =
+        state.application.organizationNationalId ?? ''
+      const { data: paymentCatalogData } = await getPaymentCatalog({
+        variables: {
+          input: {
+            performingOrganizationID,
+          },
+        },
+      })
+      const paymentCatalogItems =
+        paymentCatalogData?.paymentCatalog?.items ?? []
       const chargeItems: {
         performingOrgID: string
         chargeType: string
@@ -271,9 +294,10 @@ export const Footer = ({ externalDataAgreement }: Props) => {
             .forEach((field) => {
               if (field?.fieldSettings?.chargeItemCode) {
                 const code = field.fieldSettings.chargeItemCode
+                const paymentCatalogItem = paymentCatalogItems.find(
+                  (item: PaymentCatalogItem) => item.chargeItemCode === code,
+                )
                 let quantity: number | undefined = 1
-                const amount: number | undefined = field.fieldSettings
-                  .priceAmount as number | undefined
                 if (field.fieldSettings.paymentQuantityId) {
                   const quantityField = paymentQuantityFields.find(
                     (f) => f.id === field?.fieldSettings?.paymentQuantityId,
@@ -284,12 +308,18 @@ export const Footer = ({ externalDataAgreement }: Props) => {
                 }
                 chargeItems.push({
                   performingOrgID:
-                    state.application.organizationNationalId ?? '',
-                  chargeType: field.fieldSettings.chargeType || 'default',
+                    paymentCatalogItem?.performingOrgID ||
+                    performingOrganizationID,
+                  chargeType:
+                    paymentCatalogItem?.chargeType ||
+                    field.fieldSettings.chargeType ||
+                    'default',
                   chargeItemCode: code,
                   chargeItemName:
-                    field.fieldSettings.chargeItemName || 'Default Name',
-                  priceAmount: amount || 0,
+                    paymentCatalogItem?.chargeItemName ||
+                    field.fieldSettings.chargeItemName ||
+                    'Default Name',
+                  priceAmount: Number(paymentCatalogItem?.priceAmount ?? 0),
                   quantity,
                 })
               }
@@ -301,8 +331,7 @@ export const Footer = ({ externalDataAgreement }: Props) => {
           input: {
             applicationId: state.application.id,
             createChargeRequestDto: {
-              performingOrganizationID:
-                state.application.organizationNationalId ?? '',
+              performingOrganizationID,
               chargeItems,
             },
           },
@@ -434,13 +463,13 @@ export const Footer = ({ externalDataAgreement }: Props) => {
               onClick={handleIncrement}
               disabled={
                 !enableContinueButton ||
-                paymentLoading ||
+                isPaymentLoading ||
                 submitLoading ||
                 saveLoading ||
                 notifyLoading ||
                 (onSubmit && state.isValid === false)
               }
-              loading={submitLoading || notifyLoading || paymentLoading}
+              loading={submitLoading || notifyLoading || isPaymentLoading}
             >
               {shouldShowPay ? formatMessage(m.pay) : continueButtonText}
             </Button>
@@ -454,7 +483,7 @@ export const Footer = ({ externalDataAgreement }: Props) => {
                 disabled={
                   submitLoading ||
                   notifyLoading ||
-                  paymentLoading ||
+                  isPaymentLoading ||
                   saveLoading
                 }
               >

--- a/apps/form-system/web/src/components/Footer/Footer.tsx
+++ b/apps/form-system/web/src/components/Footer/Footer.tsx
@@ -50,6 +50,18 @@ const submitApplicationError = {
   },
 }
 
+const paymentCatalogError = {
+  hasError: true,
+  title: {
+    is: 'Ekki tókst að sækja greiðsluupplýsingar',
+    en: 'Could not fetch payment information',
+  },
+  message: {
+    is: 'Villa kom upp við að sækja greiðsluupplýsingar. Vinsamlegast reyndu aftur.',
+    en: 'An error occurred while fetching payment information. Please try again.',
+  },
+}
+
 const stripFieldListsFromSections = (
   sections: FormSystemSection[],
 ): FormSystemSection[] =>
@@ -252,15 +264,24 @@ export const Footer = ({ externalDataAgreement }: Props) => {
     if (shouldShowPay) {
       const performingOrganizationID =
         state.application.organizationNationalId ?? ''
-      const { data: paymentCatalogData } = await getPaymentCatalog({
-        variables: {
-          input: {
-            performingOrganizationID,
+      let paymentCatalogItems: PaymentCatalogItem[] = []
+      try {
+        const { data } = await getPaymentCatalog({
+          variables: {
+            input: {
+              performingOrganizationID,
+            },
           },
-        },
-      })
-      const paymentCatalogItems =
-        paymentCatalogData?.paymentCatalog?.items ?? []
+        })
+        paymentCatalogItems = data?.paymentCatalog?.items ?? []
+      } catch (error) {
+        console.error('Error fetching payment catalog:', error)
+        dispatch({
+          type: 'SAVE_FAILED',
+          payload: { screenError: paymentCatalogError },
+        })
+        return
+      }
       const chargeItems: {
         performingOrgID: string
         chargeType: string
@@ -283,47 +304,63 @@ export const Footer = ({ externalDataAgreement }: Props) => {
         })
       })
 
-      state.sections?.forEach((section) => {
-        section?.screens?.forEach((screen) => {
-          screen?.fields
-            ?.filter(
-              (field) =>
-                field?.fieldType === FieldTypesEnum.PAYMENT &&
-                field?.isHidden === false,
-            )
-            .forEach((field) => {
-              if (field?.fieldSettings?.chargeItemCode) {
-                const code = field.fieldSettings.chargeItemCode
-                const paymentCatalogItem = paymentCatalogItems.find(
-                  (item: PaymentCatalogItem) => item.chargeItemCode === code,
-                )
-                let quantity: number | undefined = 1
-                if (field.fieldSettings.paymentQuantityId) {
-                  const quantityField = paymentQuantityFields.find(
-                    (f) => f.id === field?.fieldSettings?.paymentQuantityId,
-                  )
-                  if (quantityField) {
-                    quantity = getValue(quantityField, 'number')
-                  }
-                }
-                chargeItems.push({
-                  performingOrgID:
-                    paymentCatalogItem?.performingOrgID ||
-                    performingOrganizationID,
-                  chargeType:
-                    paymentCatalogItem?.chargeType ||
-                    field.fieldSettings.chargeType ||
-                    'default',
-                  chargeItemCode: code,
-                  chargeItemName:
-                    paymentCatalogItem?.chargeItemName ||
-                    field.fieldSettings.chargeItemName ||
-                    'Default Name',
-                  priceAmount: Number(paymentCatalogItem?.priceAmount ?? 0),
-                  quantity,
-                })
-              }
-            })
+      const visiblePaymentFields =
+        state.sections?.flatMap(
+          (section) =>
+            section?.screens?.flatMap(
+              (screen) =>
+                screen?.fields?.filter(
+                  (field) =>
+                    field?.fieldType === FieldTypesEnum.PAYMENT &&
+                    field?.isHidden === false,
+                ) ?? [],
+            ) ?? [],
+        ) ?? []
+
+      const hasUnresolvedPaymentField = visiblePaymentFields.some((field) => {
+        const code = field?.fieldSettings?.chargeItemCode
+
+        return (
+          !code ||
+          !paymentCatalogItems.some(
+            (item: PaymentCatalogItem) => item.chargeItemCode === code,
+          )
+        )
+      })
+
+      if (hasUnresolvedPaymentField) {
+        dispatch({
+          type: 'SAVE_FAILED',
+          payload: { screenError: paymentCatalogError },
+        })
+        return
+      }
+
+      visiblePaymentFields.forEach((field) => {
+        const code = field?.fieldSettings?.chargeItemCode
+        const paymentCatalogItem = paymentCatalogItems.find(
+          (item: PaymentCatalogItem) => item.chargeItemCode === code,
+        )
+        if (!code || !paymentCatalogItem) return
+
+        let quantity: number | undefined = 1
+        if (field?.fieldSettings?.paymentQuantityId) {
+          const quantityField = paymentQuantityFields.find(
+            (paymentQuantityField) =>
+              paymentQuantityField.id ===
+              field.fieldSettings?.paymentQuantityId,
+          )
+          if (quantityField) {
+            quantity = getValue(quantityField, 'number')
+          }
+        }
+        chargeItems.push({
+          performingOrgID: paymentCatalogItem.performingOrgID,
+          chargeType: paymentCatalogItem.chargeType,
+          chargeItemCode: code,
+          chargeItemName: paymentCatalogItem.chargeItemName,
+          priceAmount: Number(paymentCatalogItem.priceAmount),
+          quantity,
         })
       })
       const { data } = await createPayment({

--- a/apps/form-system/web/src/components/Screen/components/Payment/Payment.tsx
+++ b/apps/form-system/web/src/components/Screen/components/Payment/Payment.tsx
@@ -1,4 +1,6 @@
-import { FormSystemField } from '@island.is/api/schema'
+import { useQuery } from '@apollo/client'
+import { FormSystemField, PaymentCatalogItem } from '@island.is/api/schema'
+import { GET_PAYMENT_CATALOG } from '@island.is/form-system/graphql'
 import {
   FieldTypesEnum,
   getValue,
@@ -21,6 +23,16 @@ import { useApplicationContext } from '../../../../context/ApplicationProvider'
 export const Payment = () => {
   const { formatMessage } = useLocale()
   const { state } = useApplicationContext()
+  const organizationNationalId = state.application.organizationNationalId ?? ''
+  const { data } = useQuery(GET_PAYMENT_CATALOG, {
+    variables: {
+      input: {
+        performingOrganizationID: organizationNationalId,
+      },
+    },
+    skip: !organizationNationalId,
+    fetchPolicy: 'network-only',
+  })
   const isPaymentSection =
     state.sections?.[state.currentSection.index]?.sectionType ===
     SectionTypes.PAYMENT
@@ -41,6 +53,28 @@ export const Payment = () => {
   const convertToPaymentNumber = (value: number): string => {
     return value.toString().replace(/\B(?=(\d{3})+(?!\d))/g, '.')
   }
+
+  const paymentCatalogItems = data?.paymentCatalog?.items ?? []
+
+  const getPaymentCatalogItem = (field?: FormSystemField | null) => {
+    return paymentCatalogItems.find(
+      (item: PaymentCatalogItem) =>
+        item.chargeItemCode === field?.fieldSettings?.chargeItemCode,
+    )
+  }
+
+  const getPriceAmount = (field?: FormSystemField | null) => {
+    return Number(getPaymentCatalogItem(field)?.priceAmount ?? 0)
+  }
+
+  const getChargeItemName = (field?: FormSystemField | null) => {
+    return (
+      getPaymentCatalogItem(field)?.chargeItemName ??
+      field?.fieldSettings?.chargeItemName ??
+      ''
+    )
+  }
+
   const getQuantity = (field?: FormSystemField | null) => {
     const quantityField = paymentQuantityFields?.find(
       (f) => f?.id === field?.fieldSettings?.paymentQuantityId,
@@ -51,7 +85,7 @@ export const Payment = () => {
 
   const total = paymentFields.reduce((sum, field) => {
     const quantity = getQuantity(field)
-    const price = Number(field?.fieldSettings?.priceAmount ?? 0)
+    const price = getPriceAmount(field)
 
     return sum + price * quantity
   }, 0)
@@ -68,16 +102,12 @@ export const Payment = () => {
     const quantity = getQuantity(field)
     const priceString =
       quantity > 1
-        ? `${quantity} x ${convertToPaymentNumber(
-            Number(field?.fieldSettings?.priceAmount ?? 0),
-          )} kr.`
-        : `${convertToPaymentNumber(
-            Number(field?.fieldSettings?.priceAmount ?? 0),
-          )} kr.`
+        ? `${quantity} x ${convertToPaymentNumber(getPriceAmount(field))} kr.`
+        : `${convertToPaymentNumber(getPriceAmount(field))} kr.`
 
     return (
       <Box key={index} display="flex" justifyContent="spaceBetween">
-        <Text>{field?.fieldSettings?.chargeItemName ?? ''}</Text>
+        <Text>{getChargeItemName(field)}</Text>
         <Text>{priceString}</Text>
       </Box>
     )
@@ -93,15 +123,10 @@ export const Payment = () => {
     const quantity = getQuantity(field)
     return (
       <Stack key={index} space={1}>
-        <Text variant="h5">{field?.fieldSettings?.chargeItemName ?? ''}</Text>
+        <Text variant="h5">{getChargeItemName(field)}</Text>
         <Inline justifyContent="spaceBetween">
           <Text>{formatMessage(m.price)}</Text>
-          <Text>
-            {convertToPaymentNumber(
-              Number(field?.fieldSettings?.priceAmount ?? 0),
-            )}{' '}
-            kr.
-          </Text>
+          <Text>{convertToPaymentNumber(getPriceAmount(field))} kr.</Text>
         </Inline>
         <Inline justifyContent="spaceBetween">
           <Text>{formatMessage(m.quantity)}</Text>

--- a/apps/form-system/web/src/components/Screen/components/Payment/Payment.tsx
+++ b/apps/form-system/web/src/components/Screen/components/Payment/Payment.tsx
@@ -8,6 +8,7 @@ import {
   SectionTypes,
 } from '@island.is/form-system/ui'
 import {
+  AlertMessage,
   Box,
   Divider,
   GridColumn,
@@ -20,11 +21,27 @@ import {
 import { useLocale } from '@island.is/localization'
 import { useApplicationContext } from '../../../../context/ApplicationProvider'
 
+const paymentCatalogError = {
+  title: {
+    is: 'Ekki tókst að sækja greiðsluupplýsingar',
+    en: 'Could not fetch payment information',
+  },
+  message: {
+    is: 'Villa kom upp við að sækja greiðsluupplýsingar. Vinsamlegast reyndu aftur.',
+    en: 'An error occurred while fetching payment information. Please try again.',
+  },
+}
+
+const paymentCatalogLoadingText = {
+  is: 'Sæki greiðsluupplýsingar',
+  en: 'Fetching payment information',
+}
+
 export const Payment = () => {
-  const { formatMessage } = useLocale()
+  const { formatMessage, lang } = useLocale()
   const { state } = useApplicationContext()
   const organizationNationalId = state.application.organizationNationalId ?? ''
-  const { data } = useQuery(GET_PAYMENT_CATALOG, {
+  const { data, loading } = useQuery(GET_PAYMENT_CATALOG, {
     variables: {
       input: {
         performingOrganizationID: organizationNationalId,
@@ -64,7 +81,9 @@ export const Payment = () => {
   }
 
   const getPriceAmount = (field?: FormSystemField | null) => {
-    return Number(getPaymentCatalogItem(field)?.priceAmount ?? 0)
+    const paymentCatalogItem = getPaymentCatalogItem(field)
+
+    return paymentCatalogItem ? Number(paymentCatalogItem.priceAmount) : null
   }
 
   const getChargeItemName = (field?: FormSystemField | null) => {
@@ -87,8 +106,26 @@ export const Payment = () => {
     const quantity = getQuantity(field)
     const price = getPriceAmount(field)
 
-    return sum + price * quantity
+    return sum + (price ?? 0) * quantity
   }, 0)
+
+  const renderPrice = (price: number | null) => {
+    if (price !== null) {
+      return <Text>{convertToPaymentNumber(price)} kr.</Text>
+    }
+
+    if (loading) {
+      return <Text>{paymentCatalogLoadingText[lang]}</Text>
+    }
+
+    return (
+      <AlertMessage
+        type="error"
+        title={paymentCatalogError.title[lang]}
+        message={paymentCatalogError.message[lang]}
+      />
+    )
+  }
 
   // Keep for demonstration purposes
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -100,15 +137,18 @@ export const Payment = () => {
     index: number
   }) => {
     const quantity = getQuantity(field)
+    const price = getPriceAmount(field)
     const priceString =
-      quantity > 1
-        ? `${quantity} x ${convertToPaymentNumber(getPriceAmount(field))} kr.`
-        : `${convertToPaymentNumber(getPriceAmount(field))} kr.`
+      price === null
+        ? null
+        : quantity > 1
+        ? `${quantity} x ${convertToPaymentNumber(price)} kr.`
+        : `${convertToPaymentNumber(price)} kr.`
 
     return (
       <Box key={index} display="flex" justifyContent="spaceBetween">
         <Text>{getChargeItemName(field)}</Text>
-        <Text>{priceString}</Text>
+        {priceString ? <Text>{priceString}</Text> : renderPrice(price)}
       </Box>
     )
   }
@@ -121,12 +161,13 @@ export const Payment = () => {
     index: number
   }) => {
     const quantity = getQuantity(field)
+    const price = getPriceAmount(field)
     return (
       <Stack key={index} space={1}>
         <Text variant="h5">{getChargeItemName(field)}</Text>
         <Inline justifyContent="spaceBetween">
           <Text>{formatMessage(m.price)}</Text>
-          <Text>{convertToPaymentNumber(getPriceAmount(field))} kr.</Text>
+          {renderPrice(price)}
         </Inline>
         <Inline justifyContent="spaceBetween">
           <Text>{formatMessage(m.quantity)}</Text>

--- a/libs/portals/admin/form-system/src/components/MainContent/components/FieldContent/components/PaymentField/PaymentField.tsx
+++ b/libs/portals/admin/form-system/src/components/MainContent/components/FieldContent/components/PaymentField/PaymentField.tsx
@@ -56,9 +56,7 @@ export const PaymentField = () => {
                   chargeItemCode: paymentSettings?.chargeItemCode || '',
                   chargeItemName: paymentSettings?.chargeItemName || '',
                   chargeType: paymentSettings?.chargeType || '',
-                  performingOrgID:
-                    paymentSettings?.performingOrganizationID || '',
-                  priceAmount: paymentSettings?.priceAmount || 0,
+                  performingOrgID: paymentSettings?.performingOrgID || '',
                   update: updateActiveItem,
                 },
               })

--- a/libs/portals/admin/form-system/src/components/MainContent/components/Payment/Payment.tsx
+++ b/libs/portals/admin/form-system/src/components/MainContent/components/Payment/Payment.tsx
@@ -7,6 +7,7 @@ import {
 } from '@island.is/form-system/graphql'
 import { FieldTypesEnum, SectionTypes } from '@island.is/form-system/ui'
 import {
+  AlertMessage,
   Box,
   Button,
   GridColumn as Column,
@@ -41,6 +42,16 @@ export const Payment = () => {
   })
 
   const paymentCatalog = data?.paymentCatalog?.items || []
+  const hasPaymentCatalog = paymentCatalog.length > 0
+  const paymentSetupError = !control.organizationNationalId
+    ? 'Vantar kennitolu stofnunar áður en hægt er að bæta við greiðslu.'
+    : error
+    ? 'Ekki tókst að sækja greiðsluskrá. Ekki er hægt að bæta við greiðslu fyrr en greiðsluskrá hefur verið sótt.'
+    : !loading && !hasPaymentCatalog
+    ? 'Engir greiðsluliðir fundust fyrir þessa stofnun. Ekki er hægt að bæta við greiðslu fyrr en greiðsluskrá er til staðar.'
+    : undefined
+  const canCreatePaymentField =
+    !isReadOnly && !paymentSetupError && hasPaymentCatalog
 
   useEffect(() => {
     if (error) {
@@ -94,6 +105,10 @@ export const Payment = () => {
   })
 
   const addField = async () => {
+    if (!canCreatePaymentField) {
+      return
+    }
+
     const newField = await createField[0]({
       variables: {
         input: {
@@ -140,7 +155,7 @@ export const Payment = () => {
             <Button
               variant="primary"
               icon="add"
-              disabled={isReadOnly}
+              disabled={!canCreatePaymentField}
               onClick={addField}
             >
               Bæta við greiðslu
@@ -148,6 +163,14 @@ export const Payment = () => {
           </Box>
         </Column>
       </Box>
+      {paymentSetupError && (
+        <Box paddingTop={2}>
+          <AlertMessage
+            type={error ? 'error' : 'warning'}
+            message={paymentSetupError}
+          />
+        </Box>
+      )}
       <Stack space={2}>
         {paymentFields.map((field) => (
           <PaymentItem

--- a/libs/portals/admin/form-system/src/components/MainContent/components/Payment/Payment.tsx
+++ b/libs/portals/admin/form-system/src/components/MainContent/components/Payment/Payment.tsx
@@ -13,7 +13,7 @@ import {
   LoadingDots,
   Stack,
 } from '@island.is/island-ui/core'
-import { useContext } from 'react'
+import { useContext, useEffect } from 'react'
 import { ControlContext } from '../../../../context/ControlContext'
 import { PaymentItem } from './components/PaymentItem'
 
@@ -31,13 +31,45 @@ export const Payment = () => {
     fields?.filter((f) => f?.screenId === paymentScreen?.id) || []
 
   const createField = useMutation(CREATE_FIELD)
-  const { data, loading } = useQuery(GET_PAYMENT_CATALOG, {
+  const { data, loading, error } = useQuery(GET_PAYMENT_CATALOG, {
     variables: {
       input: {
         performingOrganizationID: control.organizationNationalId,
       },
     },
+    skip: !control.organizationNationalId,
   })
+
+  const paymentCatalog = data?.paymentCatalog?.items || []
+
+  useEffect(() => {
+    if (error) {
+      console.error('GET_PAYMENT_CATALOG failed', {
+        organizationNationalId: control.organizationNationalId,
+        error,
+      })
+    }
+  }, [control.organizationNationalId, error])
+
+  useEffect(() => {
+    if (
+      control.organizationNationalId &&
+      !loading &&
+      !error &&
+      paymentCatalog.length === 0
+    ) {
+      console.warn('GET_PAYMENT_CATALOG returned an empty catalog', {
+        organizationNationalId: control.organizationNationalId,
+        data,
+      })
+    }
+  }, [
+    control.organizationNationalId,
+    data,
+    error,
+    loading,
+    paymentCatalog.length,
+  ])
 
   if (loading) {
     return (
@@ -54,7 +86,6 @@ export const Payment = () => {
     )
   }
 
-  const paymentCatalog = data?.paymentCatalog?.items || []
   const catalogNames = paymentCatalog.map((item: PaymentCatalogItem) => {
     return {
       label: `${item.chargeItemCode} - ${item.chargeItemName}`,

--- a/libs/portals/admin/form-system/src/components/MainContent/components/Payment/components/PaymentItem.tsx
+++ b/libs/portals/admin/form-system/src/components/MainContent/components/Payment/components/PaymentItem.tsx
@@ -68,11 +68,13 @@ export const PaymentItem = ({
               const paymentSettings = paymentCatalog.find(
                 (item: PaymentCatalogItem) => item.chargeItemCode === e?.value,
               )
-              console.log('paymentSettings', paymentSettings)
               controlDispatch({
                 type: 'SET_PAYMENT_SETTINGS',
                 payload: {
-                  ...paymentSettings,
+                  chargeItemCode: paymentSettings?.chargeItemCode || '',
+                  chargeItemName: paymentSettings?.chargeItemName || '',
+                  chargeType: paymentSettings?.chargeType || '',
+                  performingOrgID: paymentSettings?.performingOrgID || '',
                   field,
                   update: updateActiveItem,
                 },

--- a/libs/portals/admin/form-system/src/hooks/controlReducer.ts
+++ b/libs/portals/admin/form-system/src/hooks/controlReducer.ts
@@ -387,7 +387,6 @@ type InputSettingsActions =
         chargeItemName?: string
         chargeType?: string
         performingOrgID?: string
-        priceAmount?: number
         update: (updatedActiveItem?: ActiveItem) => void
       }
     }
@@ -1419,10 +1418,12 @@ export const controlReducer = (
         chargeItemName,
         chargeType,
         performingOrgID,
-        priceAmount,
         update,
         field,
       } = action.payload
+      const { priceAmount, ...fieldSettings } = removeTypename(
+        field.fieldSettings ?? {},
+      )
 
       const newField = {
         ...field,
@@ -1431,16 +1432,13 @@ export const controlReducer = (
           en: chargeItemName,
         },
         fieldSettings: {
-          ...field.fieldSettings,
-          __typename: undefined,
+          ...fieldSettings,
           chargeItemCode,
           chargeItemName,
           chargeType,
           performingOrgID,
-          priceAmount,
         },
       }
-      console.log('Updating payment settings with', newField.fieldSettings)
       update({ type: 'Field', data: newField })
       return {
         ...state,


### PR DESCRIPTION
# ...

Attach a link to issue if relevant

## What

Specify what you're trying to achieve

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: GPT-5.5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Payment forms now use the payment catalog to display charge names, prices, quantities, and totals.
  - Payment setup provides clear loading, empty-catalog, configuration, and retrieval-error messages.

- **Bug Fixes**
  - Payment processing now stops when catalog information is unavailable or payment fields cannot be matched to catalog items.
  - Payment buttons and totals more accurately reflect catalog loading and resolved pricing.
  - Payment settings now synchronize more reliably with the selected catalog information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->