### PR TITLE
feat(doe): launagreining updated version

### DIFF
--- a/libs/api/domains/directorate-of-equality-application/src/lib/dto/draftEmployee.model.ts
+++ b/libs/api/domains/directorate-of-equality-application/src/lib/dto/draftEmployee.model.ts
@@ -30,13 +30,13 @@ export class DraftEmployeeModel {
   additionalFixedCarAllowance?: number | null
 
   @Field(() => Float, { nullable: true })
+  additionalFixedOther?: number | null
+
+  @Field(() => Float, { nullable: true })
   bonusOccasionalCarAllowance?: number | null
 
   @Field(() => Float, { nullable: true })
   bonusOccasionalOvertime?: number | null
-
-  @Field(() => Float, { nullable: true })
-  bonusPayments?: number | null
 
   @Field(() => Float, { nullable: true })
   bonusOther?: number | null

--- a/libs/application/templates/directorate-of-equality/salary-report/src/fields/EmployeeClassificationEditor/index.tsx
+++ b/libs/application/templates/directorate-of-equality/salary-report/src/fields/EmployeeClassificationEditor/index.tsx
@@ -47,9 +47,9 @@ const DRAFT_EMPLOYEES_WITH_STEPS_QUERY = gql`
         baseSalary
         additionalFixedOvertime
         additionalFixedCarAllowance
-        bonusOccasionalCarAllowance
+        additionalFixedOther
         bonusOccasionalOvertime
-        bonusPayments
+        bonusOccasionalCarAllowance
         bonusOther
         additionalSalary
         bonusSalary

--- a/libs/application/templates/directorate-of-equality/salary-report/src/fields/EmployeesEditor/EmployeeForm.tsx
+++ b/libs/application/templates/directorate-of-equality/salary-report/src/fields/EmployeesEditor/EmployeeForm.tsx
@@ -59,9 +59,11 @@ export const EmployeeForm: FC<Props> = ({
 
   const componentLabels = getSalaryComponentLabels(formatMessage)
 
+  // Row 4 of the workbook, not the derived-total names: these head the input
+  // columns, and Viðbótarlaun / Aukagreiðslur are columns P and Q.
   const groupHeadings: Record<'additional' | 'bonus', string> = {
-    additional: formatMessage(m.additionalSalaryLabel),
-    bonus: formatMessage(m.bonusSalaryLabel),
+    additional: formatMessage(m.fixedPaymentsGroupLabel),
+    bonus: formatMessage(m.occasionalPaymentsGroupLabel),
   }
 
   const onValid = (data: EmployeeFormValues) => {
@@ -177,6 +179,14 @@ export const EmployeeForm: FC<Props> = ({
               rules={{ required: requiredMsg }}
               error={errors.baseSalary?.message}
             />
+          </GridColumn>
+          {/* Sits under the hours/base-salary pair rather than in a tooltip:
+              template 2.0 narrowed what Greiddar stundir means, and a
+              manual-entry applicant has no workbook header to read it off. */}
+          <GridColumn span="12/12">
+            <Text variant="small" color="dark400">
+              {formatMessage(m.paidHoursHelperText)}
+            </Text>
           </GridColumn>
           {SALARY_COMPONENT_GROUPS.map(({ group, keys }) => (
             <Fragment key={group}>

--- a/libs/application/templates/directorate-of-equality/salary-report/src/fields/EmployeesEditor/index.tsx
+++ b/libs/application/templates/directorate-of-equality/salary-report/src/fields/EmployeesEditor/index.tsx
@@ -56,9 +56,9 @@ const DRAFT_EMPLOYEES_QUERY = gql`
         baseSalary
         additionalFixedOvertime
         additionalFixedCarAllowance
-        bonusOccasionalCarAllowance
+        additionalFixedOther
         bonusOccasionalOvertime
-        bonusPayments
+        bonusOccasionalCarAllowance
         bonusOther
         additionalSalary
         bonusSalary
@@ -93,9 +93,9 @@ const toEmployee = (e: ReportEmployeeDto): Employee => ({
   baseSalary: e.baseSalary,
   additionalFixedOvertime: e.additionalFixedOvertime,
   additionalFixedCarAllowance: e.additionalFixedCarAllowance,
-  bonusOccasionalCarAllowance: e.bonusOccasionalCarAllowance,
+  additionalFixedOther: e.additionalFixedOther,
   bonusOccasionalOvertime: e.bonusOccasionalOvertime,
-  bonusPayments: e.bonusPayments,
+  bonusOccasionalCarAllowance: e.bonusOccasionalCarAllowance,
   bonusOther: e.bonusOther,
   outlierGroupId: null,
 })

--- a/libs/application/templates/directorate-of-equality/salary-report/src/fields/EmployeesEditor/utils.ts
+++ b/libs/application/templates/directorate-of-equality/salary-report/src/fields/EmployeesEditor/utils.ts
@@ -83,11 +83,11 @@ export const getSalaryComponentLabels = (
     additionalFixedCarAllowance: formatMessage(
       m.additionalFixedCarAllowanceLabel,
     ),
+    additionalFixedOther: formatMessage(m.additionalFixedOtherLabel),
+    bonusOccasionalOvertime: formatMessage(m.bonusOccasionalOvertimeLabel),
     bonusOccasionalCarAllowance: formatMessage(
       m.bonusOccasionalCarAllowanceLabel,
     ),
-    bonusOccasionalOvertime: formatMessage(m.bonusOccasionalOvertimeLabel),
-    bonusPayments: formatMessage(m.bonusPaymentsLabel),
     bonusOther: formatMessage(m.bonusOtherLabel),
   }
 }

