### PR TITLE
feat(ids-admin): allow publishing a domain to an environment it doesn't exist in

### DIFF
--- a/libs/portals/admin/ids-admin/src/components/EnvironmentHeader/EnvironmentHeader.tsx
+++ b/libs/portals/admin/ids-admin/src/components/EnvironmentHeader/EnvironmentHeader.tsx
@@ -48,18 +48,13 @@ export const EnvironmentHeader = ({
   const { formatMessage } = useLocale()
   const tenant = useRouteLoaderData(tenantLoaderId) as TenantLoaderResult
 
+  const getEnvironmentLabel = (environment: AuthAdminEnvironment) =>
+    availableEnvironments.includes(environment)
+      ? environment
+      : formatMessage(m.publishEnvironment, { environment })
+
   const options = (optionEnvironments ?? tenant.availableEnvironments)
-    .map((env) => {
-      const isAvailable = availableEnvironments.includes(env)
-
-      const label = isAvailable
-        ? env
-        : formatMessage(m.publishEnvironment, {
-            environment: env,
-          })
-
-      return formatOption(label, env)
-    })
+    .map((env) => formatOption(getEnvironmentLabel(env), env))
     .filter(isDefined)
 
   return (
@@ -89,7 +84,10 @@ export const EnvironmentHeader = ({
               onChange(opt.value)
             }
           }}
-          value={formatOption(selectedEnvironment, selectedEnvironment)}
+          value={formatOption(
+            getEnvironmentLabel(selectedEnvironment),
+            selectedEnvironment,
+          )}
           options={options}
         />
       </div>

--- a/libs/portals/admin/ids-admin/src/components/EnvironmentHeader/EnvironmentHeader.tsx
+++ b/libs/portals/admin/ids-admin/src/components/EnvironmentHeader/EnvironmentHeader.tsx
@@ -17,11 +17,6 @@ interface EnvironmentHeaderProps {
   title: string
   selectedEnvironment: AuthAdminEnvironment
   availableEnvironments: AuthAdminEnvironment[]
-  /**
-   * Environments to offer in the picker. Anything not in
-   * `availableEnvironments` is offered as a publish target. Defaults to the
-   * environments of the tenant the resource belongs to.
-   */
   optionEnvironments?: AuthAdminEnvironment[]
   onChange(value: AuthAdminEnvironment): void
   preHeader?: ReactNode

--- a/libs/portals/admin/ids-admin/src/components/EnvironmentHeader/EnvironmentHeader.tsx
+++ b/libs/portals/admin/ids-admin/src/components/EnvironmentHeader/EnvironmentHeader.tsx
@@ -17,6 +17,12 @@ interface EnvironmentHeaderProps {
   title: string
   selectedEnvironment: AuthAdminEnvironment
   availableEnvironments: AuthAdminEnvironment[]
+  /**
+   * Environments to offer in the picker. Anything not in
+   * `availableEnvironments` is offered as a publish target. Defaults to the
+   * environments of the tenant the resource belongs to.
+   */
+  optionEnvironments?: AuthAdminEnvironment[]
   onChange(value: AuthAdminEnvironment): void
   preHeader?: ReactNode
   postHeader?: ReactNode
@@ -34,6 +40,7 @@ export const EnvironmentHeader = ({
   title,
   selectedEnvironment,
   availableEnvironments,
+  optionEnvironments,
   onChange,
   preHeader,
   postHeader,
@@ -41,7 +48,7 @@ export const EnvironmentHeader = ({
   const { formatMessage } = useLocale()
   const tenant = useRouteLoaderData(tenantLoaderId) as TenantLoaderResult
 
-  const options = tenant.availableEnvironments
+  const options = (optionEnvironments ?? tenant.availableEnvironments)
     .map((env) => {
       const isAvailable = availableEnvironments.includes(env)
 

--- a/libs/portals/admin/ids-admin/src/screens/Tenants/EditTenant/EditTenant.loader.ts
+++ b/libs/portals/admin/ids-admin/src/screens/Tenants/EditTenant/EditTenant.loader.ts
@@ -7,14 +7,26 @@ import { replaceParams } from '@island.is/react-spa/shared'
 
 import { IDSAdminPaths } from '../../../lib/paths'
 import {
+  TenantConfiguredEnvironmentsDocument,
+  TenantConfiguredEnvironmentsQuery,
   TenantDetailsDocument,
   TenantDetailsQuery,
   TenantDetailsQueryVariables,
 } from '../Tenants.generated'
 
+type ConfiguredEnvironments =
+  TenantConfiguredEnvironmentsQuery['authAdminTenantConfiguredEnvironments']
+
 export type EditTenantLoaderResult = NonNullable<
   TenantDetailsQuery['authAdminTenantDetails']
->
+> & {
+  /**
+   * All environments the admin API is configured for, not just the ones the
+   * tenant exists in, so the environment picker can offer publishing to a
+   * missing environment.
+   */
+  configuredEnvironments: ConfiguredEnvironments
+}
 
 export type EditTenantEnvironment =
   EditTenantLoaderResult['environments'][number]
@@ -50,19 +62,36 @@ export const editTenantLoader: WrappedLoaderFn = ({
       )
     }
 
-    const response = await client.query<
-      TenantDetailsQuery,
-      TenantDetailsQueryVariables
-    >({
-      query: TenantDetailsDocument,
-      variables: { id: tenantId },
-      fetchPolicy: 'network-only',
-    })
+    const [response, configuredEnvironments] = await Promise.all([
+      client.query<TenantDetailsQuery, TenantDetailsQueryVariables>({
+        query: TenantDetailsDocument,
+        variables: { id: tenantId },
+        fetchPolicy: 'network-only',
+      }),
+      client
+        .query<TenantConfiguredEnvironmentsQuery>({
+          query: TenantConfiguredEnvironmentsDocument,
+          fetchPolicy: 'network-only',
+        })
+        .then((result) => result.data?.authAdminTenantConfiguredEnvironments)
+        .catch((error) => {
+          console.error('Failed to fetch configured environments', error)
+          return undefined
+        }),
+    ])
 
     if (response.error || !response.data?.authAdminTenantDetails) {
       throw response.error ?? new Error(`Tenant ${tenantId} not found`)
     }
 
-    return response.data.authAdminTenantDetails
+    const tenant = response.data.authAdminTenantDetails
+
+    return {
+      ...tenant,
+      configuredEnvironments:
+        configuredEnvironments && configuredEnvironments.length > 0
+          ? configuredEnvironments
+          : tenant.availableEnvironments,
+    }
   }
 }

--- a/libs/portals/admin/ids-admin/src/screens/Tenants/EditTenant/EditTenant.loader.ts
+++ b/libs/portals/admin/ids-admin/src/screens/Tenants/EditTenant/EditTenant.loader.ts
@@ -20,11 +20,6 @@ type ConfiguredEnvironments =
 export type EditTenantLoaderResult = NonNullable<
   TenantDetailsQuery['authAdminTenantDetails']
 > & {
-  /**
-   * All environments the admin API is configured for, not just the ones the
-   * tenant exists in, so the environment picker can offer publishing to a
-   * missing environment.
-   */
   configuredEnvironments: ConfiguredEnvironments
 }
 

--- a/libs/portals/admin/ids-admin/src/screens/Tenants/EditTenant/EditTenant.tsx
+++ b/libs/portals/admin/ids-admin/src/screens/Tenants/EditTenant/EditTenant.tsx
@@ -52,6 +52,7 @@ export const EditTenant = () => {
             title={displayName || tenant.id || formatMessage(m.editTenant)}
             selectedEnvironment={selectedEnvironment.environment}
             availableEnvironments={tenant.availableEnvironments}
+            optionEnvironments={tenant.configuredEnvironments}
             onChange={onEnvironmentChange}
           />
         }


### PR DESCRIPTION
# Allow publishing a domain to an environment it doesn't exist in

## What

- The domain environment picker now lists every configured environment, labelling the missing ones as publish targets, which makes the existing publish-tenant flow reachable.
- `editTenantLoader` fetches `authAdminTenantConfiguredEnvironments` alongside the tenant details and falls back to the tenant's own environments if that query fails.

## Why

- A domain created in production only could never be added to development or staging from the portal — the picker derived its options from the environments the domain already existed in, so the publish modal never opened.
- The backend already supports it (`publishAuthAdminTenant`), only the UI was missing.

## Screenshots / Gifs

N/A

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Tenant editing now displays configured environments in the environment picker when available.
  - If no configured environments are available, the picker uses the tenant’s available environments instead.
  - Environment labels now accurately reflect selected environments and publishing targets.
  - Tenant details and environment configuration are loaded in parallel for faster screen loading.

- **Bug Fixes**
  - Added graceful fallback behavior when environment configuration data cannot be retrieved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->