### PR TITLE
fix(j-s): Confirm review decisions once and save only what changed

### DIFF
--- a/apps/judicial-system/web/src/routes/Prosecutor/Indictments/IndictmentOverview/IndictmentOverview.spec.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/Indictments/IndictmentOverview/IndictmentOverview.spec.tsx
@@ -1,12 +1,22 @@
+import type { FC, PropsWithChildren } from 'react'
+import { useState } from 'react'
 import { MockedProvider } from '@apollo/client/testing'
-import { render, waitFor } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 
-import { UserContext } from '@island.is/judicial-system-web/src/components'
-import type { User } from '@island.is/judicial-system-web/src/graphql/schema'
+import {
+  FormContext,
+  UserContext,
+} from '@island.is/judicial-system-web/src/components'
+import type {
+  Case,
+  User,
+} from '@island.is/judicial-system-web/src/graphql/schema'
 import {
   CaseIndictmentRulingDecision,
   CaseState,
   CaseType,
+  IndictmentCaseReviewDecision,
   InstitutionType,
   UserRole,
 } from '@island.is/judicial-system-web/src/graphql/schema'
@@ -34,14 +44,71 @@ const reviewerUser: User = {
   },
 }
 
+const mockPush = jest.fn()
+
 jest.mock('next/router', () => ({
   useRouter() {
     return {
       pathname: '',
-      push: jest.fn(),
+      push: mockPush,
     }
   },
 }))
+
+// The radios only change the working case; confirming saves through
+// updateDefendant. The state update is kept real so a click is visible to the
+// page, the server call is recorded.
+const mockUpdateDefendant = jest.fn()
+
+jest.mock('../../../../utils/hooks/useDefendants', () => ({
+  __esModule: true,
+  default: () => ({
+    updateDefendant: mockUpdateDefendant,
+    isUpdatingDefendant: false,
+    updateDefendantState: (
+      update: { defendantId: string; indictmentReviewDecision: unknown },
+      setWorkingCase: (fn: (prev: Case) => Case) => void,
+    ) =>
+      setWorkingCase((prev) => ({
+        ...prev,
+        defendants: prev.defendants?.map((d) =>
+          d.id === update.defendantId
+            ? {
+                ...d,
+                indictmentReviewDecision:
+                  update.indictmentReviewDecision as IndictmentCaseReviewDecision,
+              }
+            : d,
+        ),
+      })),
+  }),
+}))
+
+// A form context whose working case actually updates, unlike the shared
+// wrapper's jest.fn setter.
+const StatefulFormContext: FC<PropsWithChildren<{ initialCase: Case }>> = ({
+  initialCase,
+  children,
+}) => {
+  const [workingCase, setWorkingCase] = useState<Case>(initialCase)
+
+  return (
+    <FormContext.Provider
+      value={{
+        workingCase,
+        setWorkingCase,
+        isLoadingWorkingCase: false,
+        caseNotFound: false,
+        isCaseUpToDate: true,
+        refreshCase: jest.fn(),
+        getCase: jest.fn(),
+        isCreating: false,
+      }}
+    >
+      {children}
+    </FormContext.Provider>
+  )
+}
 
 window.scrollTo = jest.fn()
 
