### PR TITLE
chore(j-s): Fix lint warnings in web and backend

### DIFF
--- a/apps/judicial-system/backend/src/app/modules/case/case.module.ts
+++ b/apps/judicial-system/backend/src/app/modules/case/case.module.ts
@@ -1,5 +1,4 @@
 import { forwardRef, Module } from '@nestjs/common'
-import { SequelizeModule } from '@nestjs/sequelize'
 
 import { CmsTranslationsModule } from '@island.is/cms-translations'
 import { SigningModule } from '@island.is/dokobit-signing'

--- a/apps/judicial-system/backend/src/app/modules/case/case.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/case/case.service.ts
@@ -12,7 +12,6 @@ import {
   InternalServerErrorException,
   NotFoundException,
 } from '@nestjs/common'
-import { InjectModel } from '@nestjs/sequelize'
 
 import { FormatMessage, IntlService } from '@island.is/cms-translations'
 import {

--- a/apps/judicial-system/backend/src/app/modules/case/dto/updateCase.dto.ts
+++ b/apps/judicial-system/backend/src/app/modules/case/dto/updateCase.dto.ts
@@ -23,7 +23,6 @@ import type {
   IndictmentSubtypeMap,
 } from '@island.is/judicial-system/types'
 import {
-  CaseAppealDecision,
   CaseCustodyRestrictions,
   CaseDecision,
   CaseIndictmentRulingDecision,

--- a/apps/judicial-system/backend/src/app/modules/case/test/createTestingCaseModule.ts
+++ b/apps/judicial-system/backend/src/app/modules/case/test/createTestingCaseModule.ts
@@ -1,7 +1,6 @@
 import { mock } from 'jest-mock-extended'
 import { Sequelize } from 'sequelize-typescript'
 
-import { getModelToken } from '@nestjs/sequelize'
 import { Test } from '@nestjs/testing'
 
 import { IntlService } from '@island.is/cms-translations'

--- a/apps/judicial-system/web/src/components/FeatureProvider/FeatureProvider.tsx
+++ b/apps/judicial-system/web/src/components/FeatureProvider/FeatureProvider.tsx
@@ -4,7 +4,7 @@ import { createContext, useEffect, useState } from 'react'
 import { Feature } from '@island.is/judicial-system/types'
 import { getFeature } from '@island.is/judicial-system-web/src/services/api'
 
-interface FeatureProvider {
+interface FeatureContextValue {
   // The features that are not hidden in this environment. Empty until the
   // first round trip completes, so it cannot tell "hidden" from "not loaded
   // yet" on its own - read it together with isLoading.
@@ -17,7 +17,7 @@ interface FeatureProvider {
 
 const availableFeatures = Object.values(Feature)
 
-export const FeatureContext = createContext<FeatureProvider>({
+export const FeatureContext = createContext<FeatureContextValue>({
   features: [],
   isLoading: true,
 })

--- a/apps/judicial-system/web/src/components/FormProvider/FormProvider.tsx
+++ b/apps/judicial-system/web/src/components/FormProvider/FormProvider.tsx
@@ -38,7 +38,7 @@ type ProviderState =
   | 'not-found'
   | undefined
 
-interface FormProvider {
+interface FormContextValue {
   workingCase: Case
   setWorkingCase: Dispatch<SetStateAction<Case>>
   isLoadingWorkingCase: boolean
@@ -69,7 +69,7 @@ const initialState: Case = {
   defendantWaivesRightToCounsel: false,
 }
 
-export const FormContext = createContext<FormProvider>({
+export const FormContext = createContext<FormContextValue>({
   workingCase: initialState,
   setWorkingCase: () => initialState,
   isLoadingWorkingCase: true,

--- a/apps/judicial-system/web/src/components/LawyerRegistryProvider/LawyerRegistryProvider.tsx
+++ b/apps/judicial-system/web/src/components/LawyerRegistryProvider/LawyerRegistryProvider.tsx
@@ -11,11 +11,11 @@ import {
 import { UserContext } from '@island.is/judicial-system-web/src/components/UserProvider/UserProvider'
 import { useLawyerRegistry } from '@island.is/judicial-system-web/src/utils/hooks/useLawyerRegistry/useLawyerRegistry'
 
-interface LawyerRegistryContext {
+interface LawyerRegistryContextValue {
   lawyers?: Lawyer[]
 }
 
-export const LawyerRegistryContext = createContext<LawyerRegistryContext>({
+export const LawyerRegistryContext = createContext<LawyerRegistryContextValue>({
   lawyers: [],
 })
 

--- a/apps/judicial-system/web/src/components/Modals/SigningMethodSelectionModal/SigningMethodSelectionModal.tsx
+++ b/apps/judicial-system/web/src/components/Modals/SigningMethodSelectionModal/SigningMethodSelectionModal.tsx
@@ -78,7 +78,7 @@ export const SigningMethodSelectionModal: FC<
         })
         response = result.data?.requestCourtRecordSignature
       }
-    } catch (error) {
+    } catch {
       setLoadingMethod(undefined)
     }
 

--- a/apps/judicial-system/web/src/components/UserProvider/UserProvider.tsx
+++ b/apps/judicial-system/web/src/components/UserProvider/UserProvider.tsx
@@ -13,7 +13,7 @@ import type { User } from '@island.is/judicial-system-web/src/graphql/schema'
 
 import { useCurrentUserQuery } from './currentUser.generated'
 
-interface UserProvider {
+interface UserContextValue {
   isLoading?: boolean
   isAuthenticated?: boolean
   limitedAccess?: boolean
@@ -22,7 +22,7 @@ interface UserProvider {
   hasError?: boolean
 }
 
-export const UserContext = createContext<UserProvider>({})
+export const UserContext = createContext<UserContextValue>({})
 
 // Used for accessing the current user outside of React components
 export const userRef: { current?: User; authBypass?: boolean } = {}

--- a/apps/judicial-system/web/src/routes/Prosecutor/Indictments/PoliceCaseFiles/UploadFilesToPoliceCase.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/Indictments/PoliceCaseFiles/UploadFilesToPoliceCase.tsx
@@ -1,7 +1,6 @@
 import type { FC } from 'react'
 import { useEffect, useMemo, useState } from 'react'
 import { useIntl } from 'react-intl'
-import _isEqual from 'lodash/isEqual'
 
 import { FileUploadStatus, InputFileUpload } from '@island.is/island-ui/core'
 import { errors as errorMessages } from '@island.is/judicial-system-web/messages'

--- a/apps/judicial-system/web/src/routes/PublicProsecutor/Indictments/SendToPrisonAdmin/SendToPrisonAdmin.tsx
+++ b/apps/judicial-system/web/src/routes/PublicProsecutor/Indictments/SendToPrisonAdmin/SendToPrisonAdmin.tsx
@@ -4,11 +4,7 @@ import { useIntl } from 'react-intl'
 import { useParams, useRouter } from 'next/navigation'
 
 import type { UploadFile } from '@island.is/island-ui/core'
-import {
-  Box,
-  FileUploadStatus,
-  InputFileUpload,
-} from '@island.is/island-ui/core'
+import { FileUploadStatus, InputFileUpload } from '@island.is/island-ui/core'
 import { PUBLIC_PROSECUTOR_STAFF_INDICTMENT_CASE_OVERVIEW_ROUTE } from '@island.is/judicial-system/consts'
 import { core, errors } from '@island.is/judicial-system-web/messages'
 import {

--- a/apps/judicial-system/web/src/routes/Shared/SignedVerdictOverview/Components/ModifyDatesModal/ModifyDatesModal.tsx
+++ b/apps/judicial-system/web/src/routes/Shared/SignedVerdictOverview/Components/ModifyDatesModal/ModifyDatesModal.tsx
@@ -175,7 +175,8 @@ const ModifyDatesModal: FC<Props> = ({
   isUpdatingCase,
   closeModal,
 }) => {
-  const [modifiedValidToDate, setModifiedValidToDate] = useState<DateTimeValue>()
+  const [modifiedValidToDate, setModifiedValidToDate] =
+    useState<DateTimeValue>()
   const [modifiedIsolationToDate, setModifiedIsolationToDate] =
     useState<DateTimeValue>()
   const [caseModifiedExplanation, setCaseModifiedExplanation] =

--- a/apps/judicial-system/web/src/routes/Shared/SignedVerdictOverview/Components/ModifyDatesModal/ModifyDatesModal.tsx
+++ b/apps/judicial-system/web/src/routes/Shared/SignedVerdictOverview/Components/ModifyDatesModal/ModifyDatesModal.tsx
@@ -31,7 +31,7 @@ import { validate } from '@island.is/judicial-system-web/src/utils/validate'
 
 import { createCaseModifiedExplanation } from './ModifyDatesModal.logic'
 
-interface DateTime {
+interface DateTimeValue {
   value?: Date
   isValid: boolean
 }
@@ -46,8 +46,8 @@ interface Props {
 
 const getModificationSuccessText = (
   workingCase: Case,
-  modifiedValidToDate: DateTime | undefined,
-  modifiedIsolationToDate: DateTime | undefined,
+  modifiedValidToDate: DateTimeValue | undefined,
+  modifiedIsolationToDate: DateTimeValue | undefined,
   formatMessage: IntlShape['formatMessage'],
   userRole?: UserRole | null,
 ) => {
@@ -175,9 +175,9 @@ const ModifyDatesModal: FC<Props> = ({
   isUpdatingCase,
   closeModal,
 }) => {
-  const [modifiedValidToDate, setModifiedValidToDate] = useState<DateTime>()
+  const [modifiedValidToDate, setModifiedValidToDate] = useState<DateTimeValue>()
   const [modifiedIsolationToDate, setModifiedIsolationToDate] =
-    useState<DateTime>()
+    useState<DateTimeValue>()
   const [caseModifiedExplanation, setCaseModifiedExplanation] =
     useState<string>()
 

--- a/apps/judicial-system/web/src/utils/hooks/useAppealCase/index.ts
+++ b/apps/judicial-system/web/src/utils/hooks/useAppealCase/index.ts
@@ -113,7 +113,7 @@ const useAppealCase = () => {
           }
 
           return appealCase
-        } catch (e) {
+        } catch {
           toast.error(formatMessage(errors.transitionCase))
           return undefined
         }
@@ -146,7 +146,7 @@ const useAppealCase = () => {
           })
 
           return data?.limitedAccessCreateAppealCase ?? undefined
-        } catch (e) {
+        } catch {
           toast.error(formatMessage(errors.transitionCase))
           return undefined
         }
@@ -182,7 +182,7 @@ const useAppealCase = () => {
           })
 
           return data?.createAppealCase ?? undefined
-        } catch (e) {
+        } catch {
           toast.error(formatMessage(errors.transitionCase))
           return undefined
         }
@@ -236,7 +236,7 @@ const useAppealCase = () => {
           }
 
           return true
-        } catch (e) {
+        } catch {
           toast.error(formatMessage(errors.transitionCase))
           return false
         }
@@ -268,7 +268,7 @@ const useAppealCase = () => {
           })
 
           return data?.updateAppealCase as AppealCase | undefined
-        } catch (e) {
+        } catch {
           toast.error(formatMessage(errors.updateCase))
           return undefined
         }
@@ -293,7 +293,7 @@ const useAppealCase = () => {
           })
 
           return Boolean(data)
-        } catch (e) {
+        } catch {
           toast.error(formatMessage(errors.updateCase))
           return false
         }

--- a/apps/judicial-system/web/src/utils/hooks/useCase/index.ts
+++ b/apps/judicial-system/web/src/utils/hooks/useCase/index.ts
@@ -110,7 +110,7 @@ const useCase = () => {
               return data.createCase as Case
             }
           }
-        } catch (error) {
+        } catch {
           toast.error(formatMessage(errors.createCase))
         }
       },
@@ -130,7 +130,7 @@ const useCase = () => {
               return data.createCourtCase.courtCaseNumber
             }
           }
-        } catch (error) {
+        } catch {
           // Catch all so we can return the empty string
         }
 
@@ -155,7 +155,7 @@ const useCase = () => {
         const res = data as LimitedAccessUpdateCaseMutation
 
         return res.limitedAccessUpdateCase
-      } catch (error) {
+      } catch {
         toast.error(formatMessage(errors.updateCase))
       }
     },
@@ -178,7 +178,7 @@ const useCase = () => {
         const res = data as UpdateCaseMutation
 
         return res.updateCase
-      } catch (error) {
+      } catch {
         toast.error(formatMessage(errors.updateCase))
       }
     },
@@ -233,7 +233,7 @@ const useCase = () => {
           }
 
           return true
-        } catch (e) {
+        } catch {
           toast.error(formatMessage(errors.transitionCase))
 
           return false
@@ -258,7 +258,7 @@ const useCase = () => {
             },
           })
           return Boolean(data?.sendNotification?.notificationSent)
-        } catch (e) {
+        } catch {
           return false
         }
       },
