### PR TITLE
fix(doe): Preserve þrep definitions and classifications when the step count changes

### DIFF
--- a/libs/application/templates/directorate-of-equality/salary-report/src/fields/SubCriteriaEditor/SubCriterionItem.tsx
+++ b/libs/application/templates/directorate-of-equality/salary-report/src/fields/SubCriteriaEditor/SubCriterionItem.tsx
@@ -1,5 +1,6 @@
 import { InputController } from '@island.is/shared/form-fields'
 import {
+  AlertMessage,
   Box,
   Button,
   Divider,
@@ -13,6 +14,10 @@ import { useFormContext, useWatch } from 'react-hook-form'
 import { messages } from '../../lib/messages'
 import type { SubCriterionCatalogEntryDto } from '@island.is/clients/directorate-of-equality'
 import type { SubCriterionStep } from '../../utils/types'
+import {
+  MAX_SUB_CRITERION_STEPS,
+  MIN_SUB_CRITERION_STEPS,
+} from '../../utils/constants'
 import { useStepCountSync } from './useStepCountSync'
 
 type Props = {
@@ -43,12 +48,27 @@ export const SubCriterionItem: FC<Props> = ({
     value: String(i),
   }))
 
+  const { loadedStepCount, isStepCountOutOfRange, forgetTrimmedSteps } =
+    useStepCountSync(fieldName)
+  const steps: SubCriterionStep[] =
+    useWatch({ name: `${fieldName}.steps` }) ?? []
+
+  // Steps that go away take their definitions with them, and everyone
+  // classified in them moves down the scale (see useStepCountSync). Raising the
+  // count back undoes both, but only until "Halda áfram" — so flag it while it
+  // is still the applicant's to undo.
+  const hasReducedSteps =
+    loadedStepCount !== undefined && steps.length < loadedStepCount
+
   const applyCatalogEntry = (value: string | undefined) => {
     const entry = value == null ? undefined : catalogEntries[Number(value)]
     if (!entry) return
     setValue(`${fieldName}.title`, entry.title)
     setValue(`${fieldName}.description`, entry.description)
     if (entry.steps.length > 0) {
+      // The template's definitions replace the list outright, so any step
+      // parked by an earlier reduction belongs to text that is now gone.
+      forgetTrimmedSteps()
       setValue(`${fieldName}.stepCount`, String(entry.steps.length))
       setValue(
         `${fieldName}.steps`,
@@ -59,10 +79,6 @@ export const SubCriterionItem: FC<Props> = ({
       )
     }
   }
-
-  useStepCountSync(fieldName)
-  const steps: SubCriterionStep[] =
-    useWatch({ name: `${fieldName}.steps` }) ?? []
 
   return (
     <Box>
@@ -141,10 +157,35 @@ export const SubCriterionItem: FC<Props> = ({
             name={`${fieldName}.stepCount`}
             label={formatMessage(messages.report.subCriteria.stepCountLabel)}
             type="number"
+            min={MIN_SUB_CRITERION_STEPS}
+            max={MAX_SUB_CRITERION_STEPS}
             backgroundColor="blue"
+            error={
+              isStepCountOutOfRange
+                ? formatMessage(messages.report.subCriteria.stepCountRange, {
+                    min: MIN_SUB_CRITERION_STEPS,
+                    max: MAX_SUB_CRITERION_STEPS,
+                  })
+                : undefined
+            }
           />
         </Box>
       </Box>
+
+      {hasReducedSteps && (
+        <Box marginBottom={3}>
+          <AlertMessage
+            type="warning"
+            title={formatMessage(
+              messages.report.subCriteria.stepReductionWarningTitle,
+            )}
+            message={formatMessage(
+              messages.report.subCriteria.stepReductionWarning,
+              { loaded: loadedStepCount, current: steps.length },
+            )}
+          />
+        </Box>
+      )}
 
       {/* Steps section */}
       <Box

--- a/libs/application/templates/directorate-of-equality/salary-report/src/fields/SubCriteriaEditor/SubCriterionItem.tsx
+++ b/libs/application/templates/directorate-of-equality/salary-report/src/fields/SubCriteriaEditor/SubCriterionItem.tsx
@@ -48,8 +48,12 @@ export const SubCriterionItem: FC<Props> = ({
     value: String(i),
   }))
 
-  const { loadedStepCount, isStepCountOutOfRange, forgetTrimmedSteps } =
-    useStepCountSync(fieldName)
+  const {
+    loadedStepCount,
+    canRestoreTrimmedSteps,
+    isStepCountOutOfRange,
+    forgetTrimmedSteps,
+  } = useStepCountSync(fieldName)
   const steps: SubCriterionStep[] =
     useWatch({ name: `${fieldName}.steps` }) ?? []
 
@@ -179,10 +183,21 @@ export const SubCriterionItem: FC<Props> = ({
             title={formatMessage(
               messages.report.subCriteria.stepReductionWarningTitle,
             )}
-            message={formatMessage(
-              messages.report.subCriteria.stepReductionWarning,
-              { loaded: loadedStepCount, current: steps.length },
-            )}
+            message={[
+              formatMessage(messages.report.subCriteria.stepReductionWarning, {
+                loaded: loadedStepCount,
+                current: steps.length,
+              }),
+              // Only where raising the count back really does undo it: after a
+              // sniðmát replaced the list, the þrep it discarded are gone.
+              canRestoreTrimmedSteps &&
+                formatMessage(
+                  messages.report.subCriteria.stepReductionUndoHint,
+                  { loaded: loadedStepCount },
+                ),
+            ]
+              .filter(Boolean)
+              .join(' ')}
           />
         </Box>
       )}

--- a/libs/application/templates/directorate-of-equality/salary-report/src/fields/SubCriteriaEditor/useStepCountSync.spec.tsx
+++ b/libs/application/templates/directorate-of-equality/salary-report/src/fields/SubCriteriaEditor/useStepCountSync.spec.tsx
@@ -1,0 +1,282 @@
+import { act, render, renderHook, screen } from '@testing-library/react'
+import { PropsWithChildren } from 'react'
+import {
+  FormProvider,
+  useForm,
+  useFormContext,
+  UseFormReturn,
+  useWatch,
+} from 'react-hook-form'
+import type { SubCriterionStep } from '../../utils/types'
+import { parseStepCount, useStepCountSync } from './useStepCountSync'
+
+type Values = { sc: { stepCount: string; steps: SubCriterionStep[] } }
+
+const stepsOf = (count: number): SubCriterionStep[] =>
+  Array.from({ length: count }, (_, i) => ({
+    id: `s${i + 1}`,
+    description: `skilgreining ${i + 1}`,
+  }))
+
+// Mirrors the shape SubCriteriaEditor seeds: one sub-criterion under `sc`, its
+// steps already carrying the ids the draft handed back.
+const setup = (stepCount: number) => {
+  let form: UseFormReturn<Values> | undefined
+  const Wrapper = ({ children }: PropsWithChildren) => {
+    form = useForm<Values>({
+      defaultValues: {
+        sc: { stepCount: String(stepCount), steps: stepsOf(stepCount) },
+      },
+    })
+    return <FormProvider {...form}>{children}</FormProvider>
+  }
+
+  const { result } = renderHook(() => useStepCountSync('sc'), {
+    wrapper: Wrapper,
+  })
+
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  const methods = () => form!
+
+  return {
+    result,
+    // Typing into "Fjöldi þrepa" writes the raw string on every keystroke.
+    type: (...values: string[]) =>
+      values.forEach((value) =>
+        act(() => {
+          methods().setValue('sc.stepCount', value)
+        }),
+      ),
+    steps: () => methods().getValues('sc.steps'),
+  }
+}
+
+const idsOf = (steps: SubCriterionStep[]) => steps.map((s) => s.id)
+const descriptionsOf = (steps: SubCriterionStep[]) =>
+  steps.map((s) => s.description)
+
+describe('parseStepCount', () => {
+  it.each(['2', '8', ' 4 '])('accepts the in-range integer %p', (raw) => {
+    expect(parseStepCount(raw)).toBe(Number(raw.trim()))
+  })
+
+  it.each(['', '   ', '0', '1', '9', '20', '4.5', 'x', '-3'])(
+    'rejects %p',
+    (raw) => {
+      expect(parseStepCount(raw)).toBeUndefined()
+    },
+  )
+})
+
+describe('useStepCountSync', () => {
+  it('reports the step count the screen loaded with', () => {
+    const { result } = setup(5)
+
+    expect(result.current.loadedStepCount).toBe(5)
+  })
+
+  it.each([
+    ['5', false],
+    ['', false],
+    ['1', true],
+    ['9', true],
+    ['x', true],
+  ] as const)('flags %p as out of range: %p', (raw, expected) => {
+    const { result, type } = setup(5)
+
+    type(raw)
+
+    expect(result.current.isStepCountOutOfRange).toBe(expected)
+  })
+
+  it('trims from the end when the count drops', () => {
+    const { type, steps } = setup(5)
+
+    type('4')
+
+    expect(idsOf(steps())).toEqual(['s1', 's2', 's3', 's4'])
+    expect(descriptionsOf(steps())).toEqual([
+      'skilgreining 1',
+      'skilgreining 2',
+      'skilgreining 3',
+      'skilgreining 4',
+    ])
+  })
+
+  // The reported bug: 5 -> 4 is typed as backspace-then-4, and the blank in
+  // between used to collapse the list to two steps and re-grow it out of fresh
+  // ids — dropping the definitions for þrep 3 and 4 and every classification
+  // that pointed at the old step rows.
+  it('survives the blank keystroke between 5 and 4', () => {
+    const { type, steps } = setup(5)
+
+    type('', '4')
+
+    expect(idsOf(steps())).toEqual(['s1', 's2', 's3', 's4'])
+    expect(descriptionsOf(steps())).toEqual([
+      'skilgreining 1',
+      'skilgreining 2',
+      'skilgreining 3',
+      'skilgreining 4',
+    ])
+  })
+
+  it('leaves the steps untouched while the field is empty', () => {
+    const { type, steps } = setup(5)
+
+    type('')
+
+    expect(idsOf(steps())).toEqual(['s1', 's2', 's3', 's4', 's5'])
+  })
+
+  it.each(['1', '0', '9', '12', '4.5', 'x'])(
+    'ignores the un-actionable value %p',
+    (raw) => {
+      const { type, steps } = setup(5)
+
+      type(raw)
+
+      expect(idsOf(steps())).toEqual(['s1', 's2', 's3', 's4', 's5'])
+    },
+  )
+
+  it('restores the trimmed steps, ids and all, when the count goes back up', () => {
+    const { type, steps } = setup(5)
+
+    type('4', '5')
+
+    expect(idsOf(steps())).toEqual(['s1', 's2', 's3', 's4', 's5'])
+    expect(descriptionsOf(steps())).toEqual([
+      'skilgreining 1',
+      'skilgreining 2',
+      'skilgreining 3',
+      'skilgreining 4',
+      'skilgreining 5',
+    ])
+  })
+
+  it('restores the parked steps in order across several changes', () => {
+    const { type, steps } = setup(6)
+
+    type('2')
+    expect(idsOf(steps())).toEqual(['s1', 's2'])
+
+    type('4')
+    expect(idsOf(steps())).toEqual(['s1', 's2', 's3', 's4'])
+
+    type('6')
+    expect(idsOf(steps())).toEqual(['s1', 's2', 's3', 's4', 's5', 's6'])
+    expect(descriptionsOf(steps())).toEqual([
+      'skilgreining 1',
+      'skilgreining 2',
+      'skilgreining 3',
+      'skilgreining 4',
+      'skilgreining 5',
+      'skilgreining 6',
+    ])
+  })
+
+  it('mints blank steps once the parked ones run out', () => {
+    const { type, steps } = setup(3)
+
+    type('2', '5')
+
+    expect(idsOf(steps()).slice(0, 3)).toEqual(['s1', 's2', 's3'])
+    expect(steps()).toHaveLength(5)
+    expect(descriptionsOf(steps()).slice(3)).toEqual(['', ''])
+    // Fresh ids, not a second copy of the ones already in the list.
+    expect(new Set(idsOf(steps())).size).toBe(5)
+  })
+
+  it('mints blank steps after the parked ones are forgotten', () => {
+    const { result, type, steps } = setup(5)
+
+    type('3')
+    act(() => result.current.forgetTrimmedSteps())
+    type('5')
+
+    expect(idsOf(steps()).slice(0, 3)).toEqual(['s1', 's2', 's3'])
+    expect(descriptionsOf(steps()).slice(3)).toEqual(['', ''])
+    expect(idsOf(steps())).not.toContain('s4')
+    expect(idsOf(steps())).not.toContain('s5')
+  })
+})
+
+/**
+ * The same thing again through registered inputs rather than form values: the
+ * definitions the applicant can see are the point, and SubCriterionItem renders
+ * one textarea per step keyed by index, so a step list that is silently
+ * re-minted shows up here as emptied boxes.
+ *
+ * Plain `register` inputs stand in for its InputControllers, as in
+ * emptyOutlierGroupAnswer.spec.tsx — both resolve an input's initial value out
+ * of react-hook-form's `_formValues`.
+ */
+let setStepCount: ((value: string) => void) | null = null
+
+const StepFields = () => {
+  const { register } = useFormContext<Values>()
+  useStepCountSync('sc')
+  const steps: SubCriterionStep[] = useWatch({ name: 'sc.steps' }) ?? []
+
+  return (
+    <div>
+      {steps.map((_, index) => (
+        <input
+          key={index}
+          data-testid={`step-${index}`}
+          {...register(`sc.steps.${index}.description`)}
+        />
+      ))}
+    </div>
+  )
+}
+
+const StepsForm = ({ stepCount }: { stepCount: number }) => {
+  const form = useForm<Values>({
+    defaultValues: {
+      sc: { stepCount: String(stepCount), steps: stepsOf(stepCount) },
+    },
+  })
+  setStepCount = (value) => form.setValue('sc.stepCount', value)
+
+  return (
+    <FormProvider {...form}>
+      <StepFields />
+    </FormProvider>
+  )
+}
+
+const stepInputs = () =>
+  screen
+    .queryAllByTestId(/^step-/)
+    .map((input) => (input as HTMLInputElement).value)
+
+describe('the step definitions on screen', () => {
+  it('keeps the definitions of the steps that remain, and brings back the one that returns', () => {
+    render(<StepsForm stepCount={5} />)
+    expect(stepInputs()).toHaveLength(5)
+
+    // "5" backspaced away, then "4" typed.
+    act(() => setStepCount?.(''))
+    act(() => setStepCount?.('4'))
+
+    expect(stepInputs()).toEqual([
+      'skilgreining 1',
+      'skilgreining 2',
+      'skilgreining 3',
+      'skilgreining 4',
+    ])
+
+    // Changed back before leaving the screen.
+    act(() => setStepCount?.('5'))
+
+    expect(stepInputs()).toEqual([
+      'skilgreining 1',
+      'skilgreining 2',
+      'skilgreining 3',
+      'skilgreining 4',
+      'skilgreining 5',
+    ])
+  })
+})

--- a/libs/application/templates/directorate-of-equality/salary-report/src/fields/SubCriteriaEditor/useStepCountSync.spec.tsx
+++ b/libs/application/templates/directorate-of-equality/salary-report/src/fields/SubCriteriaEditor/useStepCountSync.spec.tsx
@@ -48,6 +48,21 @@ const setup = (stepCount: number) => {
         }),
       ),
     steps: () => methods().getValues('sc.steps'),
+    // What applyCatalogEntry does, in its order and in one event: forget the
+    // parked tail, then replace both the count and the list with the
+    // template's own steps.
+    applyTemplate: (count: number) =>
+      act(() => {
+        result.current.forgetTrimmedSteps()
+        methods().setValue('sc.stepCount', String(count))
+        methods().setValue(
+          'sc.steps',
+          Array.from({ length: count }, (_, i) => ({
+            id: `t${i + 1}`,
+            description: `sniðmát ${i + 1}`,
+          })),
+        )
+      }),
   }
 }
 
@@ -139,6 +154,38 @@ describe('useStepCountSync', () => {
       expect(idsOf(steps())).toEqual(['s1', 's2', 's3', 's4', 's5'])
     },
   )
+
+  // What the applicant is told hangs on this: the warning offers "raise the
+  // count back and nothing changes", which is only true while the trimmed steps
+  // are still parked.
+  it('reports a plain reduction as restorable', () => {
+    const { result, type } = setup(5)
+
+    type('4')
+
+    expect(result.current.canRestoreTrimmedSteps).toBe(true)
+  })
+
+  it('reports a shorter catalog template as unrestorable', () => {
+    const { result, applyTemplate, steps } = setup(5)
+
+    applyTemplate(3)
+
+    // The template's steps stand, unshortened by the resize effect…
+    expect(idsOf(steps())).toEqual(['t1', 't2', 't3'])
+    // …and there is nothing parked to put the discarded þrep back.
+    expect(result.current.canRestoreTrimmedSteps).toBe(false)
+  })
+
+  it('keeps a same-length catalog template out of the warning entirely', () => {
+    const { result, applyTemplate, steps } = setup(5)
+
+    applyTemplate(5)
+
+    expect(steps()).toHaveLength(5)
+    // Nothing was reduced, so SubCriterionItem never asks about restoring.
+    expect(result.current.loadedStepCount).toBe(5)
+  })
 
   it('restores the trimmed steps, ids and all, when the count goes back up', () => {
     const { type, steps } = setup(5)

--- a/libs/application/templates/directorate-of-equality/salary-report/src/fields/SubCriteriaEditor/useStepCountSync.ts
+++ b/libs/application/templates/directorate-of-equality/salary-report/src/fields/SubCriteriaEditor/useStepCountSync.ts
@@ -1,32 +1,114 @@
-import { useEffect } from 'react'
+import { useCallback, useEffect, useRef } from 'react'
 import { useFormContext, useWatch } from 'react-hook-form'
+import {
+  MAX_SUB_CRITERION_STEPS,
+  MIN_SUB_CRITERION_STEPS,
+} from '../../utils/constants'
 import type { SubCriterionStep } from '../../utils/types'
 
-// Keeps `${fieldName}.steps` in sync with the step-count input: growing adds
-// fresh blank steps, shrinking trims from the end.
+// The only step counts worth acting on: an in-range integer. Everything else —
+// blank, mid-keystroke, out of range — leaves the step list exactly as it is.
+export const parseStepCount = (raw: string): number | undefined => {
+  const trimmed = raw.trim()
+  if (!trimmed) return undefined
+  const count = Number(trimmed)
+  if (!Number.isInteger(count)) return undefined
+  if (count < MIN_SUB_CRITERION_STEPS || count > MAX_SUB_CRITERION_STEPS) {
+    return undefined
+  }
+  return count
+}
+
+// A step's id is what a role's (or employee's) classification points at, and
+// DMR deletes the assignment rows along with the step — removeStep destroys
+// them eagerly, so nothing survives for a later read to repair. A REMOVE
+// therefore loses that þrep's definition for good, and re-points every
+// classification standing in it onto the nearest surviving þrep at or below it
+// (for a reduction, the new top þrep). That makes this hook's job less "keep
+// the array the right length" than "never drop a step id the applicant did not
+// ask to lose".
+//
+// Two rules follow from that:
+//
+//  1. "Fjöldi þrepa" is a NumberFormat input that writes its raw string into the
+//     form on every keystroke, so changing 5 to 4 goes through ''. Resizing on
+//     an unparseable or out-of-range value is what used to collapse the list to
+//     the minimum mid-edit and then re-grow it out of blank, freshly-minted
+//     steps, throwing away every definition the applicant had written from þrep
+//     3 upwards on a change they never made. Anything that is not an in-range
+//     integer is a no-op. (Before DMR clamped, those blank steps also carried
+//     new ids at the same orders, which reset every role and employee in þrep 3
+//     and up to 1. þrep — the shape of the original bug report.)
+//  2. Shrinking parks the trimmed tail instead of discarding it, so growing
+//     back restores those exact steps — same ids, same definitions. Nothing has
+//     been removed on DMR's side until "Halda áfram" flushes the screen, so
+//     5 -> 4 -> 5 within a visit costs the draft nothing, rather than a
+//     REMOVE/CREATE round trip that blanks a definition and re-points the
+//     assignment rows behind it.
 export const useStepCountSync = (fieldName: string) => {
   const { setValue, getValues } = useFormContext()
-  const stepCountStr: string =
-    useWatch({ name: `${fieldName}.stepCount` }) ?? '2'
+  const watched = useWatch({ name: `${fieldName}.stepCount` })
+  const stepCountStr = watched == null ? '' : String(watched)
+
+  // Steps cut off the end by a shrink, in step order, so a later grow can put
+  // them back before minting anything new. Lives for this mount only: on the
+  // next visit the draft is re-read and these ids are either back on it or
+  // genuinely gone.
+  const trimmedTail = useRef<SubCriterionStep[]>([])
+
+  // The step count the screen loaded with — the state every existing role and
+  // employee classification was made against. Latched on the first render
+  // (SubCriterionItem only mounts once the parent has reset the form), so a
+  // sub-criterion added during this visit starts from its own two steps.
+  const loadedStepCount = useRef<number | undefined>(undefined)
+  if (loadedStepCount.current === undefined) {
+    const steps: SubCriterionStep[] = getValues(`${fieldName}.steps`) ?? []
+    if (steps.length > 0) loadedStepCount.current = steps.length
+  }
+
+  // For the one other writer of `steps`: picking a catalog template replaces
+  // the list wholesale, which makes the parked tail belong to definitions the
+  // applicant has just discarded.
+  const forgetTrimmedSteps = useCallback(() => {
+    trimmedTail.current = []
+  }, [])
 
   useEffect(() => {
-    const count = Math.min(
-      8,
-      Math.max(2, Math.trunc(Number(stepCountStr)) || 2),
-    )
+    const count = parseStepCount(stepCountStr)
+    if (count === undefined) return
+
     const currentSteps: SubCriterionStep[] =
       getValues(`${fieldName}.steps`) ?? []
     if (count === currentSteps.length) return
 
     if (count > currentSteps.length) {
-      const extra = Array.from({ length: count - currentSteps.length }, () => ({
+      const needed = count - currentSteps.length
+      const restored = trimmedTail.current.slice(0, needed)
+      trimmedTail.current = trimmedTail.current.slice(restored.length)
+      const fresh = Array.from({ length: needed - restored.length }, () => ({
         id: crypto.randomUUID(),
         description: '',
       }))
-      setValue(`${fieldName}.steps`, [...currentSteps, ...extra])
+      setValue(`${fieldName}.steps`, [...currentSteps, ...restored, ...fresh])
     } else {
+      // Newly cut steps sit in front of anything parked earlier: together they
+      // are the tail beyond `count`, still in step order.
+      trimmedTail.current = [
+        ...currentSteps.slice(count),
+        ...trimmedTail.current,
+      ]
       setValue(`${fieldName}.steps`, currentSteps.slice(0, count))
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [stepCountStr])
+
+  return {
+    loadedStepCount: loadedStepCount.current,
+    // A blank field is someone part-way through typing, not a mistake to
+    // colour red; anything else the hook declined to act on is worth saying
+    // out loud, since the step list below it stayed where it was.
+    isStepCountOutOfRange:
+      stepCountStr.trim() !== '' && parseStepCount(stepCountStr) === undefined,
+    forgetTrimmedSteps,
+  }
 }

--- a/libs/application/templates/directorate-of-equality/salary-report/src/fields/SubCriteriaEditor/useStepCountSync.ts
+++ b/libs/application/templates/directorate-of-equality/salary-report/src/fields/SubCriteriaEditor/useStepCountSync.ts
@@ -102,8 +102,18 @@ export const useStepCountSync = (fieldName: string) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [stepCountStr])
 
+  // Whether raising the count back to what loaded would restore the parked
+  // steps rather than mint blanks. False once the list has been replaced
+  // wholesale — a catalog template forgets the tail, and those definitions are
+  // not coming back — so the screen must not offer that as a way out.
+  const stepsInForm: SubCriterionStep[] = getValues(`${fieldName}.steps`) ?? []
+  const canRestoreTrimmedSteps =
+    loadedStepCount.current !== undefined &&
+    trimmedTail.current.length >= loadedStepCount.current - stepsInForm.length
+
   return {
     loadedStepCount: loadedStepCount.current,
+    canRestoreTrimmedSteps,
     // A blank field is someone part-way through typing, not a mistake to
     // colour red; anything else the hook declined to act on is worth saying
     // out loud, since the step list below it stayed where it was.

--- a/libs/application/templates/directorate-of-equality/salary-report/src/lib/messages.ts
+++ b/libs/application/templates/directorate-of-equality/salary-report/src/lib/messages.ts
@@ -727,6 +727,28 @@ export const messages = {
         id: 'doe.sr.application:report.subCriteria.stepCountLabel',
         defaultMessage: 'Fjöldi þrepa',
       },
+      stepCountRange: {
+        id: 'doe.sr.application:report.subCriteria.stepCountRange',
+        defaultMessage:
+          'Fjöldi þrepa þarf að vera {min}–{max}. Þrepin hér að neðan fylgja síðasta gilda fjölda.',
+      },
+      // Shown while the reduction is still undoable — see useStepCountSync:
+      // raising the count back restores the same þrep, but once "Halda áfram"
+      // has flushed the screen their definitions are gone and DMR has moved
+      // everyone who stood in them down to the highest þrep left.
+      //
+      // Which, since a reduction only ever removes from the top of the scale,
+      // is the new count itself: dropping 5 þrep to 4 moves the roles that were
+      // on þrep 5 to þrep 4 — so name the number rather than describe the rule.
+      stepReductionWarningTitle: {
+        id: 'doe.sr.application:report.subCriteria.stepReductionWarningTitle',
+        defaultMessage: 'Þrepum hefur verið fækkað',
+      },
+      stepReductionWarning: {
+        id: 'doe.sr.application:report.subCriteria.stepReductionWarning',
+        defaultMessage:
+          'Þrepin voru {loaded} en eru nú {current}. Þegar þú heldur áfram eyðast skilgreiningar þrepanna sem falla brott og starfsheiti — og starfsfólk — sem voru í þeim færast í {current}. þrep. Fjölgir þú þrepunum aftur upp í {loaded} áður en þú heldur áfram helst allt óbreytt.',
+      },
       stepsLabel: {
         id: 'doe.sr.application:report.subCriteria.stepsLabel',
         defaultMessage: 'Þrep',

--- a/libs/application/templates/directorate-of-equality/salary-report/src/lib/messages.ts
+++ b/libs/application/templates/directorate-of-equality/salary-report/src/lib/messages.ts
@@ -747,7 +747,16 @@ export const messages = {
       stepReductionWarning: {
         id: 'doe.sr.application:report.subCriteria.stepReductionWarning',
         defaultMessage:
-          'Þrepin voru {loaded} en eru nú {current}. Þegar þú heldur áfram eyðast skilgreiningar þrepanna sem falla brott og starfsheiti — og starfsfólk — sem voru í þeim færast í {current}. þrep. Fjölgir þú þrepunum aftur upp í {loaded} áður en þú heldur áfram helst allt óbreytt.',
+          'Þrepin voru {loaded} en eru nú {current}. Þegar þú heldur áfram eyðast skilgreiningar þrepanna sem falla brott og starfsheiti — og starfsfólk — sem voru í þeim færast í {current}. þrep.',
+      },
+      // Appended to the warning only while the þrep really can be put back —
+      // see canRestoreTrimmedSteps. Picking a sniðmát discards the þrep it
+      // replaced, so raising the count afterwards yields blank þrep and this
+      // sentence would be a promise the screen cannot keep.
+      stepReductionUndoHint: {
+        id: 'doe.sr.application:report.subCriteria.stepReductionUndoHint',
+        defaultMessage:
+          'Fjölgir þú þrepunum aftur upp í {loaded} áður en þú heldur áfram helst allt óbreytt.',
       },
       stepsLabel: {
         id: 'doe.sr.application:report.subCriteria.stepsLabel',

--- a/libs/application/templates/directorate-of-equality/salary-report/src/utils/constants.ts
+++ b/libs/application/templates/directorate-of-equality/salary-report/src/utils/constants.ts
@@ -163,6 +163,21 @@ export const createDefaultJobFactors = (): JobFactor[] => [
   },
 ]
 
+// How many þrep a sub-criterion may be scored on. Mirrors DMR's own MIN_STEPS /
+// MAX_STEPS (report-excel/workbook.schema.ts), which its Excel parser and its
+// parsed-payload integrity check both enforce — so a workbook-imported draft
+// cannot exceed this. `POST …/draft/sync` enforces neither, and submit does not
+// re-validate, so on a portal-authored draft this bound is ours alone to keep.
+//
+// Enforced on the "Fjöldi þrepa" input itself (min/max) rather than by silently
+// rewriting the step list behind the applicant's back — see useStepCountSync,
+// where an out-of-range value is a no-op precisely so that nothing is
+// destroyed mid-keystroke. A draft that somehow arrives outside the range is
+// therefore left alone rather than trimmed to fit, and can only be brought back
+// into it by the applicant.
+export const MIN_SUB_CRITERION_STEPS = 2
+export const MAX_SUB_CRITERION_STEPS = 8
+
 export const createDefaultSubCriterion = (
   criterionId: string,
 ): SubCriterion => ({
@@ -171,11 +186,11 @@ export const createDefaultSubCriterion = (
   title: '',
   description: '',
   weight: '',
-  stepCount: '2',
-  steps: [
-    { id: crypto.randomUUID(), description: '' },
-    { id: crypto.randomUUID(), description: '' },
-  ],
+  stepCount: String(MIN_SUB_CRITERION_STEPS),
+  steps: Array.from({ length: MIN_SUB_CRITERION_STEPS }, () => ({
+    id: crypto.randomUUID(),
+    description: '',
+  })),
 })
 
 // Order is load-bearing, not cosmetic: this drives the order of the pay inputs in


### PR DESCRIPTION
  # fix(doe): Preserve þrep definitions and classifications when the step count changes

  Attach a link to issue if relevant

  ## What

  Fixes data loss on **Undirviðmið** (salary report, DOE) when the applicant changes
  *Fjöldi þrepa* on a sub-criterion.

  `useStepCountSync` resized the step list on every raw keystroke of the *Fjöldi þrepa*
  input. Because that input is a `NumberFormat` that writes its raw string into the form,
  changing 5 to 4 passes through `''`, and `Number('') || 2` collapsed the list to two
  steps — then growing back to 4 re-created þrep 3 and 4 as **blank steps with fresh
  UUIDs**:

  | keystroke | `stepCount` | `steps` after the effect |
  |---|---|---|
  | start | `'5'` | s1 s2 s3 s4 s5 — real ids, real definitions |
  | backspace | `''` | **s1 s2** — s3/s4/s5 dropped |
  | type `4` | `'4'` | s1 s2 **+ two blank, freshly minted steps** |

  A step id is what a role's (and employee's) classification points at, so the flush on
  "Halda áfram" sent `REMOVE` for the originals and `CREATE` for the replacements, taking
  the definitions the applicant had written with it.

  Three changes:

  1. **`useStepCountSync` only acts on an in-range integer.** Blank, partial, non-integer
     or out-of-range values are a no-op, so nothing is destroyed mid-edit.
     those exact steps — same ids, same definitions. `5 → 4 → 5` within a visit now costs
     the draft nothing instead of a `REMOVE`/`CREATE` round trip.
  3. **The applicant is told** when the count sits below what loaded, while raising it back
     still undoes everything, plus an inline error if the value is outside 2–8.

  `MIN_SUB_CRITERION_STEPS` / `MAX_SUB_CRITERION_STEPS` (2–8) now carry the bound, mirroring
  DMR's own `MIN_STEPS` / `MAX_STEPS` in `report-excel/workbook.schema.ts`. Confirmed with
  DMR that their Excel parser and parsed-payload integrity check enforce it, but
  `POST …/draft/sync` and submit do **not** — so on a portal-authored draft this bound is
  ours alone to keep. Recorded in a comment on the constants.

  No API or client changes: no DTO, endpoint or generated type is touched, and
  `clientConfig.json` needs no regeneration.

  ## Why

  Reported by an applicant: after importing the workbook and going back to edit
  *Ábyrgð á þjónustu*, reducing the þrep count from 5 to 4 sent every role using that
  sub-criterion to **1. þrep**, and the definitions for þrep 3 and 4 disappeared. Changing
  the count back did not restore either.

  Both halves were the same defect. The classifications reset because the step rows the
  assignments referenced were deleted and re-created under new ids; the definitions vanished
  because the replacements were blank. With a 4% weight, a role on þrep 5 went from 40/40 to
  8/40 — points that feed the classification the wage-gap analysis is computed from, silently
  and with nothing on screen to show it.

  DMR's clamp fixes the reset. It does not fix the lost definitions, and it does not stop a
  resize the applicant never asked for — those need this change.

  ## Checklist:

  - [ ] I have performed a self-review of my own code
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
  - [x] Formatting passes locally with my changes
  - [ ] I have rebased against main before asking for a review
  - [ ] No AI tools were used in preparing this pull request
  - [x] AI tools were used in preparing this pull request
        Tools used: Claude Code (Claude Opus 5)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added validation requiring between 2 and 8 sub-criterion steps.
  * Displays errors for step counts outside the allowed range.
  * Added warnings when reducing steps, with an undo hint when removed steps can be restored.
  * Restores previously removed steps, including their content, when increasing the count again where possible.
  * Catalog selection clears trimmed steps before applying catalog-defined steps.

* **Tests**
  * Expanded coverage for validation, step preservation and restoration, catalog behavior, and visible form values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->