### PR TITLE
fix(native-app): Health messages android fixes

### DIFF
--- a/.yarn/patches/react-native-screens-npm-4.24.0-c572d01561.patch
+++ b/.yarn/patches/react-native-screens-npm-4.24.0-c572d01561.patch
@@ -1,0 +1,57 @@
+diff --git a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/TabsHost.kt b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/TabsHost.kt
+index 3ab574b435d14313755e482f8f28e4bfd396931a..3d6aa4ee2c9d5b18cf9a10b64b6ace38a2c3d401 100644
+--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/TabsHost.kt
++++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/TabsHost.kt
+@@ -1,5 +1,6 @@
+ package com.swmansion.rnscreens.gamma.tabs
+ 
++import android.content.Context
+ import android.content.res.Configuration
+ import android.os.Build
+ import android.view.Choreographer
+@@ -11,6 +12,9 @@ import android.widget.FrameLayout
+ import androidx.appcompat.view.ContextThemeWrapper
+ import androidx.core.graphics.drawable.toDrawable
+ import androidx.core.view.children
++import androidx.core.view.isVisible
++import com.facebook.react.uimanager.PointerEvents
++import com.facebook.react.uimanager.ReactPointerEventsView
+ import androidx.fragment.app.FragmentManager
+ import com.facebook.react.modules.core.ReactChoreographer
+ import com.facebook.react.uimanager.ThemedReactContext
+@@ -126,7 +130,7 @@ class TabsHost(
+         )
+ 
+     private val bottomNavigationView: BottomNavigationView =
+-        BottomNavigationView(wrappedContext).apply {
++        PointerEventsAwareBottomNavigationView(wrappedContext).apply {
+             layoutParams =
+                 LayoutParams(
+                     LayoutParams.MATCH_PARENT,
+@@ -564,3 +568,26 @@ class TabsHost(
+         const val TAG = "TabsHost"
+     }
+ }
++
++/**
++ * PATCH (island.is): backport of upstream PR software-mansion/react-native-screens#4489,
++ * which fixes issue #4132.
++ *
++ * When `tabBarHidden` is set, `TabsHostAppearanceApplicator` flips this view to GONE, but the
++ * view keeps the layout bounds it was last measured with. React Native's touch target
++ * resolution still treats that rectangle as a valid target, so taps landing in the strip the
++ * tab bar used to occupy are swallowed instead of reaching the content underneath — any
++ * Pressable anchored to the bottom of a stack-pushed screen becomes dead.
++ *
++ * Reporting NONE while the bar is hidden makes RN's hit-testing skip the view entirely, which
++ * matches how Android itself treats a GONE view.
++ *
++ * Remove this patch once #4489 lands and we are on a react-native-screens that includes it.
++ */
++private class PointerEventsAwareBottomNavigationView(
++    context: Context,
++) : BottomNavigationView(context),
++    ReactPointerEventsView {
++    override val pointerEvents: PointerEvents
++        get() = if (isVisible) PointerEvents.AUTO else PointerEvents.NONE
++}

--- a/apps/native/app/package.json
+++ b/apps/native/app/package.json
@@ -67,7 +67,7 @@
     "react-native-quick-actions": "0.3.13",
     "react-native-reanimated": "~4.2.2",
     "react-native-safe-area-context": "~5.6.2",
-    "react-native-screens": "~4.24.0",
+    "react-native-screens": "patch:react-native-screens@npm%3A4.24.0#~/.yarn/patches/react-native-screens-npm-4.24.0-c572d01561.patch",
     "react-native-svg": "15.15.3",
     "react-native-vision-camera": "4.7.3",
     "react-native-web": "~0.21.0",

--- a/apps/native/app/src/app/(auth)/(modals)/notifications/_layout.tsx
+++ b/apps/native/app/src/app/(auth)/(modals)/notifications/_layout.tsx
@@ -1,6 +1,9 @@
 import { Stack } from 'expo-router'
 import { useIntl } from 'react-intl'
-import { tabScreenOptions } from '../../../../constants/screen-options'
+import {
+  modalScreenOptions,
+  tabScreenOptions,
+} from '../../../../constants/screen-options'
 
 export default function NotificationsLayout() {
   const intl = useIntl()
@@ -28,6 +31,7 @@ export default function NotificationsLayout() {
           headerTitleAlign: 'center',
         }}
       />
+      <Stack.Screen name="message/new" options={modalScreenOptions} />
     </Stack>
   )
 }

--- a/apps/native/app/src/app/(auth)/(modals)/notifications/message/new.tsx
+++ b/apps/native/app/src/app/(auth)/(modals)/notifications/message/new.tsx
@@ -1,0 +1,5 @@
+import HealthMessageCompose from '@/app/(auth)/(tabs)/health/messages/new'
+
+// Compose screen rendered inside the notifications modal so replying keeps the
+// back arrow pointing at the sheet.
+export default HealthMessageCompose

--- a/apps/native/app/src/app/(auth)/(tabs)/health/messages/[id].tsx
+++ b/apps/native/app/src/app/(auth)/(tabs)/health/messages/[id].tsx
@@ -11,7 +11,12 @@ import {
   SafeAreaView,
   View,
 } from 'react-native'
