### PR TITLE
feat(j-s): The prosecution reviewer appeals a verdict per defendant

### DIFF
--- a/apps/judicial-system/backend/src/app/modules/appeal-case/appealCase.helpers.ts
+++ b/apps/judicial-system/backend/src/app/modules/appeal-case/appealCase.helpers.ts
@@ -48,19 +48,31 @@ export const findAppealCaseOfCaseFile = (
   return theCase.appealCase
 }
 
-// The defendants that currently stand as appellants of a verdict appeal:
-// those whose most recent appeal event on it is an APPEALED rather
-// than an APPEAL_WITHDRAWN. A defendant who withdraws may appeal again while the
-// deadline still runs, so it is the latest event that decides, not the mere
-// presence of a withdrawal.
-//
-// The event log is the appellant source for out-of-court appeals - a verdict
-// appeal has no appeal_decision rows, since a party that appeals out of court is
-// precisely one that did not appeal in court.
-export const standingVerdictAppellantIds = (
+// A verdict appeal has two sides. The defence side is a defendant appealing -
+// through their defender in the system, or registered by the public
+// prosecution office on a letter; the prosecution side is the public
+// prosecution reviewer appealing the verdict regarding that defendant. Both are
+// per defendant, and they are independent: either or both may stand.
+export type VerdictAppellantSide = 'DEFENCE' | 'PROSECUTION'
+
+export interface VerdictAppellant {
+  defendantId: string
+  side: VerdictAppellantSide
+}
+
+export const verdictAppellantSide = (
+  userRole: UserRole,
+): VerdictAppellantSide =>
+  prosecutionRoles.includes(userRole) ? 'PROSECUTION' : 'DEFENCE'
+
+// The appellants of a verdict appeal that currently stand, read from the appeal
+// event log: for each (defendant, side) the latest APPEALED / APPEAL_WITHDRAWN
+// event decides, so a party that withdrew and appealed again while the deadline
+// ran still counts. Events without a defendant are not verdict appeal events.
+export const standingVerdictAppellants = (
   appealCase: Pick<AppealCase, 'appealEventLogs'>,
-): string[] => {
-  const latestByDefendant = new Map<string, AppealEventLog>()
+): VerdictAppellant[] => {
+  const latestByAppellant = new Map<string, AppealEventLog>()
 
   for (const eventLog of appealCase.appealEventLogs ?? []) {
     if (
@@ -71,17 +83,41 @@ export const standingVerdictAppellantIds = (
       continue
     }
 
-    const latest = latestByDefendant.get(eventLog.defendantId)
+    const key = `${eventLog.defendantId}:${verdictAppellantSide(
+      eventLog.userRole,
+    )}`
+    const latest = latestByAppellant.get(key)
 
     if (!latest || eventLog.created > latest.created) {
-      latestByDefendant.set(eventLog.defendantId, eventLog)
+      latestByAppellant.set(key, eventLog)
     }
   }
 
-  return Array.from(latestByDefendant)
-    .filter(([, eventLog]) => eventLog.eventType === AppealEventType.APPEALED)
-    .map(([defendantId]) => defendantId)
+  return Array.from(latestByAppellant.values())
+    .filter((eventLog) => eventLog.eventType === AppealEventType.APPEALED)
+    .map((eventLog) => ({
+      defendantId: eventLog.defendantId as string,
+      side: verdictAppellantSide(eventLog.userRole),
+    }))
 }
+
+export const hasStandingVerdictAppeal = (
+  appealCase: Pick<AppealCase, 'appealEventLogs'>,
+  defendantId: string,
+  side: VerdictAppellantSide,
+): boolean =>
+  standingVerdictAppellants(appealCase).some(
+    (appellant) =>
+      appellant.defendantId === defendantId && appellant.side === side,
+  )
+
+// The defendants whose own (defence-side) verdict appeal stands.
+export const standingVerdictAppellantIds = (
+  appealCase: Pick<AppealCase, 'appealEventLogs'>,
+): string[] =>
+  standingVerdictAppellants(appealCase)
+    .filter((appellant) => appellant.side === 'DEFENCE')
+    .map((appellant) => appellant.defendantId)
 
 // Resolves the appeal decision (Ákvörðun um kæru) recorded in court for the
 // party the user acts for - the prosecution, or the specific defendant / civil
@@ -363,8 +399,14 @@ export const userIsAppellant = (
 
   // Indictment defence: the user must be the current confirmed representative of
   // a party (defendant / civil claimant) that appealed. Resolving live against
-  // the case follows defender / spokesperson reassignment.
+  // the case follows defender / spokesperson reassignment. A prosecution
+  // event names a defendant too - the one whose verdict the prosecution
+  // appealed - and that does not make the defendant's defender an appellant.
   return appealedEvents.some((eventLog) => {
+    if (prosecutionRoles.includes(eventLog.userRole)) {
+      return false
+    }
+
     if (eventLog.defendantId) {
       return Boolean(
         Defendant.isConfirmedDefenderOfDefendant(
@@ -402,7 +444,12 @@ export const appellantRepresentativeNationalIds = (
   const nationalIds = new Set<string>()
 
   for (const eventLog of appealCase.appealEventLogs ?? []) {
-    if (eventLog.eventType !== AppealEventType.APPEALED) {
+    // A prosecution verdict appeal names the defendant whose verdict it
+    // appeals; that defendant's defender is the one to notify, not an appellant.
+    if (
+      eventLog.eventType !== AppealEventType.APPEALED ||
+      prosecutionRoles.includes(eventLog.userRole)
+    ) {
       continue
     }
 

--- a/apps/judicial-system/backend/src/app/modules/appeal-case/appealCase.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/appeal-case/appealCase.service.ts
@@ -823,7 +823,7 @@ export class AppealCaseService {
     // DISTINCT, so it holds for the null ruling file of a case-level appeal - is
     // the backstop, not the mechanism: it would turn the race into a failed
     // appeal rather than a joined one.
-    await this.caseRepositoryService.lockByIdForUpdate(theCase.id, transaction)
+    await this.lockCaseForVerdictAppeal(theCase, user, actor, transaction)
 
     const [existingAppealCase] = await this.appealCaseRepositoryService.findAll(
       {
@@ -932,6 +932,38 @@ export class AppealCaseService {
     // its own story, and the ruling appeal notifications do not apply here.
 
     return appealCase
+  }
+
+  // Locks the case row for a verdict appeal action. The reviewer's authority
+  // comes from the case's reviewer assignment, which the guard read before the
+  // transaction; locking the row *as* the case assigned to this reviewer makes
+  // the check and the lock one statement, so a reassignment committed in the
+  // meantime fails the lock instead of slipping past a stale snapshot.
+  private async lockCaseForVerdictAppeal(
+    theCase: Case,
+    user: User,
+    actor: 'DEFENDER' | 'OFFICE' | 'REVIEWER',
+    transaction: Transaction,
+  ): Promise<void> {
+    const locked =
+      actor === 'REVIEWER'
+        ? await this.caseRepositoryService.lockByIdForUpdate(
+            theCase.id,
+            transaction,
+            { id: theCase.id, indictmentReviewerId: user.id },
+          )
+        : await this.caseRepositoryService.lockByIdForUpdate(
+            theCase.id,
+            transaction,
+          )
+
+    if (!locked) {
+      throw new ForbiddenException(
+        actor === 'REVIEWER'
+          ? 'Only the reviewer assigned to the case can act on a verdict appeal for the prosecution'
+          : `Case ${theCase.id} does not exist`,
+      )
+    }
   }
 
   // The date the public prosecution office registers is the one on the filing
@@ -1356,7 +1388,7 @@ export class AppealCaseService {
     // the other as standing, so neither would withdraw the appeal case and it
     // would stand with no appellants left. The second transaction blocks here
     // and re-reads the freshly committed events.
-    await this.caseRepositoryService.lockByIdForUpdate(theCase.id, transaction)
+    await this.lockCaseForVerdictAppeal(theCase, user, actor, transaction)
 
     // Once the court of appeals has received the case the prosecution's
     // decision is made. The guard loaded the appeal case before the

--- a/apps/judicial-system/backend/src/app/modules/appeal-case/appealCase.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/appeal-case/appealCase.service.ts
@@ -36,6 +36,7 @@ import {
   isIndictmentCase,
   isProsecutionUser,
   isPublicProsecutionOfficeUser,
+  isPublicProsecutionUser,
 } from '@island.is/judicial-system/types'
 
 import { nowFactory } from '../../factories'
@@ -65,9 +66,11 @@ import {
 import { appealCaseModuleConfig } from './appealCase.config'
 import {
   findUserRulingOrderAppealDecision,
+  hasStandingVerdictAppeal,
   isInCourtRulingOrderAppeal,
-  standingVerdictAppellantIds,
+  standingVerdictAppellants,
   userRulingOrderAppealDecisions,
+  type VerdictAppellantSide,
 } from './appealCase.helpers'
 
 // What a verdict appeal is filed with, beyond the case and the user. A defender
@@ -669,32 +672,62 @@ export class AppealCaseService {
     return appealCase
   }
 
-  // A defence user files an appeal declaration for one of its defendants: the
-  // legal act of appealing the verdict, not bookkeeping about one, so every
-  // condition is checked hard here.
+  // Who is filing a verdict appeal, and for which side. The defendant's
+  // confirmed defender and the public prosecution office both file the
+  // defendant's appeal - the office on a letter that reached it outside the
+  // system - while the public prosecution reviewer files the prosecution's
+  // appeal of the verdict regarding that defendant. Each is per defendant.
+  private verdictAppealActor(
+    user: User,
+  ):
+    | { actor: 'DEFENDER' | 'OFFICE'; side: 'DEFENCE' }
+    | { actor: 'REVIEWER'; side: 'PROSECUTION' } {
+    if (isDefenceUser(user)) {
+      return { actor: 'DEFENDER', side: 'DEFENCE' }
+    }
+
+    if (isPublicProsecutionOfficeUser(user)) {
+      return { actor: 'OFFICE', side: 'DEFENCE' }
+    }
+
+    if (isPublicProsecutionUser(user)) {
+      return { actor: 'REVIEWER', side: 'PROSECUTION' }
+    }
+
+    throw new ForbiddenException(
+      'Only a defence user, the public prosecution office or the public prosecution can appeal a verdict',
+    )
+  }
+
+  // A verdict appeal is filed for one specific defendant rather than every
+  // party the lawyer represents - the action lives on that defendant's card,
+  // and two defendants of the same defender can appeal on different days or
+  // not at all - so resolveDefenceParties is deliberately not used.
   //
-  // Unlike the ruling appeal flow, this acts for one specific defendant rather than every
-  // party the lawyer represents - the action lives on that defendant's card, and
-  // two defendants of the same defender can appeal on different days or not at
-  // all. So resolveDefenceParties is deliberately not used.
+  // Three ways in. The defendant's confirmed defender appeals in the system:
+  // the legal act itself, so every condition is checked hard. The public
+  // prosecution office registers an appeal that reached it outside the system
+  // (a letter, typically from a new defender): it acts for the defendant, so it
+  // is not held to being their defender, and it records an act that already
+  // happened, so the appeal date is the filing's and the deadline is not
+  // enforced. The public prosecution reviewer appeals the verdict regarding a
+  // defendant on the prosecution's behalf: the decision confirmed on the
+  // review page is the appeal, the deadline is theirs to judge (confirmed on
+  // that page), and nothing about the defendant's own appeal - the service
+  // state, the mirror on the verdict, the appeal defender - applies.
   private async createVerdictAppeal(
     theCase: Case,
     user: User,
     request: VerdictAppealRequest,
     transaction: Transaction,
   ): Promise<AppealCase> {
-    // Two ways in: the defendant's confirmed defender appeals in the system, or
-    // the public prosecution office registers an appeal that reached it outside
-    // the system - by letter or email, typically from a new defender who is not
-    // in the system. The office acts for the defendant, so it is not held to
-    // being their defender, and it records an act that already happened, so the
-    // appeal date is the filing's and the deadline is not enforced here (see
-    // below).
-    const isRegisteredByProsecutionOffice = isPublicProsecutionOfficeUser(user)
+    const { actor, side } = this.verdictAppealActor(user)
+    const isRegisteredByProsecutionOffice = actor === 'OFFICE'
+    const isProsecutionAppeal = actor === 'REVIEWER'
 
-    if (!isDefenceUser(user) && !isRegisteredByProsecutionOffice) {
+    if (isProsecutionAppeal && theCase.indictmentReviewerId !== user.id) {
       throw new ForbiddenException(
-        'Only a defence user or the public prosecution office can appeal a verdict',
+        'Only the reviewer assigned to the case can appeal a verdict for the prosecution',
       )
     }
 
@@ -715,7 +748,7 @@ export class AppealCaseService {
     }
 
     if (
-      !isRegisteredByProsecutionOffice &&
+      actor === 'DEFENDER' &&
       !Defendant.isConfirmedDefenderOfDefendant(user.nationalId, [defendant])
     ) {
       throw new ForbiddenException(
@@ -736,9 +769,16 @@ export class AppealCaseService {
     // Prefer the newest verdict when a corrected ruling created a replacement.
     const verdict = getLatestVerdict(defendant.verdicts)
 
-    // Covers the útivistardómur (reopened rather than appealed) and the service
-    // state: the defendant must have been made aware of the verdict.
-    if (!verdict || !canDefendantAppealVerdict(verdict)) {
+    if (!verdict) {
+      throw new ForbiddenException(
+        `Defendant ${defendantId} has no verdict to appeal`,
+      )
+    }
+
+    // The defendant's appeal covers the útivistardómur (reopened rather than
+    // appealed) and the service state: the defendant must have been made aware
+    // of the verdict. The prosecution's right to appeal depends on neither.
+    if (!isProsecutionAppeal && !canDefendantAppealVerdict(verdict)) {
       throw new ForbiddenException(
         `The verdict of defendant ${defendantId} cannot be appealed`,
       )
@@ -748,8 +788,10 @@ export class AppealCaseService {
     // is the legal act. The public prosecution office registers an appeal that
     // already happened, possibly after the deadline - late bookkeeping of a
     // timely appeal, or a genuinely late one - and its screen confirms the
-    // latter with the user, the same way its appeal date picker did before.
-    if (!isRegisteredByProsecutionOffice) {
+    // latter with the user, the same way its appeal date picker did before. The
+    // reviewer's deadline runs from the ruling date and the review page
+    // confirms a late decision the same way.
+    if (actor === 'DEFENDER') {
       validateVerdictAppealUpdate({
         caseId: theCase.id,
         indictmentRulingDecision: theCase.indictmentRulingDecision,
@@ -758,7 +800,8 @@ export class AppealCaseService {
       })
     }
 
-    if (verdict.appealDate) {
+    // verdict.appealDate mirrors the defendant's own appeal only.
+    if (side === 'DEFENCE' && verdict.appealDate) {
       throw new ForbiddenException(
         `The verdict of defendant ${defendantId} has already been appealed`,
       )
@@ -793,17 +836,28 @@ export class AppealCaseService {
     // transaction, so it cannot see an appeal filed in the meantime - two
     // requests for the same defendant, a double-clicked filing being the easy
     // way there, would both pass it. This is the same question asked again under
-    // the lock, against what the appeal case actually records.
+    // the lock, against what the appeal case actually records - and for the
+    // prosecution, which has no mirror, it is the only check.
     if (existingAppealCase) {
+      // Once the court of appeals has received the case the prosecution's
+      // decision is made; a late change is not a matter for this system.
+      if (
+        isProsecutionAppeal &&
+        existingAppealCase.appealState !== AppealCaseState.APPEALED &&
+        existingAppealCase.appealState !== AppealCaseState.WITHDRAWN
+      ) {
+        throw new ForbiddenException(
+          'The verdict appeal has been received by the court of appeals',
+        )
+      }
+
       const appealEventLogs =
         await this.appealEventLogRepositoryService.findAll({
           where: { appealCaseId: existingAppealCase.id },
           transaction,
         })
 
-      if (
-        standingVerdictAppellantIds({ appealEventLogs }).includes(defendantId)
-      ) {
+      if (hasStandingVerdictAppeal({ appealEventLogs }, defendantId, side)) {
         throw new ForbiddenException(
           `The verdict of defendant ${defendantId} has already been appealed`,
         )
@@ -858,19 +912,21 @@ export class AppealCaseService {
     }
 
     // AppealCase is the source of truth for who appealed; verdict.appealDate is
-    // kept as a one-way mirror so the public prosecution office's existing
-    // screen keeps working untouched. To be retired with that screen.
-    //
-    // It mirrors when *this* defendant appealed, which is not the appeal case's
-    // own appealDate for a defendant joining an appeal someone else filed - that
-    // screen shows the date per defendant.
-    await this.verdictRepositoryService.update(
-      theCase.id,
-      defendantId,
-      verdict.id,
-      { appealDate: appealedAt },
-      { transaction },
-    )
+    // kept as a one-way mirror of the *defendant's* appeal so the public
+    // prosecution office's existing screen keeps working untouched. It mirrors
+    // when *this* defendant appealed, which is not the appeal case's own
+    // appealDate for a defendant joining an appeal someone else filed - that
+    // screen shows the date per defendant. The prosecution's appeal is read
+    // from the event log alone.
+    if (side === 'DEFENCE') {
+      await this.verdictRepositoryService.update(
+        theCase.id,
+        defendantId,
+        verdict.id,
+        { appealDate: appealedAt },
+        { transaction },
+      )
+    }
 
     // No notification: the one that tells the public prosecution office about a verdict appeal is
     // its own story, and the ruling appeal notifications do not apply here.
@@ -1260,14 +1316,23 @@ export class AppealCaseService {
     user: User,
     transaction: Transaction,
   ): Promise<AppealTransitionResult & { appealCase: AppealCase }> {
-    // The public prosecution office withdraws on the defendant's behalf, as it
-    // registers on their behalf, so it is not held to being their defender.
-    const isWithdrawnByProsecutionOffice = isPublicProsecutionOfficeUser(user)
+    // The same three actors as filing, each withdrawing their own side's appeal
+    // for the defendant: the office on the defendant's behalf, so it is not held
+    // to being their defender; the reviewer the prosecution's.
+    const { actor, side } = this.verdictAppealActor(user)
 
-    if (!isDefenceUser(user) && !isWithdrawnByProsecutionOffice) {
-      throw new ForbiddenException(
-        'Only a defence user or the public prosecution office can withdraw a verdict appeal',
-      )
+    if (actor === 'REVIEWER') {
+      if (theCase.indictmentReviewerId !== user.id) {
+        throw new ForbiddenException(
+          'Only the reviewer assigned to the case can withdraw a verdict appeal for the prosecution',
+        )
+      }
+
+      if (appealCase.appealState !== AppealCaseState.APPEALED) {
+        throw new ForbiddenException(
+          'The verdict appeal has been received by the court of appeals',
+        )
+      }
     }
 
     if (!defendantId) {
@@ -1285,7 +1350,7 @@ export class AppealCaseService {
     }
 
     if (
-      !isWithdrawnByProsecutionOffice &&
+      actor === 'DEFENDER' &&
       !Defendant.isConfirmedDefenderOfDefendant(user.nationalId, [defendant])
     ) {
       throw new ForbiddenException(
@@ -1306,13 +1371,17 @@ export class AppealCaseService {
       transaction,
     })
 
-    const standingAppellantIds = standingVerdictAppellantIds({
-      appealEventLogs,
-    })
+    const standingAppellants = standingVerdictAppellants({ appealEventLogs })
+    const isWithdrawn = (appellant: {
+      defendantId: string
+      side: VerdictAppellantSide
+    }) => appellant.defendantId === defendantId && appellant.side === side
 
-    if (!standingAppellantIds.includes(defendantId)) {
+    if (!standingAppellants.some(isWithdrawn)) {
       throw new ForbiddenException(
-        `Defendant ${defendantId} has no standing appeal of the verdict to withdraw`,
+        side === 'PROSECUTION'
+          ? `The prosecution has no standing appeal of the verdict of defendant ${defendantId} to withdraw`
+          : `Defendant ${defendantId} has no standing appeal of the verdict to withdraw`,
       )
     }
 
@@ -1325,27 +1394,32 @@ export class AppealCaseService {
       transaction,
     )
 
-    // Clear the mirror on the verdict, so the public prosecution office's screen
-    // stops showing this defendant as having appealed.
-    const verdict = getLatestVerdict(defendant.verdicts)
+    // The defendant's own appeal carries a mirror on the verdict and possibly an
+    // appeal defender; the prosecution's carries neither.
+    if (side === 'DEFENCE') {
+      // Clear the mirror on the verdict, so the public prosecution office's
+      // screen stops showing this defendant as having appealed.
+      const verdict = getLatestVerdict(defendant.verdicts)
 
-    if (verdict) {
-      await this.verdictRepositoryService.update(
-        theCase.id,
-        defendantId,
-        verdict.id,
-        { appealDate: null },
-        { transaction },
-      )
+      if (verdict) {
+        await this.verdictRepositoryService.update(
+          theCase.id,
+          defendantId,
+          verdict.id,
+          { appealDate: null },
+          { transaction },
+        )
+      }
+
+      await this.clearAppealDefender(theCase, defendantId, transaction)
     }
 
-    await this.clearAppealDefender(theCase, defendantId, transaction)
-
-    const remainingAppellantIds = standingAppellantIds.filter(
-      (id) => id !== defendantId,
+    // The appeal case stands while any appellant of either side stands.
+    const remainingAppellants = standingAppellants.filter(
+      (appellant) => !isWithdrawn(appellant),
     )
 
-    if (remainingAppellantIds.length === 0) {
+    if (remainingAppellants.length === 0) {
       return this.applyTransition(
         theCase,
         appealCase,

--- a/apps/judicial-system/backend/src/app/modules/appeal-case/appealCase.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/appeal-case/appealCase.service.ts
@@ -1321,18 +1321,10 @@ export class AppealCaseService {
     // to being their defender; the reviewer the prosecution's.
     const { actor, side } = this.verdictAppealActor(user)
 
-    if (actor === 'REVIEWER') {
-      if (theCase.indictmentReviewerId !== user.id) {
-        throw new ForbiddenException(
-          'Only the reviewer assigned to the case can withdraw a verdict appeal for the prosecution',
-        )
-      }
-
-      if (appealCase.appealState !== AppealCaseState.APPEALED) {
-        throw new ForbiddenException(
-          'The verdict appeal has been received by the court of appeals',
-        )
-      }
+    if (actor === 'REVIEWER' && theCase.indictmentReviewerId !== user.id) {
+      throw new ForbiddenException(
+        'Only the reviewer assigned to the case can withdraw a verdict appeal for the prosecution',
+      )
     }
 
     if (!defendantId) {
@@ -1365,6 +1357,22 @@ export class AppealCaseService {
     // would stand with no appellants left. The second transaction blocks here
     // and re-reads the freshly committed events.
     await this.caseRepositoryService.lockByIdForUpdate(theCase.id, transaction)
+
+    // Once the court of appeals has received the case the prosecution's
+    // decision is made. The guard loaded the appeal case before the
+    // transaction, so the state is read again under the lock.
+    if (actor === 'REVIEWER') {
+      const lockedAppealCase = await this.appealCaseRepositoryService.findById(
+        appealCase.id,
+        { transaction },
+      )
+
+      if (lockedAppealCase?.appealState !== AppealCaseState.APPEALED) {
+        throw new ForbiddenException(
+          'The verdict appeal has been received by the court of appeals',
+        )
+      }
+    }
 
     const appealEventLogs = await this.appealEventLogRepositoryService.findAll({
       where: { appealCaseId: appealCase.id },

--- a/apps/judicial-system/backend/src/app/modules/appeal-case/guards/rolesRules.ts
+++ b/apps/judicial-system/backend/src/app/modules/appeal-case/guards/rolesRules.ts
@@ -2,6 +2,7 @@ import { RolesRule, RulesType } from '@island.is/judicial-system/auth'
 import {
   AppealCaseTransition,
   AppealCaseType,
+  isProsecutionUser,
   type User,
   UserRole,
 } from '@island.is/judicial-system/types'
@@ -9,6 +10,7 @@ import {
 import { AppealCase, Case } from '../../repository'
 import {
   canWithdrawCaseLevelAppeal,
+  hasStandingVerdictAppeal,
   isInCourtRulingOrderAppeal,
   userHasActiveInCourtAppeal,
 } from '../appealCase.helpers'
@@ -117,6 +119,7 @@ const userAppealedAppealCase = (request: {
   user?: { currentUser?: User }
   case?: Case
   appealCase?: AppealCase
+  body?: { defendantId?: string }
 }): boolean => {
   const user = request.user?.currentUser
   const theCase = request.case
@@ -124,6 +127,23 @@ const userAppealedAppealCase = (request: {
 
   if (!user || !theCase || !appealCase) {
     return false
+  }
+
+  // A verdict appeal is per defendant on both sides, so the prosecution is an
+  // appellant of the requested defendant's appeal, not of the case: the
+  // prosecution reviewer withdraws the prosecution's appeal regarding one
+  // defendant, and only where one stands. The defence rules for verdict appeals
+  // go through the per-party branch of userIsAppellant below.
+  if (
+    appealCase.appealType === AppealCaseType.VERDICT &&
+    isProsecutionUser(user)
+  ) {
+    const defendantId = request.body?.defendantId
+
+    return Boolean(
+      defendantId &&
+        hasStandingVerdictAppeal(appealCase, defendantId, 'PROSECUTION'),
+    )
   }
 
   // In-court ruling-order appeals are per party and withdrawn on the decision

--- a/apps/judicial-system/backend/src/app/modules/appeal-case/test/appealCaseController/prosecutionVerdictAppeal.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/appeal-case/test/appealCaseController/prosecutionVerdictAppeal.spec.ts
@@ -1,0 +1,409 @@
+import { Transaction } from 'sequelize'
+import { v4 as uuid } from 'uuid'
+
+import { ForbiddenException } from '@nestjs/common'
+
+import { addMessagesToQueue } from '@island.is/judicial-system/message'
+import {
+  AppealCaseState,
+  AppealCaseType,
+  AppealEventType,
+  AppealOrigin,
+  CaseIndictmentRulingDecision,
+  CaseState,
+  CaseType,
+  InstitutionType,
+  ServiceRequirement,
+  User,
+  UserRole,
+} from '@island.is/judicial-system/types'
+
+import { createTestingAppealCaseModule } from '../createTestingAppealCaseModule'
+
+import { nowFactory } from '../../../../factories'
+import {
+  AppealCase,
+  AppealCaseRepositoryService,
+  AppealEventLog,
+  AppealEventLogRepositoryService,
+  Case,
+  CaseRepositoryService,
+  DefendantRepositoryService,
+  VerdictRepositoryService,
+} from '../../../repository'
+import { CreateAppealCaseDto } from '../../dto/createAppealCase.dto'
+
+jest.mock('@island.is/judicial-system/message')
+jest.mock('../../../../factories')
+
+interface Then {
+  result: AppealCase
+  error: Error
+}
+
+type GivenWhenThen = (
+  theCase: Case,
+  dto?: CreateAppealCaseDto,
+  user?: User,
+) => Promise<Then>
+
+// The public prosecution reviewer appeals the verdict regarding one defendant
+// on the prosecution's behalf: the review decision confirmed on the review page
+// is the appeal.
+describe('AppealCaseController - Prosecution verdict appeal', () => {
+  const caseId = uuid()
+  const appealCaseId = uuid()
+  const defendantId = uuid()
+  const verdictId = uuid()
+  const reviewerId = uuid()
+
+  const reviewer = {
+    id: reviewerId,
+    role: UserRole.PROSECUTOR,
+    nationalId: '3333333333',
+    name: 'Kamilla Haralz',
+    title: 'saksóknari',
+    institution: {
+      type: InstitutionType.PUBLIC_PROSECUTORS_OFFICE,
+      name: 'Ríkissaksóknari',
+    },
+  } as User
+
+  const now = new Date('2026-06-04T13:34:00Z')
+
+  const createdAppealCase = {
+    id: appealCaseId,
+    caseId,
+    appealType: AppealCaseType.VERDICT,
+    appealDate: now,
+  } as AppealCase
+
+  // Served, but not required to be: the prosecution's right does not depend on
+  // service, and the deadline is not enforced here - the ruling is old.
+  const verdict = {
+    id: verdictId,
+    serviceRequirement: ServiceRequirement.REQUIRED,
+    serviceDate: new Date('2026-01-05T10:00:00Z'),
+  }
+
+  const buildCase = (overrides: Partial<Case> = {}) =>
+    ({
+      id: caseId,
+      type: CaseType.INDICTMENT,
+      state: CaseState.COMPLETED,
+      indictmentRulingDecision: CaseIndictmentRulingDecision.RULING,
+      indictmentReviewerId: reviewerId,
+      rulingDate: new Date('2026-01-05T10:00:00Z'),
+      caseFiles: [],
+      defendants: [
+        {
+          id: defendantId,
+          isDefenderChoiceConfirmed: true,
+          defenderNationalId: '1111111111',
+          verdicts: [verdict],
+        },
+      ],
+      ...overrides,
+    } as unknown as Case)
+
+  const dto: CreateAppealCaseDto = {
+    appealType: AppealCaseType.VERDICT,
+    defendantId,
+  }
+
+  const event = (
+    eventType: AppealEventType,
+    userRole: UserRole,
+    created: string,
+    forDefendantId = defendantId,
+  ) =>
+    ({
+      defendantId: forDefendantId,
+      eventType,
+      userRole,
+      created: new Date(created),
+    } as AppealEventLog)
+
+  let mockAppealCaseRepositoryService: AppealCaseRepositoryService
+  let mockAppealEventLogRepositoryService: AppealEventLogRepositoryService
+  let mockCaseRepositoryService: CaseRepositoryService
+  let mockDefendantRepositoryService: DefendantRepositoryService
+  let mockVerdictRepositoryService: VerdictRepositoryService
+  let transaction: Transaction
+  let givenWhenThen: GivenWhenThen
+
+  beforeEach(async () => {
+    jest.clearAllMocks()
+
+    const {
+      appealCaseController,
+      appealCaseRepositoryService,
+      appealEventLogRepositoryService,
+      caseRepositoryService,
+      defendantRepositoryService,
+      verdictRepositoryService,
+      sequelize,
+    } = await createTestingAppealCaseModule()
+
+    mockAppealCaseRepositoryService = appealCaseRepositoryService
+    mockAppealEventLogRepositoryService = appealEventLogRepositoryService
+    mockCaseRepositoryService = caseRepositoryService
+    mockDefendantRepositoryService = defendantRepositoryService
+    mockVerdictRepositoryService = verdictRepositoryService
+
+    const mockNowFactory = nowFactory as jest.Mock
+    mockNowFactory.mockReturnValue(now)
+
+    const mockTransaction = sequelize.transaction as jest.Mock
+    transaction = {} as Transaction
+    mockTransaction.mockImplementation(
+      (fn: (transaction: Transaction) => unknown) => fn(transaction),
+    )
+    ;(mockAppealCaseRepositoryService.create as jest.Mock).mockResolvedValue(
+      createdAppealCase,
+    )
+    ;(mockAppealCaseRepositoryService.findAll as jest.Mock).mockResolvedValue(
+      [],
+    )
+    ;(
+      mockCaseRepositoryService.lockByIdForUpdate as jest.Mock
+    ).mockResolvedValue(true)
+
+    givenWhenThen = async (theCase, createDto = dto, user = reviewer) => {
+      const then = {} as Then
+
+      await appealCaseController
+        .create(caseId, user, theCase, createDto)
+        .then((result) => (then.result = result))
+        .catch((error) => (then.error = error))
+
+      return then
+    }
+  })
+
+  describe('the reviewer appeals the verdict of a defendant', () => {
+    let then: Then
+
+    beforeEach(async () => {
+      then = await givenWhenThen(buildCase())
+    })
+
+    it('should create a verdict appeal case dated to now', () => {
+      expect(then.error).toBeUndefined()
+      expect(mockAppealCaseRepositoryService.create).toHaveBeenCalledWith(
+        caseId,
+        {
+          appealType: AppealCaseType.VERDICT,
+          appealState: AppealCaseState.APPEALED,
+          appealDate: now,
+        },
+        { transaction },
+      )
+      expect(then.result).toBe(createdAppealCase)
+    })
+
+    // Per defendant, and on the prosecution's side: the event names the
+    // defendant whose verdict is appealed and carries the prosecution's role.
+    it('should record a prosecution APPEALED event for that defendant', () => {
+      expect(mockAppealEventLogRepositoryService.create).toHaveBeenCalledTimes(
+        1,
+      )
+      expect(mockAppealEventLogRepositoryService.create).toHaveBeenCalledWith(
+        {
+          caseId,
+          appealCaseId,
+          eventType: AppealEventType.APPEALED,
+          appealOrigin: AppealOrigin.OUT_OF_COURT,
+          userRole: UserRole.PROSECUTOR,
+          userId: reviewerId,
+          defendantId,
+          nationalId: reviewer.nationalId,
+          userName: reviewer.name,
+          userTitle: reviewer.title,
+          institutionName: reviewer.institution?.name,
+        },
+        { transaction },
+      )
+    })
+
+    // The mirror and the appeal defender belong to the defendant's own appeal.
+    it('should touch neither the verdict nor the defendant', () => {
+      expect(mockVerdictRepositoryService.update).not.toHaveBeenCalled()
+      expect(mockDefendantRepositoryService.update).not.toHaveBeenCalled()
+    })
+
+    it('should queue no messages', () => {
+      expect(addMessagesToQueue).not.toHaveBeenCalled()
+    })
+  })
+
+  // Both sides may appeal the same defendant's verdict; the prosecution joins
+  // the case the defendant's appeal created.
+  describe('the reviewer appeals a verdict the defendant has already appealed', () => {
+    const existingAppealCase = {
+      id: appealCaseId,
+      caseId,
+      appealType: AppealCaseType.VERDICT,
+      appealState: AppealCaseState.APPEALED,
+      appealDate: new Date('2026-06-02T09:00:00Z'),
+    } as AppealCase
+
+    let then: Then
+
+    beforeEach(async () => {
+      ;(mockAppealCaseRepositoryService.findAll as jest.Mock).mockResolvedValue(
+        [existingAppealCase],
+      )
+      ;(
+        mockAppealEventLogRepositoryService.findAll as jest.Mock
+      ).mockResolvedValue([
+        event(
+          AppealEventType.APPEALED,
+          UserRole.DEFENDER,
+          '2026-06-02T09:00:00Z',
+        ),
+      ])
+
+      then = await givenWhenThen(
+        buildCase({
+          defendants: [
+            {
+              id: defendantId,
+              isDefenderChoiceConfirmed: true,
+              defenderNationalId: '1111111111',
+              verdicts: [
+                { ...verdict, appealDate: new Date('2026-06-02T09:00:00Z') },
+              ],
+            },
+          ],
+        } as unknown as Partial<Case>),
+      )
+    })
+
+    it('should join the existing appeal case', () => {
+      expect(then.error).toBeUndefined()
+      expect(mockAppealCaseRepositoryService.create).not.toHaveBeenCalled()
+      expect(then.result).toBe(existingAppealCase)
+    })
+
+    it('should record its own APPEALED event', () => {
+      expect(mockAppealEventLogRepositoryService.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          appealCaseId,
+          eventType: AppealEventType.APPEALED,
+          userRole: UserRole.PROSECUTOR,
+          defendantId,
+        }),
+        { transaction },
+      )
+    })
+  })
+
+  // The deadline is the reviewer's to judge; the review page confirms a late
+  // decision with them.
+  describe('the reviewer appeals after the deadline has run out', () => {
+    it('should register the appeal', async () => {
+      const then = await givenWhenThen(
+        buildCase({ rulingDate: new Date('2020-01-01T00:00:00Z') }),
+      )
+
+      expect(then.error).toBeUndefined()
+      expect(mockAppealCaseRepositoryService.create).toHaveBeenCalled()
+    })
+  })
+
+  // The prosecution's right to appeal does not depend on the verdict having
+  // been served on the defendant.
+  describe('the reviewer appeals before the verdict has been served', () => {
+    it('should register the appeal', async () => {
+      const then = await givenWhenThen(
+        buildCase({
+          defendants: [
+            {
+              id: defendantId,
+              verdicts: [
+                {
+                  id: verdictId,
+                  serviceRequirement: ServiceRequirement.REQUIRED,
+                },
+              ],
+            },
+          ],
+        } as unknown as Partial<Case>),
+      )
+
+      expect(then.error).toBeUndefined()
+      expect(mockAppealCaseRepositoryService.create).toHaveBeenCalled()
+    })
+  })
+
+  describe('appeals that are not allowed', () => {
+    const expectRejected = async (
+      theCase: Case,
+      createDto: CreateAppealCaseDto = dto,
+      user: User = reviewer,
+    ) => {
+      const then = await givenWhenThen(theCase, createDto, user)
+
+      expect(then.error).toBeInstanceOf(ForbiddenException)
+      expect(mockAppealCaseRepositoryService.create).not.toHaveBeenCalled()
+      expect(mockAppealEventLogRepositoryService.create).not.toHaveBeenCalled()
+
+      return then
+    }
+
+    it('should reject a prosecutor who is not the reviewer assigned to the case', async () => {
+      await expectRejected(buildCase({ indictmentReviewerId: uuid() }))
+    })
+
+    // Seen only under the lock: the prosecution has no mirror on the verdict.
+    it('should reject appealing a defendant the prosecution has already appealed', async () => {
+      ;(mockAppealCaseRepositoryService.findAll as jest.Mock).mockResolvedValue(
+        [
+          {
+            id: appealCaseId,
+            appealType: AppealCaseType.VERDICT,
+            appealState: AppealCaseState.APPEALED,
+          } as AppealCase,
+        ],
+      )
+      ;(
+        mockAppealEventLogRepositoryService.findAll as jest.Mock
+      ).mockResolvedValue([
+        event(
+          AppealEventType.APPEALED,
+          UserRole.PROSECUTOR,
+          '2026-06-02T09:00:00Z',
+        ),
+      ])
+
+      await expectRejected(buildCase())
+    })
+
+    // Once the court of appeals has received the case the decision is made.
+    it('should reject an appeal once the court of appeals has received the case', async () => {
+      ;(mockAppealCaseRepositoryService.findAll as jest.Mock).mockResolvedValue(
+        [
+          {
+            id: appealCaseId,
+            appealType: AppealCaseType.VERDICT,
+            appealState: AppealCaseState.RECEIVED,
+          } as AppealCase,
+        ],
+      )
+      ;(
+        mockAppealEventLogRepositoryService.findAll as jest.Mock
+      ).mockResolvedValue([])
+
+      await expectRejected(buildCase())
+    })
+
+    it('should reject an appeal on a case that did not end in a verdict', async () => {
+      await expectRejected(
+        buildCase({
+          indictmentRulingDecision: CaseIndictmentRulingDecision.FINE,
+        }),
+      )
+    })
+  })
+})

--- a/apps/judicial-system/backend/src/app/modules/appeal-case/test/appealCaseController/prosecutionVerdictAppeal.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/appeal-case/test/appealCaseController/prosecutionVerdictAppeal.spec.ts
@@ -356,6 +356,21 @@ describe('AppealCaseController - Prosecution verdict appeal', () => {
       await expectRejected(buildCase({ indictmentReviewerId: uuid() }))
     })
 
+    // The lock is taken as the case assigned to this reviewer, so a
+    // reassignment committed after the guard's snapshot fails it.
+    it('should reject a reviewer who was reassigned away before the lock', async () => {
+      ;(
+        mockCaseRepositoryService.lockByIdForUpdate as jest.Mock
+      ).mockResolvedValue(false)
+
+      await expectRejected(buildCase())
+      expect(mockCaseRepositoryService.lockByIdForUpdate).toHaveBeenCalledWith(
+        caseId,
+        transaction,
+        { id: caseId, indictmentReviewerId: reviewerId },
+      )
+    })
+
     // Seen only under the lock: the prosecution has no mirror on the verdict.
     it('should reject appealing a defendant the prosecution has already appealed', async () => {
       ;(mockAppealCaseRepositoryService.findAll as jest.Mock).mockResolvedValue(

--- a/apps/judicial-system/backend/src/app/modules/appeal-case/test/appealCaseController/prosecutionWithdrawVerdictAppeal.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/appeal-case/test/appealCaseController/prosecutionWithdrawVerdictAppeal.spec.ts
@@ -1,0 +1,295 @@
+import { Transaction } from 'sequelize'
+import { v4 as uuid } from 'uuid'
+
+import { ForbiddenException } from '@nestjs/common'
+
+import {
+  AppealCaseState,
+  AppealCaseTransition,
+  AppealCaseType,
+  AppealEventType,
+  CaseState,
+  CaseType,
+  InstitutionType,
+  User,
+  UserRole,
+} from '@island.is/judicial-system/types'
+
+import { createTestingAppealCaseModule } from '../createTestingAppealCaseModule'
+
+import {
+  AppealCase,
+  AppealCaseRepositoryService,
+  AppealEventLog,
+  AppealEventLogRepositoryService,
+  Case,
+  CaseRepositoryService,
+  DefendantRepositoryService,
+  VerdictRepositoryService,
+} from '../../../repository'
+import { TransitionAppealCaseDto } from '../../dto/transitionAppealCase.dto'
+
+jest.mock('@island.is/judicial-system/message')
+
+interface Then {
+  result: AppealCase
+  error: Error
+}
+
+type GivenWhenThen = (
+  dto: TransitionAppealCaseDto,
+  appealCase?: AppealCase,
+  user?: User,
+) => Promise<Then>
+
+// The public prosecution reviewer withdraws the prosecution's appeal of one
+// defendant's verdict - the review decision changed away from appealing.
+describe('AppealCaseController - Prosecution withdraws a verdict appeal', () => {
+  const caseId = uuid()
+  const appealCaseId = uuid()
+  const defendantId = uuid()
+  const otherDefendantId = uuid()
+  const reviewerId = uuid()
+
+  const reviewer = {
+    id: reviewerId,
+    role: UserRole.PROSECUTOR,
+    nationalId: '3333333333',
+    name: 'Kamilla Haralz',
+    title: 'saksóknari',
+    institution: {
+      type: InstitutionType.PUBLIC_PROSECUTORS_OFFICE,
+      name: 'Ríkissaksóknari',
+    },
+  } as User
+
+  const appealCase = {
+    id: appealCaseId,
+    caseId,
+    appealType: AppealCaseType.VERDICT,
+    appealState: AppealCaseState.APPEALED,
+  } as AppealCase
+
+  const theCase = {
+    id: caseId,
+    type: CaseType.INDICTMENT,
+    state: CaseState.COMPLETED,
+    indictmentReviewerId: reviewerId,
+    caseFiles: [],
+    defendants: [
+      { id: defendantId, verdicts: [{ id: uuid() }] },
+      { id: otherDefendantId, verdicts: [{ id: uuid() }] },
+    ],
+  } as unknown as Case
+
+  const dto: TransitionAppealCaseDto = {
+    transition: AppealCaseTransition.WITHDRAW_APPEAL,
+    defendantId,
+  }
+
+  const event = (
+    forDefendantId: string,
+    eventType: AppealEventType,
+    userRole: UserRole,
+    created: string,
+  ) =>
+    ({
+      defendantId: forDefendantId,
+      eventType,
+      userRole,
+      created: new Date(created),
+    } as AppealEventLog)
+
+  let mockAppealCaseRepositoryService: AppealCaseRepositoryService
+  let mockAppealEventLogRepositoryService: AppealEventLogRepositoryService
+  let mockCaseRepositoryService: CaseRepositoryService
+  let mockDefendantRepositoryService: DefendantRepositoryService
+  let mockVerdictRepositoryService: VerdictRepositoryService
+  let transaction: Transaction
+  let givenWhenThen: GivenWhenThen
+
+  beforeEach(async () => {
+    jest.clearAllMocks()
+
+    const {
+      appealCaseController,
+      appealCaseRepositoryService,
+      appealEventLogRepositoryService,
+      caseRepositoryService,
+      defendantRepositoryService,
+      verdictRepositoryService,
+      sequelize,
+    } = await createTestingAppealCaseModule()
+
+    mockAppealCaseRepositoryService = appealCaseRepositoryService
+    mockAppealEventLogRepositoryService = appealEventLogRepositoryService
+    mockCaseRepositoryService = caseRepositoryService
+    mockDefendantRepositoryService = defendantRepositoryService
+    mockVerdictRepositoryService = verdictRepositoryService
+
+    const mockTransaction = sequelize.transaction as jest.Mock
+    transaction = {} as Transaction
+    mockTransaction.mockImplementation(
+      (fn: (transaction: Transaction) => unknown) => fn(transaction),
+    )
+    ;(
+      mockCaseRepositoryService.lockByIdForUpdate as jest.Mock
+    ).mockResolvedValue(true)
+    ;(mockAppealCaseRepositoryService.update as jest.Mock).mockResolvedValue({
+      ...appealCase,
+      appealState: AppealCaseState.WITHDRAWN,
+    })
+
+    givenWhenThen = async (
+      transitionDto,
+      anAppealCase = appealCase,
+      user = reviewer,
+    ) => {
+      const then = {} as Then
+
+      await appealCaseController
+        .transition(
+          caseId,
+          appealCaseId,
+          user,
+          theCase,
+          anAppealCase,
+          transitionDto,
+        )
+        .then((result) => (then.result = result))
+        .catch((error) => (then.error = error))
+
+      return then
+    }
+  })
+
+  // The defendant's own appeal of the same verdict stands on its own.
+  describe('the prosecution withdraws while the defendant still appeals', () => {
+    let then: Then
+
+    beforeEach(async () => {
+      ;(
+        mockAppealEventLogRepositoryService.findAll as jest.Mock
+      ).mockResolvedValue([
+        event(
+          defendantId,
+          AppealEventType.APPEALED,
+          UserRole.DEFENDER,
+          '2026-06-04T13:34:00Z',
+        ),
+        event(
+          defendantId,
+          AppealEventType.APPEALED,
+          UserRole.PROSECUTOR,
+          '2026-06-05T09:00:00Z',
+        ),
+      ])
+
+      then = await givenWhenThen(dto)
+    })
+
+    it('should record a prosecution APPEAL_WITHDRAWN event for that defendant', () => {
+      expect(then.error).toBeUndefined()
+      expect(mockAppealEventLogRepositoryService.create).toHaveBeenCalledTimes(
+        1,
+      )
+      expect(mockAppealEventLogRepositoryService.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          appealCaseId,
+          eventType: AppealEventType.APPEAL_WITHDRAWN,
+          userRole: UserRole.PROSECUTOR,
+          userId: reviewerId,
+          defendantId,
+        }),
+        { transaction },
+      )
+    })
+
+    it('should leave the defendant own appeal - mirror and defender - alone', () => {
+      expect(mockVerdictRepositoryService.update).not.toHaveBeenCalled()
+      expect(mockDefendantRepositoryService.update).not.toHaveBeenCalled()
+    })
+
+    it('should leave the appeal case standing', () => {
+      expect(mockAppealCaseRepositoryService.update).not.toHaveBeenCalled()
+      expect(then.result).toBe(appealCase)
+    })
+  })
+
+  describe('the prosecution withdraws the last standing appeal', () => {
+    let then: Then
+
+    beforeEach(async () => {
+      ;(
+        mockAppealEventLogRepositoryService.findAll as jest.Mock
+      ).mockResolvedValue([
+        event(
+          defendantId,
+          AppealEventType.APPEALED,
+          UserRole.PROSECUTOR,
+          '2026-06-05T09:00:00Z',
+        ),
+      ])
+
+      then = await givenWhenThen(dto)
+    })
+
+    it('should withdraw the appeal case', () => {
+      expect(then.error).toBeUndefined()
+      expect(mockAppealCaseRepositoryService.update).toHaveBeenCalledWith(
+        appealCaseId,
+        expect.objectContaining({ appealState: AppealCaseState.WITHDRAWN }),
+        { transaction },
+      )
+    })
+  })
+
+  describe('withdrawals that are not allowed', () => {
+    const expectRejected = async (
+      transitionDto: TransitionAppealCaseDto,
+      anAppealCase?: AppealCase,
+      user?: User,
+    ) => {
+      const then = await givenWhenThen(transitionDto, anAppealCase, user)
+
+      expect(then.error).toBeInstanceOf(ForbiddenException)
+      expect(mockAppealEventLogRepositoryService.create).not.toHaveBeenCalled()
+      expect(mockAppealCaseRepositoryService.update).not.toHaveBeenCalled()
+    }
+
+    it('should reject withdrawing a defendant the prosecution did not appeal', async () => {
+      ;(
+        mockAppealEventLogRepositoryService.findAll as jest.Mock
+      ).mockResolvedValue([
+        event(
+          defendantId,
+          AppealEventType.APPEALED,
+          UserRole.DEFENDER,
+          '2026-06-04T13:34:00Z',
+        ),
+        event(
+          otherDefendantId,
+          AppealEventType.APPEALED,
+          UserRole.PROSECUTOR,
+          '2026-06-05T09:00:00Z',
+        ),
+      ])
+
+      await expectRejected(dto)
+    })
+
+    it('should reject a prosecutor who is not the reviewer assigned to the case', async () => {
+      await expectRejected(dto, appealCase, {
+        ...reviewer,
+        id: uuid(),
+      } as User)
+    })
+
+    it('should reject a withdrawal once the court of appeals has received the case', async () => {
+      await expectRejected(dto, {
+        ...appealCase,
+        appealState: AppealCaseState.RECEIVED,
+      } as AppealCase)
+    })
+  })
+})

--- a/apps/judicial-system/backend/src/app/modules/appeal-case/test/appealCaseController/prosecutionWithdrawVerdictAppeal.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/appeal-case/test/appealCaseController/prosecutionWithdrawVerdictAppeal.spec.ts
@@ -139,6 +139,10 @@ describe('AppealCaseController - Prosecution withdraws a verdict appeal', () => 
       ...appealCase,
       appealState: AppealCaseState.WITHDRAWN,
     })
+    // The state is re-read under the case lock; by default it is unchanged.
+    ;(mockAppealCaseRepositoryService.findById as jest.Mock).mockResolvedValue(
+      appealCase,
+    )
 
     givenWhenThen = async (
       transitionDto,
@@ -285,11 +289,25 @@ describe('AppealCaseController - Prosecution withdraws a verdict appeal', () => 
       } as User)
     })
 
+    // The guard's snapshot predates the transaction; what counts is the state
+    // under the lock.
     it('should reject a withdrawal once the court of appeals has received the case', async () => {
-      await expectRejected(dto, {
+      ;(
+        mockAppealCaseRepositoryService.findById as jest.Mock
+      ).mockResolvedValue({
         ...appealCase,
         appealState: AppealCaseState.RECEIVED,
-      } as AppealCase)
+      })
+
+      await expectRejected(dto)
+      expect(mockCaseRepositoryService.lockByIdForUpdate).toHaveBeenCalledWith(
+        caseId,
+        transaction,
+      )
+      expect(mockAppealCaseRepositoryService.findById).toHaveBeenCalledWith(
+        appealCaseId,
+        { transaction },
+      )
     })
   })
 })

--- a/apps/judicial-system/backend/src/app/modules/appeal-case/test/appealCaseController/prosecutionWithdrawVerdictAppeal.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/appeal-case/test/appealCaseController/prosecutionWithdrawVerdictAppeal.spec.ts
@@ -289,6 +289,16 @@ describe('AppealCaseController - Prosecution withdraws a verdict appeal', () => 
       } as User)
     })
 
+    // The guard's snapshot may predate a reassignment; the lock is taken as the
+    // case assigned to this reviewer, so it fails instead.
+    it('should reject a reviewer who was reassigned away before the lock', async () => {
+      ;(
+        mockCaseRepositoryService.lockByIdForUpdate as jest.Mock
+      ).mockResolvedValue(false)
+
+      await expectRejected(dto)
+    })
+
     // The guard's snapshot predates the transaction; what counts is the state
     // under the lock.
     it('should reject a withdrawal once the court of appeals has received the case', async () => {
@@ -303,6 +313,7 @@ describe('AppealCaseController - Prosecution withdraws a verdict appeal', () => 
       expect(mockCaseRepositoryService.lockByIdForUpdate).toHaveBeenCalledWith(
         caseId,
         transaction,
+        { id: caseId, indictmentReviewerId: reviewerId },
       )
       expect(mockAppealCaseRepositoryService.findById).toHaveBeenCalledWith(
         appealCaseId,

--- a/apps/judicial-system/backend/src/app/modules/appeal-case/test/appealCaseController/transitionRolesRules.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/appeal-case/test/appealCaseController/transitionRolesRules.spec.ts
@@ -24,10 +24,12 @@ const buildRequest = (
   theCase: Partial<Case>,
   appealCase: Partial<AppealCase>,
   user?: Partial<User>,
+  body?: { defendantId?: string },
 ) => ({
   case: theCase as Case,
   appealCase: appealCase as AppealCase,
   user: user ? { currentUser: user as User } : undefined,
+  body,
 })
 
 // An APPEALED event on the appeal case - the appellant is now read from here.
@@ -303,6 +305,71 @@ describe('AppealCaseController - transition withdrawal rules', () => {
       )
 
       expect(defenderTransitionRule.canActivate?.(request)).toBe(false)
+    })
+  })
+
+  // The prosecution appeals a verdict per defendant, so it withdraws per
+  // defendant too - and only where its own appeal of that defendant stands.
+  describe('prosecution on a verdict appeal', () => {
+    const reviewer = {
+      role: UserRole.PROSECUTOR,
+      nationalId: '0000000000',
+      institution: { type: InstitutionType.PUBLIC_PROSECUTORS_OFFICE },
+    }
+    const verdictAppealCase = (events: AppealEventLog[]) => ({
+      appealType: AppealCaseType.VERDICT,
+      appealEventLogs: events,
+    })
+
+    it('allows withdrawing the prosecution appeal of the requested defendant', () => {
+      const request = buildRequest(
+        { type: CaseType.INDICTMENT },
+        verdictAppealCase([
+          appealed({ userRole: UserRole.PROSECUTOR, defendantId: 'd1' }),
+        ]),
+        reviewer,
+        { defendantId: 'd1' },
+      )
+
+      expect(prosecutorTransitionRule.canActivate?.(request)).toBe(true)
+    })
+
+    it('denies a defendant the prosecution did not appeal', () => {
+      const request = buildRequest(
+        { type: CaseType.INDICTMENT },
+        verdictAppealCase([
+          appealed({ userRole: UserRole.PROSECUTOR, defendantId: 'd1' }),
+        ]),
+        reviewer,
+        { defendantId: 'd2' },
+      )
+
+      expect(prosecutorTransitionRule.canActivate?.(request)).toBe(false)
+    })
+
+    it('denies withdrawing the defendant own appeal', () => {
+      const request = buildRequest(
+        { type: CaseType.INDICTMENT },
+        verdictAppealCase([
+          appealed({ userRole: UserRole.DEFENDER, defendantId: 'd1' }),
+        ]),
+        reviewer,
+        { defendantId: 'd1' },
+      )
+
+      expect(prosecutorTransitionRule.canActivate?.(request)).toBe(false)
+    })
+
+    it('denies a request that names no defendant', () => {
+      const request = buildRequest(
+        { type: CaseType.INDICTMENT },
+        verdictAppealCase([
+          appealed({ userRole: UserRole.PROSECUTOR, defendantId: 'd1' }),
+        ]),
+        reviewer,
+      )
+
+      expect(prosecutorTransitionRule.canActivate?.(request)).toBe(false)
     })
   })
 

--- a/apps/judicial-system/backend/src/app/modules/appeal-case/test/appealCaseHelpers.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/appeal-case/test/appealCaseHelpers.spec.ts
@@ -9,7 +9,9 @@ import {
 import { AppealCase, AppealEventLog, Case } from '../../repository'
 import {
   appellantRepresentativeNationalIds,
+  hasStandingVerdictAppeal,
   standingVerdictAppellantIds,
+  standingVerdictAppellants,
   userIsAppellant,
 } from '../appealCase.helpers'
 
@@ -150,6 +152,31 @@ describe('userIsAppellant', () => {
       )
     })
 
+    // The prosecution appeals a verdict regarding a defendant, so its event
+    // names the defendant too; that is not the defendant's appeal.
+    it('is false for the defender of a defendant only the prosecution appealed', () => {
+      const theCase = {
+        type: CaseType.INDICTMENT,
+        defendants: [
+          {
+            id: 'd1',
+            isDefenderChoiceConfirmed: true,
+            defenderNationalId: '1111111111',
+          },
+        ],
+      } as Case
+
+      expect(
+        userIsAppellant(
+          theCase,
+          appealCaseWith([
+            appealed({ userRole: UserRole.PROSECUTOR, defendantId: 'd1' }),
+          ]),
+          defender('1111111111'),
+        ),
+      ).toBe(false)
+    })
+
     it('is false when the defender choice is not confirmed', () => {
       const theCase = {
         type: CaseType.INDICTMENT,
@@ -213,6 +240,22 @@ describe('appellantRepresentativeNationalIds', () => {
     expect(appellantRepresentativeNationalIds(theCase, appealCase).size).toBe(0)
   })
 
+  // The defendant whose verdict the prosecution appealed is the one to notify.
+  it('does not treat the defendant named on a prosecution appeal as an appellant', () => {
+    const theCase = {
+      defendants: [{ id: 'd1', defenderNationalId: '1111111111' }],
+    } as Case
+
+    expect(
+      appellantRepresentativeNationalIds(
+        theCase,
+        appealCaseWith([
+          appealed({ userRole: UserRole.PROSECUTOR, defendantId: 'd1' }),
+        ]),
+      ),
+    ).toEqual(new Set())
+  })
+
   it('collects every appellant when several parties appealed', () => {
     const theCase = {
       type: CaseType.INDICTMENT,
@@ -237,8 +280,44 @@ describe('standingVerdictAppellantIds', () => {
     defendantId: string,
     eventType: AppealEventType,
     created: string,
+    userRole: UserRole = UserRole.DEFENDER,
   ) =>
-    ({ defendantId, eventType, created: new Date(created) } as AppealEventLog)
+    ({
+      defendantId,
+      eventType,
+      created: new Date(created),
+      userRole,
+    } as AppealEventLog)
+
+  // The prosecution's appeal regarding a defendant is the other side's appeal,
+  // not the defendant's.
+  it('does not list a defendant only the prosecution appealed', () => {
+    const appealCase = appealCaseWith([
+      event(
+        'a',
+        AppealEventType.APPEALED,
+        '2026-06-04T10:00:00Z',
+        UserRole.PROSECUTOR,
+      ),
+    ])
+
+    expect(standingVerdictAppellantIds(appealCase)).toEqual([])
+  })
+
+  // An appeal the public prosecution office registered on a letter is the
+  // defendant's appeal.
+  it('lists a defendant whose appeal the public prosecution office registered', () => {
+    const appealCase = appealCaseWith([
+      event(
+        'a',
+        AppealEventType.APPEALED,
+        '2026-06-04T10:00:00Z',
+        UserRole.PUBLIC_PROSECUTOR_STAFF,
+      ),
+    ])
+
+    expect(standingVerdictAppellantIds(appealCase)).toEqual(['a'])
+  })
 
   it('is empty when nothing has been appealed', () => {
     expect(standingVerdictAppellantIds(appealCaseWith([]))).toEqual([])
@@ -281,5 +360,74 @@ describe('standingVerdictAppellantIds', () => {
     ])
 
     expect(standingVerdictAppellantIds(appealCase)).toEqual([])
+  })
+})
+
+describe('standingVerdictAppellants', () => {
+  const event = (
+    defendantId: string,
+    eventType: AppealEventType,
+    created: string,
+    userRole: UserRole,
+  ) =>
+    ({
+      defendantId,
+      eventType,
+      created: new Date(created),
+      userRole,
+    } as AppealEventLog)
+
+  // Both sides may appeal the same defendant's verdict; each stands or falls on
+  // its own events.
+  it('keeps the two sides of one defendant apart', () => {
+    const appealCase = appealCaseWith([
+      event(
+        'a',
+        AppealEventType.APPEALED,
+        '2026-06-04T10:00:00Z',
+        UserRole.DEFENDER,
+      ),
+      event(
+        'a',
+        AppealEventType.APPEALED,
+        '2026-06-05T10:00:00Z',
+        UserRole.PROSECUTOR,
+      ),
+      event(
+        'a',
+        AppealEventType.APPEAL_WITHDRAWN,
+        '2026-06-06T10:00:00Z',
+        UserRole.DEFENDER,
+      ),
+    ])
+
+    expect(standingVerdictAppellants(appealCase)).toEqual([
+      { defendantId: 'a', side: 'PROSECUTION' },
+    ])
+    expect(hasStandingVerdictAppeal(appealCase, 'a', 'PROSECUTION')).toBe(true)
+    expect(hasStandingVerdictAppeal(appealCase, 'a', 'DEFENCE')).toBe(false)
+  })
+
+  it('treats a prosecutor representative as the prosecution side', () => {
+    const appealCase = appealCaseWith([
+      event(
+        'a',
+        AppealEventType.APPEALED,
+        '2026-06-04T10:00:00Z',
+        UserRole.PROSECUTOR_REPRESENTATIVE,
+      ),
+    ])
+
+    expect(standingVerdictAppellants(appealCase)).toEqual([
+      { defendantId: 'a', side: 'PROSECUTION' },
+    ])
+  })
+
+  it('ignores events without a defendant', () => {
+    const appealCase = appealCaseWith([
+      { eventType: AppealEventType.APPEALED, userRole: UserRole.PROSECUTOR },
+    ] as AppealEventLog[])
+
+    expect(standingVerdictAppellants(appealCase)).toEqual([])
   })
 })

--- a/apps/judicial-system/backend/src/app/modules/appeal-case/test/limitedAccessAppealCaseController/withdrawVerdictAppeal.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/appeal-case/test/limitedAccessAppealCaseController/withdrawVerdictAppeal.spec.ts
@@ -236,6 +236,40 @@ describe('LimitedAccessAppealCaseController - Withdraw verdict appeal', () => {
     })
   })
 
+  // The prosecution may appeal the same defendant's verdict; that appeal is the
+  // other side's and keeps the case standing when the defendant withdraws.
+  describe('the last defendant withdraws while the prosecution still appeals', () => {
+    let then: Then
+
+    beforeEach(async () => {
+      ;(
+        mockAppealEventLogRepositoryService.findAll as jest.Mock
+      ).mockResolvedValue([
+        appealedEvent(defendantId, '2026-06-04T13:34:00Z'),
+        {
+          defendantId,
+          eventType: AppealEventType.APPEALED,
+          userRole: UserRole.PROSECUTOR,
+          created: new Date('2026-06-05T09:00:00Z'),
+        } as AppealEventLog,
+      ])
+
+      then = await givenWhenThen(theCase, appealCase, dto)
+    })
+
+    it('should withdraw the defendant appeal but leave the appeal case standing', () => {
+      expect(then.error).toBeUndefined()
+      expect(mockAppealEventLogRepositoryService.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          eventType: AppealEventType.APPEAL_WITHDRAWN,
+          defendantId,
+        }),
+        { transaction },
+      )
+      expect(mockAppealCaseRepositoryService.update).not.toHaveBeenCalled()
+    })
+  })
+
   describe('withdrawals that are not allowed', () => {
     it('should reject a withdrawal that names no defendant', async () => {
       const then = await givenWhenThen(theCase, appealCase, {

--- a/apps/judicial-system/backend/src/app/modules/defendant/defendant.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/defendant/defendant.service.ts
@@ -11,6 +11,7 @@ import {
 } from '@island.is/judicial-system/message'
 import type { User } from '@island.is/judicial-system/types'
 import {
+  AppealCaseState,
   CaseState,
   CaseType,
   DefendantEventType,
@@ -432,6 +433,22 @@ export class DefendantService {
     ) {
       const { defenderNationalId: _, ...rest } = update
       update = rest
+    }
+
+    // The reviewer's decision on an indictment verdict is the prosecution's
+    // appeal or its absence. Once the court of appeals has received the verdict
+    // appeal the decision is made; the web creates and withdraws the appeal
+    // from the decision, and this keeps the two from drifting apart.
+    if (
+      update.indictmentReviewDecision !== undefined &&
+      update.indictmentReviewDecision !== defendant.indictmentReviewDecision &&
+      theCase.verdictAppealCase &&
+      theCase.verdictAppealCase.appealState !== AppealCaseState.APPEALED &&
+      theCase.verdictAppealCase.appealState !== AppealCaseState.WITHDRAWN
+    ) {
+      throw new BadRequestException(
+        'The review decision cannot change once the court of appeals has received the verdict appeal',
+      )
     }
 
     if (isIndictmentCase(theCase.type)) {

--- a/apps/judicial-system/backend/src/app/modules/defendant/test/defendantController/update.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/defendant/test/defendantController/update.spec.ts
@@ -5,10 +5,12 @@ import { BadRequestException } from '@nestjs/common'
 
 import { Message, MessageType } from '@island.is/judicial-system/message'
 import {
+  AppealCaseState,
   CaseType,
   DefendantEventType,
   DefendantNotificationType,
   DefenderChoice,
+  IndictmentCaseReviewDecision,
   RequestCaseNotificationType,
   User,
 } from '@island.is/judicial-system/types'
@@ -16,6 +18,7 @@ import {
 import { createTestingDefendantModule } from '../createTestingDefendantModule'
 
 import {
+  AppealCase,
   Case,
   Defendant,
   DefendantEventLogRepositoryService,
@@ -33,6 +36,7 @@ type GivenWhenThen = (
   type: CaseType,
   courtCaseNumber?: string,
   existingDefendant?: Defendant,
+  caseOverrides?: Partial<Case>,
 ) => Promise<Then>
 
 describe('DefendantController - Update', () => {
@@ -79,6 +83,7 @@ describe('DefendantController - Update', () => {
       type: CaseType,
       courtCaseNumber?: string,
       existingDefendant?: Defendant,
+      caseOverrides: Partial<Case> = {},
     ) => {
       const then = {} as Then
 
@@ -87,7 +92,7 @@ describe('DefendantController - Update', () => {
           caseId,
           defendantId,
           user,
-          { id: caseId, courtCaseNumber, type } as Case,
+          { id: caseId, courtCaseNumber, type, ...caseOverrides } as Case,
           existingDefendant ?? defendant,
           defendantUpdate,
         )
@@ -430,6 +435,67 @@ describe('DefendantController - Update', () => {
     it('should reject the update', () => {
       expect(then.error).toBeInstanceOf(BadRequestException)
       expect(mockDefendantRepositoryService.update).not.toHaveBeenCalled()
+    })
+  })
+
+  // The reviewer's decision is the prosecution's verdict appeal or its absence;
+  // once the court of appeals has received the appeal it is made.
+  describe('review decision changed after the court of appeals received the verdict appeal', () => {
+    let then: Then
+
+    beforeEach(async () => {
+      then = await givenWhenThen(
+        { indictmentReviewDecision: IndictmentCaseReviewDecision.ACCEPT },
+        CaseType.INDICTMENT,
+        caseId,
+        {
+          ...defendant,
+          indictmentReviewDecision: IndictmentCaseReviewDecision.APPEAL,
+        } as Defendant,
+        {
+          verdictAppealCase: {
+            appealState: AppealCaseState.RECEIVED,
+          } as AppealCase,
+        },
+      )
+    })
+
+    it('should reject the update', () => {
+      expect(then.error).toBeInstanceOf(BadRequestException)
+      expect(mockDefendantRepositoryService.update).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('review decision changed while the verdict appeal is still with the district court', () => {
+    const updatedDefendant = {
+      ...defendant,
+      indictmentReviewDecision: IndictmentCaseReviewDecision.ACCEPT,
+    }
+    let then: Then
+
+    beforeEach(async () => {
+      const mockUpdate = mockDefendantRepositoryService.update as jest.Mock
+      mockUpdate.mockResolvedValueOnce(updatedDefendant)
+
+      then = await givenWhenThen(
+        { indictmentReviewDecision: IndictmentCaseReviewDecision.ACCEPT },
+        CaseType.INDICTMENT,
+        caseId,
+        {
+          ...defendant,
+          indictmentReviewDecision: IndictmentCaseReviewDecision.APPEAL,
+        } as Defendant,
+        {
+          verdictAppealCase: {
+            appealState: AppealCaseState.APPEALED,
+          } as AppealCase,
+        },
+      )
+    })
+
+    it('should update the defendant', () => {
+      expect(then.error).toBeUndefined()
+      expect(then.result).toBe(updatedDefendant)
     })
   })
 


### PR DESCRIPTION
# The prosecution reviewer appeals a verdict per defendant

[Áfrýjun saksóknara - bakendi](https://app.asana.com/1/203394141643832/project/1199153462262248/task/1218388969960490)

Parent ticket: [Áfrýjun - ríkissaksóknari áfrýjar dómi](https://app.asana.com/1/203394141643832/project/1199153462262248/task/1217860765215962). Backend only; the web (review page, cards) follows in the next PR, behind `INDICTMENT_APPEAL`. Nothing calls the new paths until then.

## What

After reviewing a district court verdict, the public prosecution's reviewer decides per defendant to accept it or appeal it. Today that decision is a field on the defendant and nothing more - the case lands in the office's "Áfrýjuð mál" list and no appeal exists. This PR lets the decision be a real appeal: the reviewer becomes an appellant on the case's verdict appeal case (`appealType: VERDICT`, one per district court case), **per defendant**, alongside and independent of the defendant's own appeal of the same verdict.

## How

- **Appellants gain a side.** A verdict appeal event names the defendant whose verdict is appealed and the role of who appealed it; `standingVerdictAppellants` reads (defendantId, defence | prosecution) from the log, latest APPEALED/APPEAL_WITHDRAWN per pair. `hasStandingVerdictAppeal` asks for one pair. The defence-only helpers - `standingVerdictAppellantIds`, the defence branch of `userIsAppellant`, `appellantRepresentativeNationalIds` - now skip prosecution events: the prosecution appealing defendant X's verdict does not make X (or X's defender) an appellant, and X's defender is someone to notify, not to exclude.
- **Third actor in `createVerdictAppeal`** (`verdictAppealActor`: defender, office, reviewer). The reviewer must be the case's `indictmentReviewer`. No `canDefendantAppealVerdict` (the prosecution's right does not depend on service), no `validateVerdictAppealUpdate` (the deadline is the reviewer's to judge; the review page confirms a late decision, per the owner), no `verdict.appealDate` check or mirror, no appeal defender. Duplicate check on the prosecution side under the lock; create-or-join and WITHDRAWN revival as before.
- **Third actor in `withdrawVerdictAppeal`**: reviewer only, standing prosecution appeal of that defendant required, `APPEAL_WITHDRAWN` per defendant, no mirror or defender clearing. **The appeal case is withdrawn only when no appellant of either side stands** - previously the last *defence* withdrawal withdrew the case even if the prosecution's appeal stood (there could be none until now).
- **Received by the court of appeals = decision made.** The prosecution's create and withdraw are refused once the appeal case is past APPEALED/WITHDRAWN, and `defendant.service` refuses changing `indictmentReviewDecision` then too, so the decision and the appeal cannot drift apart (the web lock in the next PR is advisory).
- **Roles rule**: for a `VERDICT` appeal case the prosecution's `WITHDRAW_APPEAL` rule checks that the *requested defendant* has a standing prosecution appeal, instead of `userIsAppellant`'s case-wide "a prosecution APPEALED event exists".

## Tests

- `prosecutionVerdictAppeal.spec.ts` (10): create dated to now with a prosecution event naming the defendant, nothing written to verdict or defendant, no messages; join a defendant's appeal; allowed after the deadline and before service; refused for a non-reviewer, a duplicate (under the lock), a received case, a fine.
- `prosecutionWithdrawVerdictAppeal.spec.ts` (7): withdraw while the defendant still appeals leaves the case standing; last appeal withdraws it; refused for an unappealed defendant, a non-reviewer, a received case.
- `appealCaseHelpers.spec.ts` +7 (sides, representative role, office-registered appeal is defence side, prosecution event does not make the defender an appellant), `transitionRolesRules.spec.ts` +4, limited-access withdraw +1 (prosecution's appeal keeps the case), defendant `update.spec.ts` +2 (lock / no lock).

Full `appeal-case` + defendant update suites: 25 suites / 224 tests. `tsc`, `nx lint`, `nx format:check` clean.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Public prosecution reviewers can file and withdraw verdict appeals for specific defendants.
  - Appeal permissions now distinguish prosecution-side and defence-side appeals, including defendant-specific withdrawals.

- **Bug Fixes**
  - Prosecution appeals no longer incorrectly identify defendants or their representatives as defence appellants or notification recipients.
  - Indictment review decisions can no longer be changed after an appeal is received by the court of appeals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->