### PR TITLE
feat(my-pages): Plausible health pages

### DIFF
--- a/libs/plausible/src/lib/servicePortalEvents.ts
+++ b/libs/plausible/src/lib/servicePortalEvents.ts
@@ -68,6 +68,9 @@ export const healthOverviewSendMessageClick = myPagesHealthEvent(
 export const healthAppointmentsSendMessageClick = myPagesHealthEvent(
   'Appointments Send Message Click',
 )
+export const healthAppointmentsHeilsuveraClick = myPagesHealthEvent(
+  'Appointments Heilsuvera Click',
+)
 
 // Event sent when the search feature of documents is interacted with by the user
 export const documentsSearchDocumentsInitialized = (params: ParamType) => {

--- a/libs/plausible/src/lib/servicePortalEvents.ts
+++ b/libs/plausible/src/lib/servicePortalEvents.ts
@@ -43,6 +43,32 @@ export const myPagesHeaderSearchInputInitialized = myPagesHeaderEvent(
   'Search Input Initialized',
 )
 
+const myPagesHealthEvent =
+  (eventName: string) =>
+  (params: Pick<ParamType, 'url' | 'location'> & { label?: string }) =>
+    plausibleCustomEvent({
+      eventName,
+      featureName: 'Health',
+      params: {
+        location: params.location,
+        ...(params.label && { label: params.label }),
+      },
+      url: params.url,
+    })
+
+export const healthOverviewQuickLinkClick = myPagesHealthEvent(
+  'Overview Quick Link Click',
+)
+export const healthOverviewWebchatClick = myPagesHealthEvent(
+  'Overview Webchat Click',
+)
+export const healthOverviewSendMessageClick = myPagesHealthEvent(
+  'Overview Send Message Click',
+)
+export const healthAppointmentsSendMessageClick = myPagesHealthEvent(
+  'Appointments Send Message Click',
+)
+
 // Event sent when the search feature of documents is interacted with by the user
 export const documentsSearchDocumentsInitialized = (params: ParamType) => {
   const event: BaseEvent = {

--- a/libs/portals/my-pages/core/src/components/LinkButton/LinkButton.tsx
+++ b/libs/portals/my-pages/core/src/components/LinkButton/LinkButton.tsx
@@ -10,10 +10,13 @@ interface Props {
   size?: ButtonProps['size']
   disabled?: ButtonProps['disabled']
   skipOutboundTrack?: boolean
+  // For external links, LinkResolver also fires the generic outbound-link
+  // Set skipOutboundTrack when the callback sends its own
+  // Plausible event, otherwise the click is tracked twice
   callback?: () => void
 }
 
-type LinkButtonProps = Props & ButtonTypes
+export type LinkButtonProps = Props & ButtonTypes
 
 export const LinkButton = (props: LinkButtonProps) => {
   const {

--- a/libs/portals/my-pages/core/src/components/LinkButton/LinkButton.tsx
+++ b/libs/portals/my-pages/core/src/components/LinkButton/LinkButton.tsx
@@ -10,12 +10,22 @@ interface Props {
   size?: ButtonProps['size']
   disabled?: ButtonProps['disabled']
   skipOutboundTrack?: boolean
+  callback?: () => void
 }
 
 type LinkButtonProps = Props & ButtonTypes
 
 export const LinkButton = (props: LinkButtonProps) => {
-  const { size, to, text, icon, disabled, skipOutboundTrack, ...rest } = props
+  const {
+    size,
+    to,
+    text,
+    icon,
+    disabled,
+    skipOutboundTrack,
+    callback,
+    ...rest
+  } = props
   const isExternal = isExternalLink(to)
 
   if (rest.variant === 'text') {
@@ -34,6 +44,7 @@ export const LinkButton = (props: LinkButtonProps) => {
       <LinkResolver
         className={styles.link}
         skipOutboundTrack={skipOutboundTrack}
+        callback={callback}
         href={to}
       >
         <Button
@@ -64,6 +75,7 @@ export const LinkButton = (props: LinkButtonProps) => {
   ) : (
     <LinkResolver
       skipOutboundTrack={skipOutboundTrack}
+      callback={callback}
       className={styles.link}
       href={to}
     >

--- a/libs/portals/my-pages/health/src/screens/Appointments/AppointmentsOverview.tsx
+++ b/libs/portals/my-pages/health/src/screens/Appointments/AppointmentsOverview.tsx
@@ -4,10 +4,13 @@ import { Box, Tabs, Text } from '@island.is/island-ui/core'
 import { useLocale, useNamespaces } from '@island.is/localization'
 import {
   CardLoader,
+  formatPlausiblePathToParams,
   STAFRAEN_HEILSA_SLUG,
   IntroWrapper,
   LinkButton,
 } from '@island.is/portals/my-pages/core'
+import { healthAppointmentsSendMessageClick } from '@island.is/plausible'
+import { useLocation } from 'react-router-dom'
 import { Features, useFeatureFlag } from '@island.is/react/feature-flags'
 import { Problem } from '@island.is/react-spa/shared'
 import { useState } from 'react'
@@ -24,6 +27,7 @@ import { useGetAppointmentsQuery } from './Appointments.generated'
 const AppointmentsOverview = () => {
   useNamespaces('sp.health')
   const { formatMessage } = useLocale()
+  const { pathname } = useLocation()
   useHealthPlausibleSwap()
 
   const [pastTabVisited, setPastTabVisited] = useState(false)
@@ -123,6 +127,11 @@ const AppointmentsOverview = () => {
             variant="utility"
             size="small"
             icon="arrowForward"
+            callback={() =>
+              healthAppointmentsSendMessageClick(
+                formatPlausiblePathToParams(pathname),
+              )
+            }
           />
         )}
         <LinkButton

--- a/libs/portals/my-pages/health/src/screens/Appointments/AppointmentsOverview.tsx
+++ b/libs/portals/my-pages/health/src/screens/Appointments/AppointmentsOverview.tsx
@@ -9,7 +9,10 @@ import {
   IntroWrapper,
   LinkButton,
 } from '@island.is/portals/my-pages/core'
-import { healthAppointmentsSendMessageClick } from '@island.is/plausible'
+import {
+  healthAppointmentsHeilsuveraClick,
+  healthAppointmentsSendMessageClick,
+} from '@island.is/plausible'
 import { useLocation } from 'react-router-dom'
 import { Features, useFeatureFlag } from '@island.is/react/feature-flags'
 import { Problem } from '@island.is/react-spa/shared'
@@ -140,6 +143,12 @@ const AppointmentsOverview = () => {
           variant="utility"
           size="small"
           icon="open"
+          callback={() =>
+            healthAppointmentsHeilsuveraClick(
+              formatPlausiblePathToParams(pathname),
+            )
+          }
+          skipOutboundTrack
         />
       </Box>
       <Tabs

--- a/libs/portals/my-pages/health/src/screens/HealthOverview/HealthOverview.tsx
+++ b/libs/portals/my-pages/health/src/screens/HealthOverview/HealthOverview.tsx
@@ -220,7 +220,7 @@ export const HealthOverview = () => {
                       callback={() =>
                         healthOverviewQuickLinkClick({
                           ...formatPlausiblePathToParams(pathname),
-                          label: link.label,
+                          label: link.href,
                         })
                       }
                     >

--- a/libs/portals/my-pages/health/src/screens/HealthOverview/HealthOverview.tsx
+++ b/libs/portals/my-pages/health/src/screens/HealthOverview/HealthOverview.tsx
@@ -11,9 +11,12 @@ import { useLocale, useNamespaces } from '@island.is/localization'
 import { useQuery } from '@apollo/client'
 import { Query, QueryGetNamespaceArgs } from '@island.is/api/schema'
 import {
+  formatPlausiblePathToParams,
   GET_NAMESPACE_QUERY,
   LinkResolver,
 } from '@island.is/portals/my-pages/core'
+import { healthOverviewQuickLinkClick } from '@island.is/plausible'
+import { useLocation } from 'react-router-dom'
 import { z } from 'zod'
 import subYears from 'date-fns/subYears'
 import { useWindowSize } from 'react-use'
@@ -78,6 +81,7 @@ export const HealthOverview = () => {
   useNamespaces('sp.health')
   useHealthPlausibleSwap()
   const { formatMessage, locale } = useLocale()
+  const { pathname } = useLocation()
   const { width } = useWindowSize()
   const isStackedLayout = width < theme.breakpoints.lg
   const { value: showAppointments } = useFeatureFlag(
@@ -210,7 +214,16 @@ export const HealthOverview = () => {
               <Box marginTop={2}>
                 <Inline space={[1, 2]}>
                   {quickLinks.map((link) => (
-                    <LinkResolver key={link.href} href={link.href}>
+                    <LinkResolver
+                      key={link.href}
+                      href={link.href}
+                      callback={() =>
+                        healthOverviewQuickLinkClick({
+                          ...formatPlausiblePathToParams(pathname),
+                          label: link.label,
+                        })
+                      }
+                    >
                       <Tag variant="blue">{link.label}</Tag>
                     </LinkResolver>
                   ))}

--- a/libs/portals/my-pages/health/src/screens/HealthOverview/components/ContactLinks.tsx
+++ b/libs/portals/my-pages/health/src/screens/HealthOverview/components/ContactLinks.tsx
@@ -20,6 +20,7 @@ type ContactLinkItem = {
   href: string
   icon: IconMapIcon
   onClick?: () => void
+  skipOutboundTrack?: boolean
 }
 
 const ContactLinks = () => {
@@ -34,6 +35,7 @@ const ContactLinks = () => {
       icon: 'open',
       onClick: () =>
         healthOverviewWebchatClick(formatPlausiblePathToParams(pathname)),
+      skipOutboundTrack: true,
     },
     {
       title: formatMessage(messages.contactSendMessage),
@@ -68,6 +70,7 @@ const ContactLinks = () => {
       href={link.href}
       className={styles.rowLink}
       callback={link.onClick}
+      skipOutboundTrack={link.skipOutboundTrack}
     >
       <Box paddingX={3} paddingY={2} width="full">
         <Box

--- a/libs/portals/my-pages/health/src/screens/HealthOverview/components/ContactLinks.tsx
+++ b/libs/portals/my-pages/health/src/screens/HealthOverview/components/ContactLinks.tsx
@@ -1,6 +1,14 @@
 import { Box, Icon, IconMapIcon, Text } from '@island.is/island-ui/core'
 import { useLocale } from '@island.is/localization'
-import { LinkResolver } from '@island.is/portals/my-pages/core'
+import {
+  formatPlausiblePathToParams,
+  LinkResolver,
+} from '@island.is/portals/my-pages/core'
+import {
+  healthOverviewSendMessageClick,
+  healthOverviewWebchatClick,
+} from '@island.is/plausible'
+import { useLocation } from 'react-router-dom'
 import { messages } from '../../..'
 import { HealthPaths } from '../../../lib/paths'
 import * as styles from './ContactLinks.css'
@@ -11,10 +19,12 @@ type ContactLinkItem = {
   emergencyDescription?: string
   href: string
   icon: IconMapIcon
+  onClick?: () => void
 }
 
 const ContactLinks = () => {
   const { formatMessage } = useLocale()
+  const { pathname } = useLocation()
 
   const links: ContactLinkItem[] = [
     {
@@ -22,12 +32,16 @@ const ContactLinks = () => {
       description: formatMessage(messages.contactChatDesc),
       href: formatMessage(messages.heilsuveraChatLink),
       icon: 'open',
+      onClick: () =>
+        healthOverviewWebchatClick(formatPlausiblePathToParams(pathname)),
     },
     {
       title: formatMessage(messages.contactSendMessage),
       description: formatMessage(messages.contactSendMessageDesc),
       href: HealthPaths.HealthConversationsNew,
       icon: 'arrowForward',
+      onClick: () =>
+        healthOverviewSendMessageClick(formatPlausiblePathToParams(pathname)),
     },
   ]
 
@@ -50,7 +64,11 @@ const ContactLinks = () => {
   )
 
   const renderRowContent = (link: ContactLinkItem) => (
-    <LinkResolver href={link.href} className={styles.rowLink}>
+    <LinkResolver
+      href={link.href}
+      className={styles.rowLink}
+      callback={link.onClick}
+    >
       <Box paddingX={3} paddingY={2} width="full">
         <Box
           display="flex"


### PR DESCRIPTION
## What

Add plausible logging for health pages

## Why

For stats

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added analytics tracking for health portal interactions, including quick links, webchat, message links, appointment messaging, and external health-service links.
  * Health-related link clicks now include the current page and relevant link context in usage events.
  * Link buttons now support click callbacks, enabling more consistent interaction tracking across the portal.
  * Tracking covers both health overview and appointments pages, including links to external health services.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->