### PR TITLE
chore(j-s): unspecified residency copy change

### DIFF
--- a/apps/judicial-system/backend/src/app/modules/police/police.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/police/police.service.ts
@@ -24,6 +24,7 @@ import {
   XRoadMemberClass,
 } from '@island.is/shared/utils/server'
 
+import { normalizePersonAddress } from '@island.is/judicial-system/formatters'
 import {
   CaseState,
   CaseType,
@@ -736,7 +737,7 @@ export class PoliceService {
         nationalId: defendant.accusedNationalId,
         name: defendant.accusedName ?? undefined,
         gender: defendant.accusedGender ?? undefined,
-        address: defendant.accusedAddress ?? undefined,
+        address: normalizePersonAddress(defendant.accusedAddress ?? undefined),
         dateOfBirth: defendant.accusedDOB ?? undefined,
         citizenship: defendant.citizenship ?? undefined,
       }))

--- a/apps/judicial-system/web/src/utils/formatNationalRegistryAddress.spec.ts
+++ b/apps/judicial-system/web/src/utils/formatNationalRegistryAddress.spec.ts
@@ -30,4 +30,12 @@ describe('formatNationalRegistryAddress', () => {
       }),
     ).toBeUndefined()
   })
+
+  it('replaces Ótilgreindu with ótilgreindu lögheimili', () => {
+    expect(
+      formatNationalRegistryAddress({
+        street: { nominative: 'Ótilgreindu' },
+      }),
+    ).toBe('ótilgreindu lögheimili')
+  })
 })

--- a/apps/judicial-system/web/src/utils/formatNationalRegistryAddress.ts
+++ b/apps/judicial-system/web/src/utils/formatNationalRegistryAddress.ts
@@ -1,3 +1,5 @@
+import { normalizePersonAddress } from '@island.is/judicial-system/formatters'
+
 /**
  * Builds a string in the format "{gata og númer}, {póstnúmer} {staður}" (e.g. "Gervigata 2, 100 Garðabær").
  */
@@ -28,5 +30,5 @@ export const formatNationalRegistryAddress = (
     .filter(Boolean)
     .join(', ')
 
-  return streetCommaPostcodeAndLocality || undefined
+  return normalizePersonAddress(streetCommaPostcodeAndLocality || undefined)
 }

--- a/libs/judicial-system/formatters/src/lib/formatters.spec.ts
+++ b/libs/judicial-system/formatters/src/lib/formatters.spec.ts
@@ -20,6 +20,7 @@ import {
   formatRulingOrderPronouncedOrallyName,
   indictmentSubtypes,
   normalizeAndFormatNationalId,
+  normalizePersonAddress,
   readableIndictmentSubtypes,
   sanitize,
   splitStringByComma,
@@ -244,6 +245,40 @@ describe('normalizeAndFormatNationalId', () => {
 
     // Assert
     expect(res).toEqual(['1234567890', '123456-7890'])
+  })
+})
+
+describe('normalizePersonAddress', () => {
+  test('should replace Ótilgreindu with ótilgreindu lögheimili', () => {
+    expect(normalizePersonAddress('Ótilgreindu')).toEqual(
+      'ótilgreindu lögheimili',
+    )
+  })
+
+  test('should replace trimmed Ótilgreindu', () => {
+    expect(normalizePersonAddress('  Ótilgreindu  ')).toEqual(
+      'ótilgreindu lögheimili',
+    )
+  })
+
+  test('should replace regardless of casing', () => {
+    expect(normalizePersonAddress('ótilgreindu')).toEqual(
+      'ótilgreindu lögheimili',
+    )
+    expect(normalizePersonAddress('ÓTILGREINDU')).toEqual(
+      'ótilgreindu lögheimili',
+    )
+  })
+
+  test('should leave other addresses unchanged', () => {
+    expect(normalizePersonAddress('Aðalgata 1, 101 Reykjavík')).toEqual(
+      'Aðalgata 1, 101 Reykjavík',
+    )
+  })
+
+  test('should leave null and undefined unchanged', () => {
+    expect(normalizePersonAddress(null)).toBeNull()
+    expect(normalizePersonAddress(undefined)).toBeUndefined()
   })
 })
 

--- a/libs/judicial-system/formatters/src/lib/formatters.ts
+++ b/libs/judicial-system/formatters/src/lib/formatters.ts
@@ -106,6 +106,21 @@ export const normalizeAndFormatNationalId = (
   return [nationalId?.replace(/-/g, '') ?? '', formatNationalId(nationalId)]
 }
 
+/** Replaces Þjóðskrá/LÖKE placeholder "Ótilgreindu" with clearer wording. */
+export const normalizePersonAddress = <T extends string | null | undefined>(
+  address: T,
+): T | 'ótilgreindu lögheimili' => {
+  if (address === null || address === undefined) {
+    return address
+  }
+
+  if (address.trim().toLowerCase() === 'ótilgreindu') {
+    return 'ótilgreindu lögheimili'
+  }
+
+  return address
+}
+
 export const getInitials = (name?: string | null): string | undefined => {
   if (!name?.trim()) return undefined
 


### PR DESCRIPTION
[Asana](https://app.asana.com/1/203394141643832/project/1199153462262248/task/1217817156752089?focus=true)

## What

Map "Ótilgreindu" to "ótilgreindu lögheimili"

## Why

User request

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Cursor


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Standardized unspecified person and defendant addresses across the judicial system.
  * Displays “ótilgreindu lögheimili” when an address is marked as unspecified, including variations in capitalization or surrounding spaces.
  * Preserves complete address information and continues handling empty addresses appropriately.

* **Tests**
  * Added coverage for unspecified, formatted, preserved, and empty address values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->