### PR TITLE
fix(native-app): improve error messaging in heilsa in app

### DIFF
--- a/apps/native/app/src/app/(auth)/(tabs)/health/appointments/[id].tsx
+++ b/apps/native/app/src/app/(auth)/(tabs)/health/appointments/[id].tsx
@@ -320,6 +320,7 @@ export default function AppointmentDetailScreen() {
           <ProblemContainer>
             <Problem
               type="error"
+              error={error}
               title={intl.formatMessage({ id: 'problem.error.title' })}
               message={intl.formatMessage({
                 id: 'health.appointments.errorMessage',

--- a/apps/native/app/src/app/(auth)/(tabs)/health/appointments/[id].tsx
+++ b/apps/native/app/src/app/(auth)/(tabs)/health/appointments/[id].tsx
@@ -324,7 +324,6 @@ export default function AppointmentDetailScreen() {
               message={intl.formatMessage({
                 id: 'health.appointments.errorMessage',
               })}
-              tag={error.message}
             />
           </ProblemContainer>
         )}

--- a/apps/native/app/src/app/(auth)/(tabs)/health/appointments/index.tsx
+++ b/apps/native/app/src/app/(auth)/(tabs)/health/appointments/index.tsx
@@ -108,7 +108,6 @@ export default function AppointmentsScreen() {
                 message={intl.formatMessage({
                   id: 'health.appointments.errorMessage',
                 })}
-                tag={appointmentsRes.error.message}
               />
             </ErrorWrapper>
           )}

--- a/apps/native/app/src/app/(auth)/(tabs)/health/appointments/index.tsx
+++ b/apps/native/app/src/app/(auth)/(tabs)/health/appointments/index.tsx
@@ -104,6 +104,7 @@ export default function AppointmentsScreen() {
             <ErrorWrapper>
               <Problem
                 type="error"
+                error={appointmentsRes.error}
                 title={intl.formatMessage({ id: 'problem.error.title' })}
                 message={intl.formatMessage({
                   id: 'health.appointments.errorMessage',

--- a/apps/native/app/src/app/(auth)/(tabs)/health/index.tsx
+++ b/apps/native/app/src/app/(auth)/(tabs)/health/index.tsx
@@ -799,8 +799,7 @@ export default function HealthOverviewScreen() {
                 warningText={
                   !isMedicinePeriodActive
                     ? intl.formatMessage({
-                        id:
-                          'health.overview.medicinePurchaseNoActivePeriodWarning',
+                        id: 'health.overview.medicinePurchaseNoActivePeriodWarning',
                       })
                     : ''
                 }

--- a/apps/native/app/src/app/(auth)/(tabs)/health/index.tsx
+++ b/apps/native/app/src/app/(auth)/(tabs)/health/index.tsx
@@ -396,6 +396,11 @@ export default function HealthOverviewScreen() {
 
   const isOrganDonor = organDonationData?.isDonor ?? false
 
+  // The two co-payment queries are independent, so a failure only affects the
+  // fields it feeds rather than erroring the whole section. Inneign and Skuld
+  // fall back to '-' on their own, so only these two need the warning.
+  const paymentStatusFailed = !!paymentStatusRes.error && !paymentStatusRes.data
+
   const onRefresh = useCallback(async () => {
     setRefetching(true)
 
@@ -544,7 +549,6 @@ export default function HealthOverviewScreen() {
                   message={intl.formatMessage({
                     id: 'health.appointments.errorMessage',
                   })}
-                  tag={appointmentsRes.error.message}
                 />
               </AppointmentsContainer>
             )}
@@ -652,77 +656,91 @@ export default function HealthOverviewScreen() {
             )
           }
         />
-        {(paymentOverviewRes.loading || paymentOverviewRes.data) && (
-          <>
-            <InputRow background>
-              <Input
-                label={intl.formatMessage({
-                  id: 'health.overview.maxMonthlyPayment',
-                })}
-                value={
-                  paymentStatusData?.maximumMonthlyPayment
-                    ? `${intl.formatNumber(
-                        paymentStatusData?.maximumMonthlyPayment,
-                      )} kr.`
-                    : '0 kr.'
-                }
-                loading={paymentStatusRes.loading && !paymentStatusRes.data}
-                error={paymentStatusRes.error && !paymentStatusRes.data}
-                darkBorder
-              />
-            </InputRow>
-            <InputRow background>
-              <Input
-                label={intl.formatMessage({
-                  id: 'health.overview.paymentLimit',
-                })}
-                value={
-                  paymentStatusData?.maximumPayment
-                    ? `${intl.formatNumber(
-                        paymentStatusData?.maximumPayment,
-                      )} kr.`
-                    : '0 kr.'
-                }
-                loading={paymentStatusRes.loading && !paymentStatusRes.data}
-                error={paymentStatusRes.error && !paymentStatusRes.data}
-                darkBorder
-              />
-            </InputRow>
-            <InputRow background>
-              <Input
-                label={intl.formatMessage({
-                  id: 'health.overview.paymentCredit',
-                })}
-                value={
-                  paymentOverviewData?.credit
-                    ? `${intl.formatNumber(paymentOverviewData?.credit)} kr.`
-                    : '0 kr.'
-                }
-                loading={paymentOverviewRes.loading && !paymentOverviewRes.data}
-                error={paymentOverviewRes.error && !paymentOverviewRes.data}
-                noBorder
-              />
-              <Input
-                label={intl.formatMessage({
-                  id: 'health.overview.paymentDebt',
-                })}
-                value={
-                  paymentOverviewData?.debt
-                    ? `${intl.formatNumber(paymentOverviewData?.debt)} kr.`
-                    : '0 kr.'
-                }
-                loading={paymentOverviewRes.loading && !paymentOverviewRes.data}
-                error={paymentOverviewRes.error && !paymentOverviewRes.data}
-                noBorder
-              />
-            </InputRow>
-          </>
-        )}
-        {paymentOverviewRes.error &&
-          !paymentOverviewRes.data &&
-          paymentStatusRes.error &&
-          !paymentStatusRes.data &&
-          showErrorComponent(paymentOverviewRes.error)}
+        <InputRow background>
+          <Input
+            label={intl.formatMessage({
+              id: 'health.overview.maxMonthlyPayment',
+            })}
+            value={
+              paymentStatusData?.maximumMonthlyPayment != null
+                ? `${intl.formatNumber(
+                    paymentStatusData.maximumMonthlyPayment,
+                  )} kr.`
+                : ''
+            }
+            loading={
+              !hasBeenFocused ||
+              (paymentStatusRes.loading && !paymentStatusRes.data)
+            }
+            // No '-' placeholder on these two, the warning stands on its own
+            allowEmptyValue={paymentStatusFailed}
+            warningText={
+              paymentStatusFailed
+                ? intl.formatMessage({ id: 'problem.thirdParty.message' })
+                : ''
+            }
+            fullWidthWarning
+            darkBorder
+          />
+        </InputRow>
+        <InputRow background>
+          <Input
+            label={intl.formatMessage({
+              id: 'health.overview.paymentLimit',
+            })}
+            value={
+              paymentStatusData?.maximumPayment != null
+                ? `${intl.formatNumber(paymentStatusData.maximumPayment)} kr.`
+                : ''
+            }
+            loading={
+              !hasBeenFocused ||
+              (paymentStatusRes.loading && !paymentStatusRes.data)
+            }
+            allowEmptyValue={paymentStatusFailed}
+            warningText={
+              paymentStatusFailed
+                ? intl.formatMessage({ id: 'problem.thirdParty.message' })
+                : ''
+            }
+            fullWidthWarning
+            darkBorder
+          />
+        </InputRow>
+        <InputRow background>
+          <Input
+            label={intl.formatMessage({
+              id: 'health.overview.paymentCredit',
+            })}
+            value={
+              // A missing value is not the same as a zero balance, so only
+              // format an actual number and let the rest fall back to '-'
+              paymentOverviewData?.credit != null
+                ? `${intl.formatNumber(paymentOverviewData.credit)} kr.`
+                : ''
+            }
+            loading={
+              !hasBeenFocused ||
+              (paymentOverviewRes.loading && !paymentOverviewRes.data)
+            }
+            noBorder
+          />
+          <Input
+            label={intl.formatMessage({
+              id: 'health.overview.paymentDebt',
+            })}
+            value={
+              paymentOverviewData?.debt != null
+                ? `${intl.formatNumber(paymentOverviewData.debt)} kr.`
+                : ''
+            }
+            loading={
+              !hasBeenFocused ||
+              (paymentOverviewRes.loading && !paymentOverviewRes.data)
+            }
+            noBorder
+          />
+        </InputRow>
         <HeadingSection
           title={intl.formatMessage({
             id: 'health.overview.medicinePurchase',
@@ -779,7 +797,8 @@ export default function HealthOverviewScreen() {
                 warningText={
                   !isMedicinePeriodActive
                     ? intl.formatMessage({
-                        id: 'health.overview.medicinePurchaseNoActivePeriodWarning',
+                        id:
+                          'health.overview.medicinePurchaseNoActivePeriodWarning',
                       })
                     : ''
                 }

--- a/apps/native/app/src/app/(auth)/(tabs)/health/index.tsx
+++ b/apps/native/app/src/app/(auth)/(tabs)/health/index.tsx
@@ -545,6 +545,7 @@ export default function HealthOverviewScreen() {
                 <Problem
                   type="error"
                   size="small"
+                  error={appointmentsRes.error}
                   title={intl.formatMessage({ id: 'problem.error.title' })}
                   message={intl.formatMessage({
                     id: 'health.appointments.errorMessage',
@@ -601,6 +602,7 @@ export default function HealthOverviewScreen() {
                 <Problem
                   type="error"
                   size="small"
+                  error={messagesRes.error}
                   title={intl.formatMessage({ id: 'problem.error.title' })}
                   message={intl.formatMessage({
                     id: 'health.messages.errorMessage',

--- a/apps/native/app/src/app/(auth)/(tabs)/health/medicine/delegation/index.tsx
+++ b/apps/native/app/src/app/(auth)/(tabs)/health/medicine/delegation/index.tsx
@@ -1,93 +1,25 @@
-import React, { useCallback, useState } from 'react'
+import React from 'react'
 import { useIntl } from 'react-intl'
-import { RefreshControl, ScrollView, View } from 'react-native'
+import { View } from 'react-native'
 import { StackScreen } from '@/components/stack-screen'
-import styled from 'styled-components/native'
 
-import { useGetMedicineDelegationsLazyQuery } from '@/graphql/types/schema'
-import { GeneralCardSkeleton } from '@/ui'
-import { MedicineDelegationContent } from '../../../../../../components/health-tabs/medicine-delegation-tab'
-
-const Host = styled.View`
-  flex: 1;
-  padding-horizontal: ${({ theme }) => theme.spacing[2]}px;
-`
+import { MedicineDelegationTab } from '@/components/health-tabs/medicine-delegation-tab'
 
 export default function MedicineDelegationScreen() {
   const intl = useIntl()
-  const [refetching, setRefetching] = useState(false)
-  const [showInactivePermits, setShowInactivePermits] = useState(false)
-
-  const [loadDelegations, delegationsRes] = useGetMedicineDelegationsLazyQuery({
-    variables: {
-      locale: intl.locale,
-      input: {
-        status: [
-          'active',
-          'expired',
-          'inactive',
-          'unknown',
-          'awaitingApproval',
-        ],
-      },
-    },
-  })
-
-  // Load on mount
-  React.useEffect(() => {
-    if (!delegationsRes.called) {
-      loadDelegations()
-    }
-  }, [delegationsRes.called, loadDelegations])
-
-  const onRefresh = useCallback(async () => {
-    setRefetching(true)
-    try {
-      if (delegationsRes.called && delegationsRes.refetch) {
-        await delegationsRes.refetch()
-      }
-    } catch (e) {
-      // noop
-    } finally {
-      setRefetching(false)
-    }
-  }, [delegationsRes])
 
   return (
     <View style={{ flex: 1 }}>
       <StackScreen
-        networkStatus={delegationsRes.networkStatus}
         options={{
           title: intl.formatMessage({
             id: 'health.medicineDelegation.screenTitle',
           }),
         }}
       />
-      <ScrollView
-        style={{ flex: 1 }}
-        refreshControl={
-          <RefreshControl refreshing={refetching} onRefresh={onRefresh} />
-        }
-      >
-        <Host>
-          {delegationsRes.loading && !delegationsRes.data ? (
-            Array.from({ length: 3 }).map((_, index) => (
-              <GeneralCardSkeleton height={90} key={index} />
-            ))
-          ) : (
-            <MedicineDelegationContent
-              componentId="delegation"
-              delegations={
-                delegationsRes.data?.healthDirectorateMedicineDelegations
-                  ?.items ?? []
-              }
-              loading={delegationsRes.loading}
-              error={delegationsRes.error}
-              showInactivePermits={showInactivePermits}
-            />
-          )}
-        </Host>
-      </ScrollView>
+      {/* The tab owns its query, pull-to-refresh, skeletons and error state, so
+          this route is only responsible for giving it a screen to live on. */}
+      <MedicineDelegationTab />
     </View>
   )
 }

--- a/apps/native/app/src/app/(auth)/(tabs)/health/messages/[id].tsx
+++ b/apps/native/app/src/app/(auth)/(tabs)/health/messages/[id].tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { useApolloClient } from '@apollo/client'
+import { gql, useApolloClient } from '@apollo/client'
 import { useIntl } from 'react-intl'
 import {
   FlatList,
@@ -41,6 +41,7 @@ import {
   Button,
   GeneralCardSkeleton,
   ListItemSkeleton,
+  Problem,
   ProblemTemplate,
   theme,
 } from '@/ui'
@@ -66,6 +67,14 @@ const isSingularDayCount = (days: number, locale: string): boolean => {
   }
   return days === 1
 }
+
+// The list and detail queries normalize to separate cache entries, so the list's
+// title survives a failed detail fetch. Read it to fall back on for the header.
+const CONVERSATION_TITLE_FRAGMENT = gql`
+  fragment HealthConversationTitle on HealthDirectorateHealthConversation {
+    title
+  }
+`
 
 // Maps a reply-blocked reason to its explanatory message.
 const replyBlockedMessageId = (
@@ -154,6 +163,30 @@ export default function HealthMessageDetailScreen() {
   const conversation = res.data?.healthDirectorateHealthConversation
   const messages = useMemo(() => conversation?.messages ?? [], [conversation])
   const isSkeleton = res.loading && !res.data
+  // Only surface the error when we have nothing to show, so a cached
+  // conversation still renders through a failed background refetch.
+  const hasError = !!res.error && !conversation
+  // A bad or stale id (e.g. a notification outliving the thread) is a successful
+  // response carrying null, not a failure, so it needs its own branch.
+  const notFound = !hasError && !isSkeleton && !!res.data && !conversation
+
+  // Falls back to the title the list query cached, so the header still names the
+  // message when the detail fetch fails instead of going blank.
+  const cachedTitle = useMemo(() => {
+    const cacheId = client.cache.identify({
+      __typename: 'HealthDirectorateHealthConversation',
+      id,
+    })
+    if (!cacheId) {
+      return undefined
+    }
+    return (
+      client.readFragment<{ title?: string | null }>({
+        id: cacheId,
+        fragment: CONVERSATION_TITLE_FRAGMENT,
+      })?.title ?? undefined
+    )
+  }, [client, id])
 
   // An expired reply window is the one reason we can quantify, so name the
   // number of days when the server sends it. It is nullable, so fall back to
@@ -440,7 +473,7 @@ export default function HealthMessageDetailScreen() {
       <StackScreen
         networkStatus={res.networkStatus}
         options={{
-          title: conversation?.title ?? '',
+          title: conversation?.title ?? cachedTitle ?? '',
           // Android centers a long title over the back arrow; left-align there
           // so it truncates next to it instead. iOS reserves the button space.
           headerTitleAlign: Platform.OS === 'android' ? 'left' : 'center',
@@ -519,6 +552,34 @@ export default function HealthMessageDetailScreen() {
                   })}
                   hasBorder
                 />
+              </View>
+            ) : null
+          }
+          ListEmptyComponent={
+            hasError || notFound ? (
+              <View
+                style={{
+                  paddingHorizontal: theme.spacing[2],
+                  paddingTop: theme.spacing[3],
+                }}
+              >
+                {hasError ? (
+                  <Problem
+                    type="error"
+                    title={intl.formatMessage({ id: 'problem.error.title' })}
+                    message={intl.formatMessage({
+                      id: 'health.messages.errorMessage',
+                    })}
+                  />
+                ) : (
+                  <Problem
+                    type="no_data"
+                    title={intl.formatMessage({ id: 'problem.noData.title' })}
+                    message={intl.formatMessage({
+                      id: 'health.messages.notFoundMessage',
+                    })}
+                  />
+                )}
               </View>
             ) : null
           }

--- a/apps/native/app/src/app/(auth)/(tabs)/health/messages/[id].tsx
+++ b/apps/native/app/src/app/(auth)/(tabs)/health/messages/[id].tsx
@@ -566,6 +566,7 @@ export default function HealthMessageDetailScreen() {
                 {hasError ? (
                   <Problem
                     type="error"
+                    error={res.error}
                     title={intl.formatMessage({ id: 'problem.error.title' })}
                     message={intl.formatMessage({
                       id: 'health.messages.errorMessage',

--- a/apps/native/app/src/app/(auth)/(tabs)/health/messages/index.tsx
+++ b/apps/native/app/src/app/(auth)/(tabs)/health/messages/index.tsx
@@ -200,6 +200,7 @@ export default function HealthMessagesScreen() {
             <View style={{ marginHorizontal: 16, marginTop: 24 }}>
               <Problem
                 type="error"
+                error={messagesRes.error}
                 title={intl.formatMessage({ id: 'problem.error.title' })}
                 message={intl.formatMessage({
                   id: 'health.messages.errorMessage',

--- a/apps/native/app/src/app/(auth)/(tabs)/health/messages/new.tsx
+++ b/apps/native/app/src/app/(auth)/(tabs)/health/messages/new.tsx
@@ -294,6 +294,7 @@ export default function HealthMessageComposeScreen() {
         ) : recipientsError ? (
           <Problem
             type="error"
+            error={recipientsRes.error}
             title={intl.formatMessage({ id: 'problem.error.title' })}
             message={intl.formatMessage({
               id: 'health.messages.errorMessage',

--- a/apps/native/app/src/app/(auth)/(tabs)/health/vaccinations.tsx
+++ b/apps/native/app/src/app/(auth)/(tabs)/health/vaccinations.tsx
@@ -123,7 +123,7 @@ export default function VaccinationsScreen() {
         )}
         {vaccinationsRes.error && !vaccinationsRes.data && (
           <ErrorWrapper>
-            <Problem />
+            <Problem error={vaccinationsRes.error} />
           </ErrorWrapper>
         )}
       </Host>

--- a/apps/native/app/src/components/health-tabs/medicine-delegation-tab.tsx
+++ b/apps/native/app/src/components/health-tabs/medicine-delegation-tab.tsx
@@ -181,7 +181,7 @@ export function MedicineDelegationTab({ initial }: { initial?: boolean }) {
 
         {hasError ? (
           <View style={{ marginTop: theme.spacing[3] }}>
-            <Problem />
+            <Problem error={medicineDelegationsRes.error} />
           </View>
         ) : isInitialLoading ? (
           <View style={{ paddingVertical: theme.spacing[2] }}>

--- a/apps/native/app/src/messages/en.ts
+++ b/apps/native/app/src/messages/en.ts
@@ -879,6 +879,8 @@ export const en: TranslatedMessages = {
   'health.messages.screenTitle': 'Messages',
   'health.messages.errorMessage':
     'Failed to fetch messages. Please try again later.',
+  'health.messages.notFoundMessage':
+    'Message not found. It may have been removed.',
   'health.messages.noMessagesTitle': 'No messages',
   'health.messages.noMessagesText':
     'When you receive messages, they will appear here.',

--- a/apps/native/app/src/messages/is.ts
+++ b/apps/native/app/src/messages/is.ts
@@ -877,6 +877,8 @@ export const is = {
   'health.messages.screenTitle': 'Skilaboð',
   'health.messages.errorMessage':
     'Ekki tókst að sækja skilaboð. Vinsamlegast reyndu aftur síðar.',
+  'health.messages.notFoundMessage':
+    'Skilaboðin fundust ekki. Þau kunna að hafa verið fjarlægð.',
   'health.messages.noMessagesTitle': 'Engin skilaboð',
   'health.messages.noMessagesText': 'Þegar þú færð skilaboð birtast þau hér.',
   'health.messages.searchPlaceholder': 'Leita',


### PR DESCRIPTION
## What

Fixes missing and misleading error states across the Heilsa section.

- Appointments no longer show the raw `Internal server error` string as the Problem tag.
- Greiðsluþátttaka had no reachable error state — a single query failing showed an empty
  section or a grey skeleton that reads as "loading forever". Each query now reports on its
  own fields.
- `0 kr.` no longer stands in for missing data (truthiness check → `!= null`).
- Health message detail had no error handling at all; a failed fetch rendered a blank
  screen. Adds error and not-found states, plus a header fallback to the cached title.
- Fixes a crashing route: `medicine/delegation/index.tsx` imported a component that doesn't
  exist. Only reachable by deep link, so it went unnoticed. Now renders
  `MedicineDelegationTab`, which already handles its own query, refresh and errors.
- Forwards the ApolloError to `Problem` in 9 places that dropped it, so failures the API
  tags with an `organizationSlug` show the yellow card naming the service.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error states across Health, including appointments, messages, medicine delegations, and vaccinations, with more accurate details.
  - Health payment information now displays correctly when overview data is unavailable, including proper handling of zero values.
  - Added a clear warning when payment-status information cannot be loaded.
  - Message details now distinguish between loading errors and messages that cannot be found, with a suitable fallback title.
  - Improved loading and refresh behavior for medicine delegations.

- **Localization**
  - Added English and Icelandic text for unavailable health messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->