@@ -283,7 +283,7 @@ const useCase = () => {
             },
           })
           return Boolean(data?.sendAppealNotification?.notificationSent)
-        } catch (e) {
+        } catch {
           return false
         }
       },
@@ -298,7 +298,7 @@ const useCase = () => {
         })
 
         return data?.extendCase
-      } catch (error) {
+      } catch {
         toast.error(formatMessage(errors.extendCase))
       }
     },
@@ -313,7 +313,7 @@ const useCase = () => {
         })
 
         return data?.duplicateIndictmentCase
-      } catch (error) {
+      } catch {
         toast.error('Ekki tókst að afrita mál í drög')
       }
     },
@@ -328,7 +328,7 @@ const useCase = () => {
         })
 
         return data?.splitDefendantFromCase?.id
-      } catch (error) {
+      } catch {
         toast.error('Ekki tókst að kljúfa varnaraðila frá máli')
       }
     },
@@ -363,7 +363,7 @@ const useCase = () => {
       }
 
       return true
-    } catch (error) {
+    } catch {
       toast.error(formatMessage(errors.updateCase))
 
       return false

--- a/apps/judicial-system/web/src/utils/hooks/useCaseAppealDecision/index.ts
+++ b/apps/judicial-system/web/src/utils/hooks/useCaseAppealDecision/index.ts
@@ -18,7 +18,7 @@ const useCaseAppealDecision = () => {
         })
 
         return data?.updateCaseAppealDecision
