### PR TITLE
fix(my-pages-contracts): Fix messages

### DIFF
--- a/libs/api/domains/hms/src/lib/resolvers/rentalAgreements.resolver.ts
+++ b/libs/api/domains/hms/src/lib/resolvers/rentalAgreements.resolver.ts
@@ -3,9 +3,11 @@ import { Inject, UseGuards } from '@nestjs/common'
 import {
   type User,
   IdsUserGuard,
+  Scopes,
   ScopesGuard,
   CurrentUser,
 } from '@island.is/auth-nest-tools'
+import { ApiScope } from '@island.is/auth/scopes'
 import { Audit } from '@island.is/nest/audit'
 import { PaginatedRentalAgreementCollection } from '../models/rentalAgreements/rentalAgreementCollection.model'
 import { HmsRentalAgreementService } from '@island.is/clients/hms-rental-agreement'
@@ -23,6 +25,7 @@ import { CodeOwners } from '@island.is/shared/constants'
 import { RentalAgreementsInput } from '../dto/rentalAgreements.input'
 
 @UseGuards(IdsUserGuard, ScopesGuard, FeatureFlagGuard)
+@Scopes(ApiScope.meDetails, ApiScope.company)
 @CodeOwner(CodeOwners.Hugsmidjan)
 @Resolver()
 @Audit({ namespace: '@island.is/api/hms' })

