### PR TITLE
ci: run PR typecheck job on arc-iorunner runners

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,6 +1,7 @@
 self-hosted-runner:
   # Labels of self-hosted runner in array of strings.
-  labels: [arc-shared, arc-mergequeue, arc-iorunner, arc-test, ec2-runners, shared-v2]
+  labels:
+    [arc-shared, arc-mergequeue, arc-iorunner, arc-test, ec2-runners, shared-v2]
 
 # Configuration variables in array of strings defined in your repository or
 # organization. `null` means disabling configuration variables check.

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,6 +1,6 @@
 self-hosted-runner:
   # Labels of self-hosted runner in array of strings.
-  labels: [arc-shared, arc-mergequeue, arc-test, ec2-runners, shared-v2]
+  labels: [arc-shared, arc-mergequeue, arc-iorunner, arc-test, ec2-runners, shared-v2]
 
 # Configuration variables in array of strings defined in your repository or
 # organization. `null` means disabling configuration variables check.

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -269,7 +269,7 @@ jobs:
       - prepare
     permissions:
       contents: 'read'
-    runs-on: arc-shared
+    runs-on: arc-iorunner
     timeout-minutes: 35
     env:
       NODE_OPTIONS: --max-old-space-size=4096


### PR DESCRIPTION
Route the pull-request typecheck job to the new arc-iorunner runner group and whitelist the label in actionlint config.

# ...

Attach a link to issue if relevant

## What

Specify what you're trying to achieve

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated automated validation to run on the designated `arc-iorunner` runner.
  * Reformatted the self-hosted runner label configuration without changing its available labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->