### PR TITLE
feat(native-app): Use V2 endpoints for registering mileage for cars and display error from api if present

### DIFF
--- a/apps/native/app/src/app/(auth)/(tabs)/more/vehicles/[id]/mileage.tsx
+++ b/apps/native/app/src/app/(auth)/(tabs)/more/vehicles/[id]/mileage.tsx
@@ -149,10 +149,13 @@ export default function VehicleMileageScreen() {
     [latestMileage, intl],
   )
 
-  const handleFailedToUpdate = () => {
+  // Samgöngustofa explains why a registration was rejected (mileage too low,
+  // interval not elapsed, ...) - prefer that over the generic copy.
+  const handleFailedToUpdate = (serviceMessage?: string) => {
     Alert.alert(
       intl.formatMessage({ id: 'vehicle.mileage.errorTitle' }),
-      intl.formatMessage({ id: 'vehicle.mileage.errorFailedToUpdate' }),
+      serviceMessage ??
+        intl.formatMessage({ id: 'vehicle.mileage.errorFailedToUpdate' }),
     )
   }
 
@@ -167,13 +170,21 @@ export default function VehicleMileageScreen() {
       },
     })
       .then((res) => {
-        if (res.data?.vehicleMileagePost?.mileage !== String(mileage)) {
-          handleFailedToUpdate()
-        } else {
+        const result = res.data?.vehicleMileagePostV2
+        if (
+          result?.__typename === 'VehicleMileageDetail' &&
+          result.mileage === String(mileage)
+        ) {
           setInput('')
           Alert.alert(
             intl.formatMessage({ id: 'vehicle.mileage.successTitle' }),
             intl.formatMessage({ id: 'vehicle.mileage.successMessage' }),
+          )
+        } else {
+          handleFailedToUpdate(
+            result?.__typename === 'VehiclesMileageUpdateError'
+              ? result.message
+              : undefined,
           )
         }
       })
@@ -205,12 +216,20 @@ export default function VehicleMileageScreen() {
         },
       })
         .then((res) => {
-          if (res.data?.vehicleMileagePut?.mileage !== String(mileage)) {
-            handleFailedToUpdate()
-          } else {
+          const result = res.data?.vehicleMileagePutV2
+          if (
+            result?.__typename === 'VehicleMileagePutModel' &&
+            result.mileage === String(mileage)
+          ) {
             Alert.alert(
               intl.formatMessage({ id: 'vehicle.mileage.successTitle' }),
               intl.formatMessage({ id: 'vehicle.mileage.successMessage' }),
+            )
+          } else {
+            handleFailedToUpdate(
+              result?.__typename === 'VehiclesMileageUpdateError'
+                ? result.message
+                : undefined,
             )
           }
         })

--- a/apps/native/app/src/graphql/queries/vehicle-mileage.graphql
+++ b/apps/native/app/src/graphql/queries/vehicle-mileage.graphql
@@ -19,15 +19,27 @@ query GetVehicleMileage($input: GetVehicleMileageInput!) {
 }
 
 mutation PostVehicleMileage($input: PostVehicleMileageInput!) {
-  vehicleMileagePost(input: $input) {
-    ...VehicleMileageDetailFragment
+  vehicleMileagePostV2(input: $input) {
+    ... on VehicleMileageDetail {
+      ...VehicleMileageDetailFragment
+    }
+    ... on VehiclesMileageUpdateError {
+      code
+      message
+    }
   }
 }
 
 mutation UpdateVehicleMileage($input: PutVehicleMileageInput!) {
-  vehicleMileagePut(input: $input) {
-    permno
-    internalId
-    mileage
+  vehicleMileagePutV2(input: $input) {
+    ... on VehicleMileagePutModel {
+      permno
+      internalId
+      mileage
+    }
+    ... on VehiclesMileageUpdateError {
+      code
+      message
+    }
   }
 }


### PR DESCRIPTION
## What

Use V2 endpoints for registering mileage for cars and display error from api if present

## Why

Report from a user that was trying to register mileage for his car but it was not yet 30 days from the last time it was registered, so the button should not have been active, I can not reproduce that but changed so we are getting correct error message from the server to display in these edge cases.


## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated vehicle mileage submissions and edits to use the latest service endpoints.
  * Improved success detection to ensure the submitted mileage matches the saved result.
  * Display clearer service-provided error messages when mileage updates fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->