### PR TITLE
feat(ecoi): connected component calculator

### DIFF
--- a/apps/web/components/connected/ECOICalculator/Calculator.css.ts
+++ b/apps/web/components/connected/ECOICalculator/Calculator.css.ts
@@ -21,3 +21,11 @@ export const tableRow = style({
 export const stayOnSinglePageWhenPrinting = style({
   pageBreakInside: 'avoid',
 })
+
+export const totalAverageBanner = style({
+  height: 60,
+})
+
+export const tabPanelSpacer = style({
+  height: 40,
+})

--- a/apps/web/components/connected/ECOICalculator/Calculator.css.ts
+++ b/apps/web/components/connected/ECOICalculator/Calculator.css.ts
@@ -23,7 +23,7 @@ export const stayOnSinglePageWhenPrinting = style({
 })
 
 export const totalAverageBanner = style({
-  height: 60,
+  minHeight: 60,
 })
 
 export const tabPanelSpacer = style({

--- a/apps/web/components/connected/ECOICalculator/Calculator.strings.ts
+++ b/apps/web/components/connected/ECOICalculator/Calculator.strings.ts
@@ -71,6 +71,21 @@ export const m = {
       defaultMessage: 'Sundurliðun á niðurstöðum',
       description: 'Sundurliðun á niðurstöðum',
     },
+    tableTabLabel: {
+      id: 'web.ecoi.calculator:results.tableTabLabel',
+      defaultMessage: 'Tafla',
+      description: 'Tafla',
+    },
+    chartTabLabel: {
+      id: 'web.ecoi.calculator:results.chartTabLabel',
+      defaultMessage: 'Stöplarit',
+      description: 'Stöplarit',
+    },
+    radarChartTabLabel: {
+      id: 'web.ecoi.calculator:results.radarChartTabLabel',
+      defaultMessage: 'Köngulóargraf',
+      description: 'Köngulóargraf',
+    },
     tableCategory: {
       id: 'web.ecoi.calculator:results.tableCategory',
       defaultMessage: 'Flokkur',

--- a/apps/web/components/connected/ECOICalculator/Calculator.tsx
+++ b/apps/web/components/connected/ECOICalculator/Calculator.tsx
@@ -8,6 +8,20 @@ import {
 import { useIntl } from 'react-intl'
 import round from 'lodash/round'
 import { parseAsInteger, useQueryState } from 'next-usequerystate'
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  PolarAngleAxis,
+  PolarGrid,
+  PolarRadiusAxis,
+  Radar,
+  RadarChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts'
 
 import {
   Box,
@@ -17,8 +31,10 @@ import {
   RadioButton,
   Stack,
   Table,
+  Tabs,
   Text,
 } from '@island.is/island-ui/core'
+import { theme } from '@island.is/island-ui/theme'
 import { ConnectedComponent } from '@island.is/web/graphql/schema'
 import { useDateUtils } from '@island.is/web/i18n/useDateUtils'
 
@@ -123,7 +139,7 @@ const ECOIForm = ({ step, stepIndex, state, setState }: ECOIFormProps) => {
   )
 }
 
-interface ECOICalculatorResultsProps {
+export interface ECOICalculatorResultsProps {
   categoryAverages: { title: string; average: number }[]
   totalAverage: number
 }
@@ -138,7 +154,90 @@ const getBracketText = (
   return formatMessage(m.results.bracket1Text)
 }
 
-const ECOICalculatorResults = ({
+const CHART_X_AXIS_TICKS = [0, 0.5, 1, 1.5, 2, 2.5, 3]
+const CHART_CATEGORY_LABEL_MAX_LENGTH = 30
+
+const CategoryAxisTick = (props: {
+  x?: number
+  y?: number
+  payload?: { value: string }
+}) => {
+  const { x, y, payload } = props
+  const value = payload?.value ?? ''
+  const label =
+    value.length > CHART_CATEGORY_LABEL_MAX_LENGTH
+      ? `${value.slice(0, CHART_CATEGORY_LABEL_MAX_LENGTH - 1)}…`
+      : value
+  return (
+    <g transform={`translate(${x},${y})`}>
+      <text
+        x={-8}
+        y={0}
+        dy={4}
+        textAnchor="end"
+        fontSize={13}
+        fill={theme.color.dark400}
+      >
+        {label}
+        <title>{value}</title>
+      </text>
+    </g>
+  )
+}
+
+const RADAR_CATEGORY_LABEL_MAX_LENGTH = 20
+
+const RadarCategoryTick = (props: {
+  x?: number
+  y?: number
+  textAnchor?: 'start' | 'middle' | 'end'
+  payload?: { value: string }
+}) => {
+  const { x = 0, y = 0, textAnchor = 'middle', payload } = props
+  const value = payload?.value ?? ''
+  const label =
+    value.length > RADAR_CATEGORY_LABEL_MAX_LENGTH
+      ? `${value.slice(0, RADAR_CATEGORY_LABEL_MAX_LENGTH - 1)}…`
+      : value
+  return (
+    <text
+      x={x}
+      y={y}
+      textAnchor={textAnchor}
+      fontSize={12}
+      fontWeight={600}
+      fill={theme.color.dark400}
+    >
+      {label}
+      <title>{value}</title>
+    </text>
+  )
+}
+
+const BarValueLabel = (props: {
+  x?: number
+  y?: number
+  width?: number
+  height?: number
+  value?: number
+}) => {
+  const { x = 0, y = 0, width = 0, height = 0, value = 0 } = props
+  return (
+    <text
+      x={x + width - 8}
+      y={y + height / 2}
+      dy={4}
+      textAnchor="end"
+      fill={theme.color.white}
+      fontSize={13}
+      fontWeight={600}
+    >
+      {formatScore(value)}
+    </text>
+  )
+}
+
+export const ECOICalculatorResults = ({
   categoryAverages,
   totalAverage,
 }: ECOICalculatorResultsProps) => {
@@ -169,48 +268,176 @@ const ECOICalculatorResults = ({
           <Text variant="h3" as="h3">
             {formatMessage(m.results.breakdownHeading)}
           </Text>
-          <Table.Table>
-            <Table.Head>
-              <Table.Row>
-                <Table.HeadData>{''}</Table.HeadData>
-                <Table.HeadData>
-                  {formatMessage(m.results.tableCategory)}
-                </Table.HeadData>
-                <Table.HeadData align="right">
-                  {formatMessage(m.results.tableAverage)}
-                </Table.HeadData>
-              </Table.Row>
-            </Table.Head>
-            <Table.Body>
-              {categoryAverages.map((cat, index) => (
-                <Table.Row key={cat.title}>
-                  <Table.Data>{index + 1}</Table.Data>
-                  <Table.Data>{cat.title}</Table.Data>
-                  <Table.Data align="right">
-                    {formatScore(cat.average)}
-                  </Table.Data>
-                </Table.Row>
-              ))}
-            </Table.Body>
-            <Table.Foot>
-              <Table.Row>
-                <Table.Data box={{ background: 'blue100' }}>{''}</Table.Data>
-                <Table.Data
-                  box={{ background: 'blue100' }}
-                  text={{ fontWeight: 'semiBold' }}
-                >
-                  {formatMessage(m.results.totalAverage)}
-                </Table.Data>
-                <Table.Data
-                  box={{ background: 'blue100' }}
-                  text={{ fontWeight: 'semiBold' }}
-                  align="right"
-                >
-                  {formatScore(totalAverage)}
-                </Table.Data>
-              </Table.Row>
-            </Table.Foot>
-          </Table.Table>
+          <Tabs
+            label={formatMessage(m.results.breakdownHeading)}
+            selected="table"
+            contentBackground="white"
+            size="sm"
+            tabs={[
+              {
+                id: 'table',
+                label: formatMessage(m.results.tableTabLabel),
+                content: (
+                  <>
+                    <Box className={styles.tabPanelSpacer} />
+                    <Table.Table>
+                      <Table.Head>
+                        <Table.Row>
+                          <Table.HeadData>{''}</Table.HeadData>
+                          <Table.HeadData text={{ variant: 'eyebrow' }}>
+                            {formatMessage(m.results.tableCategory)}
+                          </Table.HeadData>
+                          <Table.HeadData
+                            text={{ variant: 'eyebrow' }}
+                            align="right"
+                          >
+                            {formatMessage(m.results.tableAverage)}
+                          </Table.HeadData>
+                        </Table.Row>
+                      </Table.Head>
+                      <Table.Body>
+                        {categoryAverages.map((cat, index) => (
+                          <Table.Row key={cat.title}>
+                            <Table.Data>{index + 1}</Table.Data>
+                            <Table.Data>{cat.title}</Table.Data>
+                            <Table.Data align="right">
+                              {formatScore(cat.average)}
+                            </Table.Data>
+                          </Table.Row>
+                        ))}
+                      </Table.Body>
+                    </Table.Table>
+                  </>
+                ),
+              },
+              {
+                id: 'chart',
+                label: formatMessage(m.results.chartTabLabel),
+                content: (
+                  <>
+                    <Box className={styles.tabPanelSpacer} />
+                    <Box width="full" height="full">
+                      <ResponsiveContainer
+                        width="100%"
+                        height={Math.max(
+                          380,
+                          categoryAverages.length * 42 + 40,
+                        )}
+                      >
+                        <BarChart
+                          layout="vertical"
+                          data={categoryAverages}
+                          margin={{ top: 8, right: 24, left: 8, bottom: 8 }}
+                          barCategoryGap="30%"
+                        >
+                          <CartesianGrid
+                            horizontal={false}
+                            stroke={theme.color.blue200}
+                          />
+                          <XAxis
+                            type="number"
+                            domain={[0, 3]}
+                            ticks={CHART_X_AXIS_TICKS}
+                            tickFormatter={formatScore}
+                            tickLine={false}
+                            axisLine={false}
+                            tick={{
+                              fontSize: 14,
+                              fontWeight: 400,
+                              fill: theme.color.dark400,
+                            }}
+                          />
+                          <YAxis
+                            type="category"
+                            dataKey="title"
+                            width={240}
+                            tickLine={false}
+                            axisLine={false}
+                            tick={<CategoryAxisTick />}
+                          />
+                          <Tooltip
+                            formatter={(value: number) => formatScore(value)}
+                          />
+                          <Bar
+                            dataKey="average"
+                            fill={theme.color.blue400}
+                            barSize={20}
+                            radius={[0, 4, 4, 0]}
+                            minPointSize={26}
+                            label={<BarValueLabel />}
+                          />
+                        </BarChart>
+                      </ResponsiveContainer>
+                    </Box>
+                  </>
+                ),
+              },
+              {
+                id: 'radar',
+                label: formatMessage(m.results.radarChartTabLabel),
+                content: (
+                  <>
+                    <Box className={styles.tabPanelSpacer} />
+                    <Box width="full" height="full">
+                      <ResponsiveContainer width="100%" height={520}>
+                        <RadarChart data={categoryAverages} outerRadius="65%">
+                          <PolarGrid
+                            gridType="polygon"
+                            stroke={theme.color.blue200}
+                          />
+                          <PolarAngleAxis
+                            dataKey="title"
+                            tick={<RadarCategoryTick />}
+                          />
+                          <PolarRadiusAxis
+                            angle={90}
+                            domain={[0, 3]}
+                            tickCount={CHART_X_AXIS_TICKS.length}
+                            tickFormatter={formatScore}
+                            tick={{ fontSize: 12, fill: theme.color.blue400 }}
+                            axisLine={false}
+                            stroke={theme.color.blue200}
+                          />
+                          <Tooltip
+                            formatter={(value: number) => formatScore(value)}
+                          />
+                          <Radar
+                            dataKey="average"
+                            stroke={theme.color.blue400}
+                            strokeWidth={2}
+                            fill={theme.color.blue400}
+                            fillOpacity={0.2}
+                            dot={{
+                              r: 4,
+                              fill: theme.color.blue400,
+                              stroke: theme.color.blue400,
+                            }}
+                          />
+                        </RadarChart>
+                      </ResponsiveContainer>
+                    </Box>
+                  </>
+                ),
+              },
+            ]}
+          />
+          <Box
+            display="flex"
+            alignItems="center"
+            justifyContent="spaceBetween"
+            width="full"
+            background="purple100"
+            borderRadius="large"
+            padding={2}
+            className={styles.totalAverageBanner}
+          >
+            <Text variant="medium" fontWeight="regular" color="dark400">
+              {formatMessage(m.results.totalAverage)}
+            </Text>
+            <Text variant="h5" fontWeight="semiBold" color="dark400">
+              {formatScore(totalAverage)}
+            </Text>
+          </Box>
         </Stack>
         <Stack space={1}>
           <Text variant="h3" as="h3">

--- a/apps/web/components/connected/ECOICalculator/Calculator.tsx
+++ b/apps/web/components/connected/ECOICalculator/Calculator.tsx
@@ -356,7 +356,7 @@ export const ECOICalculatorResults = ({
                             tick={<CategoryAxisTick />}
                           />
                           <Tooltip
-                            formatter={(value: number) => formatScore(value)}
+                            formatter={(value) => formatScore(Number(value))}
                           />
                           <Bar
                             dataKey="average"
@@ -399,7 +399,7 @@ export const ECOICalculatorResults = ({
                             stroke={theme.color.blue200}
                           />
                           <Tooltip
-                            formatter={(value: number) => formatScore(value)}
+                            formatter={(value) => formatScore(Number(value))}
                           />
                           <Radar
                             dataKey="average"


### PR DESCRIPTION
# ...

Attach a link to issue if relevant

## What

Added tabbed result views ("Tafla" / "Stöplarit" / "Köngulóargraf") to the ECOI Calculator results screen.

## Why

The results were previously shown as a table only. Customer wanted alternative visualizations (bar chart, radar/spider chart) so users can quickly spot weak categories at a glance, in addition to the precise table view.

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added tabs to the ECOI calculator results view for a score table, vertical bar chart, and radar chart.
  - Added clearer visualizations for category scores, including support for long category names.
  - Displayed the total average in a dedicated banner below the results tabs.
  - Added localized labels for the new results tabs.

- **Bug Fixes**
  - Improved the total average banner so it expands appropriately when its content wraps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->