### PR TITLE
feat(doe): Salary report application - outlier groups saved to answers

### DIFF
--- a/libs/application/templates/directorate-of-equality/salary-report/src/fields/SalaryAnalysisResults/OutlierEditor.tsx
+++ b/libs/application/templates/directorate-of-equality/salary-report/src/fields/SalaryAnalysisResults/OutlierEditor.tsx
@@ -17,6 +17,7 @@ import {
   emptyOutlierGroupAnswer,
   foldGroupDirection,
   isOutlierGroupComplete,
+  outlierGroupFingerprint,
 } from '../../utils/outlierGroups'
 import type { OutlierGroupAnswer, PayStatus } from '../../utils/outlierGroups'
 import { TablePagination } from '../TablePagination'
@@ -26,16 +27,39 @@ import { Markdown } from '@island.is/shared/components'
 
 const OUTLIERS_PAGE_SIZE = 10
 
+// react-hook-form's getValues hands back live references into the form's own
+// values, and it writes into those objects in place as the applicant types — so
+// anything meant to outlast a keystroke has to be copied out of them first.
+// (useWatch is the exception: it deep-clones its subtree on every change.)
+const cloneGroups = (groups: OutlierGroupAnswer[]): OutlierGroupAnswer[] =>
+  groups.map((group) => ({
+    ...group,
+    employeeOrdinals: [...(group.employeeOrdinals ?? [])],
+  }))
+
 type Props = {
   outliers: SalaryAnalysisOutlierDto[]
   errors?: RecordObject
   // draft: pre-submit, DMR-synced, keyed by employee id. postponed: answers-backed, keyed by ordinal.
   mode: 'draft' | 'postponed'
+  // Writes the whole plan to the answers buffer, resolving to whether it was
+  // persisted — see useOutlierPlanBuffer.
+  onSaveGroups: (groups: OutlierGroupAnswer[]) => Promise<boolean>
+  // What the screen was seeded with, from the buffer or from the DMR draft.
+  // Either way it is already persisted, so everything on screen starts out
+  // saved and the buttons open in their "Vistað" state.
+  initialSavedGroups: OutlierGroupAnswer[]
 }
 
