### PR TITLE
feat(native-app): add window patient reply days and treatmentId

### DIFF
--- a/apps/native/app/src/app/(auth)/(tabs)/health/messages/[id].tsx
+++ b/apps/native/app/src/app/(auth)/(tabs)/health/messages/[id].tsx
@@ -51,6 +51,17 @@ type ConversationMessage = NonNullable<
 
 type FlatListItem = ConversationMessage | { __typename: 'Skeleton'; id: string }
 
+// Hermes ships no Intl.PluralRules and the app has no polyfill for it, so ICU
+// `plural` syntax silently falls back to the raw pattern. Pick the form by
+// hand instead: Icelandic takes the singular for numbers ending in 1 except
+// 11 (1, 21, 31 ...), English only for exactly 1.
+const isSingularDayCount = (days: number, locale: string): boolean => {
+  if (locale.startsWith('is')) {
+    return days % 10 === 1 && days % 100 !== 11
+  }
+  return days === 1
+}
+
 // Maps a reply-blocked reason to its explanatory message.
 const replyBlockedMessageId = (
   reason?: HealthDirectorateHealthConversationReplyBlockedReason | null,
@@ -142,7 +153,11 @@ export default function HealthMessageDetailScreen() {
       HealthDirectorateHealthConversationReplyBlockedReason.ReplyWindowExpired &&
     replyWindowDays != null
       ? intl.formatMessage(
-          { id: 'health.messages.replyBlocked.windowExpiredDays' },
+          {
+            id: isSingularDayCount(replyWindowDays, intl.locale)
+              ? 'health.messages.replyBlocked.windowExpiredDay'
+              : 'health.messages.replyBlocked.windowExpiredDays',
+          },
           { days: replyWindowDays },
         )
       : intl.formatMessage({

--- a/apps/native/app/src/app/(auth)/(tabs)/health/messages/[id].tsx
+++ b/apps/native/app/src/app/(auth)/(tabs)/health/messages/[id].tsx
@@ -133,6 +133,22 @@ export default function HealthMessageDetailScreen() {
   const messages = useMemo(() => conversation?.messages ?? [], [conversation])
   const isSkeleton = res.loading && !res.data
 
+  // An expired reply window is the one reason we can quantify, so name the
+  // number of days when the server sends it. It is nullable, so fall back to
+  // the generic wording rather than rendering a blank count.
+  const replyWindowDays = conversation?.patientReplyWindowDays
+  const replyBlockedMessage =
+    conversation?.replyBlockedReason ===
+      HealthDirectorateHealthConversationReplyBlockedReason.ReplyWindowExpired &&
+    replyWindowDays != null
+      ? intl.formatMessage(
+          { id: 'health.messages.replyBlocked.windowExpiredDays' },
+          { days: replyWindowDays },
+        )
+      : intl.formatMessage({
+          id: replyBlockedMessageId(conversation?.replyBlockedReason),
+        })
+
   const [markAsRead] = useMarkHealthConversationAsReadMutation({
     // Fire-and-forget: the server state self-corrects on the next load.
     onError: () => undefined,
@@ -518,9 +534,7 @@ export default function HealthMessageDetailScreen() {
                 <Alert
                   type="info"
                   size="small"
-                  message={intl.formatMessage({
-                    id: replyBlockedMessageId(conversation?.replyBlockedReason),
-                  })}
+                  message={replyBlockedMessage}
                   hasBorder
                 />
               )}

--- a/apps/native/app/src/app/(auth)/(tabs)/health/messages/new.tsx
+++ b/apps/native/app/src/app/(auth)/(tabs)/health/messages/new.tsx
@@ -59,6 +59,8 @@ export default function HealthMessageComposeScreen() {
   const [recipientKey, setRecipientKey] = useState<string>()
   const [typeCode, setTypeCode] = useState<string>()
   const [termsAccepted, setTermsAccepted] = useState(false)
+  const [recipientMenuOpen, setRecipientMenuOpen] = useState(false)
+  const [serviceMenuOpen, setServiceMenuOpen] = useState(false)
 
   const recipientsRes = useGetHealthConversationRecipientsQuery({
     variables: { locale: locale === 'is' ? LocaleEnum.Is : LocaleEnum.En },
@@ -252,9 +254,19 @@ export default function HealthMessageComposeScreen() {
       ? sendButtonHeight + theme.spacing[4]
       : 0
 
+  // A selection menu lives in its own platform view controller that is not
+  // torn down with this sheet, so dragging the sheet away while one is open
+  // leaves the menu stranded over whatever is shown next. Block the dismiss
+  // gesture while a menu is up; the close button still works, because that
+  // path lets us dismiss the menu before the sheet goes.
+  const isMenuOpen = recipientMenuOpen || serviceMenuOpen
+
   return (
     <>
-      <StackScreen closeable options={{ title: '' }} />
+      <StackScreen
+        closeable
+        options={{ title: '', gestureEnabled: !isMenuOpen }}
+      />
       <ToastHost ignoreTabBar bottomOffset={toastBottomOffset} />
       <ScrollView
         style={{ flex: 1 }}
@@ -360,6 +372,7 @@ export default function HealthMessageComposeScreen() {
                   value: getRecipientKey(r),
                 }))}
                 onSelect={setRecipientKey}
+                onOpenChange={setRecipientMenuOpen}
               />
             )}
             {selectedRecipient && (
@@ -386,6 +399,7 @@ export default function HealthMessageComposeScreen() {
                     value: s.patientInitiatedTypeCode,
                   }))}
                   onSelect={setTypeCode}
+                  onOpenChange={setServiceMenuOpen}
                   disabled={isFormLocked}
                 />
               )}

--- a/apps/native/app/src/app/(auth)/(tabs)/health/messages/new.tsx
+++ b/apps/native/app/src/app/(auth)/(tabs)/health/messages/new.tsx
@@ -32,6 +32,18 @@ import {
 
 const MESSAGE_MAX_LENGTH = 300
 
+// A recipient is only unique across all three identifiers: the same node and
+// group can appear more than once, once per treatment. Mirrors the my-pages
+// getRecipientKey so both clients key the dropdown the same way.
+const getRecipientKey = (recipient: {
+  nodeId: string
+  groupId: number
+  treatmentId?: string | null
+}) =>
+  `${recipient.nodeId}-${recipient.groupId}${
+    recipient.treatmentId ? `-${recipient.treatmentId}` : ''
+  }`
+
 export default function HealthMessageComposeScreen() {
   const { conversationId, recipientName, subject } = useLocalSearchParams<{
     conversationId?: string
@@ -44,7 +56,7 @@ export default function HealthMessageComposeScreen() {
   const isReply = !!conversationId
 
   const [message, setMessage] = useState('')
-  const [recipientNodeId, setRecipientNodeId] = useState<string>()
+  const [recipientKey, setRecipientKey] = useState<string>()
   const [typeCode, setTypeCode] = useState<string>()
   const [termsAccepted, setTermsAccepted] = useState(false)
 
@@ -63,7 +75,9 @@ export default function HealthMessageComposeScreen() {
     () => allRecipients.filter((r) => r.allowsMessaging),
     [allRecipients],
   )
-  const selectedRecipient = recipients.find((r) => r.nodeId === recipientNodeId)
+  const selectedRecipient = recipients.find(
+    (r) => getRecipientKey(r) === recipientKey,
+  )
 
   // When the user has a single recipient that can't take messages (its window
   // is closed, or it doesn't offer messaging at all), we replace the whole form
@@ -104,10 +118,10 @@ export default function HealthMessageComposeScreen() {
 
   // Default to the only recipient when there is a single option.
   useEffect(() => {
-    if (!isReply && !recipientNodeId && recipients.length === 1) {
-      setRecipientNodeId(recipients[0].nodeId)
+    if (!isReply && !recipientKey && recipients.length === 1) {
+      setRecipientKey(getRecipientKey(recipients[0]))
     }
-  }, [isReply, recipients, recipientNodeId])
+  }, [isReply, recipients, recipientKey])
 
   // Reset / default the service when the recipient changes.
   useEffect(() => {
@@ -192,6 +206,9 @@ export default function HealthMessageComposeScreen() {
           input: {
             groupId: selectedRecipient.groupId,
             nodeId: selectedRecipient.nodeId,
+            // Treatment-scoped recipients share a node and group with their
+            // siblings, so the treatment is what tells them apart on send.
+            treatmentId: selectedRecipient.treatmentId,
             patientInitiatedTypeCode: typeCode,
             title: selectedType?.title,
             messageTextContent: message.trim(),
@@ -337,12 +354,12 @@ export default function HealthMessageComposeScreen() {
                 label={intl.formatMessage({
                   id: 'health.messages.compose.selectRecipient',
                 })}
-                value={recipientNodeId}
+                value={recipientKey}
                 options={recipients.map((r) => ({
                   label: r.name,
-                  value: r.nodeId,
+                  value: getRecipientKey(r),
                 }))}
-                onSelect={setRecipientNodeId}
+                onSelect={setRecipientKey}
               />
             )}
             {selectedRecipient && (

--- a/apps/native/app/src/graphql/queries/health.graphql
+++ b/apps/native/app/src/graphql/queries/health.graphql
@@ -355,6 +355,7 @@ query GetHealthConversation($id: ID!) {
     isRead
     patientCanReply
     replyBlockedReason
+    patientReplyWindowDays
     organization {
       name
       logoUrl
@@ -386,6 +387,7 @@ query GetHealthConversationRecipients($locale: LocaleEnum) {
   healthDirectorateHealthConversationRecipients(locale: $locale) {
     nodeId
     groupId
+    treatmentId
     name
     allowsMessaging
     isCurrentlyWithinWindow

--- a/apps/native/app/src/messages/en.ts
+++ b/apps/native/app/src/messages/en.ts
@@ -904,8 +904,10 @@ export const en: TranslatedMessages = {
     "You can't reply to messages outside opening hours.",
   'health.messages.replyBlocked.windowExpired':
     "You can't reply to this conversation because the reply window has passed.",
+  'health.messages.replyBlocked.windowExpiredDay':
+    "You can't reply to messages older than {days} day.",
   'health.messages.replyBlocked.windowExpiredDays':
-    "You can't reply to messages older than {days, plural, one {# day} other {# days}}.",
+    "You can't reply to messages older than {days} days.",
   'health.messages.replyBlocked.awaitingStaff':
     "You can't reply to this conversation until staff have responded to you.",
   'health.messages.compose.newTitle': 'New message',

--- a/apps/native/app/src/messages/en.ts
+++ b/apps/native/app/src/messages/en.ts
@@ -904,6 +904,8 @@ export const en: TranslatedMessages = {
     "You can't reply to messages outside opening hours.",
   'health.messages.replyBlocked.windowExpired':
     "You can't reply to this conversation because the reply window has passed.",
+  'health.messages.replyBlocked.windowExpiredDays':
+    "You can't reply to messages older than {days, plural, one {# day} other {# days}}.",
   'health.messages.replyBlocked.awaitingStaff':
     "You can't reply to this conversation until staff have responded to you.",
   'health.messages.compose.newTitle': 'New message',

--- a/apps/native/app/src/messages/is.ts
+++ b/apps/native/app/src/messages/is.ts
@@ -901,8 +901,10 @@ export const is = {
     'Ekki er hægt að svara skilaboðum utan opnunartíma.',
   'health.messages.replyBlocked.windowExpired':
     'Ekki er hægt að svara þessum skilaboðum þar sem svarfrestur er liðinn.',
+  'health.messages.replyBlocked.windowExpiredDay':
+    'Ekki er hægt að svara skilaboðum sem eru eldri en {days} dagur.',
   'health.messages.replyBlocked.windowExpiredDays':
-    'Ekki er hægt að svara skilaboðum sem eru eldri en {days, plural, one {# dagur} other {# dagar}}.',
+    'Ekki er hægt að svara skilaboðum sem eru eldri en {days} dagar.',
   'health.messages.replyBlocked.awaitingStaff':
     'Ekki er hægt að svara þessum skilaboðum fyrr en starfsfólk hefur svarað þér.',
   'health.messages.compose.newTitle': 'Ný skilaboð',

--- a/apps/native/app/src/messages/is.ts
+++ b/apps/native/app/src/messages/is.ts
@@ -901,6 +901,8 @@ export const is = {
     'Ekki er hægt að svara skilaboðum utan opnunartíma.',
   'health.messages.replyBlocked.windowExpired':
     'Ekki er hægt að svara þessum skilaboðum þar sem svarfrestur er liðinn.',
+  'health.messages.replyBlocked.windowExpiredDays':
+    'Ekki er hægt að svara skilaboðum sem eru eldri en {days, plural, one {# dagur} other {# dagar}}.',
   'health.messages.replyBlocked.awaitingStaff':
     'Ekki er hægt að svara þessum skilaboðum fyrr en starfsfólk hefur svarað þér.',
   'health.messages.compose.newTitle': 'Ný skilaboð',

--- a/apps/native/app/src/ui/lib/select/select.tsx
+++ b/apps/native/app/src/ui/lib/select/select.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from 'react'
+import React, { useCallback, useState } from 'react'
+import { useFocusEffect } from 'expo-router'
 import { SelectionMenu } from 'react-native-platform-components'
 import styled, { css } from 'styled-components/native'
 
@@ -75,6 +76,12 @@ interface SelectProps {
   onSelect: (value: string) => void
   placeholder?: string
   disabled?: boolean
+  /**
+   * Notified whenever the menu opens or closes. The platform presents the menu
+   * in its own view controller which is not torn down with the React tree, so
+   * screens that can be dismissed by gesture need to know it is up.
+   */
+  onOpenChange?: (open: boolean) => void
 }
 
 export const Select = ({
@@ -84,13 +91,34 @@ export const Select = ({
   onSelect,
   placeholder,
   disabled = false,
+  onOpenChange,
 }: SelectProps) => {
   const [open, setOpen] = useState(false)
   const selected = options.find((option) => option.value === value)
 
+  const changeOpen = useCallback(
+    (next: boolean) => {
+      setOpen(next)
+      onOpenChange?.(next)
+    },
+    [onOpenChange],
+  )
+
+  // The platform presents the menu itself and does not tear it down when this
+  // component unmounts, so a menu still open when the screen goes away stays
+  // presented and bleeds over whatever is shown next. Close it on the way out,
+  // while we are still mounted and can tell native to dismiss.
+  useFocusEffect(
+    useCallback(() => {
+      return () => {
+        changeOpen(false)
+      }
+    }, [changeOpen]),
+  )
+
   return (
     <Wrapper>
-      <Host disabled={disabled} onPress={() => setOpen(true)}>
+      <Host disabled={disabled} onPress={() => changeOpen(true)}>
         <Content>
           <Label variant="eyebrow">{label}</Label>
           <Value
@@ -115,9 +143,9 @@ export const Select = ({
         selected={value ?? null}
         onSelect={(data) => {
           onSelect(data)
-          setOpen(false)
+          changeOpen(false)
         }}
-        onRequestClose={() => setOpen(false)}
+        onRequestClose={() => changeOpen(false)}
       />
     </Wrapper>
   )


### PR DESCRIPTION
## What

* If recipient has treatmentId - make sure to send that with the message. 
* Key recipient based on nodeId+groupId+treatmentId
* Show patientReplyWindowDays if thread is blocked with `ReplyWindowExpired` reason.
* Make sure to close select dropdown before closing the new message modal (otherwise select is stuck open when you open the modal next time).

## Why

Specify why you need to achieve this

## Screenshots / Gifs
`patientReplyWindowDays` coming from the server shown as reason for thread being closed
<img height="1279" alt="Screenshot 2026-09-08 at 14 45 09" src="https://github.com/user-attachments/assets/a864582c-3d2a-4eb5-acc8-ba3b9e239ebb" />

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reply-blocked health messages now show the applicable one-day or multiple-day expiration period in English and Icelandic.
  * Health message recipients are correctly distinguished when associated with different treatments.

* **Bug Fixes**
  * Recipient and service menus remain stable while open, preventing accidental dismissal.
  * Selection menus now close correctly when navigating away from a screen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->