### PR TITLE
fix(island-ui): Modals never open in local dev under React 19

### DIFF
--- a/libs/island-ui/core/src/lib/ModalBase/ModalBase.tsx
+++ b/libs/island-ui/core/src/lib/ModalBase/ModalBase.tsx
@@ -6,9 +6,9 @@ import React, {
   useLayoutEffect,
   ReactElement,
   useEffect,
+  useRef,
 } from 'react'
 import cn from 'classnames'
-import { useUpdateEffect } from 'react-use'
 import {
   useDialogState,
   Dialog as BaseDialog,
@@ -151,9 +151,17 @@ export const ModalBase: FC<ModalBaseProps> = ({
     }
   }, [isVisible])
 
-  useUpdateEffect(() => {
-    onVisibilityChange && onVisibilityChange(modal.visible)
-  }, [modal.visible])
+  // Report only real visibility transitions. A previous-value guard instead
+  // of useUpdateEffect: react-use's first-mount tracking misfires under
+  // React 19 StrictMode double rendering, reporting visible=false on mount,
+  // which makes consumers close themselves before the dialog ever opens.
+  const prevVisible = useRef(modal.visible)
+  useEffect(() => {
+    if (prevVisible.current !== modal.visible) {
+      prevVisible.current = modal.visible
+      onVisibilityChange && onVisibilityChange(modal.visible)
+    }
+  }, [modal.visible, onVisibilityChange])
 
   const renderModal = !removeOnClose || (removeOnClose && modal.visible)
 

--- a/libs/island-ui/core/src/lib/ModalBase/ModalBase.tsx
+++ b/libs/island-ui/core/src/lib/ModalBase/ModalBase.tsx
@@ -151,10 +151,6 @@ export const ModalBase: FC<ModalBaseProps> = ({
     }
   }, [isVisible])
 
-  // Report only real visibility transitions. A previous-value guard instead
-  // of useUpdateEffect: react-use's first-mount tracking misfires under
-  // React 19 StrictMode double rendering, reporting visible=false on mount,
-  // which makes consumers close themselves before the dialog ever opens.
   const prevVisible = useRef(modal.visible)
   useEffect(() => {
     if (prevVisible.current !== modal.visible) {


### PR DESCRIPTION
# Modals not opening in local dev under React 19

## What

- Replace `useUpdateEffect` in `ModalBase` with a previous-value guard so `onVisibilityChange` only fires on real visibility transitions

## Why

- Since the React 19 upgrade, `isVisible`-driven modals (e.g. the ids-admin create-domain dialog) never open under `yarn start`: react-use's first-mount tracking breaks under React 19 StrictMode double rendering, so `onVisibilityChange(false)` fires on mount, `Modal` calls `onClose()`, and the consumer unmounts the dialog before it appears
- Dev-only (production builds don't double-render), which is why deployed environments were unaffected
- Verified locally: the ids-admin "Create domain" dialog opens again with StrictMode on

## Screenshots / Gifs

N/A

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- Fixed modal visibility callbacks triggering unexpectedly during initial rendering in React 19 Strict Mode.
- Visibility change notifications now occur only when the modal’s visibility actually changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->