### PR TITLE
refactor(j-s): Move court session orchestration out of the court session repository

### DIFF
--- a/apps/judicial-system/backend/src/app/modules/case/case.module.ts
+++ b/apps/judicial-system/backend/src/app/modules/case/case.module.ts
@@ -7,6 +7,7 @@ import { SigningModule } from '@island.is/dokobit-signing'
 import {
   AwsS3Module,
   CourtModule,
+  CourtSessionModule,
   DefendantModule,
   EventLogModule,
   EventModule,
@@ -40,6 +41,7 @@ import { PdfService } from './pdf.service'
     forwardRef(() => FileModule),
     forwardRef(() => IndictmentCountModule),
     forwardRef(() => CourtModule),
+    forwardRef(() => CourtSessionModule),
     forwardRef(() => AwsS3Module),
     forwardRef(() => EventModule),
     forwardRef(() => PoliceModule),

--- a/apps/judicial-system/backend/src/app/modules/case/case.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/case/case.service.ts
@@ -81,6 +81,7 @@ import {
 } from '../appeal-case'
 import { AwsS3Service } from '../aws-s3'
 import { CourtService } from '../court'
+import { CourtSessionService } from '../court-session'
 import { DefendantService } from '../defendant'
 import { EventService } from '../event'
 import { EventLogService } from '../event-log'
@@ -97,7 +98,6 @@ import {
   CaseRepositoryService,
   CaseStringRepositoryService,
   CourtDocumentRepositoryService,
-  CourtSessionRepositoryService,
   DateLog,
   DateLogRepositoryService,
   Defendant,
@@ -178,7 +178,8 @@ export class CaseService {
     private readonly eventService: EventService,
     private readonly eventLogService: EventLogService,
     private readonly courtDocumentRepositoryService: CourtDocumentRepositoryService,
-    private readonly courtSessionRepositoryService: CourtSessionRepositoryService,
+    @Inject(forwardRef(() => CourtSessionService))
+    private readonly courtSessionService: CourtSessionService,
     private readonly caseRepositoryService: CaseRepositoryService,
     private readonly appealCaseRepositoryService: AppealCaseRepositoryService,
     private readonly appealDecisionRepositoryService: AppealDecisionRepositoryService,
@@ -2485,10 +2486,10 @@ export class CaseService {
         !parentCase.courtSessions[parentCase.courtSessions.length - 1]
           .isConfirmed
       ) {
-        await this.courtSessionRepositoryService.addMergedCaseToLatestCourtSession(
+        await this.courtSessionService.addMergedCaseToLatestCourtSession(
           parentCase.id,
           theCase.id,
-          { transaction },
+          transaction,
         )
       }
     }

--- a/apps/judicial-system/backend/src/app/modules/case/test/caseController/update.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/case/test/caseController/update.spec.ts
@@ -38,6 +38,7 @@ import { createTestingCaseModule } from '../createTestingCaseModule'
 
 import { nowFactory } from '../../../../factories'
 import { randomDate } from '../../../../test'
+import { CourtSessionService } from '../../../court-session'
 import { DefendantService } from '../../../defendant'
 import { EventLogService } from '../../../event-log/eventLog.service'
 import { FileService } from '../../../file'
@@ -101,6 +102,7 @@ describe('CaseController - Update', () => {
   let mockVerdictService: VerdictService
   let mockCaseStringRepositoryService: CaseStringRepositoryService
   let mockDateLogRepositoryService: DateLogRepositoryService
+  let mockCourtSessionService: CourtSessionService
   let givenWhenThen: GivenWhenThen
 
   beforeEach(async () => {
@@ -116,6 +118,7 @@ describe('CaseController - Update', () => {
       verdictService,
       caseStringRepositoryService,
       dateLogRepositoryService,
+      courtSessionService,
       caseController,
     } = await createTestingCaseModule()
 
@@ -129,6 +132,7 @@ describe('CaseController - Update', () => {
     mockVerdictService = verdictService
     mockCaseStringRepositoryService = caseStringRepositoryService
     mockDateLogRepositoryService = dateLogRepositoryService
+    mockCourtSessionService = courtSessionService
 
     const mockTransaction = sequelize.transaction as jest.Mock
     transaction = {
@@ -448,6 +452,77 @@ describe('CaseController - Update', () => {
           },
         ]),
       )
+    })
+  })
+
+  // An indictment case that completes by merging into a parent case joins the
+  // parent's latest court session, provided that session is still open. The
+  // court session service owns what joining means; this is the decision to call it.
+  describe('indictment case completed by merging into a parent case', () => {
+    const parentCaseId = uuid()
+    const caseToUpdate = { state: CaseState.COMPLETED } as UpdateCaseDto
+
+    const mergingCase = (latestSessionConfirmed: boolean) =>
+      ({
+        ...theCase,
+        type: CaseType.INDICTMENT,
+        state: CaseState.RECEIVED,
+        indictmentRulingDecision: CaseIndictmentRulingDecision.MERGE,
+        mergeCaseId: parentCaseId,
+        mergeCase: {
+          id: parentCaseId,
+          state: CaseState.RECEIVED,
+          withCourtSessions: true,
+          courtSessions: [
+            { id: uuid(), isConfirmed: true },
+            { id: uuid(), isConfirmed: latestSessionConfirmed },
+          ],
+        },
+      } as Case)
+
+    describe('whose latest court session is open', () => {
+      beforeEach(async () => {
+        await givenWhenThen(caseId, user, mergingCase(false), caseToUpdate)
+      })
+
+      it('should add the case to the latest court session of the parent case', () => {
+        expect(
+          mockCourtSessionService.addMergedCaseToLatestCourtSession,
+        ).toHaveBeenCalledWith(parentCaseId, caseId, transaction)
+      })
+    })
+
+    describe('whose latest court session is confirmed', () => {
+      beforeEach(async () => {
+        await givenWhenThen(caseId, user, mergingCase(true), caseToUpdate)
+      })
+
+      it('should leave the court sessions of the parent case alone', () => {
+        expect(
+          mockCourtSessionService.addMergedCaseToLatestCourtSession,
+        ).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('that is not received', () => {
+      let then: Then
+
+      beforeEach(async () => {
+        const notReceived = mergingCase(false)
+        notReceived.mergeCase = {
+          ...notReceived.mergeCase,
+          state: CaseState.COMPLETED,
+        } as Case
+
+        then = await givenWhenThen(caseId, user, notReceived, caseToUpdate)
+      })
+
+      it('should refuse the merge', () => {
+        expect(then.error).toBeInstanceOf(BadRequestException)
+        expect(
+          mockCourtSessionService.addMergedCaseToLatestCourtSession,
+        ).not.toHaveBeenCalled()
+      })
     })
   })
 

--- a/apps/judicial-system/backend/src/app/modules/case/test/createTestingCaseModule.ts
+++ b/apps/judicial-system/backend/src/app/modules/case/test/createTestingCaseModule.ts
@@ -18,6 +18,7 @@ import { addMessagesToQueue, Message } from '@island.is/judicial-system/message'
 
 import { AwsS3Service } from '../../aws-s3'
 import { CourtService } from '../../court'
+import { CourtSessionService } from '../../court-session'
 import { CivilClaimantService } from '../../defendant'
 import { DefendantService } from '../../defendant'
 import { EventService } from '../../event'
@@ -60,6 +61,7 @@ jest.mock('../../court/court.service', () => {
   }
 })
 jest.mock('../../police/police.service')
+jest.mock('../../court-session/courtSession.service')
 jest.mock('../../event/event.service')
 jest.mock('../../event-log/eventLog.service')
 jest.mock('../../user/user.service')
@@ -97,6 +99,7 @@ export const createTestingCaseModule = async () => {
       SharedAuthModule,
       EventLogService,
       CourtService,
+      CourtSessionService,
       PoliceService,
       UserService,
       FileService,
@@ -157,6 +160,9 @@ export const createTestingCaseModule = async () => {
   const eventService = caseModule.get<EventService>(EventService)
 
   const courtService = caseModule.get<CourtService>(CourtService)
+
+  const courtSessionService =
+    caseModule.get<CourtSessionService>(CourtSessionService)
 
   const policeService = caseModule.get<PoliceService>(PoliceService)
 
@@ -268,6 +274,7 @@ export const createTestingCaseModule = async () => {
     eventLogService,
     eventService,
     courtService,
+    courtSessionService,
     policeService,
     userService,
     fileService,

--- a/apps/judicial-system/backend/src/app/modules/court-session/courtSession.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/court-session/courtSession.service.ts
@@ -11,7 +11,10 @@ import {
 import type { Logger } from '@island.is/logging'
 import { LOGGER_PROVIDER } from '@island.is/logging'
 
-import { formatRulingOrderPronouncedOrallyName } from '@island.is/judicial-system/formatters'
+import {
+  formatDate,
+  formatRulingOrderPronouncedOrallyName,
+} from '@island.is/judicial-system/formatters'
 import {
   addMessagesToQueue,
   type Message,
@@ -53,11 +56,14 @@ import {
   AppealEventLogRepositoryService,
   Case,
   CaseFile,
+  CaseRepositoryService,
+  CourtDocumentRepositoryService,
   CourtSession,
   CourtSessionRepositoryService,
   CourtSessionString,
   CourtSessionStringKey,
   CourtSessionStringRepositoryService,
+  EventLogRepositoryService,
   UpdateCourtSession,
 } from '../repository'
 import { CourtSessionAppealDecisionDto } from './dto/courtSessionAppealDecision.dto'
@@ -91,6 +97,9 @@ export class CourtSessionService {
     private readonly fileService: FileService,
     private readonly eventLogService: EventLogService,
     private readonly courtSessionStringRepositoryService: CourtSessionStringRepositoryService,
+    private readonly courtDocumentRepositoryService: CourtDocumentRepositoryService,
+    private readonly caseRepositoryService: CaseRepositoryService,
+    private readonly eventLogRepositoryService: EventLogRepositoryService,
     @Inject(LOGGER_PROVIDER) private readonly logger: Logger,
   ) {}
 
@@ -121,10 +130,126 @@ export class CourtSessionService {
     addMessagesToQueue(...messages)
   }
 
-  create(theCase: Case, transaction: Transaction): Promise<CourtSession> {
-    return this.courtSessionRepositoryService.create(theCase.id, {
+  // Records a merged case in a court session: its court documents are filed
+  // there, and if any were, the session gains the ENTRIES text that says the
+  // case was joined to this one - dated by the indictment's confirmation, or
+  // its sending to court, when the merged case has such an event.
+  private async addMergedCaseToCourtSession(
+    caseId: string,
+    courtSessionId: string,
+    mergedCase: Case,
+    transaction: Transaction,
+  ): Promise<void> {
+    const added =
+      await this.courtDocumentRepositoryService.updateMergedCourtDocuments({
+        parentCaseId: caseId,
+        parentCaseCourtSessionId: courtSessionId,
+        caseId: mergedCase.id,
+        transaction,
+      })
+
+    if (!added) {
+      return
+    }
+
+    const event =
+      await this.eventLogRepositoryService.findLatestForCaseAndTypes(
+        mergedCase.id,
+        [EventType.CASE_SENT_TO_COURT, EventType.INDICTMENT_CONFIRMED],
+        { transaction },
+      )
+
+    await this.courtSessionStringRepositoryService.create(
+      {
+        caseId,
+        courtSessionId,
+        mergedCaseId: mergedCase.id,
+        stringType: CourtSessionStringType.ENTRIES,
+        value: `Mál nr. ${
+          mergedCase.courtCaseNumber
+        } sem var höfðað á hendur ákærða${
+          event
+            ? ` með ákæru útgefinni ${formatDate(event.created, 'PPP')}`
+            : ''
+        }, er nú einnig tekið fyrir og það sameinað þessu máli, sbr. heimild í 1. mgr. 169. gr. laga nr. 88/2008 um meðferð sakamála, og verða þau eftirleiðis rekin undir málsnúmeri þessa máls.`,
+      },
+      { transaction },
+    )
+  }
+
+  // A new court session takes in everything the case has waiting for one: its
+  // unfiled court documents, then the documents of each case merged into it -
+  // oldest merge first, so the record reads in the order the cases were joined.
+  async create(theCase: Case, transaction: Transaction): Promise<CourtSession> {
+    const courtSession = await this.courtSessionRepositoryService.create(
+      theCase.id,
+      { transaction },
+    )
+
+    await this.courtDocumentRepositoryService.fileAllAvailableCourtDocumentsInCourtSession(
+      theCase.id,
+      courtSession.id,
+      { transaction },
+    )
+
+    const mergedCases = await this.caseRepositoryService.findAllMergedToCase(
+      theCase.id,
+      { transaction },
+    )
+
+    for (const mergedCase of mergedCases) {
+      await this.addMergedCaseToCourtSession(
+        theCase.id,
+        courtSession.id,
+        mergedCase,
+        transaction,
+      )
+    }
+
+    return courtSession
+  }
+
+  // A case merged into another after that case's latest court session was
+  // opened joins that session - provided it is still open. Once a session is
+  // confirmed its record is final, and the merge must not reach back into it.
+  async addMergedCaseToLatestCourtSession(
+    caseId: string,
+    mergedCaseId: string,
+    transaction: Transaction,
+  ): Promise<CourtSession> {
+    this.logger.debug(
+      `Adding merged case ${mergedCaseId} to latest court session of case ${caseId}`,
+    )
+
+    const latestCourtSession =
+      await this.courtSessionRepositoryService.findLatestByCase(caseId, {
+        transaction,
+      })
+
+    if (!latestCourtSession || latestCourtSession.isConfirmed) {
+      throw new InternalServerErrorException(
+        `The latest court session of case ${caseId} must not be confirmed when adding merged case ${mergedCaseId}`,
+      )
+    }
+
+    const mergedCase = await this.caseRepositoryService.findById(mergedCaseId, {
       transaction,
     })
+
+    if (!mergedCase) {
+      throw new InternalServerErrorException(
+        `Could not find case ${mergedCaseId} when adding it as a merged case to the latest court session of case ${caseId}`,
+      )
+    }
+
+    await this.addMergedCaseToCourtSession(
+      caseId,
+      latestCourtSession.id,
+      mergedCase,
+      transaction,
+    )
+
+    return latestCourtSession
   }
 
   async createOrUpdateCourtSessionString({
@@ -1326,6 +1451,40 @@ export class CourtSessionService {
       theCase,
       courtSession,
       transaction,
+    )
+
+    // Only the latest session can go: deleting an earlier one would leave the
+    // document orders of the sessions after it out of step. Decided against
+    // the transaction's view of the case, not the guard's earlier snapshot.
+    const latestCourtSession =
+      await this.courtSessionRepositoryService.findLatestByCase(theCase.id, {
+        transaction,
+      })
+
+    if (!latestCourtSession) {
+      throw new InternalServerErrorException(
+        `Could not find court session ${courtSession.id} of case ${theCase.id}`,
+      )
+    }
+
+    if (latestCourtSession.id !== courtSession.id) {
+      throw new InternalServerErrorException(
+        `Only the latest court session of case ${theCase.id} can be deleted`,
+      )
+    }
+
+    // Empty the session before deleting it: first its court documents, which
+    // return to the case's unfiled documents, then its strings, then the row.
+    await this.courtDocumentRepositoryService.removeAllCourtDocumentsFromCourtSession(
+      theCase.id,
+      courtSession.id,
+      transaction,
+    )
+
+    await this.courtSessionStringRepositoryService.deleteAllForCourtSession(
+      theCase.id,
+      courtSession.id,
+      { transaction },
     )
 
     await this.courtSessionRepositoryService.delete(

--- a/apps/judicial-system/backend/src/app/modules/court-session/test/courtSessionController/create.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/court-session/test/courtSessionController/create.spec.ts
@@ -1,12 +1,23 @@
 import { Transaction } from 'sequelize'
 import { v4 as uuid } from 'uuid'
 
+import { formatDate } from '@island.is/judicial-system/formatters'
+import {
+  CourtSessionStringType,
+  EventType,
+} from '@island.is/judicial-system/types'
+
 import { createTestingCourtSessionModule } from '../createTestingCourtSessionModule'
 
 import {
   Case,
+  CaseRepositoryService,
+  CourtDocumentRepositoryService,
   CourtSession,
   CourtSessionRepositoryService,
+  CourtSessionStringRepositoryService,
+  EventLog,
+  EventLogRepositoryService,
 } from '../../../repository'
 
 interface Then {
@@ -16,17 +27,33 @@ interface Then {
 
 type GivenWhenThen = (caseId: string) => Promise<Then>
 
+// A new court session takes in everything the case has waiting for one: its
+// unfiled court documents, then the documents of each case merged into it. A
+// merged case whose documents were filed also gets its ENTRIES text - the
+// court's record of why the cases were joined.
 describe('CourtSessionController - Create', () => {
   const caseId = uuid()
   const courtSessionId = uuid()
+  const createdCourtSession = { id: courtSessionId, caseId } as CourtSession
 
   let transaction: Transaction
   let mockCourtSessionRepositoryService: CourtSessionRepositoryService
+  let mockCourtDocumentRepositoryService: CourtDocumentRepositoryService
+  let mockCaseRepositoryService: CaseRepositoryService
+  let mockEventLogRepositoryService: EventLogRepositoryService
+  let mockCourtSessionStringRepositoryService: CourtSessionStringRepositoryService
   let givenWhenThen: GivenWhenThen
 
   beforeEach(async () => {
-    const { sequelize, courtSessionRepositoryService, courtSessionController } =
-      await createTestingCourtSessionModule()
+    const {
+      sequelize,
+      courtSessionRepositoryService,
+      courtDocumentRepositoryService,
+      caseRepositoryService,
+      eventLogRepositoryService,
+      courtSessionStringRepositoryService,
+      courtSessionController,
+    } = await createTestingCourtSessionModule()
 
     const mockTransaction = sequelize.transaction as jest.Mock
     transaction = {} as Transaction
@@ -35,8 +62,20 @@ describe('CourtSessionController - Create', () => {
     )
 
     mockCourtSessionRepositoryService = courtSessionRepositoryService
+    mockCourtDocumentRepositoryService = courtDocumentRepositoryService
+    mockCaseRepositoryService = caseRepositoryService
+    mockEventLogRepositoryService = eventLogRepositoryService
+    mockCourtSessionStringRepositoryService =
+      courtSessionStringRepositoryService
+
     const mockCreate = mockCourtSessionRepositoryService.create as jest.Mock
-    mockCreate.mockRejectedValue(new Error('Failed to create court session'))
+    mockCreate.mockResolvedValue(createdCourtSession)
+    const mockUpdateMergedCourtDocuments =
+      mockCourtDocumentRepositoryService.updateMergedCourtDocuments as jest.Mock
+    mockUpdateMergedCourtDocuments.mockResolvedValue(false)
+    const mockFindLatestForCaseAndTypes =
+      mockEventLogRepositoryService.findLatestForCaseAndTypes as jest.Mock
+    mockFindLatestForCaseAndTypes.mockResolvedValue(null)
 
     givenWhenThen = async (caseId: string) => {
       const then = {} as Then
@@ -55,16 +94,9 @@ describe('CourtSessionController - Create', () => {
   })
 
   describe('court session created', () => {
-    const createdCourtSession = {
-      id: courtSessionId,
-      caseId,
-    }
     let then: Then
 
     beforeEach(async () => {
-      const mockCreate = mockCourtSessionRepositoryService.create as jest.Mock
-      mockCreate.mockResolvedValueOnce(createdCourtSession)
-
       then = await givenWhenThen(caseId)
     })
 
@@ -75,18 +107,172 @@ describe('CourtSessionController - Create', () => {
       )
       expect(then.result).toBe(createdCourtSession)
     })
+
+    it('should file the available court documents in the new session', () => {
+      expect(
+        mockCourtDocumentRepositoryService.fileAllAvailableCourtDocumentsInCourtSession,
+      ).toHaveBeenCalledWith(caseId, courtSessionId, { transaction })
+    })
+
+    it('should look for cases merged into the case', () => {
+      expect(
+        mockCaseRepositoryService.findAllMergedToCase,
+      ).toHaveBeenCalledWith(caseId, { transaction })
+    })
+
+    it('should record no merged case when there is none', () => {
+      expect(
+        mockCourtDocumentRepositoryService.updateMergedCourtDocuments,
+      ).not.toHaveBeenCalled()
+      expect(
+        mockCourtSessionStringRepositoryService.create,
+      ).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('cases have been merged into the case', () => {
+    const olderMergedCase = {
+      id: uuid(),
+      courtCaseNumber: 'S-1/2026',
+    } as Case
+    const newerMergedCase = {
+      id: uuid(),
+      courtCaseNumber: 'S-2/2026',
+    } as Case
+    const indictmentConfirmed = new Date('2026-02-03T10:00:00.000Z')
+
+    beforeEach(async () => {
+      const mockFindAllMergedToCase =
+        mockCaseRepositoryService.findAllMergedToCase as jest.Mock
+      mockFindAllMergedToCase.mockResolvedValue([
+        olderMergedCase,
+        newerMergedCase,
+      ])
+      // The older case has documents to file, the newer has none left.
+      const mockUpdateMergedCourtDocuments =
+        mockCourtDocumentRepositoryService.updateMergedCourtDocuments as jest.Mock
+      mockUpdateMergedCourtDocuments.mockImplementation(
+        async ({ caseId: mergedCaseId }: { caseId: string }) =>
+          mergedCaseId === olderMergedCase.id,
+      )
+      const mockFindLatestForCaseAndTypes =
+        mockEventLogRepositoryService.findLatestForCaseAndTypes as jest.Mock
+      mockFindLatestForCaseAndTypes.mockResolvedValue({
+        created: indictmentConfirmed,
+      } as EventLog)
+
+      await givenWhenThen(caseId)
+    })
+
+    it('should file each merged case into the new session, oldest merge first', () => {
+      expect(
+        mockCourtDocumentRepositoryService.updateMergedCourtDocuments,
+      ).toHaveBeenNthCalledWith(1, {
+        parentCaseId: caseId,
+        parentCaseCourtSessionId: courtSessionId,
+        caseId: olderMergedCase.id,
+        transaction,
+      })
+      expect(
+        mockCourtDocumentRepositoryService.updateMergedCourtDocuments,
+      ).toHaveBeenNthCalledWith(2, {
+        parentCaseId: caseId,
+        parentCaseCourtSessionId: courtSessionId,
+        caseId: newerMergedCase.id,
+        transaction,
+      })
+    })
+
+    it('should date the entries by when the merged case was confirmed or sent to court', () => {
+      expect(
+        mockEventLogRepositoryService.findLatestForCaseAndTypes,
+      ).toHaveBeenCalledWith(
+        olderMergedCase.id,
+        [EventType.CASE_SENT_TO_COURT, EventType.INDICTMENT_CONFIRMED],
+        { transaction },
+      )
+    })
+
+    it('should record the merged case in the entries of the session', () => {
+      expect(
+        mockCourtSessionStringRepositoryService.create,
+      ).toHaveBeenCalledTimes(1)
+      expect(
+        mockCourtSessionStringRepositoryService.create,
+      ).toHaveBeenCalledWith(
+        {
+          caseId,
+          courtSessionId,
+          mergedCaseId: olderMergedCase.id,
+          stringType: CourtSessionStringType.ENTRIES,
+          value: `Mál nr. S-1/2026 sem var höfðað á hendur ákærða með ákæru útgefinni ${formatDate(
+            indictmentConfirmed,
+            'PPP',
+          )}, er nú einnig tekið fyrir og það sameinað þessu máli, sbr. heimild í 1. mgr. 169. gr. laga nr. 88/2008 um meðferð sakamála, og verða þau eftirleiðis rekin undir málsnúmeri þessa máls.`,
+        },
+        { transaction },
+      )
+    })
+
+    it('should file the case documents before the merged cases', () => {
+      const fileAll =
+        mockCourtDocumentRepositoryService.fileAllAvailableCourtDocumentsInCourtSession as jest.Mock
+      const updateMerged =
+        mockCourtDocumentRepositoryService.updateMergedCourtDocuments as jest.Mock
+
+      expect(fileAll.mock.invocationCallOrder[0]).toBeLessThan(
+        updateMerged.mock.invocationCallOrder[0],
+      )
+    })
+  })
+
+  describe('a merged case has no confirmation or sending event', () => {
+    const mergedCase = { id: uuid(), courtCaseNumber: 'S-3/2026' } as Case
+
+    beforeEach(async () => {
+      const mockFindAllMergedToCase =
+        mockCaseRepositoryService.findAllMergedToCase as jest.Mock
+      mockFindAllMergedToCase.mockResolvedValue([mergedCase])
+      const mockUpdateMergedCourtDocuments =
+        mockCourtDocumentRepositoryService.updateMergedCourtDocuments as jest.Mock
+      mockUpdateMergedCourtDocuments.mockResolvedValue(true)
+
+      await givenWhenThen(caseId)
+    })
+
+    it('should record the merged case without a date', () => {
+      expect(
+        mockCourtSessionStringRepositoryService.create,
+      ).toHaveBeenCalledWith(
+        expect.objectContaining({
+          mergedCaseId: mergedCase.id,
+          value:
+            'Mál nr. S-3/2026 sem var höfðað á hendur ákærða, er nú einnig tekið fyrir og það sameinað þessu máli, sbr. heimild í 1. mgr. 169. gr. laga nr. 88/2008 um meðferð sakamála, og verða þau eftirleiðis rekin undir málsnúmeri þessa máls.',
+        }),
+        { transaction },
+      )
+    })
   })
 
   describe('court session creation fails', () => {
     let then: Then
 
     beforeEach(async () => {
+      const mockCreate = mockCourtSessionRepositoryService.create as jest.Mock
+      mockCreate.mockRejectedValue(new Error('Failed to create court session'))
+
       then = await givenWhenThen(caseId)
     })
 
     it('should throw Error', () => {
       expect(then.error).toBeInstanceOf(Error)
       expect(then.error.message).toBe('Failed to create court session')
+    })
+
+    it('should file nothing', () => {
+      expect(
+        mockCourtDocumentRepositoryService.fileAllAvailableCourtDocumentsInCourtSession,
+      ).not.toHaveBeenCalled()
     })
   })
 })

--- a/apps/judicial-system/backend/src/app/modules/court-session/test/courtSessionController/delete.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/court-session/test/courtSessionController/delete.spec.ts
@@ -1,7 +1,10 @@
 import { Transaction } from 'sequelize'
 import { v4 as uuid } from 'uuid'
 
-import { BadRequestException } from '@nestjs/common'
+import {
+  BadRequestException,
+  InternalServerErrorException,
+} from '@nestjs/common'
 
 import {
   AppealCaseState,
@@ -16,8 +19,10 @@ import {
   AppealCaseRepositoryService,
   Case,
   CaseFile,
+  CourtDocumentRepositoryService,
   CourtSession,
   CourtSessionRepositoryService,
+  CourtSessionStringRepositoryService,
 } from '../../../repository'
 
 interface Then {
@@ -25,9 +30,11 @@ interface Then {
   error: Error
 }
 
-// Deleting a court session takes its account of the session's ruling with it. A
-// ruling that was only ever pronounced orally there has nothing left holding it
-// up, so it goes too - unlike one the district court has since written up.
+// Only the latest court session can be deleted, and it is emptied first - its
+// documents return to the case, its strings go - before the row does. Deleting
+// it also takes its account of the session's ruling with it. A ruling that was
+// only ever pronounced orally there has nothing left holding it up, so it goes
+// too - unlike one the district court has since written up.
 describe('CourtSessionController - Delete', () => {
   const caseId = uuid()
   const courtSessionId = uuid()
@@ -38,6 +45,8 @@ describe('CourtSessionController - Delete', () => {
   let sessionsPronouncing: CourtSession[] = []
 
   let mockCourtSessionRepositoryService: CourtSessionRepositoryService
+  let mockCourtDocumentRepositoryService: CourtDocumentRepositoryService
+  let mockCourtSessionStringRepositoryService: CourtSessionStringRepositoryService
   let mockAppealCaseRepositoryService: AppealCaseRepositoryService
   let mockFileService: FileService
   let transaction: Transaction
@@ -50,6 +59,8 @@ describe('CourtSessionController - Delete', () => {
     const {
       sequelize,
       courtSessionRepositoryService,
+      courtDocumentRepositoryService,
+      courtSessionStringRepositoryService,
       appealCaseRepositoryService,
       fileService,
       courtSessionController,
@@ -62,8 +73,18 @@ describe('CourtSessionController - Delete', () => {
     )
 
     mockCourtSessionRepositoryService = courtSessionRepositoryService
+    mockCourtDocumentRepositoryService = courtDocumentRepositoryService
+    mockCourtSessionStringRepositoryService =
+      courtSessionStringRepositoryService
     mockAppealCaseRepositoryService = appealCaseRepositoryService
     mockFileService = fileService
+    // Which session is the latest is read from the transaction, so the stub
+    // answers with the last of the sessions the test set up on the case.
+    ;(
+      mockCourtSessionRepositoryService.findLatestByCase as jest.Mock
+    ).mockImplementation(
+      async () => sessionsPronouncing[sessionsPronouncing.length - 1] ?? null,
+    )
     // The cleanup reads the ruling from the transaction, so the stub resolves it
     // the way the database would.
     ;(mockFileService.findByIdOrNull as jest.Mock).mockImplementation(
@@ -158,6 +179,87 @@ describe('CourtSessionController - Delete', () => {
         transaction,
       )
     })
+
+    it('should check it is the latest session against the transaction', () => {
+      expect(
+        mockCourtSessionRepositoryService.findLatestByCase,
+      ).toHaveBeenCalledWith(caseId, { transaction })
+    })
+
+    it('should empty the session before deleting it: documents, then strings, then the row', () => {
+      const removeDocuments =
+        mockCourtDocumentRepositoryService.removeAllCourtDocumentsFromCourtSession as jest.Mock
+      const deleteStrings =
+        mockCourtSessionStringRepositoryService.deleteAllForCourtSession as jest.Mock
+      const deleteRow = mockCourtSessionRepositoryService.delete as jest.Mock
+
+      expect(removeDocuments).toHaveBeenCalledWith(
+        caseId,
+        courtSessionId,
+        transaction,
+      )
+      expect(deleteStrings).toHaveBeenCalledWith(caseId, courtSessionId, {
+        transaction,
+      })
+      expect(removeDocuments.mock.invocationCallOrder[0]).toBeLessThan(
+        deleteStrings.mock.invocationCallOrder[0],
+      )
+      expect(deleteStrings.mock.invocationCallOrder[0]).toBeLessThan(
+        deleteRow.mock.invocationCallOrder[0],
+      )
+    })
+  })
+
+  // The controller checks the same rule against the guard's snapshot of the
+  // case; this is the check against the transaction's view, which is the one
+  // that holds when two requests race.
+  describe('session that is no longer the latest', () => {
+    let then: Then
+
+    beforeEach(async () => {
+      ;(
+        mockCourtSessionRepositoryService.findLatestByCase as jest.Mock
+      ).mockResolvedValue({ id: uuid(), caseId } as CourtSession)
+
+      then = await deleteSessionPronouncing()
+    })
+
+    it('should refuse to delete the session', () => {
+      expect(then.error).toBeInstanceOf(InternalServerErrorException)
+      expect(then.error.message).toBe(
+        `Only the latest court session of case ${caseId} can be deleted`,
+      )
+    })
+
+    it('should touch nothing', () => {
+      expect(
+        mockCourtDocumentRepositoryService.removeAllCourtDocumentsFromCourtSession,
+      ).not.toHaveBeenCalled()
+      expect(
+        mockCourtSessionStringRepositoryService.deleteAllForCourtSession,
+      ).not.toHaveBeenCalled()
+      expect(mockCourtSessionRepositoryService.delete).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('case has no sessions in the transaction', () => {
+    let then: Then
+
+    beforeEach(async () => {
+      ;(
+        mockCourtSessionRepositoryService.findLatestByCase as jest.Mock
+      ).mockResolvedValue(null)
+
+      then = await deleteSessionPronouncing()
+    })
+
+    it('should refuse to delete the session', () => {
+      expect(then.error).toBeInstanceOf(InternalServerErrorException)
+      expect(then.error.message).toBe(
+        `Could not find court session ${courtSessionId} of case ${caseId}`,
+      )
+      expect(mockCourtSessionRepositoryService.delete).not.toHaveBeenCalled()
+    })
   })
 
   // Deleting the session would leave the appeal pointing at a ruling no court
@@ -192,6 +294,9 @@ describe('CourtSessionController - Delete', () => {
         'The ruling order pronounced in this court session has been appealed, so the court session cannot be deleted',
       )
       expect(mockCourtSessionRepositoryService.delete).not.toHaveBeenCalled()
+      expect(
+        mockCourtDocumentRepositoryService.removeAllCourtDocumentsFromCourtSession,
+      ).not.toHaveBeenCalled()
     })
 
     it('should leave the ruling alone', () => {

--- a/apps/judicial-system/backend/src/app/modules/court-session/test/courtSessionService/addMergedCaseToLatestCourtSession.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/court-session/test/courtSessionService/addMergedCaseToLatestCourtSession.spec.ts
@@ -1,0 +1,224 @@
+import { Transaction } from 'sequelize'
+import { v4 as uuid } from 'uuid'
+
+import { InternalServerErrorException } from '@nestjs/common'
+
+import {
+  CourtSessionStringType,
+  EventType,
+} from '@island.is/judicial-system/types'
+
+import { createTestingCourtSessionModule } from '../createTestingCourtSessionModule'
+
+import {
+  Case,
+  CaseRepositoryService,
+  CourtDocumentRepositoryService,
+  CourtSession,
+  CourtSessionRepositoryService,
+  CourtSessionStringRepositoryService,
+  EventLogRepositoryService,
+} from '../../../repository'
+
+interface Then {
+  result: CourtSession
+  error: Error
+}
+
+type GivenWhenThen = () => Promise<Then>
+
+// Reached from CaseService.update when an indictment case completes by merging
+// into a parent case whose latest court session is still open: the merged
+// case joins that session. A confirmed session's record is final, so the merge
+// must not reach back into it.
+describe('CourtSessionService - Add merged case to latest court session', () => {
+  const caseId = uuid()
+  const mergedCaseId = uuid()
+  const courtSessionId = uuid()
+  const transaction = {} as Transaction
+  const mergedCase = { id: mergedCaseId, courtCaseNumber: 'S-9/2026' } as Case
+
+  let mockCourtSessionRepositoryService: CourtSessionRepositoryService
+  let mockCaseRepositoryService: CaseRepositoryService
+  let mockCourtDocumentRepositoryService: CourtDocumentRepositoryService
+  let mockEventLogRepositoryService: EventLogRepositoryService
+  let mockCourtSessionStringRepositoryService: CourtSessionStringRepositoryService
+  let givenWhenThen: GivenWhenThen
+
+  beforeEach(async () => {
+    const {
+      courtSessionRepositoryService,
+      caseRepositoryService,
+      courtDocumentRepositoryService,
+      eventLogRepositoryService,
+      courtSessionStringRepositoryService,
+      courtSessionService,
+    } = await createTestingCourtSessionModule()
+
+    mockCourtSessionRepositoryService = courtSessionRepositoryService
+    mockCaseRepositoryService = caseRepositoryService
+    mockCourtDocumentRepositoryService = courtDocumentRepositoryService
+    mockEventLogRepositoryService = eventLogRepositoryService
+    mockCourtSessionStringRepositoryService =
+      courtSessionStringRepositoryService
+
+    const mockFindLatestByCase =
+      mockCourtSessionRepositoryService.findLatestByCase as jest.Mock
+    mockFindLatestByCase.mockResolvedValue({
+      id: courtSessionId,
+      isConfirmed: false,
+    } as CourtSession)
+    const mockFindById = mockCaseRepositoryService.findById as jest.Mock
+    mockFindById.mockResolvedValue(mergedCase)
+    const mockUpdateMergedCourtDocuments =
+      mockCourtDocumentRepositoryService.updateMergedCourtDocuments as jest.Mock
+    mockUpdateMergedCourtDocuments.mockResolvedValue(true)
+    const mockFindLatestForCaseAndTypes =
+      mockEventLogRepositoryService.findLatestForCaseAndTypes as jest.Mock
+    mockFindLatestForCaseAndTypes.mockResolvedValue(null)
+
+    givenWhenThen = async () => {
+      const then = {} as Then
+
+      try {
+        then.result =
+          await courtSessionService.addMergedCaseToLatestCourtSession(
+            caseId,
+            mergedCaseId,
+            transaction,
+          )
+      } catch (error) {
+        then.error = error as Error
+      }
+
+      return then
+    }
+  })
+
+  describe('latest court session is open', () => {
+    let then: Then
+
+    beforeEach(async () => {
+      then = await givenWhenThen()
+    })
+
+    it('should read the latest session and the merged case in the transaction', () => {
+      expect(
+        mockCourtSessionRepositoryService.findLatestByCase,
+      ).toHaveBeenCalledWith(caseId, { transaction })
+      expect(mockCaseRepositoryService.findById).toHaveBeenCalledWith(
+        mergedCaseId,
+        { transaction },
+      )
+    })
+
+    it('should file the merged case documents into the latest session', () => {
+      expect(
+        mockCourtDocumentRepositoryService.updateMergedCourtDocuments,
+      ).toHaveBeenCalledWith({
+        parentCaseId: caseId,
+        parentCaseCourtSessionId: courtSessionId,
+        caseId: mergedCaseId,
+        transaction,
+      })
+    })
+
+    it('should record the merged case in the entries of the session', () => {
+      expect(
+        mockEventLogRepositoryService.findLatestForCaseAndTypes,
+      ).toHaveBeenCalledWith(
+        mergedCaseId,
+        [EventType.CASE_SENT_TO_COURT, EventType.INDICTMENT_CONFIRMED],
+        { transaction },
+      )
+      expect(
+        mockCourtSessionStringRepositoryService.create,
+      ).toHaveBeenCalledWith(
+        expect.objectContaining({
+          caseId,
+          courtSessionId,
+          mergedCaseId,
+          stringType: CourtSessionStringType.ENTRIES,
+          value: expect.stringContaining('Mál nr. S-9/2026'),
+        }),
+        { transaction },
+      )
+    })
+
+    it('should return the latest session', () => {
+      expect(then.result).toEqual({ id: courtSessionId, isConfirmed: false })
+    })
+  })
+
+  describe('merged case has no documents left to file', () => {
+    beforeEach(async () => {
+      const mockUpdateMergedCourtDocuments =
+        mockCourtDocumentRepositoryService.updateMergedCourtDocuments as jest.Mock
+      mockUpdateMergedCourtDocuments.mockResolvedValue(false)
+
+      await givenWhenThen()
+    })
+
+    it('should not add entries for it', () => {
+      expect(
+        mockEventLogRepositoryService.findLatestForCaseAndTypes,
+      ).not.toHaveBeenCalled()
+      expect(
+        mockCourtSessionStringRepositoryService.create,
+      ).not.toHaveBeenCalled()
+    })
+  })
+
+  describe.each([
+    ['is confirmed', { id: courtSessionId, isConfirmed: true }],
+    ['does not exist', null],
+  ])('latest court session %s', (_name, latestCourtSession) => {
+    let then: Then
+
+    beforeEach(async () => {
+      const mockFindLatestByCase =
+        mockCourtSessionRepositoryService.findLatestByCase as jest.Mock
+      mockFindLatestByCase.mockResolvedValue(latestCourtSession)
+
+      then = await givenWhenThen()
+    })
+
+    it('should refuse the merge', () => {
+      expect(then.error).toBeInstanceOf(InternalServerErrorException)
+      expect(then.error.message).toBe(
+        `The latest court session of case ${caseId} must not be confirmed when adding merged case ${mergedCaseId}`,
+      )
+    })
+
+    it('should touch nothing', () => {
+      expect(mockCaseRepositoryService.findById).not.toHaveBeenCalled()
+      expect(
+        mockCourtDocumentRepositoryService.updateMergedCourtDocuments,
+      ).not.toHaveBeenCalled()
+      expect(
+        mockCourtSessionStringRepositoryService.create,
+      ).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('merged case does not exist', () => {
+    let then: Then
+
+    beforeEach(async () => {
+      const mockFindById = mockCaseRepositoryService.findById as jest.Mock
+      mockFindById.mockResolvedValue(null)
+
+      then = await givenWhenThen()
+    })
+
+    it('should refuse the merge', () => {
+      expect(then.error).toBeInstanceOf(InternalServerErrorException)
+      expect(then.error.message).toBe(
+        `Could not find case ${mergedCaseId} when adding it as a merged case to the latest court session of case ${caseId}`,
+      )
+      expect(
+        mockCourtDocumentRepositoryService.updateMergedCourtDocuments,
+      ).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/apps/judicial-system/backend/src/app/modules/court-session/test/createTestingCourtSessionModule.ts
+++ b/apps/judicial-system/backend/src/app/modules/court-session/test/createTestingCourtSessionModule.ts
@@ -11,8 +11,11 @@ import {
   AppealCaseRepositoryService,
   AppealDecisionRepositoryService,
   AppealEventLogRepositoryService,
+  CaseRepositoryService,
+  CourtDocumentRepositoryService,
   CourtSessionRepositoryService,
   CourtSessionStringRepositoryService,
+  EventLogRepositoryService,
 } from '../../repository'
 import { CourtSessionController } from '../courtSession.controller'
 import { CourtSessionService } from '../courtSession.service'
@@ -21,6 +24,9 @@ jest.mock('../../repository/services/courtSessionRepository.service')
 jest.mock('../../repository/services/appealDecisionRepository.service')
 jest.mock('../../repository/services/appealCaseRepository.service')
 jest.mock('../../repository/services/appealEventLogRepository.service')
+jest.mock('../../repository/services/caseRepository.service')
+jest.mock('../../repository/services/courtDocumentRepository.service')
+jest.mock('../../repository/services/eventLogRepository.service')
 
 export const createTestingCourtSessionModule = async () => {
   const courtSessionModule = await Test.createTestingModule({
@@ -30,6 +36,9 @@ export const createTestingCourtSessionModule = async () => {
       AppealDecisionRepositoryService,
       AppealCaseRepositoryService,
       AppealEventLogRepositoryService,
+      CaseRepositoryService,
+      CourtDocumentRepositoryService,
+      EventLogRepositoryService,
       {
         provide: LOGGER_PROVIDER,
         useValue: {
@@ -45,6 +54,7 @@ export const createTestingCourtSessionModule = async () => {
           findByKey: jest.fn(),
           updateByKey: jest.fn(),
           create: jest.fn(),
+          deleteAllForCourtSession: jest.fn(),
         },
       },
       { provide: Sequelize, useValue: { transaction: jest.fn() } },
@@ -80,10 +90,30 @@ export const createTestingCourtSessionModule = async () => {
       AppealEventLogRepositoryService,
     )
 
+  const caseRepositoryService = courtSessionModule.get<CaseRepositoryService>(
+    CaseRepositoryService,
+  )
+
+  const courtDocumentRepositoryService =
+    courtSessionModule.get<CourtDocumentRepositoryService>(
+      CourtDocumentRepositoryService,
+    )
+
+  const eventLogRepositoryService =
+    courtSessionModule.get<EventLogRepositoryService>(EventLogRepositoryService)
+
+  const courtSessionStringRepositoryService =
+    courtSessionModule.get<CourtSessionStringRepositoryService>(
+      CourtSessionStringRepositoryService,
+    )
+
   const fileService = courtSessionModule.get<FileService>(FileService)
 
   const eventLogService =
     courtSessionModule.get<EventLogService>(EventLogService)
+
+  const courtSessionService =
+    courtSessionModule.get<CourtSessionService>(CourtSessionService)
 
   const courtSessionController = courtSessionModule.get<CourtSessionController>(
     CourtSessionController,
@@ -95,6 +125,10 @@ export const createTestingCourtSessionModule = async () => {
   // Same for the appeal cases the ruling-order cleanup checks before deleting a
   // ruling that was only ever pronounced orally.
   ;(appealCaseRepositoryService.findAll as jest.Mock).mockResolvedValue([])
+  // A new session records the cases merged into the case; default to none.
+  ;(caseRepositoryService.findAllMergedToCase as jest.Mock).mockResolvedValue(
+    [],
+  )
 
   courtSessionModule.close()
 
@@ -104,8 +138,13 @@ export const createTestingCourtSessionModule = async () => {
     appealDecisionRepositoryService,
     appealCaseRepositoryService,
     appealEventLogRepositoryService,
+    caseRepositoryService,
+    courtDocumentRepositoryService,
+    eventLogRepositoryService,
+    courtSessionStringRepositoryService,
     fileService,
     eventLogService,
+    courtSessionService,
     courtSessionController,
   }
 }

--- a/apps/judicial-system/backend/src/app/modules/repository/services/caseRepository.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/repository/services/caseRepository.service.ts
@@ -209,6 +209,41 @@ export class CaseRepositoryService {
     }
   }
 
+  // The cases merged into a given case, oldest merge first. Read through the
+  // aggregate's own path so each merged case carries its police case numbers.
+  async findAllMergedToCase(
+    caseId: string,
+    options?: { transaction?: Transaction },
+  ): Promise<Case[]> {
+    try {
+      this.logger.debug(`Finding cases merged into case ${caseId}`)
+
+      const results = await this.caseModel.findAll({
+        where: { mergeCaseId: caseId },
+        order: [['created', 'ASC']],
+        transaction: options?.transaction,
+      })
+
+      this.logger.debug(
+        `Found ${results.length} cases merged into case ${caseId}`,
+      )
+
+      if (results.length > 0) {
+        await this.resolvePoliceCaseNumbersForCaseGraph(results, {
+          transaction: options?.transaction,
+        })
+      }
+
+      return results
+    } catch (error) {
+      this.logger.error(`Error finding cases merged into case ${caseId}:`, {
+        error,
+      })
+
+      throw error
+    }
+  }
+
   async findParentCaseId(id: string): Promise<string | null | undefined> {
     const result = await this.caseModel.findByPk(id, {
       attributes: ['parentCaseId'],

--- a/apps/judicial-system/backend/src/app/modules/repository/services/courtSessionRepository.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/repository/services/courtSessionRepository.service.ts
@@ -9,19 +9,9 @@ import { InjectModel } from '@nestjs/sequelize'
 
 import { type Logger, LOGGER_PROVIDER } from '@island.is/logging'
 
-import { formatDate } from '@island.is/judicial-system/formatters'
-import {
-  CourtSessionRulingType,
-  CourtSessionStringType,
-  EventType,
-} from '@island.is/judicial-system/types'
+import { CourtSessionRulingType } from '@island.is/judicial-system/types'
 
-import { Case } from '../models/case.model'
 import { CourtSession } from '../models/courtSession.model'
-import { CourtSessionString } from '../models/courtSessionString.model'
-import { EventLog } from '../models/eventLog.model'
-import { CaseDefendantPoliceCaseNumberRepositoryService } from './caseDefendantPoliceCaseNumber.repository.service'
-import { CourtDocumentRepositoryService } from './courtDocumentRepository.service'
 
 interface FindByIdOptions {
   transaction?: Transaction
@@ -64,14 +54,8 @@ export interface UpdateCourtSession {
 @Injectable()
 export class CourtSessionRepositoryService {
   constructor(
-    @InjectModel(EventLog) private readonly eventLogModel: typeof EventLog,
-    @InjectModel(Case) private readonly caseModel: typeof Case,
-    @InjectModel(CourtSessionString)
-    private readonly courtSessionStringModel: typeof CourtSessionString,
     @InjectModel(CourtSession)
     private readonly courtSessionModel: typeof CourtSession,
-    private readonly courtDocumentRepositoryService: CourtDocumentRepositoryService,
-    private readonly caseDefendantPoliceCaseNumberRepositoryService: CaseDefendantPoliceCaseNumberRepositoryService,
     @Inject(LOGGER_PROVIDER) private readonly logger: Logger,
   ) {}
 
@@ -141,6 +125,40 @@ export class CourtSessionRepositoryService {
     }
   }
 
+  // The latest court session of a case, read from the caller's transaction.
+  // Whether it may still be added to or deleted is the caller's rule to apply.
+  async findLatestByCase(
+    caseId: string,
+    options?: { transaction?: Transaction },
+  ): Promise<CourtSession | null> {
+    try {
+      this.logger.debug(`Finding the latest court session of case ${caseId}`)
+
+      const result = await this.courtSessionModel.findOne({
+        where: { caseId },
+        order: [['created', 'DESC']],
+        ...(options?.transaction ? { transaction: options.transaction } : {}),
+      })
+
+      this.logger.debug(
+        `Latest court session of case ${caseId} ${
+          result ? 'found' : 'not found'
+        }`,
+      )
+
+      return result
+    } catch (error) {
+      this.logger.error(
+        `Error finding the latest court session of case ${caseId}:`,
+        { error },
+      )
+
+      throw error
+    }
+  }
+
+  // Creates the court session row only. Filing the case's court documents in
+  // it and recording its merged cases is CourtSessionService's sequence.
   async create(
     caseId: string,
     options: CreateCourtSessionOptions,
@@ -152,37 +170,6 @@ export class CourtSessionRepositoryService {
         { caseId },
         options,
       )
-
-      const transaction = options.transaction
-
-      await this.courtDocumentRepositoryService.fileAllAvailableCourtDocumentsInCourtSession(
-        caseId,
-        courtSession.id,
-        { transaction },
-      )
-
-      // File all unfiled merged documents
-      const mergedCases = await this.caseModel.findAll({
-        where: { mergeCaseId: caseId },
-        order: [['created', 'ASC']],
-        transaction,
-      })
-
-      if (mergedCases.length > 0) {
-        await this.caseDefendantPoliceCaseNumberRepositoryService.resolvePoliceCaseNumbersForCases(
-          mergedCases,
-          { transaction },
-        )
-      }
-
-      for (const mergedCase of mergedCases) {
-        await this.addMergedCaseToCourtSession(
-          caseId,
-          courtSession.id,
-          mergedCase,
-          transaction,
-        )
-      }
 
       this.logger.debug(
         `Created a new court session ${courtSession.id} for case ${caseId}`,
@@ -251,111 +238,8 @@ export class CourtSessionRepositoryService {
     }
   }
 
-  async addMergedCaseToLatestCourtSession(
-    caseId: string,
-    mergedCaseId: string,
-    options: UpdateCourtSessionOptions,
-  ) {
-    try {
-      this.logger.debug(
-        `Adding merged case ${mergedCaseId} to latest court session of case ${caseId}`,
-      )
-
-      const transaction = options.transaction
-
-      const latestCourtSession = await this.courtSessionModel.findOne({
-        where: { caseId },
-        order: [['created', 'DESC']],
-        transaction,
-      })
-
-      if (!latestCourtSession || latestCourtSession.isConfirmed) {
-        throw new InternalServerErrorException(
-          `The latest court session of case ${caseId} must not be confirmed when adding merged case ${mergedCaseId}`,
-        )
-      }
-
-      const mergedCase = await this.caseModel.findByPk(mergedCaseId, {
-        transaction,
-      })
-
-      if (!mergedCase) {
-        throw new InternalServerErrorException(
-          `Could not find case ${mergedCaseId} when adding it as a merged case to the latest court session of case ${caseId}`,
-        )
-      }
-
-      await this.caseDefendantPoliceCaseNumberRepositoryService.resolvePoliceCaseNumbersForCases(
-        [mergedCase],
-        { transaction },
-      )
-
-      await this.addMergedCaseToCourtSession(
-        caseId,
-        latestCourtSession.id,
-        mergedCase,
-        transaction,
-      )
-
-      return latestCourtSession
-    } catch (error) {
-      this.logger.error(
-        `Error adding merged case ${mergedCaseId} to latest court session of case ${caseId}`,
-        { error },
-      )
-
-      throw error
-    }
-  }
-
-  private async addMergedCaseToCourtSession(
-    caseId: string,
-    courtSessionId: string,
-    mergedCase: Case,
-    transaction: Transaction,
-  ) {
-    const added =
-      await this.courtDocumentRepositoryService.updateMergedCourtDocuments({
-        parentCaseId: caseId,
-        parentCaseCourtSessionId: courtSessionId,
-        caseId: mergedCase.id,
-        transaction,
-      })
-
-    if (!added) {
-      return
-    }
-
-    const event = await this.eventLogModel.findOne({
-      where: {
-        caseId: mergedCase.id,
-        eventType: [
-          EventType.CASE_SENT_TO_COURT,
-          EventType.INDICTMENT_CONFIRMED,
-        ],
-      },
-      order: [['created', 'DESC']],
-      transaction,
-    })
-
-    await this.courtSessionStringModel.create(
-      {
-        caseId,
-        courtSessionId,
-        mergedCaseId: mergedCase.id,
-        stringType: CourtSessionStringType.ENTRIES,
-        value: `Mál nr. ${
-          mergedCase.courtCaseNumber
-        } sem var höfðað á hendur ákærða${
-          event
-            ? ` með ákæru útgefinni ${formatDate(event.created, 'PPP')}`
-            : ''
-        }, er nú einnig tekið fyrir og það sameinað þessu máli, sbr. heimild í 1. mgr. 169. gr. laga nr. 88/2008 um meðferð sakamála, og verða þau eftirleiðis rekin undir málsnúmeri þessa máls.`,
-      },
-      { transaction },
-    )
-  }
-
+  // Deletes the court session row only. The caller has already emptied the
+  // session - its court documents and strings - and checked it is the latest.
   async delete(
     caseId: string,
     courtSessionId: string,
@@ -366,41 +250,23 @@ export class CourtSessionRepositoryService {
         `Deleting court session ${courtSessionId} of case ${caseId}`,
       )
 
-      const transaction = options.transaction
-
-      const courtSession = await this.courtSessionModel.findOne({
-        where: { caseId },
-        order: [['created', 'DESC']],
-        transaction,
+      const numberOfDeletedRows = await this.courtSessionModel.destroy({
+        where: { id: courtSessionId, caseId },
+        transaction: options.transaction,
       })
 
-      if (!courtSession) {
+      if (numberOfDeletedRows < 1) {
         throw new InternalServerErrorException(
-          `Could not find court session ${courtSessionId} of case ${caseId}`,
+          `Could not delete court session ${courtSessionId} of case ${caseId}`,
         )
       }
 
-      if (courtSession.id !== courtSessionId) {
-        throw new InternalServerErrorException(
-          `Only the latest court session of case ${caseId} can be deleted`,
+      if (numberOfDeletedRows > 1) {
+        // Tolerate failure, but log error
+        this.logger.error(
+          `Unexpected number of rows (${numberOfDeletedRows}) affected when deleting court session ${courtSessionId} of case ${caseId}`,
         )
       }
-
-      // First delete all documents in the session
-      await this.courtDocumentRepositoryService.removeAllCourtDocumentsFromCourtSession(
-        caseId,
-        courtSessionId,
-        transaction,
-      )
-
-      // Then delete all strings in the session
-      await this.courtSessionStringModel.destroy({
-        where: { caseId, courtSessionId },
-        transaction,
-      })
-
-      // Then delete the session itself
-      await this.deleteFromDatabase(caseId, courtSessionId, transaction)
 
       this.logger.debug(
         `Deleted court session ${courtSessionId} of case ${caseId}`,
@@ -412,30 +278,6 @@ export class CourtSessionRepositoryService {
       )
 
       throw error
-    }
-  }
-
-  private async deleteFromDatabase(
-    caseId: string,
-    courtSessionId: string,
-    transaction: Transaction,
-  ) {
-    const numberOfDeletedRows = await this.courtSessionModel.destroy({
-      where: { id: courtSessionId, caseId },
-      transaction,
-    })
-
-    if (numberOfDeletedRows < 1) {
-      throw new InternalServerErrorException(
-        `Could not delete court session ${courtSessionId} of case ${caseId}`,
-      )
-    }
-
-    if (numberOfDeletedRows > 1) {
-      // Tolerate failure, but log error
-      this.logger.error(
-        `Unexpected number of rows (${numberOfDeletedRows}) affected when deleting court session ${courtSessionId} of case ${caseId}`,
-      )
     }
   }
 }

--- a/apps/judicial-system/backend/src/app/modules/repository/services/courtSessionStringRepository.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/repository/services/courtSessionStringRepository.service.ts
@@ -144,4 +144,36 @@ export class CourtSessionStringRepositoryService {
       throw error
     }
   }
+
+  // Every string of a court session, the merged cases' included. Part of
+  // deleting the session; the caller sequences it before the row delete.
+  async deleteAllForCourtSession(
+    caseId: string,
+    courtSessionId: string,
+    options?: { transaction?: Transaction },
+  ): Promise<number> {
+    try {
+      this.logger.debug(
+        `Deleting all court session strings of court session ${courtSessionId} of case ${caseId}`,
+      )
+
+      const numberOfDeletedRows = await this.courtSessionStringModel.destroy({
+        where: { caseId, courtSessionId },
+        transaction: options?.transaction,
+      })
+
+      this.logger.debug(
+        `Deleted ${numberOfDeletedRows} court session strings of court session ${courtSessionId} of case ${caseId}`,
+      )
+
+      return numberOfDeletedRows
+    } catch (error) {
+      this.logger.error(
+        `Error deleting all court session strings of court session ${courtSessionId} of case ${caseId}:`,
+        { error },
+      )
+
+      throw error
+    }
+  }
 }

--- a/apps/judicial-system/backend/src/app/modules/repository/services/eventLogRepository.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/repository/services/eventLogRepository.service.ts
@@ -74,6 +74,37 @@ export class EventLogRepositoryService {
     }
   }
 
+  // The most recent event of any of the given types for a case - for
+  // instance, when an indictment was last confirmed or sent to court.
+  async findLatestForCaseAndTypes(
+    caseId: string,
+    eventTypes: EventType[],
+    options?: EventLogTransactionOptions,
+  ): Promise<EventLog | null> {
+    try {
+      this.logger.debug(
+        `Finding the latest ${eventTypes.join(
+          '/',
+        )} event log for case ${caseId}`,
+      )
+
+      return await this.eventLogModel.findOne({
+        where: { caseId, eventType: eventTypes },
+        order: [['created', 'DESC']],
+        transaction: options?.transaction,
+      })
+    } catch (error) {
+      this.logger.error(
+        `Error finding the latest ${eventTypes.join(
+          '/',
+        )} event log for case ${caseId}:`,
+        { error },
+      )
+
+      throw error
+    }
+  }
+
   async create(
     event: CreateEventLog,
     options?: EventLogTransactionOptions,

--- a/apps/judicial-system/backend/src/app/modules/repository/test/caseRepository.findAllMergedToCase.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/repository/test/caseRepository.findAllMergedToCase.spec.ts
@@ -1,0 +1,86 @@
+import { Transaction } from 'sequelize'
+import { v4 as uuid } from 'uuid'
+
+import { createTestingRepositoryModule } from './createTestingRepositoryModule'
+
+import { Case } from '../models/case.model'
+import { CaseDefendantPoliceCaseNumberRepositoryService } from '../services/caseDefendantPoliceCaseNumber.repository.service'
+import { CaseRepositoryService } from '../services/caseRepository.service'
+
+describe('CaseRepositoryService - findAllMergedToCase', () => {
+  const caseId = uuid()
+  const transaction = {} as Transaction
+
+  let caseRepositoryService: CaseRepositoryService
+  let mockCaseModel: { findAll: jest.Mock }
+  let mockResolvePoliceCaseNumbersForCases: jest.Mock
+
+  beforeEach(async () => {
+    const {
+      caseRepositoryService: service,
+      caseModel,
+      caseDefendantPoliceCaseNumberRepositoryService,
+    } = await createTestingRepositoryModule()
+
+    caseRepositoryService = service
+    mockCaseModel = caseModel as unknown as { findAll: jest.Mock }
+    mockResolvePoliceCaseNumbersForCases = (
+      caseDefendantPoliceCaseNumberRepositoryService as jest.Mocked<CaseDefendantPoliceCaseNumberRepositoryService>
+    ).resolvePoliceCaseNumbersForCases as jest.Mock
+  })
+
+  describe('cases have been merged into the case', () => {
+    const mergedCases = [{ id: uuid() }, { id: uuid() }] as Case[]
+    let result: Case[]
+
+    beforeEach(async () => {
+      mockCaseModel.findAll.mockResolvedValueOnce(mergedCases)
+
+      result = await caseRepositoryService.findAllMergedToCase(caseId, {
+        transaction,
+      })
+    })
+
+    it('should read them oldest merge first', () => {
+      expect(mockCaseModel.findAll).toHaveBeenCalledWith({
+        where: { mergeCaseId: caseId },
+        order: [['created', 'ASC']],
+        transaction,
+      })
+      expect(result).toBe(mergedCases)
+    })
+
+    // A merged case's police case numbers live in the junction table, so a
+    // caller reading through the aggregate gets them without asking.
+    it('should resolve their police case numbers', () => {
+      expect(mockResolvePoliceCaseNumbersForCases).toHaveBeenCalledWith(
+        mergedCases,
+        { transaction },
+      )
+    })
+  })
+
+  describe('nothing has been merged into the case', () => {
+    beforeEach(async () => {
+      mockCaseModel.findAll.mockResolvedValueOnce([])
+
+      await caseRepositoryService.findAllMergedToCase(caseId)
+    })
+
+    it('should not resolve police case numbers', () => {
+      expect(mockResolvePoliceCaseNumbersForCases).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('the read fails', () => {
+    const error = new Error('Some error')
+
+    it('should rethrow', async () => {
+      mockCaseModel.findAll.mockRejectedValueOnce(error)
+
+      await expect(
+        caseRepositoryService.findAllMergedToCase(caseId),
+      ).rejects.toThrow(error)
+    })
+  })
+})

--- a/apps/judicial-system/backend/src/app/modules/repository/test/courtSessionRepository.service.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/repository/test/courtSessionRepository.service.spec.ts
@@ -1,37 +1,30 @@
 import { Transaction } from 'sequelize'
 
+import { InternalServerErrorException } from '@nestjs/common'
 import { getModelToken } from '@nestjs/sequelize'
 import { Test } from '@nestjs/testing'
 
 import { LOGGER_PROVIDER } from '@island.is/logging'
 
-import { Case } from '../models/case.model'
 import { CourtSession } from '../models/courtSession.model'
-import { CourtSessionString } from '../models/courtSessionString.model'
-import { EventLog } from '../models/eventLog.model'
-import { CaseDefendantPoliceCaseNumberRepositoryService } from '../services/caseDefendantPoliceCaseNumber.repository.service'
-import { CourtDocumentRepositoryService } from '../services/courtDocumentRepository.service'
 import { CourtSessionRepositoryService } from '../services/courtSessionRepository.service'
 
+// The repository owns the court_session table and nothing else. Filing
+// documents into a new session, recording merged cases and emptying a session
+// before deleting it are CourtSessionService's sequences, not the repository's.
 describe('CourtSessionRepositoryService', () => {
+  const caseId = 'some-case-id'
+  const courtSessionId = 'some-court-session-id'
   const transaction = {} as Transaction
 
   let service: CourtSessionRepositoryService
-  let caseModel: { findAll: jest.Mock; findByPk: jest.Mock }
-  let courtSessionModel: { create: jest.Mock; findOne: jest.Mock }
-  let resolvePoliceCaseNumbersForCases: jest.Mock
+  let model: { create: jest.Mock; findOne: jest.Mock; destroy: jest.Mock }
 
   beforeEach(async () => {
-    resolvePoliceCaseNumbersForCases = jest.fn().mockResolvedValue(undefined)
-
-    caseModel = {
-      findAll: jest.fn().mockResolvedValue([]),
-      findByPk: jest.fn(),
-    }
-
-    courtSessionModel = {
-      create: jest.fn().mockResolvedValue({ id: 'session-1' }),
-      findOne: jest.fn(),
+    model = {
+      create: jest.fn().mockResolvedValue({ id: courtSessionId, caseId }),
+      findOne: jest.fn().mockResolvedValue(null),
+      destroy: jest.fn().mockResolvedValue(1),
     }
 
     const moduleRef = await Test.createTestingModule({
@@ -40,26 +33,7 @@ describe('CourtSessionRepositoryService', () => {
           provide: LOGGER_PROVIDER,
           useValue: { debug: jest.fn(), error: jest.fn() },
         },
-        { provide: getModelToken(EventLog), useValue: { findOne: jest.fn() } },
-        { provide: getModelToken(Case), useValue: caseModel },
-        {
-          provide: getModelToken(CourtSessionString),
-          useValue: { create: jest.fn().mockResolvedValue({}) },
-        },
-        { provide: getModelToken(CourtSession), useValue: courtSessionModel },
-        {
-          provide: CourtDocumentRepositoryService,
-          useValue: {
-            fileAllAvailableCourtDocumentsInCourtSession: jest
-              .fn()
-              .mockResolvedValue(undefined),
-            updateMergedCourtDocuments: jest.fn().mockResolvedValue(false),
-          },
-        },
-        {
-          provide: CaseDefendantPoliceCaseNumberRepositoryService,
-          useValue: { resolvePoliceCaseNumbersForCases },
-        },
+        { provide: getModelToken(CourtSession), useValue: model },
         CourtSessionRepositoryService,
       ],
     }).compile()
@@ -67,46 +41,76 @@ describe('CourtSessionRepositoryService', () => {
     service = moduleRef.get(CourtSessionRepositoryService)
   })
 
+  describe('findLatestByCase', () => {
+    it('reads the newest session of the case in the given transaction', async () => {
+      const courtSession = { id: courtSessionId } as CourtSession
+      model.findOne.mockResolvedValueOnce(courtSession)
+
+      const result = await service.findLatestByCase(caseId, { transaction })
+
+      expect(model.findOne).toHaveBeenCalledWith({
+        where: { caseId },
+        order: [['created', 'DESC']],
+        transaction,
+      })
+      expect(result).toBe(courtSession)
+    })
+
+    it('returns null when the case has no sessions', async () => {
+      expect(await service.findLatestByCase(caseId)).toBeNull()
+    })
+
+    it('rethrows when the lookup fails', async () => {
+      const error = new Error('Some error')
+      model.findOne.mockRejectedValueOnce(error)
+
+      await expect(service.findLatestByCase(caseId)).rejects.toThrow(error)
+    })
+  })
+
   describe('create', () => {
-    it('calls resolvePoliceCaseNumbersForCases when merged cases exist', async () => {
-      const merged = [{ id: 'm1' }, { id: 'm2' }] as Case[]
-      caseModel.findAll.mockResolvedValue(merged)
+    it('creates the session row and nothing else', async () => {
+      const result = await service.create(caseId, { transaction })
 
-      await service.create('parent-case', { transaction })
+      expect(model.create).toHaveBeenCalledWith({ caseId }, { transaction })
+      expect(result).toEqual({ id: courtSessionId, caseId })
+    })
 
-      expect(resolvePoliceCaseNumbersForCases).toHaveBeenCalledWith(merged, {
+    it('rethrows when the creation fails', async () => {
+      const error = new Error('Some error')
+      model.create.mockRejectedValueOnce(error)
+
+      await expect(service.create(caseId, { transaction })).rejects.toThrow(
+        error,
+      )
+    })
+  })
+
+  describe('delete', () => {
+    it('deletes the session row by id and case', async () => {
+      await service.delete(caseId, courtSessionId, { transaction })
+
+      expect(model.destroy).toHaveBeenCalledWith({
+        where: { id: courtSessionId, caseId },
         transaction,
       })
     })
 
-    it('does not call resolvePoliceCaseNumbersForCases when there are no merged cases', async () => {
-      caseModel.findAll.mockResolvedValue([])
+    it('throws when no row was deleted', async () => {
+      model.destroy.mockResolvedValueOnce(0)
 
-      await service.create('parent-case', { transaction })
-
-      expect(resolvePoliceCaseNumbersForCases).not.toHaveBeenCalled()
+      await expect(
+        service.delete(caseId, courtSessionId, { transaction }),
+      ).rejects.toThrow(InternalServerErrorException)
     })
-  })
 
-  describe('addMergedCaseToLatestCourtSession', () => {
-    it('calls resolvePoliceCaseNumbersForCases for the loaded merged case', async () => {
-      const mergedCase = { id: 'merged-id' } as Case
-      caseModel.findByPk.mockResolvedValue(mergedCase)
-      courtSessionModel.findOne.mockResolvedValue({
-        id: 'cs-1',
-        isConfirmed: false,
-      })
+    it('rethrows when the deletion fails', async () => {
+      const error = new Error('Some error')
+      model.destroy.mockRejectedValueOnce(error)
 
-      await service.addMergedCaseToLatestCourtSession(
-        'parent-case',
-        'merged-id',
-        { transaction },
-      )
-
-      expect(resolvePoliceCaseNumbersForCases).toHaveBeenCalledWith(
-        [mergedCase],
-        { transaction },
-      )
+      await expect(
+        service.delete(caseId, courtSessionId, { transaction }),
+      ).rejects.toThrow(error)
     })
   })
 })

--- a/apps/judicial-system/backend/src/app/modules/repository/test/courtSessionStringRepository.service.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/repository/test/courtSessionStringRepository.service.spec.ts
@@ -40,6 +40,7 @@ describe('CourtSessionStringRepositoryService', () => {
     findOne: jest.Mock
     update: jest.Mock
     create: jest.Mock
+    destroy: jest.Mock
   }
 
   beforeEach(async () => {
@@ -47,6 +48,7 @@ describe('CourtSessionStringRepositoryService', () => {
       findOne: jest.fn().mockResolvedValue(null),
       update: jest.fn().mockResolvedValue([0, []]),
       create: jest.fn(),
+      destroy: jest.fn().mockResolvedValue(0),
     }
 
     const moduleRef = await Test.createTestingModule({
@@ -181,6 +183,33 @@ describe('CourtSessionStringRepositoryService', () => {
 
       await expect(
         service.create({ ...key, value: 'Some value' }),
+      ).rejects.toThrow(error)
+    })
+  })
+
+  describe('deleteAllForCourtSession', () => {
+    it('deletes every string of the session, whichever merged case it belongs to', async () => {
+      model.destroy.mockResolvedValueOnce(3)
+
+      const result = await service.deleteAllForCourtSession(
+        caseId,
+        courtSessionId,
+        { transaction },
+      )
+
+      expect(model.destroy).toHaveBeenCalledWith({
+        where: { caseId, courtSessionId },
+        transaction,
+      })
+      expect(result).toBe(3)
+    })
+
+    it('rethrows when the deletion fails', async () => {
+      const error = new Error('Some error')
+      model.destroy.mockRejectedValueOnce(error)
+
+      await expect(
+        service.deleteAllForCourtSession(caseId, courtSessionId),
       ).rejects.toThrow(error)
     })
   })

--- a/apps/judicial-system/backend/src/app/modules/repository/test/eventLogRepository.service.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/repository/test/eventLogRepository.service.spec.ts
@@ -92,6 +92,47 @@ describe('EventLogRepositoryService', () => {
     })
   })
 
+  describe('findLatestForCaseAndTypes', () => {
+    const eventTypes = [
+      EventType.CASE_SENT_TO_COURT,
+      EventType.INDICTMENT_CONFIRMED,
+    ]
+
+    it('reads the newest event of any of the types in the given transaction', async () => {
+      const transaction = {} as never
+      const eventLog = { id: 'some-event-log-id' }
+      model.findOne.mockResolvedValueOnce(eventLog)
+
+      const result = await service.findLatestForCaseAndTypes(
+        'some-case-id',
+        eventTypes,
+        { transaction },
+      )
+
+      expect(model.findOne).toHaveBeenCalledWith({
+        where: { caseId: 'some-case-id', eventType: eventTypes },
+        order: [['created', 'DESC']],
+        transaction,
+      })
+      expect(result).toBe(eventLog)
+    })
+
+    it('returns null when the case has no such event', async () => {
+      expect(
+        await service.findLatestForCaseAndTypes('some-case-id', eventTypes),
+      ).toBeNull()
+    })
+
+    it('rethrows when the lookup fails', async () => {
+      const error = new Error('Some error')
+      model.findOne.mockRejectedValueOnce(error)
+
+      await expect(
+        service.findLatestForCaseAndTypes('some-case-id', eventTypes),
+      ).rejects.toThrow(error)
+    })
+  })
+
   describe('create', () => {
     it('creates the event log in the given transaction', async () => {
       const transaction = {} as never


### PR DESCRIPTION
# Move court session orchestration out of the court session repository

[Court session orchestration flutt úr court session repository](https://app.asana.com/1/203394141643832/project/1199153462262248/task/1218359813127358)

Third and final slice of chunk E of the repository-pattern migration. Independent of #23639 (E1) and #23659 (E2) — branched from `main`; the only shared file is `case.service.ts` (constructor + one call), so whichever merges second gets a trivial conflict.

## What

`CourtSessionRepositoryService` injected four models (`CourtSession`, `Case`, `EventLog`, `CourtSessionString`) and two repository services because its `create`, `delete` and `addMergedCaseToLatestCourtSession` carried the whole merged-case sequence: filing court documents into the new session, reading the cases merged into the parent and their confirmation events, composing the Icelandic ENTRIES legal text, cascading the delete through documents and strings, and enforcing the confirmed-session and only-the-latest-session rules. That is orchestration and business policy, not data access.

All of it moves into `CourtSessionService`, which already owns the create and delete routes:

- `create` — creates the row, files the available court documents, then records each merged case (oldest merge first).
- `delete` — re-checks against the transaction that the session is the latest, then empties it (documents → strings) before deleting the row.
- `addMergedCaseToLatestCourtSession` — new public method, reached from `CaseService.update` when an indictment case completes by merging into a parent whose latest session is still open. Refuses a confirmed or missing session.
- `addMergedCaseToCourtSession` (private) — files the merged case's documents and, if any were filed, writes the ENTRIES text dated by the latest `INDICTMENT_CONFIRMED` / `CASE_SENT_TO_COURT` event.

The repository keeps its own table only: `findLatestByCase` is new, `create` and `delete` touch one row, and the constructor ends at `CourtSession` + logger.

Three intent methods were added where the lifted code needed them, derived from the call sites: `CaseRepositoryService.findAllMergedToCase` (reads through the aggregate's own path, so the merged cases carry their police case numbers — the two explicit `resolvePoliceCaseNumbersForCases` calls in the old orchestration are therefore gone rather than ported), `EventLogRepositoryService.findLatestForCaseAndTypes`, and `CourtSessionStringRepositoryService.deleteAllForCourtSession`.

`CaseModule` now imports `CourtSessionModule` through `forwardRef`, mirroring the import `CourtSessionModule` already had in the other direction; `CaseService` injects `CourtSessionService` with `forwardRef`. Codegen boots the app on the cycle — two generations, identical schema.

Behaviour is unchanged: the same reads, writes, rules and text, in the same order, in the same transaction. `courtDocumentRepository`'s four `courtSessionModel` reads are deliberately left alone (they express document-filing policy).

## Tests

- `court-session/test/courtSessionController/create.spec.ts` and `delete.spec.ts` drive the real `CourtSessionService` with the repositories mocked: document filing, merged-case recording with and without a dated event, the cascade order, the only-latest rule and the no-session case.
- `court-session/test/courtSessionService/addMergedCaseToLatestCourtSession.spec.ts` — the merge method (open session, no documents left to file, confirmed/missing session, missing merged case).
- `case/test/caseController/update.spec.ts` — the update-with-merge path hands off to `CourtSessionService`, and stays away from a confirmed session or a non-received parent.
- Repository specs: `courtSessionRepository.service.spec.ts` rewritten for the single-model repository; new cases for the three intent methods, including a new `caseRepository.findAllMergedToCase.spec.ts`.
- Mutation-checked four ways: swapping the cascade order (1 test fails), dropping the confirmed-session rule (2), skipping the merged-case pass on create (5), skipping the hand-off in `CaseService` (1).

## Verified locally

- `tsc --noEmit` on `tsconfig.app.json` clean; the spec config reports only pre-existing errors in untouched code.
- `yarn nx test judicial-system-backend --testPathPatterns='modules/(court-session|case|repository)/'` — 196 suites, 8711 tests, green.
- `yarn nx lint judicial-system-backend` — 0 errors; the 4 warnings are pre-existing unused imports on `main`.
- prettier 2.6.2 clean; `codegen/backend-schema` run twice, `openapi.yaml` byte-identical.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Court sessions now automatically include available documents and cases merged into the related case.
  - Merged cases are recorded in court session entries with relevant case details and dates.
  - Court session deletion now cleans up associated documents and entries first and is limited to the latest session.
  - Case updates now add merged cases to the latest open court session when applicable.
- **Bug Fixes**
  - Improved validation prevents updates when the parent case or court session is not eligible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->