### PR TITLE
feat(my-pages): Health messages chat type

### DIFF
--- a/libs/api/domains/health-directorate/project.json
+++ b/libs/api/domains/health-directorate/project.json
@@ -14,6 +14,12 @@
       "options": {
         "jestConfig": "libs/api/domains/health-directorate/jest.config.ts"
       }
+    },
+    "extract-strings": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "yarn ts-node -P libs/localization/tsconfig.lib.json libs/localization/scripts/extract 'libs/api/domains/health-directorate/src/lib/messages.ts'"
+      }
     }
   }
 }

--- a/libs/api/domains/health-directorate/src/lib/constants.ts
+++ b/libs/api/domains/health-directorate/src/lib/constants.ts
@@ -1,5 +1,7 @@
 export const PATIENT_PERMIT_CODE = 'PATIENT_SUMMARY'
 
+export const NAMESPACE = ['api.health-directorate']
+
 // Video call link is joinable from this many minutes before the appointment start time...
 export const VIDEO_CALL_ACTIVATES_MINUTES_BEFORE = 5
 // ...until this many minutes after it, at which point it's considered expired.

--- a/libs/api/domains/health-directorate/src/lib/health-directorate.module.ts
+++ b/libs/api/domains/health-directorate/src/lib/health-directorate.module.ts
@@ -1,4 +1,5 @@
 import { HealthDirectorateClientModule } from '@island.is/clients/health-directorate'
+import { CmsTranslationsModule } from '@island.is/cms-translations'
 import { FeatureFlagModule } from '@island.is/nest/feature-flags'
 import { Module } from '@nestjs/common'
 import { HealthDirectorateService } from './health-directorate.service'