--- a/libs/application/templates/directorate-of-equality/salary-report/src/lib/messages.ts
+++ b/libs/application/templates/directorate-of-equality/salary-report/src/lib/messages.ts
@@ -812,16 +812,21 @@ export const messages = {
         id: 'doe.sr.application:report.employees.baseSalaryLabel',
         defaultMessage: 'Grunnlaun',
       },
-      additionalSalaryLabel: {
-        id: 'doe.sr.application:report.employees.additionalSalaryLabel',
-        defaultMessage: 'Viðbótarlaun',
+      // Band headings over the pay INPUTS, matching row 4 of the workbook. Named
+      // for the bands rather than for the derived read-only totals the API returns
+      // (Viðbótarlaun / Aukagreiðslur, workbook columns P and Q) — different
+      // things, and those two live in salaryAnalysis.components below.
+      fixedPaymentsGroupLabel: {
+        id: 'doe.sr.application:report.employees.fixedPaymentsGroupLabel',
+        defaultMessage: 'Fastar greiðslur',
       },
-      bonusSalaryLabel: {
-        id: 'doe.sr.application:report.employees.bonusSalaryLabel',
-        defaultMessage: 'Aukagreiðslur',
+      occasionalPaymentsGroupLabel: {
+        id: 'doe.sr.application:report.employees.occasionalPaymentsGroupLabel',
+        defaultMessage: 'Tilfallandi greiðslur',
       },
-      // Icelandic labels below are best-guess mappings of the API fields —
-      // adjust wording as needed.
+      // Verbatim from row 5 of the 2.0 workbook (DMR PR #1482), minus the sheet's
+      // "(kr.)" suffix — the row view formats these with formatCurrency. Declared
+      // in workbook column order J–O, the order SALARY_COMPONENT_GROUPS renders.
       additionalFixedOvertimeLabel: {
         id: 'doe.sr.application:report.employees.additionalFixedOvertimeLabel',
         defaultMessage: 'Föst yfirvinna',
@@ -830,21 +835,21 @@ export const messages = {
         id: 'doe.sr.application:report.employees.additionalFixedCarAllowanceLabel',
         defaultMessage: 'Föst bifreiðahlunnindi',
       },
-      bonusOccasionalCarAllowanceLabel: {
-        id: 'doe.sr.application:report.employees.bonusOccasionalCarAllowanceLabel',
-        defaultMessage: 'Tilfallandi bifreiðahlunnindi',
+      additionalFixedOtherLabel: {
+        id: 'doe.sr.application:report.employees.additionalFixedOtherLabel',
+        defaultMessage: 'Aðrar reglulegar greiðslur / hlunnindi',
       },
       bonusOccasionalOvertimeLabel: {
         id: 'doe.sr.application:report.employees.bonusOccasionalOvertimeLabel',
-        defaultMessage: 'Tilfallandi yfirvinna',
+        defaultMessage: 'Tilfallandi / mæld yfirvinna',
       },
-      bonusPaymentsLabel: {
-        id: 'doe.sr.application:report.employees.bonusPaymentsLabel',
-        defaultMessage: 'Bónusgreiðslur',
+      bonusOccasionalCarAllowanceLabel: {
+        id: 'doe.sr.application:report.employees.bonusOccasionalCarAllowanceLabel',
+        defaultMessage: 'Tilfallandi / mældur bifreiðastyrkur',
       },
       bonusOtherLabel: {
         id: 'doe.sr.application:report.employees.bonusOtherLabel',
-        defaultMessage: 'Aðrar greiðslur',
+        defaultMessage: 'Aðrar tilfallandi greiðslur / hlunnindi',
       },
       addButton: {
         id: 'doe.sr.application:report.employees.addButton',
@@ -894,6 +899,15 @@ export const messages = {
       paidHoursPlaceholder: {
         id: 'doe.sr.application:report.employees.paidHoursPlaceholder',
         defaultMessage: 'T.d. 173,33',
+      },
+      // Template 2.0 narrowed Greiddar stundir: fixed overtime hours still count,
+      // incidental paid hours no longer do. A manual-entry applicant never sees
+      // the workbook's column-E header, so this line is their only source for it —
+      // hence visible text rather than InputController's `tooltip`.
+      paidHoursHelperText: {
+        id: 'doe.sr.application:report.employees.paidHoursHelperText',
+        defaultMessage:
+          'Fastar yfirvinnustundir meðtaldar, en ekki tilfallandi greiddar stundir.',
       },
       paidHoursRangeError: {
         id: 'doe.sr.application:report.employees.paidHoursRangeError',
@@ -1137,7 +1151,7 @@ export const messages = {
       warningRowsExcluded: {
         id: 'doe.sr.application:salaryAnalysis.results.warningRowsExcluded',
         defaultMessage:
-          '{excluded} starfsmenn eru undanskildir í útreikningnum þar sem reglulegt tímakaup reiknaðist ekki hærra en núll. Kannaðu greiddar stundir og laun hjá þeim.',
+          '{excluded, plural, one {# starfsmaður er undanskilinn í útreikningnum þar sem reglulegt tímakaup reiknaðist ekki hærra en núll. Kannaðu greiddar stundir og laun hjá þeim starfsmanni.} other {# starfsmenn eru undanskildir í útreikningnum þar sem reglulegt tímakaup reiknaðist ekki hærra en núll. Kannaðu greiddar stundir og laun hjá þeim.}}',
       },
       warningNoScoreOverlap: {
         id: 'doe.sr.application:salaryAnalysis.results.warningNoScoreOverlap',

--- a/libs/application/templates/directorate-of-equality/salary-report/src/utils/constants.spec.ts
+++ b/libs/application/templates/directorate-of-equality/salary-report/src/utils/constants.spec.ts
@@ -1,0 +1,42 @@
+import { SALARY_COMPONENT_GROUPS, SALARY_COMPONENT_KEYS } from './constants'
+
+// The order of these keys is not cosmetic. SALARY_COMPONENT_GROUPS drives the
+// order of the pay inputs in EmployeeForm and of the detail rows in EmployeeRow,
+// and it mirrors columns J-O of the Jafnréttisstofa 2.0 workbook the applicant
+// filled in offline. Reordering them silently re-labels what the applicant reads,
+// and filing fixed pay as incidental (or vice versa) changes reglulegt tímakaup
+// without anything downstream flagging it — the exact failure DMR rejects 1.x
+// workbooks to avoid.
+describe('SALARY_COMPONENT_KEYS', () => {
+  it('matches workbook columns J-O in order', () => {
+    expect(SALARY_COMPONENT_KEYS).toEqual([
+      'additionalFixedOvertime', // J
+      'additionalFixedCarAllowance', // K
+      'additionalFixedOther', // L
+      'bonusOccasionalOvertime', // M
+      'bonusOccasionalCarAllowance', // N
+      'bonusOther', // O
+    ])
+  })
+
+  // Row 4 of the workbook bands these as Fastar greiðslur (I-L) and Tilfallandi
+  // greiðslur (M-O). Three each, and the split decides which side of the
+  // fixed/incidental line a payment lands on — i.e. whether it counts toward
+  // regluleg laun at all.
+  it('splits three fixed against three incidental', () => {
+    expect(SALARY_COMPONENT_GROUPS.map((group) => group.group)).toEqual([
+      'additional',
+      'bonus',
+    ])
+    expect(SALARY_COMPONENT_GROUPS[0].keys).toEqual([
+      'additionalFixedOvertime',
+      'additionalFixedCarAllowance',
+      'additionalFixedOther',
+    ])
+    expect(SALARY_COMPONENT_GROUPS[1].keys).toEqual([
+      'bonusOccasionalOvertime',
+      'bonusOccasionalCarAllowance',
+      'bonusOther',
+    ])
+  })
+})

--- a/libs/application/templates/directorate-of-equality/salary-report/src/utils/constants.ts
+++ b/libs/application/templates/directorate-of-equality/salary-report/src/utils/constants.ts
@@ -178,20 +178,27 @@ export const createDefaultSubCriterion = (
   ],
 })
 
+// Order is load-bearing, not cosmetic: this drives the order of the pay inputs in
+// EmployeeForm and of the detail rows in EmployeeRow, and it mirrors columns J–O
+// of the 2.0 workbook the applicant just filled in. The two groups are the
+// workbook's row-4 bands, Fastar greiðslur and Tilfallandi greiðslur.
 export const SALARY_COMPONENT_GROUPS: {
   group: 'additional' | 'bonus'
   keys: SalaryComponentKey[]
 }[] = [
   {
     group: 'additional',
-    keys: ['additionalFixedOvertime', 'additionalFixedCarAllowance'],
+    keys: [
+      'additionalFixedOvertime',
+      'additionalFixedCarAllowance',
+      'additionalFixedOther',
+    ],
   },
   {
     group: 'bonus',
     keys: [
-      'bonusOccasionalCarAllowance',
       'bonusOccasionalOvertime',
-      'bonusPayments',
+      'bonusOccasionalCarAllowance',
       'bonusOther',
     ],
   },

--- a/libs/application/templates/directorate-of-equality/salary-report/src/utils/types.ts
+++ b/libs/application/templates/directorate-of-equality/salary-report/src/utils/types.ts
@@ -48,14 +48,16 @@ export type SubCriterion = {
 // context for display is looked up elsewhere, not carried here.
 export type StepAssignment = { stepId: string }
 
-// Per-key breakdown (see README): the two additionalFixed* values sum to the
-// old flat additionalSalary; the four bonus/occasional values sum to bonusSalary.
+// Per-key breakdown, in workbook column order: the three additionalFixed* values
+// (columns J–L) sum to the derived additionalSalary, the three bonus* values
+// (M–O) to bonusSalary. Template 2.0 folded Bónusgreiðslur into bonusOther and
+// added additionalFixedOther, which counts toward regluleg laun.
 export type SalaryComponentKey =
   | 'additionalFixedOvertime'
   | 'additionalFixedCarAllowance'
-  | 'bonusOccasionalCarAllowance'
+  | 'additionalFixedOther'
   | 'bonusOccasionalOvertime'
-  | 'bonusPayments'
+  | 'bonusOccasionalCarAllowance'
   | 'bonusOther'
 
 // id is the client-minted UUID join key; `ordinal` is the human-facing number
@@ -73,9 +75,9 @@ export type Employee = {
   baseSalary: number
   additionalFixedOvertime?: number | null
   additionalFixedCarAllowance?: number | null
-  bonusOccasionalCarAllowance?: number | null
+  additionalFixedOther?: number | null
   bonusOccasionalOvertime?: number | null
-  bonusPayments?: number | null
+  bonusOccasionalCarAllowance?: number | null
   bonusOther?: number | null
   outlierGroupId?: string | null
 }

--- a/libs/clients/directorate-of-equality/src/clientConfig.json
+++ b/libs/clients/directorate-of-equality/src/clientConfig.json
@@ -3004,6 +3004,10 @@
           "salaryReportOverdue": {
             "type": "boolean",
             "description": "Derived: the company's next salary-report due date has passed."
+          },
+          "hasLegacyReports": {
+            "type": "boolean",
+            "description": "Derived: the Directorate's retired SharePoint register holds at least one row for this company. Drives whether the detail view offers the legacy-data tab; says nothing about compliance — the row may record a lapsed or surrendered certificate."
           }
         },
         "required": [
@@ -3020,7 +3024,8 @@
           "sectorOverride",
           "reportStatus",
           "equalityReportOverdue",
-          "salaryReportOverdue"
+          "salaryReportOverdue",
+          "hasLegacyReports"
         ]
       },
       "ApiErrorDto": {
@@ -3229,16 +3234,16 @@
           "startDate": { "type": "string" },
           "paidHours": {
             "type": "number",
-            "description": "Greiddar stundir í mánuðinum, yfirvinnustundir meðtaldar. Nefnari reglulegs tímakaups.",
+            "description": "Greiddar stundir í mánuðinum, fastar yfirvinnustundir meðtaldar en ekki tilfallandi greiddar stundir. Nefnari reglulegs tímakaups.",
             "minimum": 4,
             "maximum": 750
           },
           "baseSalary": { "type": "number" },
           "additionalFixedOvertime": { "type": "number", "nullable": true },
           "additionalFixedCarAllowance": { "type": "number", "nullable": true },
-          "bonusOccasionalCarAllowance": { "type": "number", "nullable": true },
+          "additionalFixedOther": { "type": "number", "nullable": true },
           "bonusOccasionalOvertime": { "type": "number", "nullable": true },
-          "bonusPayments": { "type": "number", "nullable": true },
+          "bonusOccasionalCarAllowance": { "type": "number", "nullable": true },
           "bonusOther": { "type": "number", "nullable": true },
           "personalStepAssignments": {
             "type": "array",
@@ -4056,7 +4061,7 @@
           "contactPhone": { "type": "string" },
           "equalityReportContent": {
             "type": "string",
-            "description": "Narrative gender-equality plan as base64-encoded HTML. Decoded server-side and persisted as `report.equality_report_content`."
+            "description": "Narrative gender-equality plan as plain HTML. Persisted as `report.equality_report_content` and rendered into the approved PDF, so send the markup itself — not a base64 blob, not a document."
           },
           "averageEmployeeMaleCount": { "type": "number", "nullable": true },
           "averageEmployeeFemaleCount": { "type": "number", "nullable": true },
@@ -4983,16 +4988,16 @@
           },
           "paidHours": {
             "type": "number",
-            "description": "Greiddar stundir í mánuðinum, yfirvinnustundir meðtaldar. Nefnari reglulegs tímakaups.",
+            "description": "Greiddar stundir í mánuðinum, fastar yfirvinnustundir meðtaldar en ekki tilfallandi greiddar stundir. Nefnari reglulegs tímakaups.",
             "minimum": 4,
             "maximum": 750
           },
           "baseSalary": { "type": "number" },
           "additionalFixedOvertime": { "type": "number", "nullable": true },
           "additionalFixedCarAllowance": { "type": "number", "nullable": true },
-          "bonusOccasionalCarAllowance": { "type": "number", "nullable": true },
+          "additionalFixedOther": { "type": "number", "nullable": true },
           "bonusOccasionalOvertime": { "type": "number", "nullable": true },
-          "bonusPayments": { "type": "number", "nullable": true },
+          "bonusOccasionalCarAllowance": { "type": "number", "nullable": true },
           "bonusOther": { "type": "number", "nullable": true },
           "stepIds": {
             "description": "Full set of personal step ids assigned to this employee (replace-all). Every id must be a step on the same draft.",
@@ -5136,16 +5141,16 @@
           "startDate": { "type": "string" },
           "paidHours": {
             "type": "number",
-            "description": "Greiddar stundir í mánuðinum, yfirvinnustundir meðtaldar. Nefnari reglulegs tímakaups.",
+            "description": "Greiddar stundir í mánuðinum, fastar yfirvinnustundir meðtaldar en ekki tilfallandi greiddar stundir. Nefnari reglulegs tímakaups.",
             "minimum": 4,
             "maximum": 750
           },
           "baseSalary": { "type": "number" },
           "additionalFixedOvertime": { "type": "number", "nullable": true },
           "additionalFixedCarAllowance": { "type": "number", "nullable": true },
-          "bonusOccasionalCarAllowance": { "type": "number", "nullable": true },
+          "additionalFixedOther": { "type": "number", "nullable": true },
           "bonusOccasionalOvertime": { "type": "number", "nullable": true },
-          "bonusPayments": { "type": "number", "nullable": true },
+          "bonusOccasionalCarAllowance": { "type": "number", "nullable": true },
           "bonusOther": { "type": "number", "nullable": true },
           "additionalSalary": { "type": "number" },
           "bonusSalary": { "type": "number" },
@@ -5190,16 +5195,16 @@
           "startDate": { "type": "string" },
           "paidHours": {
             "type": "number",
-            "description": "Greiddar stundir í mánuðinum, yfirvinnustundir meðtaldar. Nefnari reglulegs tímakaups.",
+            "description": "Greiddar stundir í mánuðinum, fastar yfirvinnustundir meðtaldar en ekki tilfallandi greiddar stundir. Nefnari reglulegs tímakaups.",
             "minimum": 4,
             "maximum": 750
           },
           "baseSalary": { "type": "number" },
           "additionalFixedOvertime": { "type": "number", "nullable": true },
           "additionalFixedCarAllowance": { "type": "number", "nullable": true },
-          "bonusOccasionalCarAllowance": { "type": "number", "nullable": true },
+          "additionalFixedOther": { "type": "number", "nullable": true },
           "bonusOccasionalOvertime": { "type": "number", "nullable": true },
-          "bonusPayments": { "type": "number", "nullable": true },
+          "bonusOccasionalCarAllowance": { "type": "number", "nullable": true },
           "bonusOther": { "type": "number", "nullable": true },
           "additionalSalary": { "type": "number" },
           "bonusSalary": { "type": "number" },


### PR DESCRIPTION
Launagreining 2.0 — DoE salary report pay fields and narrowed Greiddar stundir

  ## What

  Aligns the Directorate of Equality salary report with Excel template **2.0**, which re-cuts the employee pay fields along fixed vs. incidental and narrows *regluleg laun*.

  **Employee pay fields** — `bonusPayments` removed, `additionalFixedOther` added, and the six remaining fields reordered to workbook columns J–O:

  | Col | Field | Label |
  |---|---|---|
  | J | `additionalFixedOvertime` | Föst yfirvinna |
  | K | `additionalFixedCarAllowance` | Föst bifreiðahlunnindi |
  | L | `additionalFixedOther` | Aðrar reglulegar greiðslur / hlunnindi — **new**, counts toward regluleg laun |
  | M | `bonusOccasionalOvertime` | Tilfallandi / mæld yfirvinna |
  | N | `bonusOccasionalCarAllowance` | Tilfallandi / mældur bifreiðastyrkur |
  | O | `bonusOther` | Aðrar tilfallandi greiðslur / hlunnindi — widened, absorbs Bónusgreiðslur |

  **Greiddar stundir** — the definition narrowed (fixed overtime hours in, incidental paid hours out) with no change to the field name, type, or 4–750 range. Added a visible helper line under the input, since a manual-entry applicant never
  sees the workbook's column-E header and nothing else would tell them.

  **Copy** — three existing labels were wrong or vague against the shipped workbook; `bonusOccasionalCarAllowance` in particular said *bifreiðahlunnindi* where the sheet reserves that noun for the fixed variant (K) and uses
  *bifreiðastyrkur* for the incidental one (N). Input group headings now use the workbook's row-4 bands (*Fastar greiðslur* / *Tilfallandi greiðslur*) rather than the derived-total names *Viðbótarlaun* / *Aukagreiðslur*, which are columns
  P and Q and mean something different.

  Also fixes `warningRowsExcluded` rendering "1 starfsmenn", now reachable for a single employee after DMR unified their exclusion filters.

  Regenerated `clients/directorate-of-equality` against the 2.0 spec. `gen/fetch/**` is gitignored, so `clientConfig.json` is the only artefact here.

  ## Why

  DMR has merged 2.0 and is holding production so both sides deploy together. Two things reach us: the field shape changed, and `paidHours` changed meaning without changing shape.

  The label corrections are the load-bearing part. Column order drives the inputs via `SALARY_COMPONENT_GROUPS`, so a wrong label files fixed pay as incidental, which lowers reglulegt tímakaup with nothing downstream flagging it — the
  exact failure DMR rejects 1.x workbooks to avoid. Hence the new `constants.spec.ts`, pinning the six keys to J–O order so a future reorder fails loudly instead of silently re-labelling what applicants read.

  **Verified as not applying to us**, so deliberately absent from this PR:

  - No `ParsedReportDto` round-trip — we only use the draft flow, and `dataSchema.ts` keeps employees off `applicationAnswers` entirely, so there is no stored payload to migrate.
  - No transition remediation — DMR prod holds no drafts, dev was reseeded on 2.0.
  - No deploy sequencing — their pipe strips unknown properties rather than 400ing, and their workbook ships in the same artefact as the parser.

  ## Screenshots / Gifs

  <!-- From the end-to-end pass: the six inputs in J–O order under the two band
       headings, the Greiddar stundir helper line, and a 1.x workbook rejection
       showing DMR's five migration bullets as a bulleted list. -->

  ## Notes for the reviewer

  Two changes in the regenerated `clientConfig.json` are **not** from template 2.0 and are not acted on here:

  1. `SubmitEqualityReportDto.equalityReportContent` flipped from base64 to plain HTML. We never send that DTO (re-exported only, zero call sites); our paths use `UpdateDraftDto` and `EditEqualityContentDto`, both still base64, and DMR
  kept a compat branch that decodes base64 anyway. Migration sequencing is an open question with them.
  2. `CompanyDto.hasLegacyReports` — new required boolean on a response. Additive, no action.

  **This cannot merge and be forgotten.** Three of the label ids already have Contentful entries, which win over `defaultMessage`, so production keeps the wrong wording until those are updated at deploy. The four new ids fall back to code
  and are safe to lag.

  ## Checklist:

  - [ ] I have performed a self-review of my own code
  - [ ] I have made corresponding changes to the documentation <!-- no docs affected; code comments updated in place -->
  - [x] My changes generate no new warnings <!-- 0 errors; the 4 warnings in this project are pre-existing and on untouched lines -->
  - [x] I have added tests that prove my fix is effective or that my feature works <!-- utils/constants.spec.ts; suite now 178 tests / 17 suites -->
  - [x] Formatting passes locally with my changes <!-- prettier 2.6.2, the pinned version — note node_modules/.bin/prettier is a hoisted 2.2.0 and reports false failures -->
  - [ ] I have rebased against main before asking for a review
  - [ ] No AI tools were used in preparing this pull request
  - [x] AI tools were used in preparing this pull request
        Tools used: Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Salary reports now support the “Additional fixed other” component and updated fixed- and occasional-payment groupings.
  - Added guidance explaining that fixed overtime hours count toward paid hours, while occasional paid hours do not.
  - Company data now indicates whether legacy reports exist.

- **Improvements**
  - Updated salary-component labels and workbook column alignment.
  - Clarified report submission and paid-hours descriptions.
  - Salary-analysis warnings now display correctly for singular and multiple excluded rows.

- **Changes**
  - The obsolete bonus-payments field is no longer available in salary-report data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->