### PR TITLE
chore(infra): TEMPORARY scale api to prod envelope in dev for SH loadtest

### DIFF
--- a/apps/api/infra/api.ts
+++ b/apps/api/infra/api.ts
@@ -628,6 +628,7 @@ export const serviceSetup = (services: {
       max: 50,
       min: 3,
       cpuAverageUtilization: 70,
+      bypassReplicaClamp: true, // TEMPORARY: SH load-test window, use prod envelope in dev
     })
     .strategy({
       // prod: zero-downtime. dev/staging: downtime is fine, roll faster.

--- a/charts/islandis-services/api/values.dev.yaml
+++ b/charts/islandis-services/api/values.dev.yaml
@@ -230,8 +230,8 @@ hpa:
       cpuAverageUtilization: 70
       nginxRequestsIrate: 5
     replicas:
-      max: 2
-      min: 1
+      max: 50
+      min: 3
 httpRoute:
   primary-gw:
     hostnames:
@@ -254,9 +254,9 @@ podSecurityContext:
   fsGroup: 65534
 pvcs: []
 replicaCount:
-  default: 1
-  max: 2
-  min: 1
+  default: 3
+  max: 50
+  min: 3
 resources:
   limits:
     cpu: '3000m'

--- a/charts/islandis-services/api/values.staging.yaml
+++ b/charts/islandis-services/api/values.staging.yaml
@@ -230,8 +230,8 @@ hpa:
       cpuAverageUtilization: 70
       nginxRequestsIrate: 5
     replicas:
-      max: 2
-      min: 1
+      max: 50
+      min: 3
 httpRoute:
   primary-gw:
     hostnames:
@@ -253,9 +253,9 @@ podSecurityContext:
   fsGroup: 65534
 pvcs: []
 replicaCount:
-  default: 1
-  max: 2
-  min: 1
+  default: 3
+  max: 50
+  min: 3
 resources:
   limits:
     cpu: '3000m'

--- a/charts/islandis/values.dev.yaml
+++ b/charts/islandis/values.dev.yaml
@@ -340,8 +340,8 @@ api:
         cpuAverageUtilization: 70
         nginxRequestsIrate: 5
       replicas:
-        max: 2
-        min: 1
+        max: 50
+        min: 3
   httpRoute:
     primary-gw:
       hostnames:
@@ -364,9 +364,9 @@ api:
     fsGroup: 65534
   pvcs: []
   replicaCount:
-    default: 1
-    max: 2
-    min: 1
+    default: 3
+    max: 50
+    min: 3
   resources:
     limits:
       cpu: '3000m'

--- a/charts/islandis/values.staging.yaml
+++ b/charts/islandis/values.staging.yaml
@@ -340,8 +340,8 @@ api:
         cpuAverageUtilization: 70
         nginxRequestsIrate: 5
       replicas:
-        max: 2
-        min: 1
+        max: 50
+        min: 3
   httpRoute:
     primary-gw:
       hostnames:
@@ -363,9 +363,9 @@ api:
     fsGroup: 65534
   pvcs: []
   replicaCount:
-    default: 1
-    max: 2
-    min: 1
+    default: 3
+    max: 50
+    min: 3
   resources:
     limits:
       cpu: '3000m'


### PR DESCRIPTION

Opt api out of the dev/staging replica clamp via bypassReplicaClamp so it uses its explicit 3-50 @ 70% envelope in dev. Only api is scaled; SH caches IDS tokens so the IDS services do not need scaling. Revert after the test.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [x] No AI tools were used in preparing this pull request
- [ ] AI tools were used in preparing this pull request
      Tools used:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Replica scaling can temporarily exceed the configured autoscaling limit during load testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->