### PR TITLE
fix(native-app): Make sure to show links correctly in health messages

### DIFF
--- a/apps/native/app/src/components/health-conversation-message-content.tsx
+++ b/apps/native/app/src/components/health-conversation-message-content.tsx
@@ -6,7 +6,50 @@ import { useTheme } from 'styled-components/native'
 import { HealthConversationMessageContentFragment } from '@/graphql/types/schema'
 import { useBrowser } from '@/hooks/use-browser'
 import { Button, Label, Typography } from '@/ui'
-import { Markdown } from '@/ui/lib/markdown/markdown'
+import { linkifyText } from '@/utils/linkify-text'
+
+const bodyTextStyle = { fontSize: 16, lineHeight: 24 }
+
+// A run of message text, with any bare URL in it rendered as a tappable link.
+// Message bodies are plain text (no markup), so URLs are not marked up as links
+// by the sender and have to be detected here.
+const MessageText = ({ text }: { text: string }) => {
+  const theme = useTheme()
+  const { openBrowser } = useBrowser()
+
+  return (
+    <>
+      {linkifyText(text).map((part, index) => {
+        const href = part.href
+        if (part.type === 'link' && href) {
+          return (
+            <Typography
+              key={index}
+              variant="body2"
+              weight="600"
+              color={theme.color.blue400}
+              style={{ ...bodyTextStyle, textDecorationLine: 'underline' }}
+              accessibilityRole="link"
+              onPress={() => openBrowser(href)}
+            >
+              {part.value}
+            </Typography>
+          )
+        }
+        return (
+          <Typography
+            key={index}
+            variant="body2"
+            color={theme.color.dark400}
+            style={bodyTextStyle}
+          >
+            {part.value}
+          </Typography>
+        )
+      })}
+    </>
+  )
+}
 
 // Renders a health conversation message body from the structured `content`
 // union: plain text, segmented text/link content, or a video-call card.
@@ -27,9 +70,13 @@ export const HealthConversationMessageContent = ({
   switch (content.__typename) {
     case 'HealthDirectorateHealthConversationTextContent':
       return (
-        <Markdown fontSize={16} lineHeight={24}>
-          {content.text}
-        </Markdown>
+        <Typography
+          variant="body2"
+          color={theme.color.dark400}
+          style={bodyTextStyle}
+        >
+          <MessageText text={content.text} />
+        </Typography>
       )
 
     case 'HealthDirectorateHealthConversationSegmentedContent':
@@ -37,11 +84,12 @@ export const HealthConversationMessageContent = ({
         <Typography
           variant="body2"
           color={theme.color.dark400}
-          style={{ fontSize: 16, lineHeight: 24 }}
+          style={bodyTextStyle}
         >
           {(content.segments ?? []).map((segment, index) => {
             // Treat any segment carrying an href as a link (robust to enum
-            // casing); everything else renders as text.
+            // casing); everything else renders as text — which can still hold a
+            // bare URL, so it goes through the same linkifying renderer.
             if (segment.href) {
               const href = segment.href
               return (
@@ -50,11 +98,8 @@ export const HealthConversationMessageContent = ({
                   variant="body2"
                   weight="600"
                   color={theme.color.blue400}
-                  style={{
-                    textDecorationLine: 'underline',
-                    fontSize: 16,
-                    lineHeight: 24,
-                  }}
+                  style={{ ...bodyTextStyle, textDecorationLine: 'underline' }}
+                  accessibilityRole="link"
                   onPress={() => openBrowser(href)}
                 >
                   {segment.label ?? href}
@@ -62,14 +107,10 @@ export const HealthConversationMessageContent = ({
               )
             }
             return (
-              <Typography
+              <MessageText
                 key={index}
-                variant="body2"
-                color={theme.color.dark400}
-                style={{ fontSize: 16, lineHeight: 24 }}
-              >
-                {segment.text ?? segment.label ?? ''}
-              </Typography>
+                text={segment.text ?? segment.label ?? ''}
+              />
             )
           })}
         </Typography>

--- a/apps/native/app/src/utils/linkify-text.ts
+++ b/apps/native/app/src/utils/linkify-text.ts
@@ -1,7 +1,8 @@
 // Health conversation message bodies arrive as free text with no markup, so any
 // URL in them has to be detected before it can be rendered as a tappable link.
 // Mirrors the my-pages implementation so both clients linkify the same way.
-const URL_REGEX = /(https?:\/\/[^\s<]+[^\s<.,:;!?'")\]]|www\.[^\s<]+[^\s<.,:;!?'")\]])/gi
+const URL_REGEX =
+  /(https?:\/\/[^\s<]+[^\s<.,:;!?'")\]]|www\.[^\s<]+[^\s<.,:;!?'")\]])/gi
 
 export interface LinkifiedTextPart {
   type: 'text' | 'link'

--- a/apps/native/app/src/utils/linkify-text.ts
+++ b/apps/native/app/src/utils/linkify-text.ts
@@ -1,0 +1,40 @@
+// Health conversation message bodies arrive as free text with no markup, so any
+// URL in them has to be detected before it can be rendered as a tappable link.
+// Mirrors the my-pages implementation so both clients linkify the same way.
+const URL_REGEX = /(https?:\/\/[^\s<]+[^\s<.,:;!?'")\]]|www\.[^\s<]+[^\s<.,:;!?'")\]])/gi
+
+export interface LinkifiedTextPart {
+  type: 'text' | 'link'
+  value: string
+  href?: string
+}
+
+export const linkifyText = (text: string): LinkifiedTextPart[] => {
+  const parts: LinkifiedTextPart[] = []
+  let lastIndex = 0
+  let match: RegExpExecArray | null
+
+  URL_REGEX.lastIndex = 0
+  while ((match = URL_REGEX.exec(text))) {
+    if (match.index > lastIndex) {
+      parts.push({ type: 'text', value: text.slice(lastIndex, match.index) })
+    }
+
+    const url = match[0]
+    parts.push({
+      type: 'link',
+      value: url,
+      // Bare `www.` URLs have no scheme, so give them one — the in-app browser
+      // can't open a schemeless link.
+      href: url.startsWith('www.') ? `https://${url}` : url,
+    })
+
+    lastIndex = match.index + url.length
+  }
+
+  if (lastIndex < text.length) {
+    parts.push({ type: 'text', value: text.slice(lastIndex) })
+  }
+
+  return parts
+}


### PR DESCRIPTION
## What

Make sure to handle links correctly in messages.

## Why

To make them clickable

## Screenshots / Gifs
Before and after:
<div>
<img height="687" alt="Screenshot 2026-09-10 at 11 32 41" src="https://github.com/user-attachments/assets/f3ed9fa3-db54-4c91-a151-19910e59b4bd" />

<img height="678" alt="Screenshot 2026-09-10 at 11 31 41" src="https://github.com/user-attachments/assets/7c73a89e-131f-4b7f-88de-07f52c26ed25" />
</div>

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * URLs in health conversation messages are automatically detected and displayed as tappable links.
  * Links using either `http://`, `https://`, or `www.` formats open in the browser.
  * Plain text and links are rendered consistently across health conversation message types.
  * Link elements include accessibility information to help users identify and interact with them.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->