### PR TITLE
fix(j-s): Increase fontsize of pdf confirmation section 

### DIFF
--- a/apps/judicial-system/backend/src/app/formatters/confirmation/confirmedPdf.ts
+++ b/apps/judicial-system/backend/src/app/formatters/confirmation/confirmedPdf.ts
@@ -1,13 +1,14 @@
 import { PDFDocument, rgb, StandardFonts } from 'pdf-lib'
 
-import { formatDate, lowercase } from '@island.is/judicial-system/formatters'
+import { formatDate } from '@island.is/judicial-system/formatters'
 import { CaseFileCategory } from '@island.is/judicial-system/types'
 
 import {
   calculatePt,
   Confirmation,
+  confirmationFontSize,
   drawTextWithEllipsisPDFKit,
-  xsFontSize,
+  formatActor,
 } from '../pdfHelpers'
 import { PDFKitCoatOfArms } from '../svgs/PDFKitCoatOfArms'
 
@@ -88,24 +89,25 @@ const createRulingConfirmation = async (
   const timesRomanBoldFont = await pdfDoc.embedFont(
     StandardFonts.TimesRomanBold,
   )
+  const fontSize = calculatePt(confirmationFontSize)
   doc.drawText('Réttarvörslugátt', {
     x: titleX,
     y: height - pageMargin - titleHeight + calculatePt(16),
-    size: calculatePt(xsFontSize),
+    size: fontSize,
     font: timesRomanBoldFont,
   })
 
   doc.drawText('Rafræn staðfesting', {
     x: 158,
     y: height - pageMargin - titleHeight + calculatePt(16),
-    size: calculatePt(xsFontSize),
+    size: fontSize,
     font: timesRomanFont,
   })
 
   doc.drawText(formatDate(confirmation.date) || '', {
     x: shadowWidth - calculatePt(24),
     y: height - pageMargin - titleHeight + calculatePt(16),
-    size: calculatePt(xsFontSize),
+    size: fontSize,
     font: timesRomanFont,
   })
 
@@ -123,7 +125,7 @@ const createRulingConfirmation = async (
   doc.drawText('Dómstóll', {
     x: titleX,
     y: height - pageMargin - titleHeight - calculatePt(10),
-    size: calculatePt(xsFontSize),
+    size: fontSize,
     font: timesRomanBoldFont,
   })
 
@@ -132,7 +134,7 @@ const createRulingConfirmation = async (
       x: titleX,
       y: height - pageMargin - titleHeight - calculatePt(22),
       font: timesRomanFont,
-      size: calculatePt(xsFontSize),
+      size: fontSize,
     })
   }
 