-      } catch (error) {
+      } catch {
         toast.error('Upp kom villa við að uppfæra ákvörðun um kæru')
 
         return undefined

--- a/apps/judicial-system/web/src/utils/hooks/useCivilClaimants/index.ts
+++ b/apps/judicial-system/web/src/utils/hooks/useCivilClaimants/index.ts
@@ -39,7 +39,7 @@ const useCivilClaimants = () => {
           }
         }
         return null
-      } catch (error) {
+      } catch {
         toast.error(formatMessage(errors.createCivilClaimant))
         return null
       }
@@ -55,7 +55,7 @@ const useCivilClaimants = () => {
         })
 
         return Boolean(data?.deleteCivilClaimant.deleted)
-      } catch (error) {
+      } catch {
         toast.error(formatMessage(errors.deleteCivilClaimant))
         return false
       }
@@ -73,7 +73,7 @@ const useCivilClaimants = () => {
         })
 
         return Boolean(data)
-      } catch (error) {
+      } catch {
         toast.error(formatMessage(errors.updateCivilClaimant))
         return false
       }

--- a/apps/judicial-system/web/src/utils/hooks/useCourtDocuments/index.ts
+++ b/apps/judicial-system/web/src/utils/hooks/useCourtDocuments/index.ts
@@ -39,7 +39,7 @@ const useCourtDocuments = () => {
         }
 
         return data.createCourtDocument
