### PR TITLE
fix(j-s): Delete civil claim files with their civil claimant

### DIFF
--- a/apps/judicial-system/backend/src/app/modules/defendant/civilClaimant.controller.ts
+++ b/apps/judicial-system/backend/src/app/modules/defendant/civilClaimant.controller.ts
@@ -130,9 +130,8 @@ export class CivilClaimantController {
       `Deleting civil claimant ${civilClaimantId} of case ${caseId}`,
     )
 
-    const deleted = await this.civilClaimantService.delete(
-      caseId,
-      civilClaimantId,
+    const deleted = await this.sequelize.transaction((transaction) =>
+      this.civilClaimantService.delete(caseId, civilClaimantId, transaction),
     )
 
     return { deleted }

--- a/apps/judicial-system/backend/src/app/modules/defendant/civilClaimant.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/defendant/civilClaimant.service.ts
@@ -22,6 +22,7 @@ import { CourtService } from '../court'
 import {
   Case,
   CaseDefendantPoliceCaseNumberRepositoryService,
+  CaseFileRepositoryService,
   CivilClaimant,
   CivilClaimantRepositoryService,
 } from '../repository'
@@ -32,6 +33,7 @@ import { DeliverResponse } from './models/deliver.response'
 export class CivilClaimantService {
   constructor(
     private readonly civilClaimantRepositoryService: CivilClaimantRepositoryService,
+    private readonly caseFileRepositoryService: CaseFileRepositoryService,
     private readonly caseDefendantPoliceCaseNumberRepositoryService: CaseDefendantPoliceCaseNumberRepositoryService,
     private readonly courtService: CourtService,
     @Inject(LOGGER_PROVIDER) private readonly logger: Logger,
@@ -185,11 +187,25 @@ export class CivilClaimantService {
     }
   }
 
-  async delete(caseId: string, civilClaimantId: string): Promise<boolean> {
+  // A civil claimant's files go with the claimant, so they are deleted first in
+  // the same transaction - the delete of the claimant would otherwise fail on
+  // the case file foreign key.
+  async delete(
+    caseId: string,
+    civilClaimantId: string,
+    transaction: Transaction,
+  ): Promise<boolean> {
+    await this.caseFileRepositoryService.deleteAllForCivilClaimant(
+      caseId,
+      civilClaimantId,
+      { transaction },
+    )
+
     const numberOfAffectedRows =
       await this.civilClaimantRepositoryService.deleteByIdAndCase(
         civilClaimantId,
         caseId,
+        { transaction },
       )
 
     if (numberOfAffectedRows > 1) {
@@ -207,6 +223,11 @@ export class CivilClaimantService {
   }
 
   async deleteAll(caseId: string, transaction: Transaction): Promise<void> {
+    await this.caseFileRepositoryService.deleteAllForCivilClaimantsOfCase(
+      caseId,
+      { transaction },
+    )
+
     await this.civilClaimantRepositoryService.deleteAllForCase(caseId, {
       transaction,
     })

--- a/apps/judicial-system/backend/src/app/modules/defendant/test/civilClaimantController/delete.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/defendant/test/civilClaimantController/delete.spec.ts
@@ -1,8 +1,12 @@
+import { Transaction } from 'sequelize'
 import { v4 as uuid } from 'uuid'
 
 import { createTestingDefendantModule } from '../createTestingDefendantModule'
 
-import { CivilClaimantRepositoryService } from '../../../repository'
+import {
+  CaseFileRepositoryService,
+  CivilClaimantRepositoryService,
+} from '../../../repository'
 import { DeleteCivilClaimantResponse } from '../../models/deleteCivilClaimant.response'
 
 interface Then {
@@ -18,15 +22,27 @@ type GivenWhenThen = (
 describe('CivilClaimantController - Delete', () => {
   const caseId = uuid()
   const civilClaimantId = uuid()
+  const transaction = {} as Transaction
 
   let mockCivilClaimantRepositoryService: CivilClaimantRepositoryService
+  let mockCaseFileRepositoryService: CaseFileRepositoryService
   let givenWhenThen: GivenWhenThen
 
   beforeEach(async () => {
-    const { civilClaimantController, civilClaimantRepositoryService } =
-      await createTestingDefendantModule()
+    const {
+      sequelize,
+      civilClaimantController,
+      civilClaimantRepositoryService,
+      caseFileRepositoryService,
+    } = await createTestingDefendantModule()
 
     mockCivilClaimantRepositoryService = civilClaimantRepositoryService
+    mockCaseFileRepositoryService = caseFileRepositoryService
+
+    const mockTransaction = sequelize.transaction as jest.Mock
+    mockTransaction.mockImplementation(
+      (fn: (transaction: Transaction) => unknown) => fn(transaction),
+    )
 
     const mockDelete =
       mockCivilClaimantRepositoryService.deleteByIdAndCase as jest.Mock
@@ -58,11 +74,49 @@ describe('CivilClaimantController - Delete', () => {
 
       then = await givenWhenThen(caseId, civilClaimantId)
     })
+
+    it("should delete the civil claimant's case files", () => {
+      expect(
+        mockCaseFileRepositoryService.deleteAllForCivilClaimant,
+      ).toHaveBeenCalledWith(caseId, civilClaimantId, { transaction })
+    })
+
     it('should delete civil claimant', () => {
       expect(
         mockCivilClaimantRepositoryService.deleteByIdAndCase,
-      ).toHaveBeenCalledWith(civilClaimantId, caseId)
+      ).toHaveBeenCalledWith(civilClaimantId, caseId, { transaction })
       expect(then.result).toEqual({ deleted: true })
+    })
+
+    it('should delete the case files before the civil claimant', () => {
+      const mockDeleteFiles =
+        mockCaseFileRepositoryService.deleteAllForCivilClaimant as jest.Mock
+      const mockDelete =
+        mockCivilClaimantRepositoryService.deleteByIdAndCase as jest.Mock
+
+      expect(mockDeleteFiles.mock.invocationCallOrder[0]).toBeLessThan(
+        mockDelete.mock.invocationCallOrder[0],
+      )
+    })
+  })
+
+  describe('case file deletion fails', () => {
+    let then: Then
+
+    beforeEach(async () => {
+      const mockDeleteFiles =
+        mockCaseFileRepositoryService.deleteAllForCivilClaimant as jest.Mock
+      mockDeleteFiles.mockRejectedValue(new Error('Case file error'))
+
+      then = await givenWhenThen(caseId, civilClaimantId)
+    })
+
+    it('should not delete the civil claimant', () => {
+      expect(
+        mockCivilClaimantRepositoryService.deleteByIdAndCase,
+      ).not.toHaveBeenCalled()
+      expect(then.error).toBeInstanceOf(Error)
+      expect(then.error.message).toBe('Case file error')
     })
   })
 

--- a/apps/judicial-system/backend/src/app/modules/defendant/test/createTestingDefendantModule.ts
+++ b/apps/judicial-system/backend/src/app/modules/defendant/test/createTestingDefendantModule.ts
@@ -20,6 +20,7 @@ import { CourtService } from '../../court'
 import { EventLogService } from '../../event-log'
 import {
   CaseDefendantPoliceCaseNumberRepositoryService,
+  CaseFileRepositoryService,
   CivilClaimantRepositoryService,
   DefendantEventLogRepositoryService,
   DefendantRepositoryService,
@@ -83,6 +84,13 @@ export const createTestingDefendantModule = async () => {
           findLatestBySpokespersonNationalId: jest.fn(),
         },
       },
+      {
+        provide: CaseFileRepositoryService,
+        useValue: {
+          deleteAllForCivilClaimant: jest.fn(),
+          deleteAllForCivilClaimantsOfCase: jest.fn(),
+        },
+      },
       DefendantService,
       CivilClaimantService,
     ],
@@ -130,6 +138,9 @@ export const createTestingDefendantModule = async () => {
       CivilClaimantRepositoryService,
     )
 
+  const caseFileRepositoryService =
+    defendantModule.get<CaseFileRepositoryService>(CaseFileRepositoryService)
+
   const civilClaimantService =
     defendantModule.get<CivilClaimantService>(CivilClaimantService)
 
@@ -167,5 +178,6 @@ export const createTestingDefendantModule = async () => {
     civilClaimantService,
     civilClaimantController,
     civilClaimantRepositoryService,
+    caseFileRepositoryService,
   }
 }

--- a/apps/judicial-system/backend/src/app/modules/repository/services/caseFileRepository.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/repository/services/caseFileRepository.service.ts
@@ -337,4 +337,73 @@ export class CaseFileRepositoryService {
       throw error
     }
   }
+
+  // A civil claimant's files go with the claimant. Files are soft-deleted, so
+  // the row stays for anything that references it, but the claimant reference
+  // has to be cleared: the foreign key does not cascade, and a soft-deleted row
+  // still pointing at the claimant would block the claimant's own delete.
+  async deleteAllForCivilClaimant(
+    caseId: string,
+    civilClaimantId: string,
+    options: { transaction: Transaction },
+  ): Promise<number> {
+    try {
+      this.logger.debug(
+        `Deleting the case files of civil claimant ${civilClaimantId} of case ${caseId}`,
+      )
+
+      const [numberOfAffectedRows] = await this.caseFileModel.update(
+        {
+          state: CaseFileState.DELETED,
+          isKeyAccessible: false,
+          civilClaimantId: null,
+        },
+        {
+          where: { caseId, civilClaimantId },
+          transaction: options.transaction,
+        },
+      )
+
+      return numberOfAffectedRows
+    } catch (error) {
+      this.logger.error(
+        `Error deleting the case files of civil claimant ${civilClaimantId} of case ${caseId}:`,
+        { error },
+      )
+
+      throw error
+    }
+  }
+
+  async deleteAllForCivilClaimantsOfCase(
+    caseId: string,
+    options: { transaction: Transaction },
+  ): Promise<number> {
+    try {
+      this.logger.debug(
+        `Deleting the case files of all civil claimants of case ${caseId}`,
+      )
+
+      const [numberOfAffectedRows] = await this.caseFileModel.update(
+        {
+          state: CaseFileState.DELETED,
+          isKeyAccessible: false,
+          civilClaimantId: null,
+        },
+        {
+          where: { caseId, civilClaimantId: { [Op.not]: null } },
+          transaction: options.transaction,
+        },
+      )
+
+      return numberOfAffectedRows
+    } catch (error) {
+      this.logger.error(
+        `Error deleting the case files of all civil claimants of case ${caseId}:`,
+        { error },
+      )
+
+      throw error
+    }
+  }
 }

--- a/apps/judicial-system/backend/src/app/modules/repository/services/civilClaimantRepository.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/repository/services/civilClaimantRepository.service.ts
@@ -93,6 +93,7 @@ export class CivilClaimantRepositoryService {
   async deleteByIdAndCase(
     civilClaimantId: string,
     caseId: string,
+    options: { transaction: Transaction },
   ): Promise<number> {
     try {
       this.logger.debug(
@@ -101,6 +102,7 @@ export class CivilClaimantRepositoryService {
 
       return await this.civilClaimantModel.destroy({
         where: { id: civilClaimantId, caseId },
+        transaction: options.transaction,
       })
     } catch (error) {
       this.logger.error(

--- a/apps/judicial-system/backend/src/app/modules/repository/test/caseFileRepository.service.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/repository/test/caseFileRepository.service.spec.ts
@@ -378,4 +378,74 @@ describe('CaseFileRepositoryService', () => {
       ).rejects.toThrow(error)
     })
   })
+
+  describe('deleteAllForCivilClaimant', () => {
+    const civilClaimantId = 'some-civil-claimant-id'
+
+    it("soft-deletes the claimant's files within the case, clears the claimant reference and returns the count", async () => {
+      model.update.mockResolvedValueOnce([2, []])
+
+      const result = await service.deleteAllForCivilClaimant(
+        caseId,
+        civilClaimantId,
+        { transaction },
+      )
+
+      expect(model.update).toHaveBeenCalledWith(
+        {
+          state: CaseFileState.DELETED,
+          isKeyAccessible: false,
+          civilClaimantId: null,
+        },
+        {
+          where: { caseId, civilClaimantId },
+          transaction,
+        },
+      )
+      expect(result).toBe(2)
+    })
+
+    it('rethrows when the update fails', async () => {
+      const error = new Error('Some error')
+      model.update.mockRejectedValueOnce(error)
+
+      await expect(
+        service.deleteAllForCivilClaimant(caseId, civilClaimantId, {
+          transaction,
+        }),
+      ).rejects.toThrow(error)
+    })
+  })
+
+  describe('deleteAllForCivilClaimantsOfCase', () => {
+    it('soft-deletes every file of the case linked to a claimant, clears the claimant references and returns the count', async () => {
+      model.update.mockResolvedValueOnce([3, []])
+
+      const result = await service.deleteAllForCivilClaimantsOfCase(caseId, {
+        transaction,
+      })
+
+      expect(model.update).toHaveBeenCalledWith(
+        {
+          state: CaseFileState.DELETED,
+          isKeyAccessible: false,
+          civilClaimantId: null,
+        },
+        {
+          where: { caseId, civilClaimantId: { [Op.not]: null } },
+          transaction,
+        },
+      )
+      expect(result).toBe(3)
+    })
+
+    it('rethrows when the update fails', async () => {
+      const error = new Error('Some error')
+      model.update.mockRejectedValueOnce(error)
+
+      await expect(
+        service.deleteAllForCivilClaimantsOfCase(caseId, { transaction }),
+      ).rejects.toThrow(error)
+    })
+  })
 })

--- a/apps/judicial-system/backend/src/app/modules/repository/test/civilClaimantRepository.service.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/repository/test/civilClaimantRepository.service.spec.ts
@@ -112,13 +112,16 @@ describe('CivilClaimantRepositoryService', () => {
   })
 
   describe('deleteByIdAndCase', () => {
-    it('scopes the delete to the civil claimant within its case and returns the row count', async () => {
+    it('scopes the delete to the civil claimant within its case in the transaction and returns the row count', async () => {
       model.destroy.mockResolvedValueOnce(1)
 
-      const result = await service.deleteByIdAndCase(civilClaimantId, caseId)
+      const result = await service.deleteByIdAndCase(civilClaimantId, caseId, {
+        transaction,
+      })
 
       expect(model.destroy).toHaveBeenCalledWith({
         where: { id: civilClaimantId, caseId },
+        transaction,
       })
       expect(result).toBe(1)
     })
@@ -128,7 +131,7 @@ describe('CivilClaimantRepositoryService', () => {
       model.destroy.mockRejectedValueOnce(error)
 
       await expect(
-        service.deleteByIdAndCase(civilClaimantId, caseId),
+        service.deleteByIdAndCase(civilClaimantId, caseId, { transaction }),
       ).rejects.toThrow(error)
     })
   })

--- a/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Processing/Processing.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Processing/Processing.tsx
@@ -36,6 +36,7 @@ import type {
   UpdateDefendantInput,
 } from '@island.is/judicial-system-web/src/graphql/schema'
 import {
+  CaseFileCategory,
   CaseState,
   CaseTransition,
   DefendantPlea,
@@ -284,10 +285,14 @@ const Processing: FC = () => {
       return
     }
 
+    // The claimant's civil claim files are deleted with the claimant
     setWorkingCase((prev) => ({
       ...prev,
       civilClaimants: prev.civilClaimants?.filter(
         (civilClaimant) => civilClaimant.id !== civilClaimantId,
+      ),
+      caseFiles: prev.caseFiles?.filter(
+        (caseFile) => caseFile.civilClaimantId !== civilClaimantId,
       ),
     }))
   }
@@ -301,10 +306,16 @@ const Processing: FC = () => {
       return
     }
 
+    // Turning civil claims off deletes every claimant along with their files
     setWorkingCase((prev) => ({
       ...prev,
       hasCivilClaims,
       civilClaimants: res.civilClaimants,
+      caseFiles: hasCivilClaims
+        ? prev.caseFiles
+        : prev.caseFiles?.filter(
+            (caseFile) => caseFile.category !== CaseFileCategory.CIVIL_CLAIM,
+          ),
     }))
 
     if (hasCivilClaims) {


### PR DESCRIPTION
# Delete civil claim files with their civil claimant

## What

When a civil claimant is deleted, or civil claims are turned off for a case, the claimant's civil claim files are now soft-deleted in the same transaction. The files get the deleted state, their key is made inaccessible, and their claimant reference is cleared. The single-claimant delete route now runs in a transaction, which it previously did not.

The processing page drops the affected files from the working case so the local state matches the server.

Replaces #23014, which instead changed the `case_file` foreign keys to `ON DELETE SET NULL`.

## Why

The `case_file` foreign keys to `civil_claimant` and `defendant` have no `ON DELETE` rule, so deleting a claimant that still has files fails with a foreign key violation. Nulling the reference on delete would have left the files on the case without a claimant. Such files are hidden on the prosecutor's processing page, which filters civil claim files by the case's own claimants, but are still listed on the court overview and attached to every subpoena delivered to the police. The files belong to the claimant and should go with it.

## Screenshots / Gifs


## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Deleting a civil claimant now also handles associated case files cleanly.
  - Disabling civil claims now removes civil claim case files from the active case view.
  - Related records are processed together to prevent incomplete or failed deletions.
  - Deletion failures are reported without partially applying the change.
  - Case files are no longer left blocking claimant deletion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->