### PR TITLE
fix(j-s): post Slack event when reopening an indictment case

### DIFF
--- a/apps/judicial-system/backend/src/app/modules/case/case.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/case/case.service.ts
@@ -2187,6 +2187,8 @@ export class CaseService {
       theCase.courtId !== update.courtId &&
       theCase.state === CaseState.RECEIVED
 
+    const isReopeningCase = update.reopenReason !== undefined
+
     if (isReceivingCase) {
       update = transitionCase(CaseTransition.RECEIVE, theCase, user, update)
     }
@@ -2195,7 +2197,7 @@ export class CaseService {
       update = transitionCase(CaseTransition.MOVE, theCase, user, update)
     }
 
-    if (update.reopenReason !== undefined) {
+    if (isReopeningCase) {
       const header = `${capitalize(formatDate(nowFactory(), 'PPPPp'))} - ${
         user.name
       } ${lowercase(user.title)}.`
@@ -2540,6 +2542,10 @@ export class CaseService {
         from: theCase.court?.name,
         to: updatedCase?.court?.name,
       })
+    }
+
+    if (isReopeningCase) {
+      this.eventService.postEvent(CaseTransition.REOPEN, updatedCase)
     }
 
     if (returnUpdatedCase) {

--- a/apps/judicial-system/backend/src/app/modules/case/test/caseController/update.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/case/test/caseController/update.spec.ts
@@ -17,6 +17,7 @@ import {
   CaseIndictmentRulingDecision,
   CaseOrigin,
   CaseState,
+  CaseTransition,
   CaseType,
   DateType,
   DefendantEventType,
@@ -39,6 +40,7 @@ import { createTestingCaseModule } from '../createTestingCaseModule'
 import { nowFactory } from '../../../../factories'
 import { randomDate } from '../../../../test'
 import { DefendantService } from '../../../defendant'
+import { EventService } from '../../../event'
 import { EventLogService } from '../../../event-log/eventLog.service'
 import { FileService } from '../../../file'
 import {
@@ -92,6 +94,7 @@ describe('CaseController - Update', () => {
 
   let mockQueuedMessages: Message[]
   let mockEventLogService: EventLogService
+  let mockEventService: EventService
   let mockUserService: UserService
   let mockFileService: FileService
   let transaction: Transaction
@@ -107,6 +110,7 @@ describe('CaseController - Update', () => {
     const {
       queuedMessages,
       eventLogService,
+      eventService,
       userService,
       fileService,
       sequelize,
@@ -121,6 +125,7 @@ describe('CaseController - Update', () => {
 
     mockQueuedMessages = queuedMessages
     mockEventLogService = eventLogService
+    mockEventService = eventService
     mockUserService = userService
     mockFileService = fileService
     mockCaseRepositoryService = caseRepositoryService
@@ -1710,6 +1715,13 @@ describe('CaseController - Update', () => {
         caseId,
         user,
         transaction,
+      )
+    })
+
+    it('should post a REOPEN Slack event', () => {
+      expect(mockEventService.postEvent).toHaveBeenCalledWith(
+        CaseTransition.REOPEN,
+        expect.objectContaining({ id: caseId, state: CaseState.RECEIVED }),
       )
     })
   })


### PR DESCRIPTION
[Bæta við Slack event fyrir enduropnun sakamáls](https://app.asana.com/1/203394141643832/project/1199153462262248/task/1218361374808404)

## What

Post a `REOPEN` Slack event from `CaseService.update` when an indictment case is reopened via `reopenReason`, matching how `RECEIVE` and `MOVE` side-effect transitions are already announced.

Also assert the Slack post in the existing reopen update controller spec.

## Why

Reopening an indictment (e.g. after retrial) never reached Slack because that path bypasses `PATCH .../state` and forgot the `postEvent` call. Other Slack transition titles were already defined; only the call site was missing. A quick check of the state machine showed no other transition with the same gap.

## Screenshots / Gifs

N/A

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Cursor


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reopening a completed indictment case now records a case-reopened event after the update.

* **Bug Fixes**
  * Case reopening transitions now consistently trigger the corresponding event notification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->