@@ -104,5 +171,116 @@ describe('Prosecutor IndictmentOverview', () => {
     expect(
       container.querySelector('#review-option-appeal-dismissed_defendant_id'),
     ).not.toBeInTheDocument()
+  })
+
+  describe('confirming the review decisions', () => {
+    // Two defendants; the first was already reviewed as ACCEPT, the second is
+    // still undecided.
+    const reviewCase = (): Case => ({
+      ...mockCase(CaseType.INDICTMENT),
+      state: CaseState.COMPLETED,
+      indictmentRulingDecision: CaseIndictmentRulingDecision.RULING,
+      indictmentReviewer: { id: reviewerUser.id },
+      defendants: [
+        {
+          id: 'reviewed_defendant_id',
+          name: 'Reviewed Defendant',
+          indictmentReviewDecision: IndictmentCaseReviewDecision.ACCEPT,
+        },
+        {
+          id: 'undecided_defendant_id',
+          name: 'Undecided Defendant',
+          indictmentReviewDecision: null,
+        },
+      ],
+    })
+
+    const renderReview = () =>
+      render(
+        <MockedProvider
+          mocks={[...mockCaseTableMembershipQuery('test_id')]}
+          addTypename={false}
+        >
+          <UserContext.Provider value={{ user: reviewerUser }}>
+            <IntlProviderWrapper>
+              <StatefulFormContext initialCase={reviewCase()}>
+                <IndictmentOverview />
+                {/* Modals portal into this container, normally supplied by PageLayout */}
+                <div id="modal" />
+              </StatefulFormContext>
+            </IntlProviderWrapper>
+          </UserContext.Provider>
+        </MockedProvider>,
+      )
+
+    beforeEach(() => {
+      mockUpdateDefendant.mockReset()
+      mockPush.mockReset()
+      mockUpdateDefendant.mockResolvedValue({ id: 'updated' })
+    })
+
+    it('opens one confirmation for the case and saves only the decisions that changed', async () => {
+      const { container } = renderReview()
+
+      await waitFor(() =>
+        expect(
+          container.querySelector(
+            '#review-option-appeal-undecided_defendant_id',
+          ),
+        ).toBeInTheDocument(),
+      )
+      expect(
+        screen.getByRole('button', { name: 'Ljúka yfirlestri' }),
+      ).toBeDisabled()
+
+      await userEvent.click(
+        screen.getByLabelText('Áfrýja héraðsdómi til Landsréttar', {
+          selector: '#review-option-appeal-undecided_defendant_id',
+        }),
+      )
+      await userEvent.click(
+        screen.getByRole('button', { name: 'Ljúka yfirlestri' }),
+      )
+
+      // One modal, whatever the number of defendants.
+      expect(await screen.findAllByText('Staðfesta ákvörðun')).toHaveLength(1)
+
+      await userEvent.click(screen.getByRole('button', { name: 'Staðfesta' }))
+
+      await waitFor(() => expect(mockUpdateDefendant).toHaveBeenCalledTimes(1))
+      expect(mockUpdateDefendant).toHaveBeenCalledWith({
+        caseId: 'test_id',
+        defendantId: 'undecided_defendant_id',
+        indictmentReviewDecision: IndictmentCaseReviewDecision.APPEAL,
+      })
+      await waitFor(() => expect(mockPush).toHaveBeenCalled())
+    })
+
+    it('stays on the page when a save fails', async () => {
+      mockUpdateDefendant.mockResolvedValue(undefined)
+      const { container } = renderReview()
+
+      await waitFor(() =>
+        expect(
+          container.querySelector(
+            '#review-option-appeal-undecided_defendant_id',
+          ),
+        ).toBeInTheDocument(),
+      )
+      await userEvent.click(
+        screen.getByLabelText('Áfrýja héraðsdómi til Landsréttar', {
+          selector: '#review-option-appeal-undecided_defendant_id',
+        }),
+      )
+      await userEvent.click(
+        screen.getByRole('button', { name: 'Ljúka yfirlestri' }),
+      )
+      await userEvent.click(
+        await screen.findByRole('button', { name: 'Staðfesta' }),
+      )
+
+      await waitFor(() => expect(mockUpdateDefendant).toHaveBeenCalledTimes(1))
+      expect(mockPush).not.toHaveBeenCalled()
+    })
   })
 })

--- a/apps/judicial-system/web/src/routes/Prosecutor/Indictments/IndictmentOverview/IndictmentOverview.spec.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/Indictments/IndictmentOverview/IndictmentOverview.spec.tsx
@@ -256,6 +256,55 @@ describe('Prosecutor IndictmentOverview', () => {
       await waitFor(() => expect(mockPush).toHaveBeenCalled())
     })
 