--- a/libs/portals/my-pages/information/src/lib/messages.ts
+++ b/libs/portals/my-pages/information/src/lib/messages.ts
@@ -687,8 +687,11 @@ export const contractsMessages = defineMessages({
   },
   rentalAgreementDate: {
     id: 'sp.contracts:rental-agreement-date',
-    defaultMessage:
-      '{from, date, long} - {to, select, undefined {} other {to, date, long}}',
+    defaultMessage: '{from, date, long} - {to, date, long}',
+  },
+  rentalAgreementDateFrom: {
+    id: 'sp.contracts:rental-agreement-date-from',
+    defaultMessage: '{from, date, long}',
   },
   status: {
     id: 'sp.contracts:status',

--- a/libs/portals/my-pages/information/src/lib/messages.ts
+++ b/libs/portals/my-pages/information/src/lib/messages.ts
@@ -691,7 +691,7 @@ export const contractsMessages = defineMessages({
   },
   rentalAgreementDateFrom: {
     id: 'sp.contracts:rental-agreement-date-from',
-    defaultMessage: '{from, date, long}',
+    defaultMessage: '{from, date, long} -',
   },
   status: {
     id: 'sp.contracts:status',

--- a/libs/portals/my-pages/information/src/lib/navigation.ts
+++ b/libs/portals/my-pages/information/src/lib/navigation.ts
@@ -165,6 +165,24 @@ export const companyInformationNavigation: PortalNavigationItem = {
       path: InformationPaths.Company,
     },
     {
+      name: m.contracts,
+      description: m.contractsDescription,
+      searchTags: [
+        searchTagsMessages.rent,
+        searchTagsMessages.rentalAgreements,
+      ],
+      path: InformationPaths.CompanyContracts,
+      children: [
+        {
+          name: m.contract,
+          navHide: true,
+          searchHide: true,
+          breadcrumbHide: true,
+          path: InformationPaths.CompanyContractsDetail,
+        },
+      ],
+    },
+    {
       name: m.companySettings,
       path: InformationPaths.CompanySettings,
     },

--- a/libs/portals/my-pages/information/src/lib/paths.ts
+++ b/libs/portals/my-pages/information/src/lib/paths.ts
@@ -13,6 +13,8 @@ export enum InformationPaths {
   Company = '/fyrirtaeki',
   CompanySettings = '/fyrirtaeki/stillingar/',
   CompanyNotifications = '/fyrirtaeki/tilkynningar',
+  CompanyContracts = '/fyrirtaeki/samningar',
+  CompanyContractsDetail = '/fyrirtaeki/samningar/:id',
   Notifications = '/min-gogn/tilkynningar',
   NotificationDetail = '/min-gogn/tilkynningar/:id',
   Lists = '/min-gogn/listar',

--- a/libs/portals/my-pages/information/src/module.tsx
+++ b/libs/portals/my-pages/information/src/module.tsx
@@ -169,6 +169,20 @@ export const companyInformationModule: PortalModule = {
         element: <CompanyInfo />,
       },
       {
+        name: m.contracts,
+        path: InformationPaths.CompanyContracts,
+        enabled: hasCompanyAccess,
+        key: Features.isServicePortalMyContractsPageEnabled,
+        element: <UserContractsOverview />,
+      },
+      {
+        name: m.contract,
+        path: InformationPaths.CompanyContractsDetail,
+        enabled: hasCompanyAccess,
+        key: Features.isServicePortalMyContractsPageEnabled,
+        element: <UserContract />,
+      },
+      {
         name: m.companySettings,
         path: InformationPaths.CompanySettings,
         enabled: hasSettingsAccess,
@@ -229,6 +243,14 @@ export const companyInformationModule: PortalModule = {
         element: (
           <Navigate to={InformationPaths.CompanyNotifications} replace />
         ),
+      },
+      {
+        name: m.contracts,
+        path: InformationPaths.MyContracts,
+        enabled: true,
+        navHide: true,
+        key: Features.isServicePortalMyContractsPageEnabled,
+        element: <Navigate to={InformationPaths.CompanyContracts} replace />,
       },
     ]
   },

--- a/libs/portals/my-pages/information/src/screens/UserContracts/Contract/UserContract.tsx
+++ b/libs/portals/my-pages/information/src/screens/UserContracts/Contract/UserContract.tsx
@@ -132,12 +132,14 @@ const UserContract = () => {
               label={cm.lengthOfRentalAgreement}
               content={
                 contract?.dateFrom
-                  ? formatMessage(cm.rentalAgreementDate, {
-                      from: new Date(contract.dateFrom),
-                      to: contract.dateTo
-                        ? new Date(contract.dateTo)
-                        : undefined,
-                    })
+                  ? contract.dateTo
+                    ? formatMessage(cm.rentalAgreementDate, {
+                        from: new Date(contract.dateFrom),
+                        to: new Date(contract.dateTo),
+                      })
+                    : formatMessage(cm.rentalAgreementDateFrom, {
+                        from: new Date(contract.dateFrom),
+                      })
                   : undefined
               }
             />

--- a/libs/portals/my-pages/information/src/screens/UserContracts/UserContractsOverview/UserContractsOverview.tsx
+++ b/libs/portals/my-pages/information/src/screens/UserContracts/UserContractsOverview/UserContractsOverview.tsx
@@ -20,7 +20,6 @@ import { useUserContractsOverviewQuery } from './UserContractsOverview.generated
 import { mapStatusTypeToTag } from '../../../utils/mapStatusTypeToTag'
 import { generateRentalAgreementAddress } from '../../../utils/mapAddress'
 import { mapPropertyTypeToMessage } from '../../../utils/mapPropertyTypeToMessage'
-import { InformationPaths } from '../../../lib/paths'
 import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 
@@ -129,10 +128,7 @@ const UserContractsOverview = () => {
                   headingVariant="h4"
                   cta={{
                     label: formatMessage(cm.seeInfo),
-                    onClick: () =>
-                      navigate(
-                        InformationPaths.MyContractsDetail.replace(':id', id),
-                      ),
+                    onClick: () => navigate(id),
                     variant: 'text',
                   }}
                   subText={subText}


### PR DESCRIPTION
## What

* Use 2 date strings

## Why
* Broke

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: claude code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated rental agreement dates to display consistently in a clear date-range format.
  * Agreements with only a start date now show the start date without an incomplete or misleading end-date display.
  * Agreements with both start and end dates continue to show the complete rental period.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->