### PR TITLE
feat(child-protection-notification): hide reason for notification

### DIFF
--- a/libs/application/templates/national-agency-for-children-and-families/child-protection-notification/src/forms/shared/reasonForNotificationSection/reasonForNotificationSubSection.ts
+++ b/libs/application/templates/national-agency-for-children-and-families/child-protection-notification/src/forms/shared/reasonForNotificationSection/reasonForNotificationSubSection.ts
@@ -16,12 +16,18 @@ import {
   shouldShowBiggestConcernField,
   shouldShowReasonForNotificationSubCategoryDetails,
 } from '../../../utils/conditionUtils'
-import { RISK_TO_UNBORN } from '../../../utils/constants'
+import {
+  RISK_TO_UNBORN,
+  SHOW_REASON_FOR_NOTIFICATION_SUBSECTION,
+} from '../../../utils/constants'
 import { getApplicationExternalData } from '../../../utils/getApplicationExternalData'
 
 export const reasonForNotificationSubSection = buildSubSection({
   id: 'reasonForNotificationSubSection',
   title: reasonForNotificationMessages.shared.sectionTitle,
+  // Client requested this be temporarily hidden; keeping the implementation
+  // intact in case they want it back.
+  condition: () => SHOW_REASON_FOR_NOTIFICATION_SUBSECTION,
   children: [
     buildMultiField({
       id: 'reasonForNotification',

--- a/libs/application/templates/national-agency-for-children-and-families/child-protection-notification/src/utils/adultPersonalOverviewFields.ts
+++ b/libs/application/templates/national-agency-for-children-and-families/child-protection-notification/src/utils/adultPersonalOverviewFields.ts
@@ -7,6 +7,7 @@ import {
   prerequisitesMessages,
   reasonForNotificationMessages,
 } from '../lib/messages'
+import { SHOW_REASON_FOR_NOTIFICATION_SUBSECTION } from './constants'
 import {
   isKnowsNationalId,
   isNoNationalId,
@@ -93,6 +94,9 @@ export const adultPersonalOverviewFields = (editable?: boolean) => [
     backId: editable ? 'reasonForNotification' : undefined,
     items: getReasonForNotificationItems,
     hideIfEmpty: true,
+    // Client requested this be temporarily hidden; keeping the implementation
+    // intact in case they want it back.
+    condition: () => SHOW_REASON_FOR_NOTIFICATION_SUBSECTION,
   }),
   buildOverviewField({
     id: 'overview.childSafety',

--- a/libs/application/templates/national-agency-for-children-and-families/child-protection-notification/src/utils/adultProcurationOverviewFields.ts
+++ b/libs/application/templates/national-agency-for-children-and-families/child-protection-notification/src/utils/adultProcurationOverviewFields.ts
@@ -9,6 +9,7 @@ import {
   protectiveFactorsMessages,
   reasonForNotificationMessages,
 } from '../lib/messages'
+import { SHOW_REASON_FOR_NOTIFICATION_SUBSECTION } from './constants'
 import {
   isKnowsNationalId,
   isNoNationalId,
@@ -139,6 +140,9 @@ export const adultProcurationOverviewFields = (editable?: boolean) => [
     backId: editable ? 'reasonForNotification' : undefined,
     items: getReasonForNotificationItems,
     hideIfEmpty: true,
+    // Client requested this be temporarily hidden; keeping the implementation
+    // intact in case they want it back.
+    condition: () => SHOW_REASON_FOR_NOTIFICATION_SUBSECTION,
   }),
   buildOverviewField({
     id: 'overview.reasonNotificationHistory',

--- a/libs/application/templates/national-agency-for-children-and-families/child-protection-notification/src/utils/constants.ts
+++ b/libs/application/templates/national-agency-for-children-and-families/child-protection-notification/src/utils/constants.ts
@@ -3,6 +3,10 @@ import { DefaultEvents } from '@island.is/application/types'
 export const RISK_TO_UNBORN = 'RiskToUnborn'
 export const IS = 'IS'
 
+// Client requested this section be temporarily removed from the flow but may
+// want it reinstated later, so it's hidden via this flag rather than deleted.
+export const SHOW_REASON_FOR_NOTIFICATION_SUBSECTION = false
+
 export type Events = {
   type: DefaultEvents.SUBMIT | DefaultEvents.ABORT
 }


### PR DESCRIPTION
https://dit-iceland.atlassian.net/browse/SIA-91?atlOrigin=eyJpIjoiMjhmODIwNzlhY2Q0NDIwMjlkZDIxMmZhZDg4YWJmZTEiLCJwIjoiaiJ9

## What

Client wants it removed for now but may change their mind, so gate it with
SHOW_REASON_FOR_NOTIFICATION_SUBSECTION instead of deleting the implementation.

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [x] No AI tools were used in preparing this pull request
- [ ] AI tools were used in preparing this pull request
      Tools used:
