### PR TITLE
fix(application-system): default national registry lookups to v3

### DIFF
--- a/libs/application/template-api-modules/src/lib/modules/shared/api/national-registry-v3/national-registry-v3.service.spec.ts
+++ b/libs/application/template-api-modules/src/lib/modules/shared/api/national-registry-v3/national-registry-v3.service.spec.ts
@@ -1,0 +1,100 @@
+import { User } from '@island.is/auth-nest-tools'
+import { NationalRegistryParameters } from '@island.is/application/types'
+import { FeatureFlagService, Features } from '@island.is/nest/feature-flags'
+import { NationalRegistryV3ApplicationsClientService } from '@island.is/clients/national-registry-v3-applications'
+
+import { TemplateApiModuleActionProps } from '../../../../types'
+import { NationalRegistryService } from '../national-registry/national-registry.service'
+import { NationalRegistryV3Service } from './national-registry-v3.service'
+
+const auth = { nationalId: '0101302479', authorization: 'Bearer x' } as User
+
+const buildProps = (
+  params?: NationalRegistryParameters,
+): TemplateApiModuleActionProps<NationalRegistryParameters> =>
+  ({ auth, params } as TemplateApiModuleActionProps<NationalRegistryParameters>)
+
+describe('NationalRegistryV3Service', () => {
+  let service: NationalRegistryV3Service
+  let v2Service: jest.Mocked<NationalRegistryService>
+  let v3Api: jest.Mocked<NationalRegistryV3ApplicationsClientService>
+  let featureFlagService: jest.Mocked<FeatureFlagService>
+
+  beforeEach(() => {
+    v2Service = {
+      nationalRegistry: jest.fn(),
+      getIndividual: jest.fn(),
+    } as unknown as jest.Mocked<NationalRegistryService>
+
+    v3Api = {
+      getIndividual: jest.fn().mockResolvedValue({
+        nationalId: auth.nationalId,
+        name: 'Name Nameson',
+        givenName: 'Name',
+        familyName: 'Nameson',
+        birthdate: new Date('1990-01-01'),
+        genderCode: '1',
+        legalDomicile: { municipalityNumber: '0000' },
+      }),
+      getCitizenship: jest
+        .fn()
+        .mockResolvedValue({ countryCode: 'IS', countryName: 'Ísland' }),
+      getCohabitationInfo: jest.fn().mockResolvedValue(null),
+      getCustodyChildren: jest.fn().mockResolvedValue([]),
+    } as unknown as jest.Mocked<NationalRegistryV3ApplicationsClientService>
+
+    featureFlagService = {
+      getValue: jest.fn().mockResolvedValue(true),
+    } as unknown as jest.Mocked<FeatureFlagService>
+
+    service = new NationalRegistryV3Service(
+      v2Service,
+      v3Api,
+      featureFlagService,
+    )
+  })
+
+  // A ConfigCat outage makes getValue return whichever default we pass. It must
+  // be `true`, otherwise an unreachable ConfigCat silently downgrades the
+  // request to the deprecated v2 client.
+  it('asks for the flag with v3 as the default', async () => {
+    await service.nationalRegistry(buildProps({ icelandicCitizenship: true }))
+
+    expect(featureFlagService.getValue).toHaveBeenNthCalledWith(
+      1,
+      Features.shouldApplicationSystemUseNationalRegistryV3,
+      true,
+      auth,
+    )
+    // every lookup this flow makes must default to v3, not just the first
+    expect(featureFlagService.getValue.mock.calls.length).toBeGreaterThan(0)
+    for (const [feature, defaultValue] of featureFlagService.getValue.mock
+      .calls) {
+      expect(feature).toBe(
+        Features.shouldApplicationSystemUseNationalRegistryV3,
+      )
+      expect(defaultValue).toBe(true)
+    }
+  })
+
+  it('asks for the flag with v3 as the default in getIndividual too', async () => {
+    await service.getIndividual(auth.nationalId, auth)
+
+    expect(featureFlagService.getValue).toHaveBeenCalledWith(
+      Features.shouldApplicationSystemUseNationalRegistryV3,
+      true,
+      auth,
+    )
+  })
+
+  // The flag stays usable as a rollback lever: switching it off in ConfigCat
+  // must still route to v2 for as long as that service exists.
+  it('still falls back to v2 when the flag is deliberately turned off', async () => {
+    featureFlagService.getValue = jest.fn().mockResolvedValue(false)
+
+    await service.nationalRegistry(buildProps({ icelandicCitizenship: true }))
+
+    expect(v2Service.nationalRegistry).toHaveBeenCalledTimes(1)
+    expect(v3Api.getIndividual).not.toHaveBeenCalled()
+  })
+})

--- a/libs/application/template-api-modules/src/lib/modules/shared/api/national-registry-v3/national-registry-v3.service.ts
+++ b/libs/application/template-api-modules/src/lib/modules/shared/api/national-registry-v3/national-registry-v3.service.ts
@@ -51,7 +51,11 @@ export class NationalRegistryV3Service extends BaseTemplateApiService {
   > {
     const shouldUseNationalRegistryV3 = await this.featureFlagService.getValue(
       Features.shouldApplicationSystemUseNationalRegistryV3,
-      false,
+      // The flag is on in production, and Þjóðskrá is deprecating v2, so an
+      // unreadable flag must not silently downgrade the request to v2. This
+      // default only applies when ConfigCat cannot be reached; turning the
+      // flag off there still rolls back to v2 while that service exists.
+      true,
       auth,
     )
     if (!shouldUseNationalRegistryV3) {
@@ -320,7 +324,11 @@ export class NationalRegistryV3Service extends BaseTemplateApiService {
   ): Promise<NationalRegistryV3Individual | NationalRegistryIndividual | null> {
     const shouldUseNationalRegistryV3 = await this.featureFlagService.getValue(
       Features.shouldApplicationSystemUseNationalRegistryV3,
-      false,
+      // The flag is on in production, and Þjóðskrá is deprecating v2, so an
+      // unreadable flag must not silently downgrade the request to v2. This
+      // default only applies when ConfigCat cannot be reached; turning the
+      // flag off there still rolls back to v2 while that service exists.
+      true,
       auth,
     )
     if (!shouldUseNationalRegistryV3) {
@@ -382,7 +390,11 @@ export class NationalRegistryV3Service extends BaseTemplateApiService {
   > {
     const shouldUseNationalRegistryV3 = await this.featureFlagService.getValue(
       Features.shouldApplicationSystemUseNationalRegistryV3,
-      false,
+      // The flag is on in production, and Þjóðskrá is deprecating v2, so an
+      // unreadable flag must not silently downgrade the request to v2. This
+      // default only applies when ConfigCat cannot be reached; turning the
+      // flag off there still rolls back to v2 while that service exists.
+      true,
       auth,
     )
     if (!shouldUseNationalRegistryV3) {
@@ -404,7 +416,11 @@ export class NationalRegistryV3Service extends BaseTemplateApiService {
   > {
     const shouldUseNationalRegistryV3 = await this.featureFlagService.getValue(
       Features.shouldApplicationSystemUseNationalRegistryV3,
-      false,
+      // The flag is on in production, and Þjóðskrá is deprecating v2, so an
+      // unreadable flag must not silently downgrade the request to v2. This
+      // default only applies when ConfigCat cannot be reached; turning the
+      // flag off there still rolls back to v2 while that service exists.
+      true,
       auth,
     )
     if (!shouldUseNationalRegistryV3) {
@@ -474,7 +490,11 @@ export class NationalRegistryV3Service extends BaseTemplateApiService {
   > {
     const shouldUseNationalRegistryV3 = await this.featureFlagService.getValue(
       Features.shouldApplicationSystemUseNationalRegistryV3,
-      false,
+      // The flag is on in production, and Þjóðskrá is deprecating v2, so an
+      // unreadable flag must not silently downgrade the request to v2. This
+      // default only applies when ConfigCat cannot be reached; turning the
+      // flag off there still rolls back to v2 while that service exists.
+      true,
       auth,
     )
     if (!shouldUseNationalRegistryV3) {
@@ -596,7 +616,11 @@ export class NationalRegistryV3Service extends BaseTemplateApiService {
   > {
     const shouldUseNationalRegistryV3 = await this.featureFlagService.getValue(
       Features.shouldApplicationSystemUseNationalRegistryV3,
-      false,
+      // The flag is on in production, and Þjóðskrá is deprecating v2, so an
+      // unreadable flag must not silently downgrade the request to v2. This
+      // default only applies when ConfigCat cannot be reached; turning the
+      // flag off there still rolls back to v2 while that service exists.
+      true,
       auth,
     )
     if (!shouldUseNationalRegistryV3) {
@@ -634,7 +658,11 @@ export class NationalRegistryV3Service extends BaseTemplateApiService {
   }: TemplateApiModuleActionProps): Promise<NationalRegistryMaritalTitle | null> {
     const shouldUseNationalRegistryV3 = await this.featureFlagService.getValue(
       Features.shouldApplicationSystemUseNationalRegistryV3,
-      false,
+      // The flag is on in production, and Þjóðskrá is deprecating v2, so an
+      // unreadable flag must not silently downgrade the request to v2. This
+      // default only applies when ConfigCat cannot be reached; turning the
+      // flag off there still rolls back to v2 while that service exists.
+      true,
       auth,
     )
     if (!shouldUseNationalRegistryV3) {
@@ -663,7 +691,11 @@ export class NationalRegistryV3Service extends BaseTemplateApiService {
   }: TemplateApiModuleActionProps<BirthplaceParameters>): Promise<NationalRegistryBirthplace | null> {
     const shouldUseNationalRegistryV3 = await this.featureFlagService.getValue(
       Features.shouldApplicationSystemUseNationalRegistryV3,
-      false,
+      // The flag is on in production, and Þjóðskrá is deprecating v2, so an
+      // unreadable flag must not silently downgrade the request to v2. This
+      // default only applies when ConfigCat cannot be reached; turning the
+      // flag off there still rolls back to v2 while that service exists.
+      true,
       auth,
     )
     if (!shouldUseNationalRegistryV3) {
@@ -704,7 +736,11 @@ export class NationalRegistryV3Service extends BaseTemplateApiService {
   }: TemplateApiModuleActionProps): Promise<NationalRegistryResidenceHistory | null> {
     const shouldUseNationalRegistryV3 = await this.featureFlagService.getValue(
       Features.shouldApplicationSystemUseNationalRegistryV3,
-      false,
+      // The flag is on in production, and Þjóðskrá is deprecating v2, so an
+      // unreadable flag must not silently downgrade the request to v2. This
+      // default only applies when ConfigCat cannot be reached; turning the
+      // flag off there still rolls back to v2 while that service exists.
+      true,
       auth,
     )
     if (!shouldUseNationalRegistryV3) {
@@ -738,7 +774,11 @@ export class NationalRegistryV3Service extends BaseTemplateApiService {
   > {
     const shouldUseNationalRegistryV3 = await this.featureFlagService.getValue(
       Features.shouldApplicationSystemUseNationalRegistryV3,
-      false,
+      // The flag is on in production, and Þjóðskrá is deprecating v2, so an
+      // unreadable flag must not silently downgrade the request to v2. This
+      // default only applies when ConfigCat cannot be reached; turning the
+      // flag off there still rolls back to v2 while that service exists.
+      true,
       auth,
     )
     if (!shouldUseNationalRegistryV3) {
@@ -770,7 +810,11 @@ export class NationalRegistryV3Service extends BaseTemplateApiService {
   }: TemplateApiModuleActionProps): Promise<string[] | null> {
     const shouldUseNationalRegistryV3 = await this.featureFlagService.getValue(
       Features.shouldApplicationSystemUseNationalRegistryV3,
-      false,
+      // The flag is on in production, and Þjóðskrá is deprecating v2, so an
+      // unreadable flag must not silently downgrade the request to v2. This
+      // default only applies when ConfigCat cannot be reached; turning the
+      // flag off there still rolls back to v2 while that service exists.
+      true,
       auth,
     )
     if (!shouldUseNationalRegistryV3) {
@@ -800,7 +844,11 @@ export class NationalRegistryV3Service extends BaseTemplateApiService {
   ): Promise<(NationalRegistryOtherIndividual | null)[]> {
     const shouldUseNationalRegistryV3 = await this.featureFlagService.getValue(
       Features.shouldApplicationSystemUseNationalRegistryV3,
-      false,
+      // The flag is on in production, and Þjóðskrá is deprecating v2, so an
+      // unreadable flag must not silently downgrade the request to v2. This
+      // default only applies when ConfigCat cannot be reached; turning the
+      // flag off there still rolls back to v2 while that service exists.
+      true,
       props.auth,
     )
     if (!shouldUseNationalRegistryV3) {
@@ -835,7 +883,11 @@ export class NationalRegistryV3Service extends BaseTemplateApiService {
   }: TemplateApiModuleActionProps): Promise<NationalRegistryCustodian[]> {
     const shouldUseNationalRegistryV3 = await this.featureFlagService.getValue(
       Features.shouldApplicationSystemUseNationalRegistryV3,
-      false,
+      // The flag is on in production, and Þjóðskrá is deprecating v2, so an
+      // unreadable flag must not silently downgrade the request to v2. This
+      // default only applies when ConfigCat cannot be reached; turning the
+      // flag off there still rolls back to v2 while that service exists.
+      true,
       auth,
     )
     if (!shouldUseNationalRegistryV3) {


### PR DESCRIPTION
Asana: https://app.asana.com/1/23849317865981/project/1204431115744096/task/1218169042898264

## What

Flips the fallback default from `false` to `true` at all 13 `shouldApplicationSystemUseNationalRegistryV3` lookups in `NationalRegistryV3Service`, so a flag that cannot be read keeps the request on the v3 Þjóðskrá client instead of downgrading it to v2.

Normal operation is unchanged — the flag is on in production, so this default only applies when ConfigCat is unreachable. Turning the flag off in ConfigCat still rolls back to v2 for as long as that service exists.

## Why

The ticket reported that the passport application was still calling Þjóðskrá v2. It isn't — passport moved to `NationalRegistryV3UserApi` in #21066. The real cause is that the hardcoded default contradicts the live flag value:

```ts
getValue(Features.shouldApplicationSystemUseNationalRegistryV3, false, auth)
//                                                              ^^^^^ flag is true in prod
```

So whenever ConfigCat cannot be reached, every lookup resolves to the stale `false` and silently uses v2. Observed twice in the last 21 days, both on a pod whose first ConfigCat fetch failed at startup:

```
10:34:00  ConfigCat - ERROR - [1103] … FetchError: network or protocol error
10:34:36  ConfigCat - ERROR - [1000] Config JSON is not present when evaluating setting
          'shouldApplicationSystemUseNationalRegistryV3'. Returning the `defaultValue`
          parameter that you specified in your application: 'false'
10:34:36–38  9 × Fetch (clients-national-registry-v2)
```

Same `trace_id` throughout. Once on `Passport` (2026-09-04, 9 calls), once on `MedicalAndRehabilitationPayments` (2026-09-08, 8 calls) — so it is not specific to any one template. Those 17 calls are the only v2 traffic from `application-system-api` in the whole retained log window, which also confirms the flag is on for everyone.

Þjóðskrá is deprecating v2, so a silent downgrade needs to stop being the failure mode.

Removing the flag and its fallbacks altogether is the natural follow-up once v2's shutdown date is known. It is deliberately not in this PR: the v2 `NationalRegistryService` also serves `pension-supplement`, which declares `namespace: 'NationalRegistry'` directly rather than going through the flag, so it has to stay registered until that template migrates.

## Screenshots / Gifs

No UI change.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - National Registry requests now default to the V3 implementation when the feature flag cannot be evaluated.
  - Explicitly disabling the feature flag continues to use the V2 implementation.

- **Tests**
  - Added coverage for V3 defaults across individual and registry flows.
  - Added coverage confirming fallback to V2 when the feature is explicitly disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->