### PR TITLE
fix(j-s): disable next/image disk cache to stop EACCES in prod

### DIFF
--- a/apps/judicial-system/web/next.config.js
+++ b/apps/judicial-system/web/next.config.js
@@ -15,6 +15,12 @@ const nextConfig = {
     // Important: return the modified config
     return config
   },
+  // The prod container's .next/cache is owned by root and the app runs as a
+  // non-root user, so Next 16's on-disk image LRU throws EACCES on mkdir.
+  // This app doesn't use next/image, so the disk cache is not needed.
+  images: {
+    maximumDiskCacheSize: 0,
+  },
   // Runtime configuration lives in environments/runtimeEnvironment.ts
   env: {
     API_MOCKS: process.env.API_MOCKS ?? '',


### PR DESCRIPTION
# Disable the next/image disk cache in judicial-system-web

## What

Add `images: { maximumDiskCacheSize: 0 }` to `apps/judicial-system/web/next.config.js`, mirroring the fix already applied to `apps/web` in #23447.

## Why

Prod Datadog logs for `judicial-system-web` repeatedly show:

```
Error: EACCES: permission denied, mkdir '/webapp/.next/cache/images'
    at async /webapp/node_modules/next/dist/server/lib/disk-lru-cache.external.js:36:17
```

Since the Next 16 upgrade (#23240) the image optimizer creates an on-disk LRU cache under `.next/cache/images` on the first `/_next/image` request. The `output-next` Docker target copies `/webapp` as root but the container runs as the `runner` user, so the `mkdir` fails.

`judicial-system-web` does not use `next/image` anywhere, so the disk cache has no value here. Setting `maximumDiskCacheSize` to `0` skips creating the cache entirely.

Note: the other Next apps without an `images` config are exposed to the same error. A Dockerfile-level fix that would cover all of them exists on `origin/fix/eaccess-issues-next` but is not merged.

## Screenshots / Gifs

N/A

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled on-disk caching for optimized images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->