### PR TITLE
chore(infra): remove TEMPORARY api dev scaling override after SH loadtest

### DIFF
--- a/apps/api/infra/api.ts
+++ b/apps/api/infra/api.ts
@@ -628,7 +628,6 @@ export const serviceSetup = (services: {
       max: 50,
       min: 3,
       cpuAverageUtilization: 70,
-      bypassReplicaClamp: true, // TEMPORARY: SH load-test window, use prod envelope in dev
     })
     .strategy({
       // prod: zero-downtime. dev/staging: downtime is fine, roll faster.

--- a/charts/islandis-services/api/values.dev.yaml
+++ b/charts/islandis-services/api/values.dev.yaml
@@ -229,8 +229,8 @@ hpa:
       cpuAverageUtilization: 70
       nginxRequestsIrate: 5
     replicas:
-      max: 50
-      min: 3
+      max: 2
+      min: 1
 httpRoute:
   primary-gw:
     hostnames:
@@ -253,9 +253,9 @@ podSecurityContext:
   fsGroup: 65534
 pvcs: []
 replicaCount:
-  default: 3
-  max: 50
-  min: 3
+  default: 1
+  max: 2
+  min: 1
 resources:
   limits:
     cpu: '3000m'

--- a/charts/islandis-services/api/values.staging.yaml
+++ b/charts/islandis-services/api/values.staging.yaml
@@ -229,8 +229,8 @@ hpa:
       cpuAverageUtilization: 70
       nginxRequestsIrate: 5
     replicas:
-      max: 50
-      min: 3
+      max: 2
+      min: 1
 httpRoute:
   primary-gw:
     hostnames:
@@ -252,9 +252,9 @@ podSecurityContext:
   fsGroup: 65534
 pvcs: []
 replicaCount:
-  default: 3
-  max: 50
-  min: 3
+  default: 1
+  max: 2
+  min: 1
 resources:
   limits:
     cpu: '3000m'

--- a/charts/islandis/values.dev.yaml
+++ b/charts/islandis/values.dev.yaml
@@ -339,8 +339,8 @@ api:
         cpuAverageUtilization: 70
         nginxRequestsIrate: 5
       replicas:
-        max: 50
-        min: 3
+        max: 2
+        min: 1
   httpRoute:
     primary-gw:
       hostnames:
@@ -363,9 +363,9 @@ api:
     fsGroup: 65534
   pvcs: []
   replicaCount:
-    default: 3
-    max: 50
-    min: 3
+    default: 1
+    max: 2
+    min: 1
   resources:
     limits:
       cpu: '3000m'

--- a/charts/islandis/values.staging.yaml
+++ b/charts/islandis/values.staging.yaml
@@ -339,8 +339,8 @@ api:
         cpuAverageUtilization: 70
         nginxRequestsIrate: 5
       replicas:
-        max: 50
-        min: 3
+        max: 2
+        min: 1
   httpRoute:
     primary-gw:
       hostnames:
@@ -362,9 +362,9 @@ api:
     fsGroup: 65534
   pvcs: []
   replicaCount:
-    default: 3
-    max: 50
-    min: 3
+    default: 1
+    max: 2
+    min: 1
   resources:
     limits:
       cpu: '3000m'


### PR DESCRIPTION
SH load-test window is over. Removes bypassReplicaClamp from api so it returns to the dev/staging 1-2 replica clamp. The bypassReplicaClamp mechanism itself is retained for future test windows.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [x] No AI tools were used in preparing this pull request
- [ ] AI tools were used in preparing this pull request
      Tools used:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Replica scaling now consistently follows configured limits across all environments, improving predictability during load changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->