-export const OutlierEditor: FC<Props> = ({ outliers, errors, mode }) => {
+export const OutlierEditor: FC<Props> = ({
+  outliers,
+  errors,
+  mode,
+  onSaveGroups,
+  initialSavedGroups,
+}) => {
   const { formatMessage } = useLocale()
-  const { control, setValue } = useFormContext()
+  const { control, getValues, setValue } = useFormContext()
   const m = messages.salaryAnalysis.outlierGroup
 
   // Only this component holds the outliers; OutlierGroupCard has ordinals and
@@ -65,6 +89,19 @@ export const OutlierEditor: FC<Props> = ({ outliers, errors, mode }) => {
 
   const [selected, setSelected] = useState<Set<number>>(new Set())
   const [page, setPage] = useState(1)
+
+  // The plan exactly as last written to the answers buffer — the values, not
+  // just their fingerprints, because a removal has to be able to write this set
+  // back minus one group. Cloned, so nothing here is aliased to the form.
+  //
+  // One save carries the whole array, so this is what every card compares
+  // itself against: a save from any one of them leaves them all matching.
+  const [savedGroups, setSavedGroups] = useState(() =>
+    cloneGroups(initialSavedGroups),
+  )
+  const [savingIndex, setSavingIndex] = useState<number>()
+  const [saveErrorIndex, setSaveErrorIndex] = useState<number>()
+  const [removeFailed, setRemoveFailed] = useState(false)
 
   // Membership is edited with setValue (assigning into an existing group, or a
   // pill click freeing one member), which useFieldArray's `fields` does not
@@ -157,6 +194,49 @@ export const OutlierEditor: FC<Props> = ({ outliers, errors, mode }) => {
     setPage(1)
   }
 
+  // Where this group sits in the saved set, or -1 if it was never saved.
+  //
+  // Matched by id where there is one (draft mode mints one per group), so a
+  // removal higher up the list doesn't make every group below it look edited.
+  // POSTPONED has no ids and falls back to the position: both arrays only ever
+  // grow at the end, and the removal keeps them in step, so the positions
+  // line up — and a group past the end of the saved set is simply not in it.
+  const savedIndexOf = (
+    group: OutlierGroupAnswer | undefined,
+    index: number,
+  ) => {
+    if (group?.id) {
+      return savedGroups.findIndex((candidate) => candidate.id === group.id)
+    }
+    return index < savedGroups.length ? index : -1
+  }
+
+  const handleRemoveGroup = async (index: number) => {
+    // Read before the removal, and the save error goes with the card it was
+    // reported on: the index it is keyed by belongs to a different group once
+    // the array closes up.
+    const savedIndex = savedIndexOf(watchedGroups[index], index)
+    setSaveErrorIndex(undefined)
+    setRemoveFailed(false)
+    remove(index)
+
+    // A group the buffer already holds has to come out of it too, or the next
+    // visit seeds it straight back in. Written as the saved set minus this
+    // group rather than as the live values, so removing one group does not
+    // quietly persist the half-finished text in the others — the button is
+    // still the only thing that saves.
+    //
+    // A group that was never saved needs no write at all, which is the common
+    // case: created, then thought better of.
+    if (savedIndex === -1) return
+
+    const remaining = savedGroups.filter(
+      (_group, position) => position !== savedIndex,
+    )
+    if (await onSaveGroups(remaining)) setSavedGroups(remaining)
+    else setRemoveFailed(true)
+  }
+
   const handleRemoveMember = (index: number, ordinal: number) => {
     setValue(
       `${fieldName}.${index}.employeeOrdinals`,
@@ -165,6 +245,48 @@ export const OutlierEditor: FC<Props> = ({ outliers, errors, mode }) => {
     // The freed row joins the table, which may now need its first page shown.
     setPage(1)
   }
+
+  // Read straight off the form rather than from watchedGroups: the values are
+  // what goes to the server, and this is the one place that needs them exactly
+  // as react-hook-form holds them — cloned on the way out, since it keeps
+  // writing into them while the request is in flight.
+  const handleSave = async (index: number) => {
+    const groups = cloneGroups(
+      (getValues(fieldName) ?? []) as OutlierGroupAnswer[],
+    )
+    setSavingIndex(index)
+    setSaveErrorIndex(undefined)
+    // A save writes the whole array from the live values, which no longer hold
+    // the removed group — so it settles whatever a failed removal left behind.
+    setRemoveFailed(false)
+    const persisted = await onSaveGroups(groups)
+    setSavingIndex(undefined)
+    if (!persisted) {
+      // Reported on the card whose button was pressed, so the failure is where
+      // the applicant is looking.
+      setSaveErrorIndex(index)
+      return
+    }
+    setSavedGroups(groups)
+  }
+
+  const isGroupSaved = (index: number) => {
+    const group = watchedGroups[index]
+    const savedIndex = savedIndexOf(group, index)
+    return (
+      savedIndex !== -1 &&
+      outlierGroupFingerprint(savedGroups[savedIndex]) ===
+        outlierGroupFingerprint(group)
+    )
+  }
+
+  // Newest first. The array itself stays in creation order — the index is what
+  // names the inputs, numbers the groups and attributes the sync commands — so
+  // only the render order flips, and each entry carries its real index with it.
+  const groupsNewestFirst = useMemo(
+    () => fields.map((field, index) => ({ field, index })).reverse(),
+    [fields],
+  )
 
   // Suffixed with the index because the name is free text: two groups the
   // applicant calls "Sölufólk" would otherwise render two identical menu rows
@@ -332,7 +454,9 @@ export const OutlierEditor: FC<Props> = ({ outliers, errors, mode }) => {
                   </Button>
                 }
                 items={[
-                  ...fields.map((_field, index) => ({
+                  // Same order as the cards below, so the menu reads top-down
+                  // against what is on screen.
+                  ...groupsNewestFirst.map(({ index }) => ({
                     title: groupLabel(index),
                     onClick: () => handleAddToGroup(index),
                   })),
@@ -363,7 +487,7 @@ export const OutlierEditor: FC<Props> = ({ outliers, errors, mode }) => {
       )}
 
       <Box>
-        {fields.map((field, index) => {
+        {groupsNewestFirst.map(({ field, index }) => {
           const memberOrdinals = memberOrdinalsByIndex[index]
           return (
             <OutlierGroupCard
@@ -381,13 +505,27 @@ export const OutlierEditor: FC<Props> = ({ outliers, errors, mode }) => {
               )}
               mode={mode}
               errors={errors}
-              onRemove={() => remove(index)}
+              isSaved={isGroupSaved(index)}
+              isSaving={savingIndex === index}
+              saveFailed={saveErrorIndex === index}
+              onRemove={() => void handleRemoveGroup(index)}
               onRemoveMember={(ordinal) => handleRemoveMember(index, ordinal)}
+              onSave={() => handleSave(index)}
             />
           )
         })}
       </Box>
 
+      {/* Editor-level rather than on a card, because the card whose removal
+          failed to persist is the one that has just gone. */}
+      {removeFailed && (
+        <Box marginTop={2}>
+          <AlertMessage
+            type="error"
+            message={formatMessage(m.removeGroupError)}
+          />
+        </Box>
+      )}
       {unassignedOutliers.length > 0 && (
         <Box marginTop={2}>
           <AlertMessage

--- a/libs/application/templates/directorate-of-equality/salary-report/src/fields/SalaryAnalysisResults/OutlierGroupCard.tsx
+++ b/libs/application/templates/directorate-of-equality/salary-report/src/fields/SalaryAnalysisResults/OutlierGroupCard.tsx
@@ -4,6 +4,7 @@ import { getErrorViaPath } from '@island.is/application/core'
 import { RecordObject } from '@island.is/application/types'
 import {
   AccordionCard,
+  AlertMessage,
   Box,
   Button,
   GridColumn,
@@ -38,8 +39,14 @@ type Props = {
   direction: GroupDirection
   mode: 'draft' | 'postponed'
   errors?: RecordObject
+  // Whether this group still matches the copy last written to answers. One save
+  // carries every group, so a save from any card leaves them all saved.
+  isSaved: boolean
+  isSaving: boolean
+  saveFailed: boolean
   onRemove: () => void
   onRemoveMember: (ordinal: number) => void
+  onSave: () => void
 }
 
 // One accordion card per outlier group, split out of OutlierEditor.
@@ -52,8 +59,12 @@ export const OutlierGroupCard: FC<Props> = ({
   direction,
   mode,
   errors,
+  isSaved,
+  isSaving,
+  saveFailed,
   onRemove,
   onRemoveMember,
+  onSave,
 }) => {
   const { formatMessage, lang } = useLocale()
   const m = messages.salaryAnalysis.outlierGroup
@@ -217,6 +228,8 @@ export const OutlierGroupCard: FC<Props> = ({
               locale={lang as Locale}
               minDate={minRemedyDate}
               maxDate={maxRemedyDate}
+              maxYear={maxRemedyDate.getFullYear()}
+              minYear={minRemedyDate.getFullYear()}
               required
               backgroundColor="blue"
               error={remedyDateError}
@@ -255,6 +268,34 @@ export const OutlierGroupCard: FC<Props> = ({
             />
           </Box>
         </Box>
+        {/* The live region is the wrapper, which stays mounted: a disabled
+            button announces nothing when it becomes disabled, so the change
+            from "Vista" to "Vistað" would otherwise pass silently. */}
+        <Box
+          marginTop={3}
+          display="flex"
+          justifyContent="flexEnd"
+          aria-live="polite"
+        >
+          <Button
+            size="small"
+            variant="ghost"
+            icon={isSaved ? 'checkmark' : undefined}
+            disabled={isSaved}
+            loading={isSaving}
+            onClick={onSave}
+          >
+            {formatMessage(isSaved ? m.groupSavedButton : m.saveGroupButton)}
+          </Button>
+        </Box>
+        {saveFailed && (
+          <Box marginTop={2}>
+            <AlertMessage
+              type="error"
+              message={formatMessage(m.saveGroupError)}
+            />
+          </Box>
+        )}
       </AccordionCard>
     </Box>
   )

--- a/libs/application/templates/directorate-of-equality/salary-report/src/fields/SalaryAnalysisResults/OutlierGroupPanel.tsx
+++ b/libs/application/templates/directorate-of-equality/salary-report/src/fields/SalaryAnalysisResults/OutlierGroupPanel.tsx
@@ -29,6 +29,8 @@ type Props = {
   outlierGroupsFormMethods?: UseFormReturn<{
     salaryAnalysis: { outlierGroups: OutlierGroupAnswer[] }
   }>
+  onSaveGroups: (groups: OutlierGroupAnswer[]) => Promise<boolean>
+  initialSavedGroups: OutlierGroupAnswer[]
 }
 
 export const OutlierGroupPanel: FC<Props> = ({
@@ -36,6 +38,8 @@ export const OutlierGroupPanel: FC<Props> = ({
   hidePostponeCheckbox,
   errors,
   outlierGroupsFormMethods,
+  onSaveGroups,
+  initialSavedGroups,
 }) => {
   const { formatMessage } = useLocale()
   const { setValue } = useFormContext()
@@ -53,6 +57,18 @@ export const OutlierGroupPanel: FC<Props> = ({
   }, [hidePostponeCheckbox])
 
   if (outliers.length === 0) return null
+
+  // One element, two scopes: draft phase wraps it in the local form, the review
+  // states leave it on the ambient one.
+  const editor = (
+    <OutlierEditor
+      outliers={outliers}
+      errors={errors}
+      mode={hidePostponeCheckbox ? 'postponed' : 'draft'}
+      onSaveGroups={onSaveGroups}
+      initialSavedGroups={initialSavedGroups}
+    />
+  )
 
   return (
     <Box>
@@ -92,19 +108,9 @@ export const OutlierGroupPanel: FC<Props> = ({
 
       {!isPostponed &&
         (outlierGroupsFormMethods ? (
-          <FormProvider {...outlierGroupsFormMethods}>
-            <OutlierEditor
-              outliers={outliers}
-              errors={errors}
-              mode={hidePostponeCheckbox ? 'postponed' : 'draft'}
-            />
-          </FormProvider>
+          <FormProvider {...outlierGroupsFormMethods}>{editor}</FormProvider>
         ) : (
-          <OutlierEditor
-            outliers={outliers}
-            errors={errors}
-            mode={hidePostponeCheckbox ? 'postponed' : 'draft'}
-          />
+          editor
         ))}
     </Box>
   )

--- a/libs/application/templates/directorate-of-equality/salary-report/src/fields/SalaryAnalysisResults/PayDispersionTable.tsx
+++ b/libs/application/templates/directorate-of-equality/salary-report/src/fields/SalaryAnalysisResults/PayDispersionTable.tsx
@@ -7,6 +7,7 @@ import { formatWageAmount } from '../EmployeesEditor/utils'
 import {
   formatDeviationLabel,
   formatSalaryAnalysisGenderLabel,
+  formatStig,
 } from '../../utils/salaryAnalysisLabels'
 import { formatSignedPercentMagnitude } from '../../utils/wageGap'
 import { EmployeeOrdinalHeader } from '../../components/EmployeeOrdinalHeader'
@@ -232,7 +233,9 @@ export const PayDispersionTable = ({ payDispersion }: Props) => {
                       formatMessage,
                     )}
                   </DataCell>
-                  <DataCell align="right">{employee.score}</DataCell>
+                  <DataCell align="right">
+                    {formatStig(employee.score)}
+                  </DataCell>
                   <DataCell align="right">
                     {formatWageAmount(employee.regularHourlyWage)}
                   </DataCell>

--- a/libs/application/templates/directorate-of-equality/salary-report/src/fields/SalaryAnalysisResults/SalaryImprovementPlan.tsx
+++ b/libs/application/templates/directorate-of-equality/salary-report/src/fields/SalaryAnalysisResults/SalaryImprovementPlan.tsx
@@ -111,10 +111,7 @@ export const SalaryImprovementPlan: FC<React.PropsWithChildren<Props>> = ({
     [outlierGroupsContent, employeesContent],
   )
   const { sync } = useDraftSync(application)
-  const writeOutlierPlan = useOutlierPlanBuffer(
-    application.id,
-    answerQuestions,
-  )
+  const writeOutlierPlan = useOutlierPlanBuffer(application.id, answerQuestions)
   // Both captured on the first render rather than watched, because the shell's
   // answers move underneath this screen: saving the plan mirrors it into them,
   // as does the navigation-flag effect below. A seed keyed on the live value

--- a/libs/application/templates/directorate-of-equality/salary-report/src/fields/SalaryAnalysisResults/SalaryImprovementPlan.tsx
+++ b/libs/application/templates/directorate-of-equality/salary-report/src/fields/SalaryAnalysisResults/SalaryImprovementPlan.tsx
@@ -1,7 +1,7 @@
 import { FC, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useForm, useFormContext, useWatch } from 'react-hook-form'
 import { useMutation } from '@apollo/client'
-import { YES } from '@island.is/application/core'
+import { getValueViaPath, YES } from '@island.is/application/core'
 import { UPDATE_APPLICATION_EXTERNAL_DATA } from '@island.is/application/graphql'
 import { CustomField, FieldBaseProps } from '@island.is/application/types'
 import {
@@ -37,6 +37,7 @@ import {
 import type { DraftOutlierGroupDto, ReportEmployeeDto } from '../../utils/types'
 import { useDraftQueries } from '../../utils/useDraftQuery'
 import { useDraftSync } from '../../utils/useDraftSync'
+import { useOutlierPlanBuffer } from '../../utils/useOutlierPlanBuffer'
 import { useSeedOnce } from '../../utils/useSeedOnce'
 import { OutlierGroupPanel } from './OutlierGroupPanel'
 
@@ -110,11 +111,69 @@ export const SalaryImprovementPlan: FC<React.PropsWithChildren<Props>> = ({
     [outlierGroupsContent, employeesContent],
   )
   const { sync } = useDraftSync(application)
+  const writeOutlierPlan = useOutlierPlanBuffer(
+    application.id,
+    answerQuestions,
+  )
+  // Both captured on the first render rather than watched, because the shell's
+  // answers move underneath this screen: saving the plan mirrors it into them,
+  // as does the navigation-flag effect below. A seed keyed on the live value
+  // would fire again on a save and setValue the editor's own work back over it,
+  // taking focus with it. What a seed wants is the plan as this visit found it.
+  const [bufferedGroups] = useState(() =>
+    getValueViaPath<OutlierGroupAnswer[]>(
+      application.answers,
+      'salaryAnalysis.outlierGroupsDraft',
+    ),
+  )
+  // Presence, not length. An empty buffer is the applicant having removed every
+  // group, and it has to win over the committed plan the same way a full one
+  // does — otherwise deleting the last group leaves nothing to shadow the DMR
+  // draft, and it comes straight back. That is why beforeSubmit refreshes the
+  // buffer rather than emptying it: `[]` has to keep meaning "no groups".
+  const hasBufferedPlan = bufferedGroups !== undefined
+  const [answeredGroups] = useState(
+    () =>
+      getValueViaPath<OutlierGroupAnswer[]>(
+        application.answers,
+        'salaryAnalysis.outlierGroups',
+      ) ?? NO_GROUPS,
+  )
+  // Whether there is anything in the buffer to clear on the way out. The frozen
+  // answers only know about saves from earlier visits, so a save made in this
+  // session has to flip it too. Without the guard, every Continue from this
+  // screen would write an empty buffer into the answers of applicants who never
+  // pressed the button.
+  const hasSavedPlan = useRef(hasBufferedPlan)
+
+  const saveOutlierPlan = useCallback(
+    async (groups: OutlierGroupAnswer[]) => {
+      const persisted = await writeOutlierPlan(groups)
+      if (persisted) hasSavedPlan.current = true
+      return persisted
+    },
+    [writeOutlierPlan],
+  )
+
+  // Brings the buffer up to what a Continue has just committed. Only for a
+  // buffer that already exists: an applicant who never pressed the button gets
+  // no key at all, and so keeps seeding from the committed plan.
+  const commitSavedPlan = useCallback(
+    async (groups: OutlierGroupAnswer[]) => {
+      if (!hasSavedPlan.current) return
+      await writeOutlierPlan(groups)
+    },
+    [writeOutlierPlan],
+  )
+
   const draftForm = useForm<DraftOutlierFormValues>({
     defaultValues: { salaryAnalysis: { outlierGroups: [] } },
   })
-  const { control: ambientControl, setValue: setAmbientValue } =
-    useFormContext()
+  const {
+    control: ambientControl,
+    getValues: getAmbientValues,
+    setValue: setAmbientValue,
+  } = useFormContext()
   const postponed: string[] =
     useWatch({
       name: 'salaryAnalysis.postponed',
@@ -228,11 +287,29 @@ export const SalaryImprovementPlan: FC<React.PropsWithChildren<Props>> = ({
     }))
   }, [content])
 
+  // What the editor opens with, and equally what its save buttons treat as
+  // already persisted — every source below has been written somewhere.
+  //
+  // The buffer wins wherever it exists, empty included: the "Vista" button
+  // writes it and beforeSubmit brings it up to whatever a Continue committed,
+  // so it is never older than either — while the sources below are only ever as
+  // new as the last Continue.
+  const seedGroups = useMemo((): OutlierGroupAnswer[] => {
+    if (bufferedGroups) return bufferedGroups
+    if (!isDraftPhase && answeredGroups.length > 0) return answeredGroups
+    // Empty outside DRAFT and DRAFT_RETRY: the review states are not granted
+    // the draft providers, so there is no content to cross over from.
+    return outlierGroupAnswersFromDraft()
+  }, [
+    answeredGroups,
+    bufferedGroups,
+    isDraftPhase,
+    outlierGroupAnswersFromDraft,
+  ])
+
   useSeedOnce(isDraftPhase && Boolean(content), () => {
     if (!content) return
-    draftForm.reset({
-      salaryAnalysis: { outlierGroups: outlierGroupAnswersFromDraft() },
-    })
+    draftForm.reset({ salaryAnalysis: { outlierGroups: seedGroups } })
   })
 
   const draftOutlierGroups =
@@ -258,6 +335,14 @@ export const SalaryImprovementPlan: FC<React.PropsWithChildren<Props>> = ({
     setAmbientValue('salaryAnalysis.outlierGroups', draftOutlierGroups)
   }, [draftOutlierGroups, isDraftPhase, setAmbientValue])
 
+  // The review states edit the plan on the ambient form, so a saved buffer has
+  // to be put back there. Not gated on the ambient groups being empty, unlike
+  // the DRAFT_RETRY seed below: the answers already hold whatever the last
+  // "Halda áfram" wrote, and the buffer is never older than that.
+  useSeedOnce(!isDraftPhase && hasBufferedPlan, () => {
+    setAmbientValue('salaryAnalysis.outlierGroups', seedGroups)
+  })
+
   // The mirror above is what puts a DRAFT-phase plan into the answers, and it
   // only exists as of the postpone-flow change. Applications that left DRAFT
   // before it carry their groups on the stored draft snapshot alone, so
@@ -270,9 +355,14 @@ export const SalaryImprovementPlan: FC<React.PropsWithChildren<Props>> = ({
   // branch in beforeSubmit) precisely so the plan is written from scratch there
   // — seeding it from a snapshot taken before that clear would resurrect a plan
   // the applicant chose to defer.
+  //
+  // Behind the buffer seed above, and explicitly so: both read
+  // `ambientOutlierGroups` from the same render, so without the guard this one
+  // would still see it empty and overwrite the buffer it had just been given.
   useSeedOnce(
     application.state === States.DRAFT_RETRY &&
       Boolean(content) &&
+      !hasBufferedPlan &&
       ambientOutlierGroups.length === 0,
     () => {
       const groups = outlierGroupAnswersFromDraft()
@@ -373,6 +463,7 @@ export const SalaryImprovementPlan: FC<React.PropsWithChildren<Props>> = ({
       }
 
       if (currentOutliers.length === 0) {
+        await commitSavedPlan(NO_GROUPS)
         return [true, null]
       }
 
@@ -396,6 +487,17 @@ export const SalaryImprovementPlan: FC<React.PropsWithChildren<Props>> = ({
         }
       }
 
+      // What this Continue has persisted, and so what the buffer has to be
+      // brought up to below. The review states carry the plan in the answers
+      // the screen's own submit writes; read from the form at this point rather
+      // than from the render's watch value, so it cannot be a beat behind.
+      let committedGroups = isDraftPhase
+        ? NO_GROUPS
+        : getValueViaPath<OutlierGroupAnswer[]>(
+            getAmbientValues(),
+            'salaryAnalysis.outlierGroups',
+          ) ?? NO_GROUPS
+
       if (isDraftPhase) {
         if (!content) {
           return [false, formatMessage(messages.errors.draftLoadFailed)]
@@ -412,18 +514,18 @@ export const SalaryImprovementPlan: FC<React.PropsWithChildren<Props>> = ({
               await sync(clear)
             }
             draftForm.setValue('salaryAnalysis.outlierGroups', [])
+            committedGroups = NO_GROUPS
           } else {
             // Emptied groups are discarded rather than synced as memberless
             // rows on the draft.
-            const finalGroups = outlierGroupsWithMembers(
-              draftForm.getValues().salaryAnalysis.outlierGroups,
-            )
-            await sync(
-              buildOutlierSyncCommands(
-                content,
-                withFallbackOutlierGroupNames(finalGroups, fallbackGroupName),
+            const finalGroups = withFallbackOutlierGroupNames(
+              outlierGroupsWithMembers(
+                draftForm.getValues().salaryAnalysis.outlierGroups,
               ),
+              fallbackGroupName,
             )
+            await sync(buildOutlierSyncCommands(content, finalGroups))
+            committedGroups = finalGroups
           }
           await refetch({ silent: true })
         } catch (error) {
@@ -431,6 +533,14 @@ export const SalaryImprovementPlan: FC<React.PropsWithChildren<Props>> = ({
           return [false, formatMessage(messages.errors.draftSyncFailed)]
         }
       }
+
+      // The buffer follows what was just committed, rather than being emptied:
+      // a Continue carries the whole screen, including text no button was ever
+      // pressed on, so a buffer left at the last explicit save would shadow the
+      // newer plan the next time this screen seeds. Never blocks Continue — the
+      // write reports a failure rather than throwing, and what it would have
+      // recorded is what the applicant just submitted anyway.
+      await commitSavedPlan(committedGroups)
 
       return [true, null]
     })
@@ -451,6 +561,8 @@ export const SalaryImprovementPlan: FC<React.PropsWithChildren<Props>> = ({
     refetch,
     formatMessage,
     fallbackGroupName,
+    commitSavedPlan,
+    getAmbientValues,
   ])
 
   if (hasError) {
@@ -531,6 +643,8 @@ export const SalaryImprovementPlan: FC<React.PropsWithChildren<Props>> = ({
       hidePostponeCheckbox={hidePostponeCheckbox}
       errors={errors}
       outlierGroupsFormMethods={isDraftPhase ? draftForm : undefined}
+      onSaveGroups={saveOutlierPlan}
+      initialSavedGroups={seedGroups}
     />
   )
 }

--- a/libs/application/templates/directorate-of-equality/salary-report/src/fields/SalaryAnalysisResults/outlierColumns.tsx
+++ b/libs/application/templates/directorate-of-equality/salary-report/src/fields/SalaryAnalysisResults/outlierColumns.tsx
@@ -9,7 +9,10 @@ import { useLocale } from '@island.is/localization'
 import type { SalaryAnalysisOutlierDto } from '@island.is/clients/directorate-of-equality'
 import { messages } from '../../lib/messages'
 import { GENDER_LABELS } from '../../utils/constants'
-import { formatDeviationLabel } from '../../utils/salaryAnalysisLabels'
+import {
+  formatDeviationLabel,
+  formatStig,
+} from '../../utils/salaryAnalysisLabels'
 import { EmployeeOrdinalHeader } from '../../components/EmployeeOrdinalHeader'
 import { formatWageAmount } from '../EmployeesEditor/utils'
 
@@ -202,7 +205,7 @@ const GenderCell = ({ row }: CellProps) =>
   compactCell(GENDER_LABELS[row.original.gender] ?? row.original.gender)
 
 const StigCell = ({ row }: CellProps) =>
-  compactCell(String(row.original.score), 'right')
+  compactCell(formatStig(row.original.score), 'right')
 
 const HourlyWageCell = ({ row }: CellProps) =>
   compactCell(formatWageAmount(row.original.regularHourlyWage), 'right')

--- a/libs/application/templates/directorate-of-equality/salary-report/src/lib/dataSchema.spec.ts
+++ b/libs/application/templates/directorate-of-equality/salary-report/src/lib/dataSchema.spec.ts
@@ -128,3 +128,41 @@ describe('subsidiaries schema', () => {
     })
   })
 })
+
+// The per-group "Vista" button writes the plan straight to answers, and every
+// PUT re-runs this schema over what it is handed. `outlierGroups` cannot take
+// that write — its refinement demands a filled-in group — so the button writes
+// `outlierGroupsDraft` instead, and these are the shapes a screen mid-edit
+// really produces.
+const parseSalaryAnalysis = (value: unknown) =>
+  dataSchema.shape.salaryAnalysis.safeParse(value)
+
+describe('salaryAnalysis.outlierGroupsDraft', () => {
+  const BLANK_GROUP = {
+    name: '',
+    reason: '',
+    action: '',
+    remedyDate: '',
+    signatureName: '',
+    signatureRole: '',
+    employeeOrdinals: [1, 2],
+  }
+
+  it('accepts a group that has not been filled in yet', () => {
+    expect(
+      parseSalaryAnalysis({ outlierGroupsDraft: [BLANK_GROUP] }).success,
+    ).toBe(true)
+  })
+
+  it('accepts a group saved without its members', () => {
+    expect(parseSalaryAnalysis({ outlierGroupsDraft: [{}] }).success).toBe(true)
+  })
+
+  // The point of the separate key: the same content under `outlierGroups` is
+  // what the submit has to reject.
+  it('still requires the real answer to be complete', () => {
+    expect(parseSalaryAnalysis({ outlierGroups: [BLANK_GROUP] }).success).toBe(
+      false,
+    )
+  })
+})

--- a/libs/application/templates/directorate-of-equality/salary-report/src/lib/dataSchema.ts
+++ b/libs/application/templates/directorate-of-equality/salary-report/src/lib/dataSchema.ts
@@ -160,6 +160,22 @@ const salaryAnalysis = z
   .object({
     postponed: z.array(z.string()).optional(),
     outlierGroups: z.array(outlierGroup).optional(),
+    // Scratch copy of outlierGroups, written by the per-group "Vista" button so
+    // a half-filled plan survives leaving the screen (see useOutlierPlanBuffer).
+    //
+    // All-optional, and deliberately untouched by the refinement below: it holds
+    // work in progress, while the completeness rules belong to `outlierGroups` —
+    // the value the submit actually validates. Writing the groups themselves
+    // incrementally is not possible, because every PUT re-runs that refinement
+    // over whatever it is handed, and a group still being filled in would fail
+    // it.
+    //
+    // Absent and empty mean different things, and the editor reads them that
+    // way: no key at all is a plan this screen has never persisted, so it seeds
+    // from the committed one (the DMR draft, or the submitted answers), while
+    // `[]` says the applicant removed every group. Collapsing the two would
+    // resurrect the last group anyone deleted.
+    outlierGroupsDraft: z.array(outlierGroup.partial()).optional(),
     hasMinimumSetOutliers: z.boolean().optional(),
     // Mirrored from the analysis result so the overview screen can read it —
     // see the comment on BenchmarkVerdict.

--- a/libs/application/templates/directorate-of-equality/salary-report/src/lib/messages.ts
+++ b/libs/application/templates/directorate-of-equality/salary-report/src/lib/messages.ts
@@ -1648,6 +1648,23 @@ export const messages = {
         id: 'doe.sr.application:salaryAnalysis.outlierGroup.removeGroupButton',
         defaultMessage: 'Fjarlægja hóp',
       },
+      saveGroupButton: {
+        id: 'doe.sr.application:salaryAnalysis.outlierGroup.saveGroupButton',
+        defaultMessage: 'Vista',
+      },
+      groupSavedButton: {
+        id: 'doe.sr.application:salaryAnalysis.outlierGroup.groupSavedButton',
+        defaultMessage: 'Vistað',
+      },
+      saveGroupError: {
+        id: 'doe.sr.application:salaryAnalysis.outlierGroup.saveGroupError',
+        defaultMessage: 'Ekki tókst að vista hópinn. Reyndu aftur.',
+      },
+      removeGroupError: {
+        id: 'doe.sr.application:salaryAnalysis.outlierGroup.removeGroupError',
+        defaultMessage:
+          'Ekki tókst að uppfæra vistuðu gögnin. Hópurinn getur birst aftur næst þegar þú opnar þennan skjá.',
+      },
       unassignedWarning: {
         id: 'doe.sr.application:salaryAnalysis.outlierGroup.unassignedWarning',
         defaultMessage:

--- a/libs/application/templates/directorate-of-equality/salary-report/src/utils/outlierGroups.spec.ts
+++ b/libs/application/templates/directorate-of-equality/salary-report/src/utils/outlierGroups.spec.ts
@@ -5,6 +5,7 @@ import {
   outlierGroupsWithMembers,
   isOutlierGroupComplete,
   isOutlierGroupSubmittable,
+  outlierGroupFingerprint,
   unassignedOutlierOrdinals,
   withFallbackOutlierGroupNames,
 } from './outlierGroups'
@@ -267,5 +268,62 @@ describe('buildOutlierSyncCommands with an emptied group', () => {
 
     expect(outlierGroups).toEqual([])
     expect(employees).toEqual([])
+  })
+})
+
+// What decides whether a group's "Vista" button still reads "Vistað".
+describe('outlierGroupFingerprint', () => {
+  const GROUP = {
+    id: 'group-1',
+    name: 'Sölufólk',
+    reason: 'Reynsla',
+    action: 'Endurskoðun',
+    remedyDate: '2027-01-31',
+    signatureName: 'Jón Jónsson',
+    signatureRole: 'Framkvæmdastjóri',
+    employeeOrdinals: [1, 2],
+  }
+
+  it('matches a group against an unedited copy of itself', () => {
+    expect(outlierGroupFingerprint(GROUP)).toBe(
+      outlierGroupFingerprint({ ...GROUP }),
+    )
+  })
+
+  it('ignores the id, which the applicant cannot change', () => {
+    expect(outlierGroupFingerprint({ ...GROUP, id: 'group-2' })).toBe(
+      outlierGroupFingerprint(GROUP),
+    )
+  })
+
+  it.each([
+    ['name', { name: 'Sérfræðingar' }],
+    ['reason', { reason: 'Menntun' }],
+    ['action', { action: 'Launaleiðrétting' }],
+    ['remedyDate', { remedyDate: '2027-02-01' }],
+    ['signatureName', { signatureName: 'Anna Ansdóttir' }],
+    ['signatureRole', { signatureRole: 'Mannauðsstjóri' }],
+    ['employeeOrdinals', { employeeOrdinals: [1] }],
+  ])('notices an edit to %s', (_field, edit) => {
+    expect(outlierGroupFingerprint({ ...GROUP, ...edit })).not.toBe(
+      outlierGroupFingerprint(GROUP),
+    )
+  })
+
+  // A blank field and a missing one are the same group as far as the button is
+  // concerned: emptyOutlierGroupAnswer writes '' where the buffer round-trip
+  // can hand back undefined.
+  it('reads a missing field as blank', () => {
+    expect(outlierGroupFingerprint({ employeeOrdinals: [] })).toBe(
+      outlierGroupFingerprint({
+        name: '',
+        reason: '',
+        action: '',
+        remedyDate: '',
+        signatureName: '',
+        signatureRole: '',
+        employeeOrdinals: [],
+      }),
+    )
   })
 })

--- a/libs/application/templates/directorate-of-equality/salary-report/src/utils/outlierGroups.ts
+++ b/libs/application/templates/directorate-of-equality/salary-report/src/utils/outlierGroups.ts
@@ -59,6 +59,28 @@ export const emptyOutlierGroupAnswer = (
   employeeOrdinals,
 })
 
+// What the "Vista" button compares to decide whether a group still matches the
+// copy last written to answers. By content rather than by identity: useWatch
+// hands back a fresh clone of its whole subtree on every keystroke, so two
+// renders never share an object.
+//
+// `id` is left out — it is bookkeeping, not something the applicant can change,
+// and a group seeded from the buffer without one gets a fresh id on the way in.
+//
+// Keep this in step with OutlierGroupAnswer, as with emptyOutlierGroupAnswer
+// above: a field added there but not here can be edited without the button ever
+// leaving its "Vistað" state.
+export const outlierGroupFingerprint = (group?: OutlierGroupAnswer): string =>
+  JSON.stringify([
+    group?.name ?? '',
+    group?.reason ?? '',
+    group?.action ?? '',
+    group?.remedyDate ?? '',
+    group?.signatureName ?? '',
+    group?.signatureRole ?? '',
+    group?.employeeOrdinals ?? [],
+  ])
+
 // An empty group (all its members freed by a removal) has nothing to explain,
 // so it's vacuously complete — same exemption dataSchema's superRefine makes.
 //

--- a/libs/application/templates/directorate-of-equality/salary-report/src/utils/salaryAnalysisLabels.spec.ts
+++ b/libs/application/templates/directorate-of-equality/salary-report/src/utils/salaryAnalysisLabels.spec.ts
@@ -4,6 +4,7 @@ import {
   formatDeviationLabel,
   formatPayStatusLabel,
   formatSalaryAnalysisGenderLabel,
+  formatStig,
 } from './salaryAnalysisLabels'
 
 // Real react-intl over the bundled defaultMessages, so the ICU template in
@@ -59,5 +60,32 @@ describe('formatDeviationLabel', () => {
     expect(formatDeviationLabel(0, 'ON_LINE', formatMessage)).toBe(
       '0,0% (á línu)',
     )
+  })
+})
+
+describe('formatStig', () => {
+  // The reported figure: summing the per-step weights leaves floating-point
+  // noise on what is really a two-decimal number.
+  it('trims floating-point noise to two decimals', () => {
+    expect(formatStig(524.6700000000001)).toBe('524,67')
+  })
+
+  it('rounds a longer figure rather than truncating it', () => {
+    expect(formatStig(524.6789)).toBe('524,68')
+  })
+
+  it('leaves a whole score whole', () => {
+    expect(formatStig(524)).toBe('524')
+    expect(formatStig(0)).toBe('0')
+  })
+
+  it('groups thousands the Icelandic way', () => {
+    expect(formatStig(1234.5)).toBe('1.234,5')
+  })
+
+  // A dash, not a zero: a missing score is not a score of nothing.
+  it('shows a dash for a missing score', () => {
+    expect(formatStig(null)).toBe('—')
+    expect(formatStig(undefined)).toBe('—')
   })
 })

--- a/libs/application/templates/directorate-of-equality/salary-report/src/utils/salaryAnalysisLabels.ts
+++ b/libs/application/templates/directorate-of-equality/salary-report/src/utils/salaryAnalysisLabels.ts
@@ -16,6 +16,24 @@ export const formatSalaryAnalysisGenderLabel = (
 }
 
 /**
+ * Starfsmatsstig, as shown in the Stig column of the úrbótaáætlun and
+ * ábendingar tables.
+ *
+ * Capped at two decimals rather than printed raw: DMR computes these by summing
+ * the per-step weights, and binary floating point turns a clean 524,67 into
+ * 524.6700000000001 on the way. Two is what the underlying steps carry, so the
+ * rest is arithmetic noise, never precision the applicant could act on.
+ *
+ * `maximumFractionDigits` alone, with no minimum: a whole-numbered score reads
+ * "524", not "524,00" — trimming noise is the job here, not asserting a
+ * precision the figure may not have.
+ */
+export const formatStig = (value?: number | null): string =>
+  value == null
+    ? '—'
+    : value.toLocaleString('is-IS', { maximumFractionDigits: 2 })
+
+/**
  * "undir" / "yfir" / "á línu" — where an employee sits relative to the fitted
  * line. Shared by the úrbótaáætlun table, the ábendingar table and the chart
  * tooltip, all three of which show the same figure and must gloss it the same

--- a/libs/application/templates/directorate-of-equality/salary-report/src/utils/useOutlierPlanBuffer.ts
+++ b/libs/application/templates/directorate-of-equality/salary-report/src/utils/useOutlierPlanBuffer.ts
@@ -1,0 +1,73 @@
+import { useCallback, useEffect, useRef } from 'react'
+import { useMutation } from '@apollo/client'
+import { UPDATE_APPLICATION } from '@island.is/application/graphql'
+import type { FieldBaseProps } from '@island.is/application/types'
+import { useLocale } from '@island.is/localization'
+import type { OutlierGroupAnswer } from './outlierGroups'
+
+/**
+ * Persists the outlier plan behind `answers.salaryAnalysis.outlierGroupsDraft`,
+ * so an applicant who leaves the úrbótaáætlun screen — back navigation, or
+ * closing the application and reopening it — finds their groups and
+ * explanations where they left them. Nothing else reads this key: the submit
+ * still goes through the DMR draft sync in DRAFT and through the screen's own
+ * answers in the review states, exactly as before.
+ *
+ * Why a scratch key rather than writing `salaryAnalysis.outlierGroups`
+ * directly: every PUT runs the template's dataSchema over the answers it is
+ * handed, and the refinement on `salaryAnalysis` requires reason, action,
+ * remedyDate and signatureRole on every group that has members. Saving one
+ * group while another is still blank would therefore be rejected — and that
+ * refinement is what produces the per-field errors in the postponed flow, so it
+ * has to stay. `outlierGroupsDraft` is declared all-optional and exempt from
+ * it (see dataSchema.ts).
+ *
+ * Every write is also mirrored into the form shell's own answers through
+ * `answerQuestions`. The shell freezes its copy at mount and a plain mutation
+ * never reaches it, so without the mirror a save would be in the database but
+ * not in the session: going back a screen and forward again re-seeds this field
+ * from the shell's answers, which would still be the ones it loaded with, and
+ * the group would vanish until a full reload. Same reason useProgressMarker
+ * mirrors its markers.
+ *
+ * The write resolves to whether it was persisted rather than throwing, so the
+ * card can put its button back and say so.
+ */
+export const useOutlierPlanBuffer = (
+  applicationId: string,
+  answerQuestions?: FieldBaseProps['answerQuestions'],
+) => {
+  const { lang: locale } = useLocale()
+  const [updateApplication] = useMutation(UPDATE_APPLICATION)
+
+  // A fresh arrow on every shell render, and the ANSWER it dispatches causes
+  // another one — so it is held rather than closed over (see useProgressMarker).
+  const answerQuestionsRef = useRef(answerQuestions)
+  useEffect(() => {
+    answerQuestionsRef.current = answerQuestions
+  }, [answerQuestions])
+
+  const save = useCallback(
+    async (outlierGroupsDraft: OutlierGroupAnswer[]) => {
+      const answers = { salaryAnalysis: { outlierGroupsDraft } }
+
+      try {
+        await updateApplication({
+          variables: { input: { id: applicationId, answers }, locale },
+        })
+      } catch (error) {
+        console.error('Failed to save the outlier plan to answers', error)
+        return false
+      }
+
+      // Only on success, unlike useProgressMarker: a mirror of a write that
+      // failed would read back as "Vistað" on the next visit while nothing had
+      // been persisted.
+      answerQuestionsRef.current?.(answers)
+      return true
+    },
+    [applicationId, locale, updateApplication],
+  )
+
+  return save
+}


### PR DESCRIPTION
# DOE - Salary report application

## What

* Outlier group changes are saved to answers object to preserve the data between screens and closing the application
* Add save button to outlier groups
* Reverse the outlier groups sorting
* Add min/max year to date picker

## Why

* Better UX


## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Save individual outlier groups and see saved, saving, or error states.
  - Draft outlier-group changes are preserved while editing and synchronized when submitting.
  - Outlier groups and assignment options now display newest entries first.

- **Improvements**
  - Salary analysis scores now use consistent Icelandic number formatting.
  - Remedy date fields restrict selectable years based on the applicable date range.
  - Importing a replacement workbook clears previously saved outlier-plan data.
  - Removing groups provides clear progress and error feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->