-      } catch (error) {
+      } catch {
         toast.error('Upp kom villa við að búa til þingskjal')
 
         return
@@ -58,7 +58,7 @@ const useCourtDocuments = () => {
         })
 
         return Boolean(data?.updateCourtDocument)
-      } catch (error) {
+      } catch {
         toast.error('Upp kom villa við að uppfæra þingskjal')
 
         return false
@@ -77,7 +77,7 @@ const useCourtDocuments = () => {
         })
 
         return Boolean(data?.deleteCourtDocument)
-      } catch (error) {
+      } catch {
         toast.error('Upp kom villa við að eyða þingskjali')
 
         return false
@@ -102,7 +102,7 @@ const useCourtDocuments = () => {
         }
 
         return data.fileCourtDocumentInCourtSession
-      } catch (error) {
+      } catch {
         toast.error('Upp kom villa við að leggja fram þingskjal')
 
         return

--- a/apps/judicial-system/web/src/utils/hooks/useCourtSessions/index.ts
+++ b/apps/judicial-system/web/src/utils/hooks/useCourtSessions/index.ts
@@ -45,7 +45,7 @@ const useCourtSessions = () => {
           id: data.createCourtSession.id,
           created: data.createCourtSession.created,
         }
-      } catch (error) {
+      } catch {
         toast.error('Upp kom villa við að bæta við þinghaldi')
 
         return
@@ -64,7 +64,7 @@ const useCourtSessions = () => {
         })
 
         return Boolean(data)
-      } catch (error) {
+      } catch {
         toast.error('Upp kom villa við að uppfæra þinghald')
 
         return false
@@ -83,7 +83,7 @@ const useCourtSessions = () => {
         })
 
         return Boolean(data)
-      } catch (error) {
+      } catch {
         toast.error('Upp kom villa við að uppfæra þinghald')
 
         return false
@@ -104,7 +104,7 @@ const useCourtSessions = () => {
         })
 
         return data?.updateCourtSessionAppealDecision