+    // The saves are independent requests; one that succeeded must not be sent
+    // again when the reviewer retries after another failed.
+    it('retries only the decision whose save failed', async () => {
+      mockUpdateDefendant.mockImplementation(
+        async ({ defendantId }: { defendantId: string }) =>
+          defendantId === 'reviewed_defendant_id'
+            ? { id: defendantId }
+            : undefined,
+      )
+      const { container } = renderReview()
+
+      await waitFor(() =>
+        expect(
+          container.querySelector(
+            '#review-option-appeal-undecided_defendant_id',
+          ),
+        ).toBeInTheDocument(),
+      )
+      // Change both: the reviewed one flips to APPEAL, the undecided one is set.
+      await userEvent.click(
+        screen.getByLabelText('Áfrýja héraðsdómi til Landsréttar', {
+          selector: '#review-option-appeal-reviewed_defendant_id',
+        }),
+      )
+      await userEvent.click(
+        screen.getByLabelText('Áfrýja héraðsdómi til Landsréttar', {
+          selector: '#review-option-appeal-undecided_defendant_id',
+        }),
+      )
+      await userEvent.click(
+        screen.getByRole('button', { name: 'Ljúka yfirlestri' }),
+      )
+      await userEvent.click(
+        await screen.findByRole('button', { name: 'Staðfesta' }),
+      )
+
+      await waitFor(() => expect(mockUpdateDefendant).toHaveBeenCalledTimes(2))
+      expect(mockPush).not.toHaveBeenCalled()
+
+      // Retry: only the failed defendant is sent.
+      mockUpdateDefendant.mockClear()
+      await userEvent.click(screen.getByRole('button', { name: 'Staðfesta' }))
+
+      await waitFor(() => expect(mockUpdateDefendant).toHaveBeenCalledTimes(1))
+      expect(mockUpdateDefendant).toHaveBeenCalledWith(
+        expect.objectContaining({ defendantId: 'undecided_defendant_id' }),
+      )
+    })
+
     it('stays on the page when a save fails', async () => {
       mockUpdateDefendant.mockResolvedValue(undefined)
       const { container } = renderReview()

--- a/apps/judicial-system/web/src/routes/Prosecutor/Indictments/IndictmentOverview/IndictmentOverview.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/Indictments/IndictmentOverview/IndictmentOverview.tsx
@@ -322,6 +322,20 @@ const IndictmentOverview: FC = () => {
             caseId={workingCase.id}
             changedDefendants={changedReviewDecisions}
             onClose={() => setModalVisible(undefined)}
+            // A saved decision is the new original: it no longer counts as
+            // changed, so a retry after a partial failure sends only the rest.
+            onSaved={(savedDefendantIds) =>
+              setOriginalReviewDecisions((previous) => ({
+                ...previous,
+                ...Object.fromEntries(
+                  savedDefendantIds.map((id) => [
+                    id,
+                    workingCase.defendants?.find((d) => d.id === id)
+                      ?.indictmentReviewDecision,
+                  ]),
+                ),
+              }))
+            }
             onConfirmed={() => router.push(getStandardUserDashboardRoute(user))}
           />
         )}

--- a/apps/judicial-system/web/src/routes/Prosecutor/Indictments/IndictmentOverview/IndictmentOverview.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/Indictments/IndictmentOverview/IndictmentOverview.tsx
@@ -34,7 +34,6 @@ import {
 } from '@island.is/judicial-system-web/src/components'
 import InputPenalties from '@island.is/judicial-system-web/src/components/Inputs/InputPenalties'
 import VerdictStatusAlert from '@island.is/judicial-system-web/src/components/VerdictStatusAlert/VerdictStatusAlert'
-import type { IndictmentCaseReviewDecision } from '@island.is/judicial-system-web/src/graphql/schema'
 import {
   AppealCaseState,
   CaseIndictmentRulingDecision,
@@ -43,10 +42,14 @@ import {
   UserRole,
 } from '@island.is/judicial-system-web/src/graphql/schema'
 import { ReviewDecision } from '@island.is/judicial-system-web/src/routes/PublicProsecutor/components/ReviewDecision/ReviewDecision'
+import type { ReviewDecisions } from '@island.is/judicial-system-web/src/routes/PublicProsecutor/components/ReviewDecision/ReviewDecision.logic'
+import { getChangedReviewDecisions } from '@island.is/judicial-system-web/src/routes/PublicProsecutor/components/ReviewDecision/ReviewDecision.logic'
+import { ReviewDecisionModal } from '@island.is/judicial-system-web/src/routes/PublicProsecutor/components/ReviewDecision/ReviewDecisionModal'
 import type { ModalId } from '@island.is/judicial-system-web/src/routes/PublicProsecutor/components/utils'
 import {
   CONFIRM_PROSECUTOR_DECISION,
   DUPLICATE_INDICTMENT,
+  isConfirmProsecutorDecisionModal,
   isDuplicateIndictmentModal,
 } from '@island.is/judicial-system-web/src/routes/PublicProsecutor/components/utils'
 import { useAppealCaseBanner } from '@island.is/judicial-system-web/src/utils/hooks'
@@ -111,9 +114,8 @@ const IndictmentOverview: FC = () => {
       workingCase.appealCase?.appealState === AppealCaseState.COMPLETED ||
       workingCase.appealCase?.appealState === AppealCaseState.WITHDRAWN)
 
-  const [originalReviewDecisions, setOriginalReviewDecisions] = useState<
-    Record<string, IndictmentCaseReviewDecision | null | undefined>
-  >({})
+  const [originalReviewDecisions, setOriginalReviewDecisions] =
+    useState<ReviewDecisions>({})
 
   // Store original review decisions when workingCase loads to see if they change
   useEffect(() => {
@@ -125,16 +127,17 @@ const IndictmentOverview: FC = () => {
       const decisions = defendantsRequiringReview.reduce((acc, defendant) => {
         acc[defendant.id] = defendant.indictmentReviewDecision
         return acc
-      }, {} as Record<string, IndictmentCaseReviewDecision | null | undefined>)
+      }, {} as ReviewDecisions)
       setOriginalReviewDecisions(decisions)
     }
   }, [defendantsRequiringReview, originalReviewDecisions])
 
