### PR TITLE
fix(my-pages): Add link to health contact info

### DIFF
--- a/libs/portals/my-pages/core/src/components/SidebarContactBox/SidebarContactBox.tsx
+++ b/libs/portals/my-pages/core/src/components/SidebarContactBox/SidebarContactBox.tsx
@@ -1,6 +1,8 @@
-import { Box, Icon, Text } from '@island.is/island-ui/core'
+import { Box, Button, Icon, Text } from '@island.is/island-ui/core'
 import { useLocale } from '@island.is/localization'
 import { m } from '../../lib/messages'
+import LinkResolver from '../LinkResolver/LinkResolver'
+import * as linkButtonStyles from '../LinkButton/LinkButton.css'
 
 export const SidebarContactBox = () => {
   const { formatMessage } = useLocale()
@@ -12,15 +14,32 @@ export const SidebarContactBox = () => {
       padding={3}
       marginTop={[4, 4, 3]}
     >
-      <Box display="flex" alignItems="center" marginBottom={1} columnGap={2}>
+      <Box display="flex" alignItems="flexStart" marginBottom={1} columnGap={2}>
         <Icon icon="mail" type="outline" color="purple400" />
         <Text variant="h4" color="purple400">
           {formatMessage(m.sidebarContactBoxTitle)}
         </Text>
       </Box>
-      <Text variant="default" color="dark400">
+      <Text variant="default" color="dark400" marginBottom={1}>
         {formatMessage(m.sidebarContactBoxBody)}
       </Text>
+      <Box display="flex" justifyContent="flexEnd">
+        <LinkResolver
+          className={linkButtonStyles.link}
+          href={formatMessage(m.sidebarContactBoxLinkUrl)}
+        >
+          <Button
+            as="span"
+            variant="text"
+            size="small"
+            unfocusable
+            icon="arrowForward"
+            iconType="outline"
+          >
+            {formatMessage(m.sidebarContactBoxLinkText)}
+          </Button>
+        </LinkResolver>
+      </Box>
     </Box>
   )
 }

--- a/libs/portals/my-pages/core/src/components/SidebarContactBox/SidebarContactBox.tsx
+++ b/libs/portals/my-pages/core/src/components/SidebarContactBox/SidebarContactBox.tsx
@@ -27,6 +27,9 @@ export const SidebarContactBox = () => {
         <LinkResolver
           className={linkButtonStyles.link}
           href={formatMessage(m.sidebarContactBoxLinkUrl)}
+          aria-label={`${formatMessage(
+            m.sidebarContactBoxLinkText,
+          )} – ${formatMessage(m.sidebarContactBoxTitle)}`}
         >
           <Button
             as="span"

--- a/libs/portals/my-pages/core/src/lib/messages.ts
+++ b/libs/portals/my-pages/core/src/lib/messages.ts
@@ -2281,12 +2281,20 @@ export const m = defineMessages({
   },
   sidebarContactBoxTitle: {
     id: 'service.portal:sidebar-contact-box-title',
-    defaultMessage: 'Ertu með spurningu?',
+    defaultMessage: 'Aðstoð við Mínar síður',
   },
   sidebarContactBoxBody: {
     id: 'service.portal:sidebar-contact-box-body',
     defaultMessage:
-      'Ef þú ert í vandræðum getur þú sent okkur fyrirspurn eða ábendingu á netfangið island@island.is',
+      'Finnurðu ekki það sem þú leitar að eða ertu í tæknilegum vandræðum? Sendu fyrirspurn eða ábendingu.',
+  },
+  sidebarContactBoxLinkText: {
+    id: 'service.portal:sidebar-contact-box-link-text',
+    defaultMessage: 'Opna form',
+  },
+  sidebarContactBoxLinkUrl: {
+    id: 'service.portal:sidebar-contact-box-link-url',
+    defaultMessage: 'https://island.is/s/stafraen-heilsa/hafa-samband',
   },
   unemploymentHasConfirmedJobSearch: {
     id: 'service.portal:unemployment-has-confirmed-job-search',


### PR DESCRIPTION
## What

Added CMS controlled link to health contact information box in side panel

## Why

So we can send users to a form to fill out when they need assistance or have questions

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a link button to the sidebar contact box for submitting inquiries or suggestions.
  - Added localized text and URL support for the contact form link.

- **Style**
  - Improved contact box layout, including icon alignment, text spacing, and button positioning.

- **Content**
  - Updated the contact title and message to reflect the inquiry and suggestion flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->