-      } catch (error) {
+      } catch {
         toast.error('Upp kom villa við að uppfæra ákvörðun um kæru')
 
         return undefined
@@ -130,7 +130,7 @@ const useCourtSessions = () => {
         }
 
         return data.pronounceRulingOrally
-      } catch (error) {
+      } catch {
         toast.error('Upp kom villa við að kveða upp úrskurð')
 
         return undefined
@@ -149,7 +149,7 @@ const useCourtSessions = () => {
         })
 
         return Boolean(data?.deleteCourtSession?.deleted)
-      } catch (error) {
+      } catch {
         toast.error('Upp kom villa við að eyða þinghaldi')
 
         return false

--- a/apps/judicial-system/web/src/utils/hooks/useDefendants/index.ts
+++ b/apps/judicial-system/web/src/utils/hooks/useDefendants/index.ts
@@ -48,7 +48,7 @@ const useDefendants = () => {
             return data.createDefendant?.id
           }
         }
-      } catch (error) {
+      } catch {
         toast.error(formatMessage(errors.createDefendant))
       }
     },
@@ -63,7 +63,7 @@ const useDefendants = () => {
         })
 
         return Boolean(data?.deleteDefendant?.deleted)
-      } catch (error) {
+      } catch {
         toast.error(formatMessage(errors.deleteDefendant))
 
         return false
@@ -82,7 +82,7 @@ const useDefendants = () => {
         })
 
         return Boolean(data)
-      } catch (error) {
+      } catch {
         toast.error(formatMessage(errors.updateDefendant))
 
         return false
@@ -101,7 +101,7 @@ const useDefendants = () => {
         })
 
         return Boolean(data)
-      } catch (error) {
+      } catch {
         toast.error(formatMessage(errors.updateDefendant))
 
         return false

--- a/apps/judicial-system/web/src/utils/hooks/useEventLog/index.ts
+++ b/apps/judicial-system/web/src/utils/hooks/useEventLog/index.ts
@@ -21,7 +21,7 @@ const useEventLog = () => {
         })
 
         return Boolean(data?.createEventLog)
-      } catch (error) {
+      } catch {
         toast.error(formatMessage(errors.createEventLog))
 
         return false

--- a/apps/judicial-system/web/src/utils/hooks/useIndictmentCounts/index.ts
+++ b/apps/judicial-system/web/src/utils/hooks/useIndictmentCounts/index.ts
@@ -45,7 +45,7 @@ const useIndictmentCounts = () => {
         }
 
         return data?.createIndictmentCount
-      } catch (e) {
+      } catch {
         toast.error(formatMessage(errors.createIndictmentCount))
       }
     },
@@ -60,7 +60,7 @@ const useIndictmentCounts = () => {
         })
 
         return data?.deleteIndictmentCount?.deleted
-      } catch (e) {
+      } catch {
         toast.error(formatMessage(errors.deleteIndictmentCount))
       }
     },
@@ -89,7 +89,7 @@ const useIndictmentCounts = () => {
         }
 
         return data?.updateIndictmentCount
-      } catch (e) {
+      } catch {
         toast.error(formatMessage(errors.updateIndictmentCount))
       }
     },

--- a/apps/judicial-system/web/src/utils/hooks/useOffenses/index.ts
+++ b/apps/judicial-system/web/src/utils/hooks/useOffenses/index.ts
@@ -51,7 +51,7 @@ const useOffenses = () => {
         }
 
         return data?.createOffense
-      } catch (e) {
+      } catch {
         toast.error(formatMessage(errors.createOffense))
       }
     },
@@ -72,7 +72,7 @@ const useOffenses = () => {
         })
 
         return data?.deleteOffense?.deleted
-      } catch (e) {
+      } catch {
         toast.error(formatMessage(errors.deleteOffense))
       }
     },
@@ -102,7 +102,7 @@ const useOffenses = () => {
           toast.error(formatMessage(errors.updateOffense))
         }
         return data?.updateOffense
-      } catch (e) {
+      } catch {
         toast.error(formatMessage(errors.updateOffense))
       }
     },

--- a/apps/judicial-system/web/src/utils/hooks/usePoliceDigitalCaseFile/index.ts
+++ b/apps/judicial-system/web/src/utils/hooks/usePoliceDigitalCaseFile/index.ts
@@ -76,7 +76,7 @@ const usePoliceDigitalCaseFile = () => {
         }
 
         return Boolean(data?.deletePoliceDigitalCaseFile)