-import { router, useFocusEffect, useLocalSearchParams } from 'expo-router'
+import {
+  router,
+  useFocusEffect,
+  useLocalSearchParams,
+  usePathname,
+} from 'expo-router'
 
 import { StackScreen } from '@/components/stack-screen'
 import { ButtonDrawer } from '@/components/button-drawer'
@@ -75,6 +80,12 @@ export default function HealthMessageDetailScreen() {
   const client = useApolloClient()
   const userName = useAuthStore((s) => s.userInfo?.name)
   const [refetching, setRefetching] = useState(false)
+  // Also re-exported in the notifications modal, so compose has to be pushed
+  // onto whichever stack we are in.
+  const pathname = usePathname()
+  const composeHref = pathname.startsWith('/notifications/')
+    ? '/notifications/message/new'
+    : '/health/messages/new'
 
   const res = useGetHealthConversationQuery({
     variables: { id },
@@ -432,7 +443,7 @@ export default function HealthMessageDetailScreen() {
                   icon={require('@/assets/icons/reply.png')}
                   onPress={() =>
                     router.push({
-                      pathname: '/health/messages/new',
+                      pathname: composeHref,
                       params: {
                         conversationId: id,
                         recipientName:

--- a/yarn.lock
+++ b/yarn.lock
@@ -10525,7 +10525,7 @@ __metadata:
     react-native-quick-actions: "npm:0.3.13"
     react-native-reanimated: "npm:~4.2.2"
     react-native-safe-area-context: "npm:~5.6.2"
-    react-native-screens: "npm:~4.24.0"
+    react-native-screens: "patch:react-native-screens@npm%3A4.24.0#~/.yarn/patches/react-native-screens-npm-4.24.0-c572d01561.patch"
     react-native-svg: "npm:15.15.3"
     react-native-vision-camera: "npm:4.7.3"
     react-native-web: "npm:~0.21.0"
@@ -47148,7 +47148,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-screens@npm:~4.24.0":
+"react-native-screens@npm:4.24.0":
   version: 4.24.0
   resolution: "react-native-screens@npm:4.24.0"
   dependencies:
@@ -47158,6 +47158,19 @@ __metadata:
     react: "*"
     react-native: "*"
   checksum: 10/1ac705f7c0c37f62f0c29c5bf477b4a2360c37dec6b689e7fa9a768cc8a08d828ac7260d168a60638d207e0be21ae22bb3f170d55f0ae97837c2053ba8e38aff
+  languageName: node
+  linkType: hard
+
+"react-native-screens@patch:react-native-screens@npm%3A4.24.0#~/.yarn/patches/react-native-screens-npm-4.24.0-c572d01561.patch":
+  version: 4.24.0
+  resolution: "react-native-screens@patch:react-native-screens@npm%3A4.24.0#~/.yarn/patches/react-native-screens-npm-4.24.0-c572d01561.patch::version=4.24.0&hash=0777a6"
+  dependencies:
+    react-freeze: "npm:^1.0.0"
+    warn-once: "npm:^0.1.0"
+  peerDependencies:
+    react: "*"
+    react-native: "*"
+  checksum: 10/6f274799a4a813686c3292dfacb1a5c02e620ba11593ad974355c52f26cd3505e9a3ac736cdf56605e59fcd724ae9d80318ed6897a10c1b0d73de3955d1c32f4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What

Two Android fixes for the health messages / inbox reply flow:

1. Patch `react-native-screens` so a hidden native tab bar stops swallowing
   touches. Bottom-anchored buttons — reply in health messages and inbox
   communications, and the Android bulk-select action bar — were unclickable.
2. Push the health-message compose screen onto the notifications modal stack
   when the conversation was opened from a notification, instead of into the
   health tab's stack.

## Why

**1.** When `<NativeTabs hidden>` hides the tab bar on Android, the
`BottomNavigationView` is set to `GONE` but keeps its layout bounds, and RN's
hit-testing still treats that rectangle as a valid target. Taps in the bottom
strip never reach JS — `onPress` never fires. The patch makes the view report
`PointerEvents.NONE` while hidden, matching how Android treats a `GONE` view.

This is a backport of upstream PR software-mansion/react-native-screens#4489
(issue #4132), which is open and unreleased. We can't get it by upgrading:
`react-native-screens` ≥ 4.25 fails codegen on RN 0.83.2 (`SplitHost`'s
`showColumn` command), so any version above our pinned 4.24.0 is unbuildable
until we bump the Expo SDK. The patch comment records the removal condition.

**2.** The conversation screen is re-exported inside the notifications modal,
but its reply button hard-coded `/health/messages/new`. Opened from a
notification, that pushed into the health tab's stack: the compose screen
rendered with no header at all, hardware back landed in Pósthólf, and the
orphaned screen stayed on the Heilsa tab afterwards.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a message composition screen within the notifications modal.
  * Added support for replying to health messages while preserving the notifications navigation context.
  * The back arrow now returns users to the notifications sheet when composing from notifications.



<!-- end of auto-generated comment: release notes by coderabbit.ai -->