### PR TITLE
fix(j-s): Skip police digital case files query for unauthorized roles

### DIFF
--- a/apps/judicial-system/web/src/utils/hooks/usePoliceDigitalCaseFile/index.ts
+++ b/apps/judicial-system/web/src/utils/hooks/usePoliceDigitalCaseFile/index.ts
@@ -1,13 +1,18 @@
 import { useCallback, useContext, useEffect } from 'react'
 
 import { CaseOrigin } from '@island.is/judicial-system/types'
-import { FormContext } from '@island.is/judicial-system-web/src/components'
+import {
+  FormContext,
+  UserContext,
+} from '@island.is/judicial-system-web/src/components'
 import { toast } from '@island.is/judicial-system-web/src/utils/toast'
 
 import { useDeletePoliceDigitalCaseFileMutation } from './deletePoliceDigitalCaseFile.generated'
 import { usePoliceDigitalCaseFilesQuery } from './policeDigitalCaseFiles.generated'
+import { canAccessPoliceDigitalCaseFiles } from './usePoliceDigitalCaseFile.logic'
 
 const usePoliceDigitalCaseFile = () => {
+  const { user } = useContext(UserContext)
   const { workingCase, isLoadingWorkingCase, refreshCase } =
     useContext(FormContext)
   const { id: caseId, origin: caseOrigin, originalAncestorId } = workingCase
@@ -34,7 +39,10 @@ const usePoliceDigitalCaseFile = () => {
     refetch,
   } = usePoliceDigitalCaseFilesQuery({
     variables: { input: { caseId: effectiveCaseId } },
-    skip: isLoadingWorkingCase || caseOrigin !== CaseOrigin.LOKE,
+    skip:
+      isLoadingWorkingCase ||
+      caseOrigin !== CaseOrigin.LOKE ||
+      !canAccessPoliceDigitalCaseFiles(user),
     fetchPolicy: 'no-cache',
     errorPolicy: 'all',
     onCompleted: handleCompleted,

--- a/apps/judicial-system/web/src/utils/hooks/usePoliceDigitalCaseFile/usePoliceDigitalCaseFile.logic.spec.ts
+++ b/apps/judicial-system/web/src/utils/hooks/usePoliceDigitalCaseFile/usePoliceDigitalCaseFile.logic.spec.ts
@@ -1,0 +1,55 @@
+import {
+  InstitutionType,
+  type InstitutionUser,
+  UserRole,
+} from '@island.is/judicial-system/types'
+
+import { canAccessPoliceDigitalCaseFiles } from './usePoliceDigitalCaseFile.logic'
+
+const user = (role: UserRole, type: InstitutionType): InstitutionUser => ({
+  role,
+  institution: { type },
+})
+
+describe('canAccessPoliceDigitalCaseFiles', () => {
+  it.each([
+    [UserRole.PROSECUTOR, InstitutionType.POLICE_PROSECUTORS_OFFICE],
+    [UserRole.PROSECUTOR, InstitutionType.DISTRICT_PROSECUTORS_OFFICE],
+    [UserRole.PROSECUTOR, InstitutionType.PUBLIC_PROSECUTORS_OFFICE],
+    [
+      UserRole.PROSECUTOR_REPRESENTATIVE,
+      InstitutionType.POLICE_PROSECUTORS_OFFICE,
+    ],
+    [UserRole.DISTRICT_COURT_JUDGE, InstitutionType.DISTRICT_COURT],
+    [UserRole.DISTRICT_COURT_REGISTRAR, InstitutionType.DISTRICT_COURT],
+    [UserRole.DISTRICT_COURT_ASSISTANT, InstitutionType.DISTRICT_COURT],
+    [UserRole.COURT_OF_APPEALS_JUDGE, InstitutionType.COURT_OF_APPEALS],
+    [UserRole.COURT_OF_APPEALS_REGISTRAR, InstitutionType.COURT_OF_APPEALS],
+    [UserRole.COURT_OF_APPEALS_ASSISTANT, InstitutionType.COURT_OF_APPEALS],
+  ])('allows %s at %s', (role, type) => {
+    expect(canAccessPoliceDigitalCaseFiles(user(role, type))).toBe(true)
+  })
+
+  it.each([
+    [UserRole.PRISON_SYSTEM_STAFF, InstitutionType.PRISON],
+    [UserRole.PRISON_SYSTEM_STAFF, InstitutionType.PRISON_ADMIN],
+    [
+      UserRole.PUBLIC_PROSECUTOR_STAFF,
+      InstitutionType.PUBLIC_PROSECUTORS_OFFICE,
+    ],
+    [UserRole.LOCAL_ADMIN, InstitutionType.DISTRICT_COURT],
+    [UserRole.ADMIN, InstitutionType.DISTRICT_COURT],
+  ])('denies %s at %s', (role, type) => {
+    expect(canAccessPoliceDigitalCaseFiles(user(role, type))).toBe(false)
+  })
+
+  it('denies defenders, who have no institution', () => {
+    expect(canAccessPoliceDigitalCaseFiles({ role: UserRole.DEFENDER })).toBe(
+      false,
+    )
+  })
+
+  it('denies while the user has not loaded yet', () => {
+    expect(canAccessPoliceDigitalCaseFiles(undefined)).toBe(false)
+  })
+})

--- a/apps/judicial-system/web/src/utils/hooks/usePoliceDigitalCaseFile/usePoliceDigitalCaseFile.logic.ts
+++ b/apps/judicial-system/web/src/utils/hooks/usePoliceDigitalCaseFile/usePoliceDigitalCaseFile.logic.ts
@@ -1,0 +1,16 @@
+import {
+  type InstitutionUser,
+  isCourtOfAppealsUser,
+  isDistrictCourtUser,
+  isProsecutionUser,
+} from '@island.is/judicial-system/types'
+
+// Mirrors the role rules on the backend's policeDigitalCaseFiles endpoints.
+// Prison staff, public prosecutor staff and defenders are rejected with a 403
+// there, so the hook must not query on their behalf.
+export const canAccessPoliceDigitalCaseFiles = (
+  user?: InstitutionUser,
+): boolean =>
+  isProsecutionUser(user) ||
+  isDistrictCourtUser(user) ||
+  isCourtOfAppealsUser(user)


### PR DESCRIPTION
## What
The `usePoliceDigitalCaseFile` hook now skips the `policeDigitalCaseFiles` query unless the current user is a prosecution, district court or court of appeals user. The role check lives in a small `usePoliceDigitalCaseFile.logic.ts` predicate that mirrors the backend role rules, with a spec covering every role and institution combination.

## Why
The hook only checked that the case originated in LOKE and never looked at the user. The backend endpoint only allows prosecution and court roles, so prison staff (`/fangelsi/krafa/yfirlit`, `/fangelsi/akaera/yfirlit`), public prosecutor staff (`/rikissaksoknari/akaera/yfirlit`) and defenders (`/verjandi/akaera/[id]`) triggered a 403 on every page load. The UI already hid the result for those roles, so the request was wasted and only showed up as a Forbidden error in Datadog browser logs.

## Screenshots / Gifs
Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code
- [ ] No AI tools were used in preparing this pull request

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Police digital case files are now queried only for users with the appropriate access rights.
  * Unauthorized roles no longer attempt to access police digital case file information, preventing rejected requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->