### PR TITLE
fix(my-pages-licenses): Remove extra space from URL

### DIFF
--- a/libs/portals/my-pages/licenses/src/screens/LicensesOverview/LicensesOverview.tsx
+++ b/libs/portals/my-pages/licenses/src/screens/LicensesOverview/LicensesOverview.tsx
@@ -65,7 +65,7 @@ export const LicensesOverview = () => {
               userLicense.payload?.metadata.ctaLink?.value ??
                 `${getPathFromType(userLicense.license.type)}/${
                   userLicense.payload?.metadata.licenseId
-                } `,
+                }`,
             ),
           variant: 'text',
         }}


### PR DESCRIPTION
## What
Remove space

## Why

License nax fix after package upgrades

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: claude code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed unnecessary whitespace from license card navigation handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->