-      } catch (error) {
+      } catch {
         toast.error('Upp kom villa við að eyða hljóð- og myndupptöku')
         return false
       }

--- a/apps/judicial-system/web/src/utils/hooks/useS3Upload/useS3Upload.ts
+++ b/apps/judicial-system/web/src/utils/hooks/useS3Upload/useS3Upload.ts
@@ -415,7 +415,7 @@ const useS3Upload = (
           )
 
           return true
-        } catch (e) {
+        } catch {
           toast.error(formatMessage(strings.uploadFailed))
           updateFile({ ...file, percent: 0, status: FileUploadStatus.error })
 
@@ -554,7 +554,7 @@ const useS3Upload = (
             },
             fileId,
           )
-        } catch (error) {
+        } catch {
           if (noNationalId) {
             toast.error(`Ákærði: ${defendantName} er ekki með kennitölu`, {
               logMessage: 'Defendant has no national id',

--- a/apps/judicial-system/web/src/utils/hooks/useSubpoena/index.ts
+++ b/apps/judicial-system/web/src/utils/hooks/useSubpoena/index.ts
@@ -60,7 +60,7 @@ export const useCreateSubpoenas = () => {
           }
         }
         return false
-      } catch (error) {
+      } catch {
         toast.error('Upp kom villa við að búa til fyrirkall')
         return false
       }

--- a/apps/judicial-system/web/src/utils/hooks/useVerdict/index.ts
+++ b/apps/judicial-system/web/src/utils/hooks/useVerdict/index.ts
@@ -60,7 +60,7 @@ const useVerdict = (currentVerdict?: Verdict) => {
       })
 
       return Boolean(data)
-    } catch (error) {
+    } catch {
       toast.error('Upp kom villa við að uppfæra mál')
       return false
     }
@@ -76,7 +76,7 @@ const useVerdict = (currentVerdict?: Verdict) => {
         })
 
         return Boolean(data)
-      } catch (error) {
+      } catch {
         toast.error('Upp kom villa við að uppfæra dóm')
         return false
       }
@@ -124,7 +124,7 @@ const useVerdict = (currentVerdict?: Verdict) => {
           variables: { input: { caseId } },
         })
         return result.data?.deliverCaseVerdict?.queued ?? false
-      } catch (error) {
+      } catch {
         toast.error('Upp kom villa við senda dóm í birtingu')
         return false
       }

--- a/apps/judicial-system/web/src/utils/hooks/useVictim/index.ts
+++ b/apps/judicial-system/web/src/utils/hooks/useVictim/index.ts
@@ -35,7 +35,7 @@ const useVictims = () => {
           }
         }
         return null
-      } catch (error) {
+      } catch {
         toast.error('Upp kom villa við að bæta við brotaþola')
         return null
       }
@@ -51,7 +51,7 @@ const useVictims = () => {
         })
 
         return Boolean(data?.deleteVictim.deleted)
-      } catch (error) {
+      } catch {
         toast.error('Upp kom villa við að eyða brotaþola')
         return false
       }
@@ -69,7 +69,7 @@ const useVictims = () => {
         })
 
         return Boolean(data)
-      } catch (error) {
+      } catch {
         toast.error('Upp kom villa við að uppfæra brotaþola')
         return false
       }


### PR DESCRIPTION
## What
Fixes all 60 lint warnings in `judicial-system-web` and all 4 in `judicial-system-backend`. Both projects now lint clean.

- Unused `catch (error)` / `catch (e)` bindings in the web hooks replaced with bare `catch {}` (52 occurrences, only on the flagged lines)
- `no-redeclare` warnings fixed by renaming file-local interfaces that shared a name with the component/context they typed: `FeatureContextValue`, `FormContextValue`, `UserContextValue`, `LawyerRegistryContextValue`, `DateTimeValue`
- Removed unused imports (`_isEqual`, `Box` in web; `SequelizeModule`, `InjectModel`, `CaseAppealDecision`, `getModelToken` in backend)

No behavior changes, no exported names changed.

## Why
Lint warnings had accumulated and were adding noise to CI output, making new warnings easy to miss.

## Screenshots / Gifs
Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code
- [ ] No AI tools were used in preparing this pull request

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal consistency across case-management workflows by cleaning up unused references and simplifying error handling.
  * Clarified naming for provider, context, and date-related types to improve maintainability.
  * Preserved existing error notifications, fallback behavior, and user-facing functionality across affected workflows.
  * No changes to available features or application behavior are expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->