### PR TITLE
fix(doe): Disable footer navigation while the Excel workbook is being…

### DIFF
--- a/libs/application/templates/directorate-of-equality/salary-report/src/fields/ExcelTemplateDownload/index.tsx
+++ b/libs/application/templates/directorate-of-equality/salary-report/src/fields/ExcelTemplateDownload/index.tsx
@@ -54,7 +54,14 @@ const ANALYSIS_SCREEN_ID = ScreenIds.analysisOverview
 
 export const ExcelTemplateDownload: FC<
   React.PropsWithChildren<FieldBaseProps>
-> = ({ application, goToScreen, setBeforeSubmitCallback, answerQuestions }) => {
+> = ({
+  application,
+  goToScreen,
+  setBeforeSubmitCallback,
+  setFieldLoadingState,
+  setSubmitButtonDisabled,
+  answerQuestions,
+}) => {
   const { formatMessage, lang: locale } = useLocale()
   const m = messages.report.dataEntry
   const [isImporting, setIsImporting] = useState(false)
@@ -312,6 +319,16 @@ export const ExcelTemplateDownload: FC<
       setIsImporting(false)
     }
   }
+
+  // Reading the workbook is a multi-leg server round-trip (presign, upload,
+  // import, read back), and the footer's own "Halda áfram" would meanwhile
+  // seed default job factors and advance past an import that is still running
+  // — see setBeforeSubmitCallback below. Same pair FileUploadController uses:
+  // the loading state puts the button in its spinner, disabled throughout.
+  useEffect(() => {
+    setFieldLoadingState?.(isImporting)
+    setSubmitButtonDisabled?.(isImporting)
+  }, [isImporting, setFieldLoadingState, setSubmitButtonDisabled])
 
   const handleFilesChanged = (newFiles: File[]) => {
     const file = newFiles[0]


### PR DESCRIPTION
  ## What

  Disables the footer's `Halda áfram` (and `Til baka`) buttons on the salary report's
  **Gögn** screen while an uploaded Excel workbook is being read, instead of leaving
  them live next to the loading dots.

  `ExcelTemplateDownload` now drives the shell's two footer setters off its existing
  `isImporting` state:

  ```tsx
  useEffect(() => {
    setFieldLoadingState?.(isImporting)
    setSubmitButtonDisabled?.(isImporting)
  }, [isImporting, setFieldLoadingState, setSubmitButtonDisabled])
  ```

  This is the same pair FileUploadController already uses for uploads. Both setters
  reach custom fields through FieldBaseProps, and setFieldLoadingState feeds
  canProceed in Screen.tsx, which puts the button into its spinner state —
  island-ui's Button treats loading as disabled.

  Why

  Reported by a user: the continue button stays clickable while the system reads the
  spreadsheet.

  It wasn't only cosmetic. The import is a multi-leg round-trip (presign → upload →
  import → read back), and mid-import the footer's setBeforeSubmitCallback still sees
  importSucceededRef.current === false. So clicking Halda áfram during an import
  would seed the default job factors onto the draft and advance to the criteria screen —
  racing an import that replaces the entire scoring graph (criteria, sub-criteria, steps,
  roles, employees, step assignments), and leaving the applicant on the wrong screen.

  Til baka is disabled for the same window, since navigating back mid-import has the
  same problem.

  Screenshots / Gifs

  Before: loading dots in the panel, Halda áfram fully enabled.
  After: Halda áfram shows its spinner and is unclickable until the import settles.

  Checklist:

  - [x] I have performed a self-review of my own code
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [x] Formatting passes locally with my changes
  - [ ] I have rebased against main before asking for a review
  - [ ] No AI tools were used in preparing this pull request
  - [x] AI tools were used in preparing this pull request
    Tools used: Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The continue button now remains disabled and displays a loading state while an Excel import is processing.
  * Prevented users from advancing or unintentionally creating default job factors before the import is complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->