@@ -150,23 +152,15 @@ const createRulingConfirmation = async (
   doc.drawText('Samþykktaraðili', {
     x: titleX + institutionWidth,
     y: height - pageMargin - titleHeight - calculatePt(10),
-    size: calculatePt(xsFontSize),
+    size: fontSize,
     font: timesRomanBoldFont,
   })
 
   if (confirmation?.actor) {
-    timesRomanFont.widthOfTextAtSize(
-      `${confirmation.actor}${
-        confirmation.title ? `, ${lowercase(confirmation.title)}` : ''
-      }`,
-      calculatePt(xsFontSize),
-    )
     drawTextWithEllipsisPDFKit(
       doc,
-      `${confirmation.actor}${
-        confirmation.title ? `, ${lowercase(confirmation.title)}` : ''
-      }`,
-      { type: timesRomanFont, size: calculatePt(xsFontSize) },
+      formatActor(confirmation.actor, confirmation.title),
+      { type: timesRomanFont, size: fontSize },
       titleX + institutionWidth,
       height - pageMargin - titleHeight - calculatePt(22),
       confirmedByWidth - 16,
@@ -225,24 +219,25 @@ const createCourtRecordConfirmation = async (
   const timesRomanBoldFont = await pdfDoc.embedFont(
     StandardFonts.TimesRomanBold,
   )
+  const fontSize = calculatePt(confirmationFontSize)
   doc.drawText('Réttarvörslugátt', {
     x: titleX,
     y: height - pageMargin - titleHeight + calculatePt(16),
-    size: calculatePt(xsFontSize),
+    size: fontSize,
     font: timesRomanBoldFont,
   })
 
   doc.drawText('Rafræn staðfesting', {
     x: 158,
     y: height - pageMargin - titleHeight + calculatePt(16),
-    size: calculatePt(xsFontSize),
+    size: fontSize,
     font: timesRomanFont,
   })
 
   doc.drawText(formatDate(confirmation.date) || '', {
     x: shadowWidth - calculatePt(24),
     y: height - pageMargin - titleHeight + calculatePt(16),
-    size: calculatePt(xsFontSize),
+    size: fontSize,
     font: timesRomanFont,
   })
 
@@ -260,7 +255,7 @@ const createCourtRecordConfirmation = async (
   doc.drawText('Dómstóll', {
     x: titleX,
     y: height - pageMargin - titleHeight - calculatePt(10),
-    size: calculatePt(xsFontSize),
+    size: fontSize,
     font: timesRomanBoldFont,
   })
 
@@ -269,7 +264,7 @@ const createCourtRecordConfirmation = async (
       x: titleX,
       y: height - pageMargin - titleHeight - calculatePt(22),
       font: timesRomanFont,
-      size: calculatePt(xsFontSize),
+      size: fontSize,
     })
   }
 }

--- a/apps/judicial-system/backend/src/app/formatters/pdfHelpers/pdfHelpers.ts
+++ b/apps/judicial-system/backend/src/app/formatters/pdfHelpers/pdfHelpers.ts
@@ -129,9 +129,6 @@ interface ConfirmationConfig {
 }
 
 export const formatActor = (name: string, title?: string) => {
-  // DEBUG: force a long samþykktaraðili to check wrap/overflow — remove before commit
-  name = 'Guðrún Sigríður Halldóra Bjarnhéðinsdóttir'
-  title = title ?? 'saksóknari við embætti héraðssaksóknara'
   return `${name}${title ? ` ${lowercase(title)}` : ''}`
 }
 

--- a/apps/judicial-system/backend/src/app/formatters/pdfHelpers/pdfHelpers.ts
+++ b/apps/judicial-system/backend/src/app/formatters/pdfHelpers/pdfHelpers.ts
@@ -219,19 +219,21 @@ export const drawConfirmation = (
     const dateString = formatDate(date) ?? ''
     const dateWidth = doc.widthOfString(dateString)
 
-    doc.fontSize(fontSize).text(
-      formatDate(date) ?? '',
-      coatOfArmsX +
-        coatOfArmsWidth +
-        (totalWidth - coatOfArmsWidth) -
-        dateWidth -
-        calculatePt(8),
-      titleTextY,
-      {
-        align: 'right',
-        width: dateWidth,
-      },
-    )
+    doc
+      .fontSize(fontSize)
+      .text(
+        formatDate(date) ?? '',
+        coatOfArmsX +
+          coatOfArmsWidth +
+          (totalWidth - coatOfArmsWidth) -
+          dateWidth -
+          calculatePt(8),
+        titleTextY,
+        {
+          align: 'right',
+          width: dateWidth,
+        },
+      )
   }
 
   const boxY = titleBoxY + titleHeight

--- a/apps/judicial-system/backend/src/app/formatters/pdfHelpers/pdfHelpers.ts
+++ b/apps/judicial-system/backend/src/app/formatters/pdfHelpers/pdfHelpers.ts
@@ -16,6 +16,7 @@ export interface Confirmation {
 
 export const calculatePt = (px: number) => Math.ceil(px * 0.74999943307122)
 export const xsFontSize = 5
+export const confirmationFontSize = 7
 export const smallFontSize = 9
 export const baseFontSize = 11
 export const basePlusFontSize = 12
@@ -128,7 +129,10 @@ interface ConfirmationConfig {
 }
 
 export const formatActor = (name: string, title?: string) => {
-  return `${name}${title ? `, ${lowercase(title)}` : ''}`
+  // DEBUG: force a long samþykktaraðili to check wrap/overflow — remove before commit
+  name = 'Guðrún Sigríður Halldóra Bjarnhéðinsdóttir'
+  title = title ?? 'saksóknari við embætti héraðssaksóknara'
+  return `${name}${title ? ` ${lowercase(title)}` : ''}`
 }
 
 export const drawConfirmation = (
@@ -144,7 +148,7 @@ export const drawConfirmation = (
   const coatOfArmsX = pageMargin + calculatePt(8)
   const titleHeight = calculatePt(16)
   const titleX = coatOfArmsX + coatOfArmsWidth + calculatePt(8)
-  const fontSize = calculatePt(xsFontSize) * 0.7
+  const fontSize = calculatePt(confirmationFontSize)
 
   // Page width minus 2 times the page margin
   const totalWidth = doc.page.width - pageMargin * 2
@@ -189,12 +193,10 @@ export const drawConfirmation = (
   // Draw the title text
   doc.fill('black')
   doc.font('Times-Bold')
-  doc
-    .fontSize(calculatePt(xsFontSize))
-    .text('Réttarvörslugátt', titleX, titleTextY, {
-      continued: true,
-      lineBreak: false,
-    })
+  doc.fontSize(fontSize).text('Réttarvörslugátt', titleX, titleTextY, {
+    continued: true,
+    lineBreak: false,
+  })
 
   doc.text('  ', { continued: true })
 
@@ -217,21 +219,19 @@ export const drawConfirmation = (
     const dateString = formatDate(date) ?? ''
     const dateWidth = doc.widthOfString(dateString)
 
-    doc
-      .fontSize(calculatePt(xsFontSize))
-      .text(
-        formatDate(date) ?? '',
-        coatOfArmsX +
-          coatOfArmsWidth +
-          (totalWidth - coatOfArmsWidth) -
-          dateWidth -
-          calculatePt(8),
-        titleTextY,
-        {
-          align: 'right',
-          width: dateWidth,
-        },
-      )
+    doc.fontSize(fontSize).text(
+      formatDate(date) ?? '',
+      coatOfArmsX +
+        coatOfArmsWidth +
+        (totalWidth - coatOfArmsWidth) -
+        dateWidth -
+        calculatePt(8),
+      titleTextY,
+      {
+        align: 'right',
+        width: dateWidth,
+      },
+    )
   }
 
   const boxY = titleBoxY + titleHeight
@@ -247,6 +247,7 @@ export const drawConfirmation = (
       .fillAndStroke('white', darkGray)
     doc.fill('black')
     doc.font('Times-Bold')
+    doc.fontSize(fontSize)
     doc.text(box.title, currentX + calculatePt(8), boxY + calculatePt(9), {
       lineGap: 1,
       width: boxWidth - calculatePt(16),


### PR DESCRIPTION
[Asana](https://app.asana.com/1/203394141643832/project/1212657017130395/task/1212681319145442?focus=true)

## What

Increase fontsize of pdf confirmation section by 2 pts
Removed a comma from the confirmation between name and title

## Why

Text was so small on printed paper it needed a magnifying glass to be readable. 
Users requested to remove the comma

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Cursor


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Confirmation PDFs now use consistent text sizing for titles, dates, and confirmation sections.
  - Actor information in confirmation documents now follows a standardized display format, with the name and title separated by a space.
  - Ruling and court record confirmations now share consistent typography and actor-line formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->