-  const hasReviewDecisionChanged = defendantsRequiringReview?.some(
-    (defendant) =>
-      defendant.indictmentReviewDecision !==
-      originalReviewDecisions[defendant.id],
+  // Confirming saves only the decisions that changed since the page loaded.
+  const changedReviewDecisions = getChangedReviewDecisions(
+    defendantsRequiringReview,
+    originalReviewDecisions,
   )
+  const hasReviewDecisionChanged = changedReviewDecisions.length > 0
 
   const handleNavigationTo = useCallback(
     (destination: string) => router.push(`${destination}/${workingCase.id}`),
@@ -271,8 +274,6 @@ const IndictmentOverview: FC = () => {
                         <ReviewDecision
                           caseId={workingCase.id}
                           defendant={defendant}
-                          modalVisible={modalVisible}
-                          setModalVisible={setModalVisible}
                           isFine={
                             workingCase.indictmentRulingDecision ===
                             CaseIndictmentRulingDecision.FINE
@@ -316,6 +317,14 @@ const IndictmentOverview: FC = () => {
           />
         </FormContentContainer>
         {appealModals}
+        {isConfirmProsecutorDecisionModal(modalVisible) && (
+          <ReviewDecisionModal
+            caseId={workingCase.id}
+            changedDefendants={changedReviewDecisions}
+            onClose={() => setModalVisible(undefined)}
+            onConfirmed={() => router.push(getStandardUserDashboardRoute(user))}
+          />
+        )}
         {isDuplicateIndictmentModal(modalVisible) && (
           <DuplicateIndictmentModal
             onClose={() => setModalVisible(undefined)}

--- a/apps/judicial-system/web/src/routes/PublicProsecutor/components/ReviewDecision/ReviewDecision.logic.spec.ts
+++ b/apps/judicial-system/web/src/routes/PublicProsecutor/components/ReviewDecision/ReviewDecision.logic.spec.ts
@@ -1,0 +1,50 @@
+import type { Defendant } from '@island.is/judicial-system-web/src/graphql/schema'
+import { IndictmentCaseReviewDecision } from '@island.is/judicial-system-web/src/graphql/schema'
+
+import { getChangedReviewDecisions } from './ReviewDecision.logic'
+
+describe('getChangedReviewDecisions', () => {
+  const defendants: Defendant[] = [
+    { id: 'a', indictmentReviewDecision: IndictmentCaseReviewDecision.APPEAL },
+    { id: 'b', indictmentReviewDecision: IndictmentCaseReviewDecision.ACCEPT },
+    { id: 'c', indictmentReviewDecision: null },
+  ]
+
+  it('returns the defendants whose decision differs from the original', () => {
+    const changed = getChangedReviewDecisions(defendants, {
+      a: null,
+      b: IndictmentCaseReviewDecision.ACCEPT,
+      c: null,
+    })
+
+    expect(changed.map((d) => d.id)).toEqual(['a'])
+  })
+
+  it('treats a changed decision as changed, not only a first one', () => {
+    const changed = getChangedReviewDecisions(defendants, {
+      a: IndictmentCaseReviewDecision.ACCEPT,
+      b: IndictmentCaseReviewDecision.APPEAL,
+    })
+
+    expect(changed.map((d) => d.id)).toEqual(['a', 'b'])
+  })
+
+  it('never returns a defendant with no decision', () => {
+    expect(
+      getChangedReviewDecisions(defendants, {
+        c: IndictmentCaseReviewDecision.ACCEPT,
+      }),
+    ).not.toContainEqual(expect.objectContaining({ id: 'c' }))
+  })
+
+  it('returns nothing when nothing changed', () => {
+    expect(
+      getChangedReviewDecisions(defendants, {
+        a: IndictmentCaseReviewDecision.APPEAL,
+        b: IndictmentCaseReviewDecision.ACCEPT,
+        c: null,
+      }),
+    ).toEqual([])
+    expect(getChangedReviewDecisions(undefined, {})).toEqual([])
+  })
+})

--- a/apps/judicial-system/web/src/routes/PublicProsecutor/components/ReviewDecision/ReviewDecision.logic.ts
+++ b/apps/judicial-system/web/src/routes/PublicProsecutor/components/ReviewDecision/ReviewDecision.logic.ts
@@ -1,0 +1,24 @@
+import type {
+  Defendant,
+  IndictmentCaseReviewDecision,
+} from '@island.is/judicial-system-web/src/graphql/schema'
+
+export type ReviewDecisions = Record<
+  string,
+  IndictmentCaseReviewDecision | null | undefined
+>
+
+// The defendants whose review decision differs from the one the page loaded
+// with. Confirming saves these and no others: a decision that did not change
+// is not an act of review, and the backend records a review event for every
+// decision it is sent.
+export const getChangedReviewDecisions = (
+  defendants: Defendant[] | undefined,
+  originalDecisions: ReviewDecisions,
+): Defendant[] =>
+  (defendants ?? []).filter(
+    (defendant) =>
+      defendant.indictmentReviewDecision !== undefined &&
+      defendant.indictmentReviewDecision !== null &&
+      defendant.indictmentReviewDecision !== originalDecisions[defendant.id],
+  )

--- a/apps/judicial-system/web/src/routes/PublicProsecutor/components/ReviewDecision/ReviewDecision.tsx
+++ b/apps/judicial-system/web/src/routes/PublicProsecutor/components/ReviewDecision/ReviewDecision.tsx
@@ -1,155 +1,81 @@
-import type { Dispatch, FC, SetStateAction } from 'react'
+import type { FC } from 'react'
 import { useContext } from 'react'
-import { useIntl } from 'react-intl'
-import { useRouter } from 'next/router'
 
 import { RadioButton } from '@island.is/island-ui/core'
-import { getStandardUserDashboardRoute } from '@island.is/judicial-system/consts'
 import {
   isPublicProsecutionOfficeUser,
   isPublicProsecutionUser,
 } from '@island.is/judicial-system/types'
 import {
   FormContext,
-  Modal,
   UserContext,
 } from '@island.is/judicial-system-web/src/components'
 import type { Defendant } from '@island.is/judicial-system-web/src/graphql/schema'
 import { IndictmentCaseReviewDecision } from '@island.is/judicial-system-web/src/graphql/schema'
-import type { ModalId } from '@island.is/judicial-system-web/src/routes/PublicProsecutor/components/utils'
-import { isConfirmProsecutorDecisionModal } from '@island.is/judicial-system-web/src/routes/PublicProsecutor/components/utils'
 import { useDefendants } from '@island.is/judicial-system-web/src/utils/hooks'
 
-import { strings } from './ReviewDecision.strings'
 import * as styles from './ReviewDecision.css'
 
 interface Props {
   caseId: string
   defendant: Defendant
-  modalVisible?: ModalId
-  setModalVisible: Dispatch<SetStateAction<ModalId | undefined>>
   isFine: boolean
 }
 
+/**
+ * One defendant's review decision - appeal or accept - as a radio pair. Only
+ * the working case changes here; the decisions of the whole case are confirmed
+ * and saved together by ReviewDecisionModal.
+ */
 export const ReviewDecision: FC<Props> = (props) => {
-  const { caseId, defendant, modalVisible, setModalVisible, isFine } = props
+  const { caseId, defendant, isFine } = props
 
   const { user } = useContext(UserContext)
-  const { workingCase, setWorkingCase } = useContext(FormContext)
-  const router = useRouter()
-  const { formatMessage: fm } = useIntl()
-  const { updateDefendant, updateDefendantState } = useDefendants()
-
-  const handleReviewDecision = async () => {
-    if (!defendant.indictmentReviewDecision) {
-      return
-    }
-    const promises = []
-
-    for (const d of workingCase.defendants || []) {
-      // Defendants whose indictment was cancelled or dismissed (completed for
-      // some) do not receive a verdict and require no review decision.
-      if (d.indictmentCancelledOrDismissedState) {
-        continue
-      }
-
-      if (!d.indictmentReviewDecision) {
-        return
-      }
-
-      promises.push(
-        updateDefendant({
-          caseId,
-          defendantId: d.id,
-          indictmentReviewDecision: d.indictmentReviewDecision,
-        }),
-      )
-    }
-
-    const results = await Promise.all(promises)
-    const updateSuccess = results.every((result) => result)
-
-    if (!updateSuccess) {
-      return
-    }
-
-    router.push(getStandardUserDashboardRoute(user))
-  }
+  const { setWorkingCase } = useContext(FormContext)
+  const { updateDefendantState } = useDefendants()
 
   if (!(isPublicProsecutionUser(user) || isPublicProsecutionOfficeUser(user))) {
     return null
   }
 
+  const choose = (indictmentReviewDecision: IndictmentCaseReviewDecision) =>
+    updateDefendantState(
+      { caseId, defendantId: defendant.id, indictmentReviewDecision },
+      setWorkingCase,
+    )
+
   return (
-    <>
-      <div className={styles.gridRow}>
-        <RadioButton
-          id={`review-option-appeal-${defendant.id}`}
-          name={`review-option-appeal-${defendant.id}`}
-          label={
-            isFine
-              ? 'Kæra viðurlagaákvörðun til Landsréttar'
-              : 'Áfrýja héraðsdómi til Landsréttar'
-          }
-          value={IndictmentCaseReviewDecision.APPEAL}
-          checked={
-            defendant.indictmentReviewDecision ===
-            IndictmentCaseReviewDecision.APPEAL
-          }
-          onChange={() =>
-            updateDefendantState(
-              {
-                caseId,
-                defendantId: defendant.id,
-                indictmentReviewDecision: IndictmentCaseReviewDecision.APPEAL,
-              },
-              setWorkingCase,
-            )
-          }
-          backgroundColor="white"
-          large
-        />
-        <RadioButton
-          id={`review-option-accept-${defendant.id}`}
-          name={`review-option-accept-${defendant.id}`}
-          label={isFine ? 'Una viðurlagaákvörðun' : 'Una héraðsdómi'}
-          value={IndictmentCaseReviewDecision.ACCEPT}
-          checked={
-            defendant.indictmentReviewDecision ===
-            IndictmentCaseReviewDecision.ACCEPT
-          }
-          onChange={() =>
-            updateDefendantState(
-              {
-                caseId,
-                defendantId: defendant.id,
-                indictmentReviewDecision: IndictmentCaseReviewDecision.ACCEPT,
-              },
-              setWorkingCase,
-            )
-          }
-          backgroundColor="white"
-          large
-        />
-      </div>
-      {isConfirmProsecutorDecisionModal(modalVisible) && (
-        <Modal
-          title={fm(strings.reviewModalTitle)}
-          text="Ertu viss um að þú viljir ljúka yfirlestri?"
-          buttons={[
-            {
-              text: fm(strings.reviewModalSecondaryButtonText),
-              onClick: () => setModalVisible(undefined),
-              variant: 'ghost',
-            },
-            {
-              text: fm(strings.reviewModalPrimaryButtonText),
-              onClick: handleReviewDecision,
-            },
-          ]}
-          onClose={() => setModalVisible(undefined)}
-        />
-      )}
-    </>
+    <div className={styles.gridRow}>
+      <RadioButton
+        id={`review-option-appeal-${defendant.id}`}
+        name={`review-option-appeal-${defendant.id}`}
+        label={
+          isFine
+            ? 'Kæra viðurlagaákvörðun til Landsréttar'
+            : 'Áfrýja héraðsdómi til Landsréttar'
+        }
+        value={IndictmentCaseReviewDecision.APPEAL}
+        checked={
+          defendant.indictmentReviewDecision ===
+          IndictmentCaseReviewDecision.APPEAL
+        }
+        onChange={() => choose(IndictmentCaseReviewDecision.APPEAL)}
+        backgroundColor="white"
+        large
+      />
+      <RadioButton
+        id={`review-option-accept-${defendant.id}`}
+        name={`review-option-accept-${defendant.id}`}
+        label={isFine ? 'Una viðurlagaákvörðun' : 'Una héraðsdómi'}
+        value={IndictmentCaseReviewDecision.ACCEPT}
+        checked={
+          defendant.indictmentReviewDecision ===
+          IndictmentCaseReviewDecision.ACCEPT
+        }
+        onChange={() => choose(IndictmentCaseReviewDecision.ACCEPT)}
+        backgroundColor="white"
+        large
+      />
+    </div>
   )
 }

--- a/apps/judicial-system/web/src/routes/PublicProsecutor/components/ReviewDecision/ReviewDecisionModal.tsx
+++ b/apps/judicial-system/web/src/routes/PublicProsecutor/components/ReviewDecision/ReviewDecisionModal.tsx
@@ -12,6 +12,10 @@ interface Props {
   // The defendants whose review decision changed - the only ones saved.
   changedDefendants: Defendant[]
   onClose: () => void
+  // Called with the defendants whose decision was saved, whether or not every
+  // save succeeded, so the page can stop counting them as changed and a retry
+  // sends only what failed.
+  onSaved: (savedDefendantIds: string[]) => void
   // Called once every changed decision has been saved.
   onConfirmed: () => void
 }
@@ -23,22 +27,36 @@ interface Props {
  * pair - knows which of them changed.
  */
 export const ReviewDecisionModal: FC<Props> = (props) => {
-  const { caseId, changedDefendants, onClose, onConfirmed } = props
+  const { caseId, changedDefendants, onClose, onSaved, onConfirmed } = props
   const { formatMessage: fm } = useIntl()
   const { updateDefendant, isUpdatingDefendant } = useDefendants()
 
+  // The saves are independent requests, not one transaction: some may succeed
+  // while another fails. Those that did are reported back so they are not sent
+  // again; the modal stays open for the rest.
   const handleConfirm = async () => {
     const results = await Promise.all(
-      changedDefendants.map((defendant) =>
-        updateDefendant({
-          caseId,
-          defendantId: defendant.id,
-          indictmentReviewDecision: defendant.indictmentReviewDecision,
-        }),
-      ),
+      changedDefendants.map(async (defendant) => ({
+        defendant,
+        saved: Boolean(
+          await updateDefendant({
+            caseId,
+            defendantId: defendant.id,
+            indictmentReviewDecision: defendant.indictmentReviewDecision,
+          }),
+        ),
+      })),
     )
 
-    if (!results.every(Boolean)) {
+    const savedDefendantIds = results
+      .filter(({ saved }) => saved)
+      .map(({ defendant }) => defendant.id)
+
+    if (savedDefendantIds.length > 0) {
+      onSaved(savedDefendantIds)
+    }
+
+    if (savedDefendantIds.length < changedDefendants.length) {
       return
     }
 

--- a/apps/judicial-system/web/src/routes/PublicProsecutor/components/ReviewDecision/ReviewDecisionModal.tsx
+++ b/apps/judicial-system/web/src/routes/PublicProsecutor/components/ReviewDecision/ReviewDecisionModal.tsx
@@ -1,0 +1,67 @@
+import type { FC } from 'react'
+import { useIntl } from 'react-intl'
+
+import { Modal } from '@island.is/judicial-system-web/src/components'
+import type { Defendant } from '@island.is/judicial-system-web/src/graphql/schema'
+import { useDefendants } from '@island.is/judicial-system-web/src/utils/hooks'
+
+import { strings } from './ReviewDecision.strings'
+
+interface Props {
+  caseId: string
+  // The defendants whose review decision changed - the only ones saved.
+  changedDefendants: Defendant[]
+  onClose: () => void
+  // Called once every changed decision has been saved.
+  onConfirmed: () => void
+}
+
+/**
+ * Confirms the reviewer's decisions for the whole case and saves the ones that
+ * changed. One modal for the page, whatever the number of defendants: the
+ * decisions are confirmed together, and the page - not each defendant's radio
+ * pair - knows which of them changed.
+ */
+export const ReviewDecisionModal: FC<Props> = (props) => {
+  const { caseId, changedDefendants, onClose, onConfirmed } = props
+  const { formatMessage: fm } = useIntl()
+  const { updateDefendant, isUpdatingDefendant } = useDefendants()
+
+  const handleConfirm = async () => {
+    const results = await Promise.all(
+      changedDefendants.map((defendant) =>
+        updateDefendant({
+          caseId,
+          defendantId: defendant.id,
+          indictmentReviewDecision: defendant.indictmentReviewDecision,
+        }),
+      ),
+    )
+
+    if (!results.every(Boolean)) {
+      return
+    }
+
+    onConfirmed()
+  }
+
+  return (
+    <Modal
+      title={fm(strings.reviewModalTitle)}
+      text="Ertu viss um að þú viljir ljúka yfirlestri?"
+      buttons={[
+        {
+          text: fm(strings.reviewModalSecondaryButtonText),
+          onClick: onClose,
+          variant: 'ghost',
+        },
+        {
+          text: fm(strings.reviewModalPrimaryButtonText),
+          onClick: handleConfirm,
+          isLoading: isUpdatingDefendant,
+        },
+      ]}
+      onClose={onClose}
+    />
+  )
+}


### PR DESCRIPTION
# Confirm review decisions once and save only what changed

[Yfirlestur - staðfestingargluggi og vistun breytinga](https://app.asana.com/1/203394141643832/project/1199153462262248/task/1218387434735564)

Parent ticket: [Áfrýjun - ríkissaksóknari áfrýjar dómi](https://app.asana.com/1/203394141643832/project/1199153462262248/task/1217860765215962) — preparation for it; no behaviour of the appeal itself in this PR.

## What

On the reviewer's indictment overview, the "Staðfesta ákvörðun" modal lived inside `ReviewDecision`, which the page renders **once per defendant** bound to the page's shared `modalVisible`. A case with two defendants therefore mounted two identical modals into the portal, stacked; each modal's confirm handler saved *every* reviewable defendant's decision, changed or not. One defendant (the common case) hid both.

## How

- New `ReviewDecisionModal`, rendered once by `IndictmentOverview`. Confirming saves only the defendants whose decision differs from what the page loaded with, then navigates to the dashboard; a failed save keeps the page open.
- `getChangedReviewDecisions` (`ReviewDecision.logic.ts`) does the diff against the page's existing `originalReviewDecisions` snapshot, and now also drives the footer button's enabled state (same rule as before, one implementation).
- `ReviewDecision` is the radio pair alone — it only updates the working case, as before. Modal copy and behaviour are unchanged; the upcoming reviewer-appeal ticket changes the copy to list each defendant's decision, which is why the modal needed to be the page's.

## Tests

- `ReviewDecision.logic.spec.ts` (4).
- `IndictmentOverview.spec.tsx` +2: one modal for two defendants and only the changed decision saved (with a stateful form context so the radio click is visible to the page); a failed save does not navigate.

Web lint 0 errors, `nx format:check` clean, `tsc` only the pre-existing errors.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Review decisions can be selected directly for each defendant.
  - A confirmation step appears before saving changes.
  - Only defendants with changed decisions are updated.
  - After successful saves, the page returns to the dashboard.
  - If some saves fail, the confirmation remains open and retrying sends only unsuccessful changes.
  - The page stays in place when saving cannot be completed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->