@@ -13,7 +14,11 @@ import { CertificateResolver } from './resolvers/certificate.resolver'
 import { TreatmentsResolver } from './resolvers/treatments.resolver'
 
 @Module({
-  imports: [HealthDirectorateClientModule, FeatureFlagModule],
+  imports: [
+    HealthDirectorateClientModule,
+    FeatureFlagModule,
+    CmsTranslationsModule,
+  ],
   providers: [
     HealthConversationsResolver,
     HealthConversationOrganizationResolver,

--- a/libs/api/domains/health-directorate/src/lib/health-directorate.service.ts
+++ b/libs/api/domains/health-directorate/src/lib/health-directorate.service.ts
@@ -25,7 +25,8 @@ import {
   Injectable,
 } from '@nestjs/common'
 import sortBy from 'lodash/sortBy'
-import { PATIENT_PERMIT_CODE } from './constants'
+import { IntlService } from '@island.is/cms-translations'
+import { NAMESPACE, PATIENT_PERMIT_CODE } from './constants'
 import {
   HealthDirectorateAppointmentInput,
   HealthDirectorateAppointmentsInput,
@@ -53,6 +54,8 @@ import {
   mapVaccinationStatus,
 } from './mappers/basicInformationMapper'
 import {
+  getWebChatConversationType,
+  WEB_CHAT_TYPE_CODE,
   mapConversationMessageContent,
   mapMessagingRecipient,
   toConversationDirectionEnum,
@@ -130,6 +133,7 @@ export class HealthDirectorateService {
     private readonly downloadServiceConfig: ConfigType<
       typeof DownloadServiceConfig
     >,
+    private readonly intlService: IntlService,
   ) {}
 
   /* Organ Donation */
@@ -908,6 +912,14 @@ export class HealthDirectorateService {
     auth: Auth,
     input: HealthDirectorateCreateConversationInput,
   ): Promise<HealthDirectorateHealthConversationDetail | null> {
+    // The web chat entry is advertised in allowedMessageTypes but is an
+    // external link, not a conversation type Hekla knows about.
+    if (input.patientInitiatedTypeCode === WEB_CHAT_TYPE_CODE) {
+      throw new BadRequestException(
+        'patientInitiatedTypeCode is not a valid conversation type',
+      )
+    }
+
     const body: CreateConversationRequestDto = {
       nodeId: input.nodeId,
       groupId: input.groupId,
@@ -970,7 +982,15 @@ export class HealthDirectorateService {
     const items = await this.healthApi.getMessagingRecipients(auth, locale)
     if (!items) return null
 
-    return items.map(mapMessagingRecipient)
+    const { formatMessage } = await this.intlService.useIntl(NAMESPACE, locale)
+    const webChat = getWebChatConversationType(formatMessage)
+    return items.map((item) => {
+      const recipient = mapMessagingRecipient(item)
+      return {
+        ...recipient,
+        allowedMessageTypes: [...recipient.allowedMessageTypes, webChat],
+      }
+    })
   }
 
   /* Certificates */

--- a/libs/api/domains/health-directorate/src/lib/health-directorate.service.ts
+++ b/libs/api/domains/health-directorate/src/lib/health-directorate.service.ts
@@ -984,6 +984,12 @@ export class HealthDirectorateService {
 
     const { formatMessage } = await this.intlService.useIntl(NAMESPACE, locale)
     const webChat = getWebChatConversationType(formatMessage)
+    // A link-out entry without a link is useless and would render as a
+    // broken regular option — skip it if the URL was blanked in Contentful.
+    if (!webChat.externalLinkUrl) {
+      return items.map(mapMessagingRecipient)
+    }
+
     return items.map((item) => {
       const recipient = mapMessagingRecipient(item)
       return {

--- a/libs/api/domains/health-directorate/src/lib/mappers/conversationMapper.ts
+++ b/libs/api/domains/health-directorate/src/lib/mappers/conversationMapper.ts
@@ -175,9 +175,11 @@ export const getWebChatConversationType = (
   return {
     patientInitiatedTypeCode: WEB_CHAT_TYPE_CODE,
     title: formatMessage(m.webChatTitle),
-    description: formatMessage(
-      isCurrentlyOpen ? m.webChatDescriptionOpen : m.webChatDescriptionClosed,
-    ),
+    description: formatMessage(m.webChatDescription, {
+      status: formatMessage(
+        isCurrentlyOpen ? m.webChatStatusOpen : m.webChatStatusClosed,
+      ),
+    }),
     isCertificate: false,
     externalLinkUrl: formatMessage(m.webChatUrl),
     isCurrentlyOpen,

--- a/libs/api/domains/health-directorate/src/lib/mappers/conversationMapper.ts
+++ b/libs/api/domains/health-directorate/src/lib/mappers/conversationMapper.ts
@@ -1,3 +1,4 @@
+import type { FormatMessage } from '@island.is/cms-translations'
 import {
   ContentSegmentDto,
   ContentSegmentType,
@@ -16,6 +17,7 @@ import {
   HealthConversationSegmentTypeEnum,
   HealthConversationStatusFilterEnum,
 } from '../models/enums'
+import { m } from '../messages'
 import { HealthDirectorateHealthConversationMessageContent } from '../models/healthConversationMessageContent.model'
 import { HealthDirectorateHealthConversationRecipient } from '../models/healthConversationRecipient.model'
 import { HealthDirectorateHealthConversationSegment } from '../models/healthConversationSegment.model'
@@ -140,6 +142,45 @@ export const toConversationRecipientBlockedReasonEnum = (
       return HealthConversationRecipientBlockedReasonEnum.NO_ALLOWED_TYPES
     default:
       return undefined
+  }
+}
+
+/* 
+  The Heilsuvera web chat is not a Hekla conversation type, it's appended
+  manually to every recipient's service list so both web and app render it
+  from the same source, as an external link at the bottom of the dropdown.
+*/
+export const WEB_CHAT_TYPE_CODE = 'HEILSUVERA_WEB_CHAT'
+// Must match the hours stated in the translated web chat description strings.
+const WEB_CHAT_OPENS_MINUTES = 8 * 60 // 08:00
+const WEB_CHAT_CLOSES_MINUTES = 15 * 60 + 30 // 15:30
+
+const isWebChatOpen = (now: Date): boolean => {
+  const day = now.getUTCDay()
+  const minutes = now.getUTCHours() * 60 + now.getUTCMinutes()
+  const isWeekday = day >= 1 && day <= 5
+  return (
+    isWeekday &&
+    minutes >= WEB_CHAT_OPENS_MINUTES &&
+    minutes < WEB_CHAT_CLOSES_MINUTES
+  )
+}
+
+export const getWebChatConversationType = (
+  formatMessage: FormatMessage,
+  now: Date = new Date(),
+): HealthDirectorateHealthConversationType => {
+  const isCurrentlyOpen = isWebChatOpen(now)
+
+  return {
+    patientInitiatedTypeCode: WEB_CHAT_TYPE_CODE,
+    title: formatMessage(m.webChatTitle),
+    description: formatMessage(
+      isCurrentlyOpen ? m.webChatDescriptionOpen : m.webChatDescriptionClosed,
+    ),
+    isCertificate: false,
+    externalLinkUrl: formatMessage(m.webChatUrl),
+    isCurrentlyOpen,
   }
 }
 

--- a/libs/api/domains/health-directorate/src/lib/messages.ts
+++ b/libs/api/domains/health-directorate/src/lib/messages.ts
@@ -5,13 +5,17 @@ export const m = defineMessages({
     id: 'api.health-directorate:web-chat-title',
     defaultMessage: 'Ráðgjöf í netspjalli Heilsuveru',
   },
-  webChatDescriptionOpen: {
-    id: 'api.health-directorate:web-chat-description-open',
-    defaultMessage: 'Opið núna. Opið frá 8:00 til 15:30 virka daga.',
+  webChatStatusOpen: {
+    id: 'api.health-directorate:web-chat-status-open',
+    defaultMessage: 'Opið núna.',
   },
-  webChatDescriptionClosed: {
-    id: 'api.health-directorate:web-chat-description-closed',
-    defaultMessage: 'Lokað núna. Opið frá 8:00 til 15:30 virka daga.',
+  webChatStatusClosed: {
+    id: 'api.health-directorate:web-chat-status-closed',
+    defaultMessage: 'Lokað núna.',
+  },
+  webChatDescription: {
+    id: 'api.health-directorate:web-chat-description',
+    defaultMessage: '{status} Opið frá 8:00 til 15:30 virka daga.',
   },
   webChatUrl: {
     id: 'api.health-directorate:web-chat-url',

--- a/libs/api/domains/health-directorate/src/lib/messages.ts
+++ b/libs/api/domains/health-directorate/src/lib/messages.ts
@@ -1,0 +1,20 @@
+import { defineMessages } from 'react-intl'
+
+export const m = defineMessages({
+  webChatTitle: {
+    id: 'api.health-directorate:web-chat-title',
+    defaultMessage: 'Ráðgjöf í netspjalli Heilsuveru',
+  },
+  webChatDescriptionOpen: {
+    id: 'api.health-directorate:web-chat-description-open',
+    defaultMessage: 'Opið núna. Opið frá 8:00 til 15:30 virka daga.',
+  },
+  webChatDescriptionClosed: {
+    id: 'api.health-directorate:web-chat-description-closed',
+    defaultMessage: 'Lokað núna. Opið frá 8:00 til 15:30 virka daga.',
+  },
+  webChatUrl: {
+    id: 'api.health-directorate:web-chat-url',
+    defaultMessage: 'https://direct.lc.chat/15092154',
+  },
+})

--- a/libs/api/domains/health-directorate/src/lib/models/healthConversationType.model.ts
+++ b/libs/api/domains/health-directorate/src/lib/models/healthConversationType.model.ts
@@ -19,4 +19,18 @@ export class HealthDirectorateHealthConversationType {
       'True for certificate-request types (use POST /certificates); false for regular messages.',
   })
   isCertificate!: boolean
+
+  @Field({
+    nullable: true,
+    description:
+      'Set for entries that link to an external service (e.g. the Heilsuvera web chat). Open this URL instead of creating a conversation.',
+  })
+  externalLinkUrl?: string
+
+  @Field({
+    nullable: true,
+    description:
+      'Whether the external service is open right now. Only set when externalLinkUrl is present.',
+  })
+  isCurrentlyOpen?: boolean
 }

--- a/libs/portals/my-pages/health/src/screens/HealthConversations/NewHealthConversation.graphql
+++ b/libs/portals/my-pages/health/src/screens/HealthConversations/NewHealthConversation.graphql
@@ -14,7 +14,10 @@ fragment HealthConversationRecipient on HealthDirectorateHealthConversationRecip
   allowedMessageTypes {
     patientInitiatedTypeCode
     title
+    description
     isCertificate
+    externalLinkUrl
+    isCurrentlyOpen
   }
 }
 

--- a/libs/portals/my-pages/health/src/screens/HealthConversations/NewHealthConversation.tsx
+++ b/libs/portals/my-pages/health/src/screens/HealthConversations/NewHealthConversation.tsx
@@ -134,9 +134,7 @@ const NewHealthConversation = () => {
     recipient?.allowedMessageTypes.map((t) => ({
       label: t.title,
       value: t.patientInitiatedTypeCode,
-      description: t.externalLinkUrl
-        ? t.description ?? undefined
-        : undefined,
+      description: t.externalLinkUrl ? t.description ?? undefined : undefined,
     })) ?? []
 
   const selectedOption =

--- a/libs/portals/my-pages/health/src/screens/HealthConversations/NewHealthConversation.tsx
+++ b/libs/portals/my-pages/health/src/screens/HealthConversations/NewHealthConversation.tsx
@@ -134,6 +134,9 @@ const NewHealthConversation = () => {
     recipient?.allowedMessageTypes.map((t) => ({
       label: t.title,
       value: t.patientInitiatedTypeCode,
+      description: t.externalLinkUrl
+        ? t.description ?? undefined
+        : undefined,
     })) ?? []
 
   const selectedOption =
@@ -213,6 +216,11 @@ const NewHealthConversation = () => {
     const newType = recipient?.allowedMessageTypes.find(
       (t) => t.patientInitiatedTypeCode === typeCode,
     )
+
+    if (newType?.externalLinkUrl) {
+      window.open(newType.externalLinkUrl, '_blank', 'noopener,noreferrer')
+      return
+    }
 
     setSelectedTypeCode(typeCode)
     setCertificateForm({})


### PR DESCRIPTION
## What

Append a new health message category to the patient initiated type codes to handle opening up a new chat. Logic placed in domain layer to support the app alongside my pages. 

## Why

So users can be redirected to the chat if they so choose. 

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a Health Directorate web chat option with localized title, description, status, opening hours, and external link.
  - Web chat availability is shown based on weekday hours.
  - External services can be opened in a new browser tab instead of starting an in-app conversation.
  - Added support for displaying whether an external service is currently open.

- **Bug Fixes**
  - Prevented web chat options from being submitted as regular health conversations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->