### PR TITLE
fix(my-pages): Use Digital Health org for health pages

### DIFF
--- a/libs/portals/my-pages/core/src/utils/constants.ts
+++ b/libs/portals/my-pages/core/src/utils/constants.ts
@@ -19,6 +19,7 @@ export const HUGVERKASTOFAN_SLUG = 'hugverkastofan'
 export const DOMSMALARADUNEYTID_SLUG = 'domsmalaraduneytid'
 export const LANDLAEKNIR_SLUG = 'landlaeknir'
 export const LANDSPITALI_SLUG = 'landspitali'
+export const STAFRAEN_HEILSA_SLUG = 'stafraen-heilsa'
 export const LANDSKJORSTJORN_SLUG = 'landskjorstjorn'
 export const ATVINNUVEGARADUNEYTID_SLUG = 'atvinnuvegaraduneytid'
 

--- a/libs/portals/my-pages/health/src/lib/messages.ts
+++ b/libs/portals/my-pages/health/src/lib/messages.ts
@@ -802,31 +802,38 @@ export const messages = defineMessages({
     defaultMessage: 'Reikningar',
     id: 'sp.health:invoices',
   },
-  landlaeknirMedicineDelegationTooltip: {
-    defaultMessage: 'Landlæknir hefur umsjón með gögnum um þín lyfjaumboð.',
-    id: 'sp.health:landlaeknir-delegation-tooltip',
-  },
-  landlaeknirMedicinePrescriptionsTooltip: {
+  landlaeknirOrganDonationTooltip: {
     defaultMessage:
-      'Landlæknir hefur umsjón með gögnum um þínar lyfjaávísanir.',
-    id: 'sp.health:landlaeknir-prescriptions-tooltip',
+      'Landlæknir hefur umsjón með gögnum um afstöðu þína til líffæragjafar.',
+    id: 'sp.health:landlaeknir-organ-donation-tooltip',
   },
-  landlaeknirVaccinationsTooltip: {
+  stafraenHeilsaMedicineDelegationTooltip: {
+    defaultMessage: 'Stafræn heilsa hefur umsjón með gögnum um þín lyfjaumboð.',
+    id: 'sp.health:stafraen-heilsa-delegation-tooltip',
+  },
+  stafraenHeilsaMedicinePrescriptionsTooltip: {
     defaultMessage:
-      'Landlæknir hefur umsjón með gögnum um þínar bólusetningar.',
-    id: 'sp.health:landlaeknir-tooltip',
+      'Stafræn heilsa hefur umsjón með gögnum um þínar lyfjaávísanir.',
+    id: 'sp.health:stafraen-heilsa-prescriptions-tooltip',
   },
-  landlaeknirPatientPermitsTooltip: {
-    defaultMessage: 'Landlæknir hefur umsjón með gögnum um þínar heimildir.',
-    id: 'sp.health:landlaeknir-patient-permits-tooltip',
+  stafraenHeilsaVaccinationsTooltip: {
+    defaultMessage:
+      'Stafræn heilsa hefur umsjón með gögnum um þínar bólusetningar.',
+    id: 'sp.health:stafraen-heilsa-vaccinations-tooltip',
   },
-  landlaeknirWaitlistTooltip: {
-    defaultMessage: 'Landlæknir hefur umsjón með stöðu þinni á biðlistum.',
-    id: 'sp.health:landlaeknir-waitlist-tooltip',
+  stafraenHeilsaPatientPermitsTooltip: {
+    defaultMessage:
+      'Stafræn heilsa hefur umsjón með gögnum um þínar heimildir.',
+    id: 'sp.health:stafraen-heilsa-patient-permits-tooltip',
   },
-  landlaeknirReferralTooltip: {
-    defaultMessage: 'Landlæknir hefur umsjón með gögnum um þínar tilvísanir.',
-    id: 'sp.health:landlaeknir-referral-tooltip',
+  stafraenHeilsaWaitlistTooltip: {
+    defaultMessage: 'Stafræn heilsa hefur umsjón með stöðu þinni á biðlistum.',
+    id: 'sp.health:stafraen-heilsa-waitlist-tooltip',
+  },
+  stafraenHeilsaReferralTooltip: {
+    defaultMessage:
+      'Stafræn heilsa hefur umsjón með gögnum um þínar tilvísanir.',
+    id: 'sp.health:stafraen-heilsa-referral-tooltip',
   },
   lastDispensed: {
     defaultMessage: 'Síðast afgreitt',
@@ -2247,9 +2254,10 @@ export const messages = defineMessages({
     defaultMessage: 'https://minarsidur.heilsuvera.is/timabokun/boka-tima',
     id: 'sp.health:book-appointment-heilsuveru-link',
   },
-  landlaeknirAppointmentsTooltip: {
-    defaultMessage: 'Landlæknir hefur umsjón með gögnum um þínar tímabókanir.',
-    id: 'sp.health:landlaeknir-appointments-tooltip',
+  stafraenHeilsaAppointmentsTooltip: {
+    defaultMessage:
+      'Stafræn heilsa hefur umsjón með gögnum um þínar tímabókanir.',
+    id: 'sp.health:stafraen-heilsa-appointments-tooltip',
   },
   myPregnancy: {
     defaultMessage: 'Meðgangan mín',
@@ -2429,9 +2437,10 @@ export const messages = defineMessages({
       'Hér getur þú fundið allar upplýsingar sem tengjast meðferðinni þinni og átt í samskiptum við meðferðarteymið þitt.',
     id: 'sp.health:treatment-intro',
   },
-  landlaeknirTreatmentTooltip: {
-    defaultMessage: 'Landlæknir hefur umsjón með gögnum um þínar meðferðir.',
-    id: 'sp.health:landlaeknir-treatment-tooltip',
+  stafraenHeilsaTreatmentTooltip: {
+    defaultMessage:
+      'Stafræn heilsa hefur umsjón með gögnum um þínar meðferðir.',
+    id: 'sp.health:stafraen-heilsa-treatment-tooltip',
   },
   treatmentTeam: {
     defaultMessage: 'Meðferðarteymi',

--- a/libs/portals/my-pages/health/src/screens/Appointments/AppointmentsOverview.tsx
+++ b/libs/portals/my-pages/health/src/screens/Appointments/AppointmentsOverview.tsx
@@ -4,7 +4,7 @@ import { Box, Tabs, Text } from '@island.is/island-ui/core'
 import { useLocale, useNamespaces } from '@island.is/localization'
 import {
   CardLoader,
-  HEALTH_DIRECTORATE_SLUG,
+  STAFRAEN_HEILSA_SLUG,
   IntroWrapper,
   LinkButton,
 } from '@island.is/portals/my-pages/core'
@@ -105,8 +105,8 @@ const AppointmentsOverview = () => {
       title={messages.appointmentsOverviewTitle}
       intro={messages.appointmentsIntro}
       serviceProvider={{
-        slug: HEALTH_DIRECTORATE_SLUG,
-        tooltip: formatMessage(messages.landlaeknirAppointmentsTooltip),
+        slug: STAFRAEN_HEILSA_SLUG,
+        tooltip: formatMessage(messages.stafraenHeilsaAppointmentsTooltip),
       }}
     >
       <Box

--- a/libs/portals/my-pages/health/src/screens/Appointments/BookAppointment.tsx
+++ b/libs/portals/my-pages/health/src/screens/Appointments/BookAppointment.tsx
@@ -6,7 +6,7 @@ import {
 } from '@island.is/island-ui/core'
 import { useLocale, useNamespaces } from '@island.is/localization'
 import {
-  HEALTH_DIRECTORATE_SLUG,
+  STAFRAEN_HEILSA_SLUG,
   IntroWrapper,
   LinkButton,
 } from '@island.is/portals/my-pages/core'
@@ -23,8 +23,8 @@ const BookAppointment = () => {
       title={messages.bookAppointmentTitle}
       intro={messages.bookAppointmentIntro}
       serviceProvider={{
-        slug: HEALTH_DIRECTORATE_SLUG,
-        tooltip: formatMessage(messages.landlaeknirAppointmentsTooltip),
+        slug: STAFRAEN_HEILSA_SLUG,
+        tooltip: formatMessage(messages.stafraenHeilsaAppointmentsTooltip),
       }}
     >
       <Box

--- a/libs/portals/my-pages/health/src/screens/MedicineDelegation/MedicineDelegation.tsx
+++ b/libs/portals/my-pages/health/src/screens/MedicineDelegation/MedicineDelegation.tsx
@@ -10,7 +10,7 @@ import {
 import { useLocale } from '@island.is/localization'
 import {
   ActionCardLoader,
-  HEALTH_DIRECTORATE_SLUG,
+  STAFRAEN_HEILSA_SLUG,
   IntroWrapper,
   LinkButton,
   formatDate,
@@ -49,21 +49,23 @@ const MedicineDelegation = () => {
   const dataLength =
     data?.healthDirectorateMedicineDelegations?.items?.length ?? 0
 
-  const filteredData =
-    data?.healthDirectorateMedicineDelegations?.items?.filter((item) =>
+  const filteredData = data?.healthDirectorateMedicineDelegations?.items?.filter(
+    (item) =>
       showExpiredPermits
         ? item.status
         : item.status === HealthDirectoratePermitStatus.active ||
           item.status === HealthDirectoratePermitStatus.awaitingApproval,
-    )
+  )
 
   return (
     <IntroWrapper
       title={formatMessage(messages.medicineDelegation)}
       intro={formatMessage(messages.medicineDelegationIntroText)}
       serviceProvider={{
-        slug: HEALTH_DIRECTORATE_SLUG,
-        tooltip: formatMessage(messages.landlaeknirMedicineDelegationTooltip),
+        slug: STAFRAEN_HEILSA_SLUG,
+        tooltip: formatMessage(
+          messages.stafraenHeilsaMedicineDelegationTooltip,
+        ),
       }}
       loading={loading}
       buttonGroup={{

--- a/libs/portals/my-pages/health/src/screens/MedicineDelegation/MedicineDelegation.tsx
+++ b/libs/portals/my-pages/health/src/screens/MedicineDelegation/MedicineDelegation.tsx
@@ -49,13 +49,13 @@ const MedicineDelegation = () => {
   const dataLength =
     data?.healthDirectorateMedicineDelegations?.items?.length ?? 0
 
-  const filteredData = data?.healthDirectorateMedicineDelegations?.items?.filter(
-    (item) =>
+  const filteredData =
+    data?.healthDirectorateMedicineDelegations?.items?.filter((item) =>
       showExpiredPermits
         ? item.status
         : item.status === HealthDirectoratePermitStatus.active ||
           item.status === HealthDirectoratePermitStatus.awaitingApproval,
-  )
+    )
 
   return (
     <IntroWrapper

--- a/libs/portals/my-pages/health/src/screens/MedicineDelegation/MedicineDelegationDetail.tsx
+++ b/libs/portals/my-pages/health/src/screens/MedicineDelegation/MedicineDelegationDetail.tsx
@@ -44,12 +44,10 @@ const MedicineDelegationDetail = () => {
     },
   })
 
-  const [
-    deleteMedicineDelegation,
-    { loading: deleteLoading },
-  ] = useDeleteMedicineDelegationMutation({
-    refetchQueries: ['GetMedicineDelegations'],
-  })
+  const [deleteMedicineDelegation, { loading: deleteLoading }] =
+    useDeleteMedicineDelegationMutation({
+      refetchQueries: ['GetMedicineDelegations'],
+    })
 
   const filteredData = data?.healthDirectorateMedicineDelegations?.items?.find(
     (item) => item.nationalId === id,

--- a/libs/portals/my-pages/health/src/screens/MedicineDelegation/MedicineDelegationDetail.tsx
+++ b/libs/portals/my-pages/health/src/screens/MedicineDelegation/MedicineDelegationDetail.tsx
@@ -1,7 +1,7 @@
 import { toast } from '@island.is/island-ui/core'
 import { useLocale } from '@island.is/localization'
 import {
-  HEALTH_DIRECTORATE_SLUG,
+  STAFRAEN_HEILSA_SLUG,
   InfoLine,
   InfoLineStack,
   IntroWrapper,
@@ -44,10 +44,12 @@ const MedicineDelegationDetail = () => {
     },
   })
 
-  const [deleteMedicineDelegation, { loading: deleteLoading }] =
-    useDeleteMedicineDelegationMutation({
-      refetchQueries: ['GetMedicineDelegations'],
-    })
+  const [
+    deleteMedicineDelegation,
+    { loading: deleteLoading },
+  ] = useDeleteMedicineDelegationMutation({
+    refetchQueries: ['GetMedicineDelegations'],
+  })
 
   const filteredData = data?.healthDirectorateMedicineDelegations?.items?.find(
     (item) => item.nationalId === id,
@@ -83,8 +85,10 @@ const MedicineDelegationDetail = () => {
       title={formatMessage(messages.medicineDelegation)}
       intro={formatMessage(messages.medicineDelegationIntroText)}
       serviceProvider={{
-        slug: HEALTH_DIRECTORATE_SLUG,
-        tooltip: formatMessage(messages.landlaeknirMedicineDelegationTooltip),
+        slug: STAFRAEN_HEILSA_SLUG,
+        tooltip: formatMessage(
+          messages.stafraenHeilsaMedicineDelegationTooltip,
+        ),
       }}
       loading={loading}
       desktopContentSpan="10/12"

--- a/libs/portals/my-pages/health/src/screens/MedicineDelegation/NewMedicineDelegation.tsx
+++ b/libs/portals/my-pages/health/src/screens/MedicineDelegation/NewMedicineDelegation.tsx
@@ -24,13 +24,11 @@ const NewMedicineDelegation = () => {
   const [formState, setFormState] = useState<DelegationState>()
   const navigate = useNavigate()
 
-  const [
-    postMedicineDelegation,
-    { loading },
-  ] = usePostMedicineDelegationMutation({
-    refetchQueries: ['GetMedicineDelegations'],
-    awaitRefetchQueries: true,
-  })
+  const [postMedicineDelegation, { loading }] =
+    usePostMedicineDelegationMutation({
+      refetchQueries: ['GetMedicineDelegations'],
+      awaitRefetchQueries: true,
+    })
 
   const handleSubmit = () => {
     if (formState?.nationalId && formState?.dateFrom && formState?.dateTo) {

--- a/libs/portals/my-pages/health/src/screens/MedicineDelegation/NewMedicineDelegation.tsx
+++ b/libs/portals/my-pages/health/src/screens/MedicineDelegation/NewMedicineDelegation.tsx
@@ -1,7 +1,7 @@
 import { ActionCard, Box, Button, toast } from '@island.is/island-ui/core'
 import { useLocale } from '@island.is/localization'
 import {
-  HEALTH_DIRECTORATE_SLUG,
+  STAFRAEN_HEILSA_SLUG,
   IntroWrapper,
   m,
 } from '@island.is/portals/my-pages/core'
@@ -24,11 +24,13 @@ const NewMedicineDelegation = () => {
   const [formState, setFormState] = useState<DelegationState>()
   const navigate = useNavigate()
 
-  const [postMedicineDelegation, { loading }] =
-    usePostMedicineDelegationMutation({
-      refetchQueries: ['GetMedicineDelegations'],
-      awaitRefetchQueries: true,
-    })
+  const [
+    postMedicineDelegation,
+    { loading },
+  ] = usePostMedicineDelegationMutation({
+    refetchQueries: ['GetMedicineDelegations'],
+    awaitRefetchQueries: true,
+  })
 
   const handleSubmit = () => {
     if (formState?.nationalId && formState?.dateFrom && formState?.dateTo) {
@@ -71,8 +73,10 @@ const NewMedicineDelegation = () => {
       title={formatMessage(messages.medicineDelegation)}
       intro={formatMessage(messages.newMedicineDelegationIntroText)}
       serviceProvider={{
-        slug: HEALTH_DIRECTORATE_SLUG,
-        tooltip: formatMessage(messages.landlaeknirMedicineDelegationTooltip),
+        slug: STAFRAEN_HEILSA_SLUG,
+        tooltip: formatMessage(
+          messages.stafraenHeilsaMedicineDelegationTooltip,
+        ),
       }}
       desktopContentSpan="10/12"
     >

--- a/libs/portals/my-pages/health/src/screens/MedicineHistory/MedicinePrescriptionHistory.tsx
+++ b/libs/portals/my-pages/health/src/screens/MedicineHistory/MedicinePrescriptionHistory.tsx
@@ -3,7 +3,7 @@ import { Box, Button, Icon } from '@island.is/island-ui/core'
 import { useLocale } from '@island.is/localization'
 import {
   formatDate,
-  HEALTH_DIRECTORATE_SLUG,
+  STAFRAEN_HEILSA_SLUG,
   IntroWrapper,
   SortableTable,
 } from '@island.is/portals/my-pages/core'
@@ -43,10 +43,12 @@ const MedicinePrescriptionHistory = () => {
     variables: { locale: lang },
   })
 
-  const [getMedicineDispensationsATC, { loading: atcLoading, data: atcData }] =
-    useGetMedicineDispensationForAtcLazyQuery({
-      fetchPolicy: 'no-cache',
-    })
+  const [
+    getMedicineDispensationsATC,
+    { loading: atcLoading, data: atcData },
+  ] = useGetMedicineDispensationForAtcLazyQuery({
+    fetchPolicy: 'no-cache',
+  })
 
   const history = data?.healthDirectorateMedicineHistory.medicineHistory ?? []
 
@@ -65,9 +67,9 @@ const MedicinePrescriptionHistory = () => {
       title={formatMessage(messages.medicinePrescriptionHistory)}
       intro={formatMessage(messages.medicinePrescriptionHistoryIntroText)}
       serviceProvider={{
-        slug: HEALTH_DIRECTORATE_SLUG,
+        slug: STAFRAEN_HEILSA_SLUG,
         tooltip: formatMessage(
-          messages.landlaeknirMedicinePrescriptionsTooltip,
+          messages.stafraenHeilsaMedicinePrescriptionsTooltip,
         ),
       }}
       marginBottom={6}

--- a/libs/portals/my-pages/health/src/screens/MedicineHistory/MedicinePrescriptionHistory.tsx
+++ b/libs/portals/my-pages/health/src/screens/MedicineHistory/MedicinePrescriptionHistory.tsx
@@ -43,12 +43,10 @@ const MedicinePrescriptionHistory = () => {
     variables: { locale: lang },
   })
 
-  const [
-    getMedicineDispensationsATC,
-    { loading: atcLoading, data: atcData },
-  ] = useGetMedicineDispensationForAtcLazyQuery({
-    fetchPolicy: 'no-cache',
-  })
+  const [getMedicineDispensationsATC, { loading: atcLoading, data: atcData }] =
+    useGetMedicineDispensationForAtcLazyQuery({
+      fetchPolicy: 'no-cache',
+    })
 
   const history = data?.healthDirectorateMedicineHistory.medicineHistory ?? []
 

--- a/libs/portals/my-pages/health/src/screens/MedicinePrescriptions/MedicinePrescriptions.tsx
+++ b/libs/portals/my-pages/health/src/screens/MedicinePrescriptions/MedicinePrescriptions.tsx
@@ -13,7 +13,7 @@ import {
 } from '@island.is/island-ui/core'
 import { useLocale } from '@island.is/localization'
 import {
-  HEALTH_DIRECTORATE_SLUG,
+  STAFRAEN_HEILSA_SLUG,
   IntroWrapper,
   m,
 } from '@island.is/portals/my-pages/core'
@@ -42,8 +42,9 @@ const MedicinePrescriptions = () => {
   const { formatMessage, lang } = useLocale()
   useHealthPlausibleSwap()
   const [page, setPage] = useState(1)
-  const [filterValues, setFilterValues] =
-    useState<FilterValues>(defaultFilterValues)
+  const [filterValues, setFilterValues] = useState<FilterValues>(
+    defaultFilterValues,
+  )
 
   const { data, error, loading } = useGetMedicinePrescriptionsQuery({
     variables: { locale: lang },
@@ -133,9 +134,9 @@ const MedicinePrescriptions = () => {
       title={formatMessage(messages.medicinePrescriptions)}
       intro={formatMessage(messages.medicinePrescriptionIntroText)}
       serviceProvider={{
-        slug: HEALTH_DIRECTORATE_SLUG,
+        slug: STAFRAEN_HEILSA_SLUG,
         tooltip: formatMessage(
-          messages.landlaeknirMedicinePrescriptionsTooltip,
+          messages.stafraenHeilsaMedicinePrescriptionsTooltip,
         ),
       }}
     >

--- a/libs/portals/my-pages/health/src/screens/MedicinePrescriptions/MedicinePrescriptions.tsx
+++ b/libs/portals/my-pages/health/src/screens/MedicinePrescriptions/MedicinePrescriptions.tsx
@@ -42,9 +42,8 @@ const MedicinePrescriptions = () => {
   const { formatMessage, lang } = useLocale()
   useHealthPlausibleSwap()
   const [page, setPage] = useState(1)
-  const [filterValues, setFilterValues] = useState<FilterValues>(
-    defaultFilterValues,
-  )
+  const [filterValues, setFilterValues] =
+    useState<FilterValues>(defaultFilterValues)
 
   const { data, error, loading } = useGetMedicinePrescriptionsQuery({
     variables: { locale: lang },

--- a/libs/portals/my-pages/health/src/screens/OrganDonation/OrganDonation.tsx
+++ b/libs/portals/my-pages/health/src/screens/OrganDonation/OrganDonation.tsx
@@ -2,6 +2,7 @@ import { Box, Button, Text, ActionCard } from '@island.is/island-ui/core'
 import { useLocale, useNamespaces } from '@island.is/localization'
 import {
   CardLoader,
+  HEALTH_DIRECTORATE_SLUG,
   IntroWrapper,
   LinkResolver,
 } from '@island.is/portals/my-pages/core'
@@ -59,6 +60,10 @@ const OrganDonation = () => {
     <IntroWrapper
       title={formatMessage(m.organDonation)}
       intro={formatMessage(m.organDonationDescription)}
+      serviceProvider={{
+        slug: HEALTH_DIRECTORATE_SLUG,
+        tooltip: formatMessage(m.landlaeknirOrganDonationTooltip),
+      }}
       buttonGroup={{
         actions: [
           <LinkResolver

--- a/libs/portals/my-pages/health/src/screens/OrganDonation/components/RegistrationForm.tsx
+++ b/libs/portals/my-pages/health/src/screens/OrganDonation/components/RegistrationForm.tsx
@@ -8,6 +8,7 @@ import {
 } from '@island.is/island-ui/core'
 import { useLocale, useNamespaces } from '@island.is/localization'
 import {
+  HEALTH_DIRECTORATE_SLUG,
   IntroWrapper,
   LinkResolver,
   m as coreMessages,
@@ -109,6 +110,10 @@ export const OrganRegistrationForm = () => {
     <IntroWrapper
       title={formatMessage(messages.organDonation)}
       intro={formatMessage(messages.organDonationDescription)}
+      serviceProvider={{
+        slug: HEALTH_DIRECTORATE_SLUG,
+        tooltip: formatMessage(messages.landlaeknirOrganDonationTooltip),
+      }}
       desktopContentSpan="10/12"
     >
       <Text variant="eyebrow" color="purple400" marginBottom={1}>

--- a/libs/portals/my-pages/health/src/screens/PatientDataPermits/NewPermit.tsx
+++ b/libs/portals/my-pages/health/src/screens/PatientDataPermits/NewPermit.tsx
@@ -1,6 +1,9 @@
 import { toast } from '@island.is/island-ui/core'
 import { useLocale, useNamespaces } from '@island.is/localization'
-import { IntroWrapper } from '@island.is/portals/my-pages/core'
+import {
+  IntroWrapper,
+  STAFRAEN_HEILSA_SLUG,
+} from '@island.is/portals/my-pages/core'
 import React, { useState } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 
@@ -115,8 +118,8 @@ const NewPermit: React.FC = () => {
         <Markdown>{formatMessage(messages.permitDetailIntroWithLink)}</Markdown>
       }
       serviceProvider={{
-        slug: 'landlaeknir',
-        tooltip: formatMessage(messages.landlaeknirPatientPermitsTooltip),
+        slug: STAFRAEN_HEILSA_SLUG,
+        tooltip: formatMessage(messages.stafraenHeilsaPatientPermitsTooltip),
       }}
       desktopContentSpan="10/12"
     >

--- a/libs/portals/my-pages/health/src/screens/PatientDataPermits/PermitDetail.tsx
+++ b/libs/portals/my-pages/health/src/screens/PatientDataPermits/PermitDetail.tsx
@@ -16,6 +16,7 @@ import {
   InfoLine,
   InfoLineStack,
   IntroWrapper,
+  STAFRAEN_HEILSA_SLUG,
 } from '@island.is/portals/my-pages/core'
 import { Problem } from '@island.is/react-spa/shared'
 import React, { useState } from 'react'
@@ -85,8 +86,8 @@ const PermitDetail: React.FC = () => {
         <Markdown>{formatMessage(messages.permitDetailIntroWithLink)}</Markdown>
       }
       serviceProvider={{
-        slug: 'landlaeknir',
-        tooltip: formatMessage(messages.landlaeknirPatientPermitsTooltip),
+        slug: STAFRAEN_HEILSA_SLUG,
+        tooltip: formatMessage(messages.stafraenHeilsaPatientPermitsTooltip),
       }}
       buttonGroup={
         !loading && !error

--- a/libs/portals/my-pages/health/src/screens/PatientDataPermits/Permits.tsx
+++ b/libs/portals/my-pages/health/src/screens/PatientDataPermits/Permits.tsx
@@ -4,6 +4,7 @@ import {
   ActionCardLoader,
   IntroWrapper,
   LinkButton,
+  STAFRAEN_HEILSA_SLUG,
 } from '@island.is/portals/my-pages/core'
 import { Problem } from '@island.is/react-spa/shared'
 import { FC } from 'react'
@@ -34,8 +35,8 @@ const PatientDataPermits: FC = () => {
       title={formatMessage(messages.patientDataPermitTitle)}
       intro={formatMessage(messages.patientDataPermitDescription)}
       serviceProvider={{
-        slug: 'landlaeknir',
-        tooltip: formatMessage(messages.landlaeknirPatientPermitsTooltip),
+        slug: STAFRAEN_HEILSA_SLUG,
+        tooltip: formatMessage(messages.stafraenHeilsaPatientPermitsTooltip),
       }}
       loading={loading}
       buttonGroup={

--- a/libs/portals/my-pages/health/src/screens/Referrals/Referrals.tsx
+++ b/libs/portals/my-pages/health/src/screens/Referrals/Referrals.tsx
@@ -2,7 +2,7 @@ import { useLocale, useNamespaces } from '@island.is/localization'
 import {
   CardLoader,
   formatDate,
-  HEALTH_DIRECTORATE_SLUG,
+  STAFRAEN_HEILSA_SLUG,
   IntroWrapper,
 } from '@island.is/portals/my-pages/core'
 import React from 'react'
@@ -57,8 +57,8 @@ const Referrals: React.FC = () => {
       title={formatMessage(messages.referrals)}
       intro={formatMessage(messages.referralsIntro)}
       serviceProvider={{
-        slug: HEALTH_DIRECTORATE_SLUG,
-        tooltip: formatMessage(messages.landlaeknirReferralTooltip),
+        slug: STAFRAEN_HEILSA_SLUG,
+        tooltip: formatMessage(messages.stafraenHeilsaReferralTooltip),
       }}
       desktopContentSpan="10/12"
     >

--- a/libs/portals/my-pages/health/src/screens/Referrals/ReferralsDetail.tsx
+++ b/libs/portals/my-pages/health/src/screens/Referrals/ReferralsDetail.tsx
@@ -1,7 +1,7 @@
 import { useLocale, useNamespaces } from '@island.is/localization'
 import {
   formatDate,
-  HEALTH_DIRECTORATE_SLUG,
+  STAFRAEN_HEILSA_SLUG,
   InfoLine,
   InfoLineStack,
   IntroWrapper,
@@ -34,8 +34,8 @@ const ReferralsDetail: React.FC = () => {
       title={referral?.serviceName || formatMessage(messages.referrals)}
       intro={formatMessage(messages.referralsDetailIntro)}
       serviceProvider={{
-        slug: HEALTH_DIRECTORATE_SLUG,
-        tooltip: formatMessage(messages.landlaeknirReferralTooltip),
+        slug: STAFRAEN_HEILSA_SLUG,
+        tooltip: formatMessage(messages.stafraenHeilsaReferralTooltip),
       }}
       loading={loading}
       marginBottom={6}

--- a/libs/portals/my-pages/health/src/screens/Treatments/TreatmentEducationalContent.tsx
+++ b/libs/portals/my-pages/health/src/screens/Treatments/TreatmentEducationalContent.tsx
@@ -3,7 +3,7 @@ import { useLocale, useNamespaces } from '@island.is/localization'
 import {
   CardLoader,
   formatDate,
-  HEALTH_DIRECTORATE_SLUG,
+  STAFRAEN_HEILSA_SLUG,
   IntroWrapper,
   LinkButton,
   m,
@@ -54,8 +54,8 @@ const TreatmentEducationalContent = () => {
       title={formatMessage(m.healthTreatmentEducationalContent)}
       intro={messages.educationalContentIntro}
       serviceProvider={{
-        slug: HEALTH_DIRECTORATE_SLUG,
-        tooltip: formatMessage(messages.landlaeknirTreatmentTooltip),
+        slug: STAFRAEN_HEILSA_SLUG,
+        tooltip: formatMessage(messages.stafraenHeilsaTreatmentTooltip),
       }}
     >
       {error && !loading ? (

--- a/libs/portals/my-pages/health/src/screens/Treatments/TreatmentOverview.tsx
+++ b/libs/portals/my-pages/health/src/screens/Treatments/TreatmentOverview.tsx
@@ -11,7 +11,7 @@ import { useLocale, useNamespaces } from '@island.is/localization'
 import {
   CardLoader,
   formatDate,
-  HEALTH_DIRECTORATE_SLUG,
+  STAFRAEN_HEILSA_SLUG,
   IntroWrapper,
   LinkResolver,
   m,
@@ -112,8 +112,8 @@ const TreatmentOverview = () => {
           : formatMessage(messages.treatmentIntro)
       }
       serviceProvider={{
-        slug: HEALTH_DIRECTORATE_SLUG,
-        tooltip: formatMessage(messages.landlaeknirTreatmentTooltip),
+        slug: STAFRAEN_HEILSA_SLUG,
+        tooltip: formatMessage(messages.stafraenHeilsaTreatmentTooltip),
       }}
       marginBottom={[0, 0, 0, 2]}
     >

--- a/libs/portals/my-pages/health/src/screens/Treatments/Treatments.tsx
+++ b/libs/portals/my-pages/health/src/screens/Treatments/Treatments.tsx
@@ -2,7 +2,7 @@ import { ActionCard, Stack } from '@island.is/island-ui/core'
 import { useLocale, useNamespaces } from '@island.is/localization'
 import {
   CardLoader,
-  HEALTH_DIRECTORATE_SLUG,
+  STAFRAEN_HEILSA_SLUG,
   IntroWrapper,
   m,
 } from '@island.is/portals/my-pages/core'
@@ -36,8 +36,8 @@ const Treatments = () => {
       title={formatMessage(m.healthTreatment)}
       intro={messages.treatmentsIntro}
       serviceProvider={{
-        slug: HEALTH_DIRECTORATE_SLUG,
-        tooltip: formatMessage(messages.landlaeknirTreatmentTooltip),
+        slug: STAFRAEN_HEILSA_SLUG,
+        tooltip: formatMessage(messages.stafraenHeilsaTreatmentTooltip),
       }}
     >
       {error && !loading && <Problem error={error} noBorder={false} />}

--- a/libs/portals/my-pages/health/src/screens/Vaccinations/VaccinationsWrapper.tsx
+++ b/libs/portals/my-pages/health/src/screens/Vaccinations/VaccinationsWrapper.tsx
@@ -2,7 +2,7 @@ import { Box, Button, SkeletonLoader, Tabs } from '@island.is/island-ui/core'
 import { useLocale, useNamespaces } from '@island.is/localization'
 import {
   EmptyTable,
-  HEALTH_DIRECTORATE_SLUG,
+  STAFRAEN_HEILSA_SLUG,
   IntroWrapper,
   LinkButton,
 } from '@island.is/portals/my-pages/core'
@@ -49,8 +49,8 @@ export const VaccinationsWrapper = () => {
       title={formatMessage(m.vaccinations)}
       intro={formatMessage(m.vaccinationsIntro)}
       serviceProvider={{
-        slug: HEALTH_DIRECTORATE_SLUG,
-        tooltip: formatMessage(m.landlaeknirVaccinationsTooltip),
+        slug: STAFRAEN_HEILSA_SLUG,
+        tooltip: formatMessage(m.stafraenHeilsaVaccinationsTooltip),
       }}
       buttonGroup={{
         actions: [

--- a/libs/portals/my-pages/health/src/screens/Waitlists/Waitlists.tsx
+++ b/libs/portals/my-pages/health/src/screens/Waitlists/Waitlists.tsx
@@ -11,7 +11,7 @@ import { useLocale, useNamespaces } from '@island.is/localization'
 import {
   CardLoader,
   formatDate,
-  HEALTH_DIRECTORATE_SLUG,
+  STAFRAEN_HEILSA_SLUG,
   IntroWrapper,
   LinkButton,
 } from '@island.is/portals/my-pages/core'
@@ -79,8 +79,8 @@ const Waitlists: React.FC = () => {
         </Box>
       }
       serviceProvider={{
-        slug: HEALTH_DIRECTORATE_SLUG,
-        tooltip: formatMessage(messages.landlaeknirWaitlistTooltip),
+        slug: STAFRAEN_HEILSA_SLUG,
+        tooltip: formatMessage(messages.stafraenHeilsaWaitlistTooltip),
       }}
       buttonGroup={{
         actions: [

--- a/libs/portals/my-pages/health/src/screens/Waitlists/WaitlistsDetail.tsx
+++ b/libs/portals/my-pages/health/src/screens/Waitlists/WaitlistsDetail.tsx
@@ -2,7 +2,7 @@ import { HealthDirectorateWaitlist } from '@island.is/api/schema'
 import { useLocale, useNamespaces } from '@island.is/localization'
 import {
   formatDate,
-  HEALTH_DIRECTORATE_SLUG,
+  STAFRAEN_HEILSA_SLUG,
   InfoLine,
   InfoLineStack,
   IntroWrapper,
@@ -37,8 +37,8 @@ const WaitlistsDetail: React.FC = () => {
       title={formatMessage(messages.waitlists)}
       intro={formatMessage(messages.waitlistsIntro)}
       serviceProvider={{
-        slug: HEALTH_DIRECTORATE_SLUG,
-        tooltip: formatMessage(messages.landlaeknirWaitlistTooltip),
+        slug: STAFRAEN_HEILSA_SLUG,
+        tooltip: formatMessage(messages.stafraenHeilsaWaitlistTooltip),
       }}
       marginBottom={6}
       desktopContentSpan="10/12"

--- a/libs/shared/constants/src/lib/organizationSlug.ts
+++ b/libs/shared/constants/src/lib/organizationSlug.ts
@@ -54,3 +54,4 @@ export type OrganizationSlugType =
   | 'landspitali'
   | 'lyfjastofnun'
   | 'vinnumalastofnun'
+  | 'stafraen-heilsa'


### PR DESCRIPTION
## What

Use Digital health organization for health pages instead of landlæknir (in most cases)

## Why

It's more correct

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Updated Service Information**
  - Health portal screens now identify Stafræn heilsa as the service provider for appointments, medicines, vaccinations, permits, referrals, treatments, and waitlists.
  - Related explanatory tooltips now reflect the responsible service.

- **Organ Donation**
  - Organ donation information identifies Landlæknir as the responsible authority, with a dedicated explanatory tooltip.

- **Consistency**
  - Service provider information is presented consistently across related health portal pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->