### PR TITLE
fix(native-app): multiple minor health fixes

### DIFF
--- a/apps/native/app/src/app/(auth)/(tabs)/health/categories.tsx
+++ b/apps/native/app/src/app/(auth)/(tabs)/health/categories.tsx
@@ -4,6 +4,7 @@ import { ScrollView } from 'react-native'
 import styled from 'styled-components/native'
 
 import calendarIcon from '@/assets/icons/calendar.png'
+import envelopeIcon from '@/assets/icons/tabbar-mail.png'
 import medicineIcon from '@/assets/icons/medicine.png'
 import readerIcon from '@/assets/icons/reader.png'
 import vaccinationsIcon from '@/assets/icons/vaccinations.png'
@@ -67,6 +68,11 @@ export default function HealthCategoriesScreen() {
     false,
     null,
   )
+  const isHealthMessagesEnabled = useFeatureFlag(
+    'isAppHealthMessagesEnabled',
+    false,
+    null,
+  )
 
   const healthCardRows = useMemo(() => {
     // Build the medicine subLinks based on feature flags
@@ -124,6 +130,13 @@ export default function HealthCategoriesScreen() {
           enabled: isAppointmentsEnabled,
         },
         {
+          id: 'messages',
+          titleId: 'health.messages.screenTitle',
+          icon: envelopeIcon,
+          route: '/health/messages',
+          enabled: isHealthMessagesEnabled,
+        },
+        {
           id: 'questionnaires',
           titleId: 'health.overview.questionnaires',
           icon: readerIcon,
@@ -145,6 +158,7 @@ export default function HealthCategoriesScreen() {
     isQuestionnaireFeatureEnabled,
     isVaccinationsEnabled,
     isAppointmentsEnabled,
+    isHealthMessagesEnabled,
   ])
 
   const externalLinks = [

--- a/apps/native/app/src/app/(auth)/(tabs)/health/messages/[id].tsx
+++ b/apps/native/app/src/app/(auth)/(tabs)/health/messages/[id].tsx
@@ -498,7 +498,8 @@ export default function HealthMessageDetailScreen() {
               onRefresh={refreshConversation}
             />
           }
-          contentContainerStyle={{ flexGrow: 1 }}
+          // No `flexGrow: 1`: it stretches the content past the visible area
+          // by the header's content inset, so even one message scrolled.
           contentInsetAdjustmentBehavior="automatic"
           automaticallyAdjustContentInsets
           ListHeaderComponent={
@@ -522,11 +523,9 @@ export default function HealthMessageDetailScreen() {
               </View>
             ) : null
           }
-          ListFooterComponent={
-            <SafeAreaView
-              style={{ height: conversation?.patientCanReply ? 160 : 24 }}
-            />
-          }
+          // Just an end-of-thread gap — the reply drawer below is a flow
+          // sibling, not an overlay, so it needs no space reserved here.
+          ListFooterComponent={<View style={{ height: theme.spacing[3] }} />}
         />
         {isSkeleton || conversation ? (
           <ButtonDrawer>

--- a/apps/native/app/src/app/(auth)/(tabs)/health/messages/index.tsx
+++ b/apps/native/app/src/app/(auth)/(tabs)/health/messages/index.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useMemo, useRef, useState } from 'react'
+import { NetworkStatus } from '@apollo/client'
 import { FormattedMessage, useIntl } from 'react-intl'
 import {
   FlatList,
@@ -64,6 +65,14 @@ export default function HealthMessagesScreen() {
   }, [conversations, query])
 
   const showSearch = conversations.length > 0 || query.length > 0
+
+  // `cache-and-network` hands back a persisted empty inbox before the network
+  // reply lands, so `data` being set is no proof we have rows — that flashed the
+  // empty state on open. Refresh keeps its spinner instead.
+  const showSkeletons =
+    messagesRes.loading &&
+    messagesRes.networkStatus !== NetworkStatus.refetch &&
+    conversations.length === 0
 
   const [refetching, setRefetching] = useState(false)
   const loadingTimeout = useRef<ReturnType<typeof setTimeout>>(undefined)
@@ -190,7 +199,7 @@ export default function HealthMessagesScreen() {
           </Pressable>
         )}
         ListEmptyComponent={
-          messagesRes.loading && !messagesRes.data ? (
+          showSkeletons ? (
             <View>
               {Array.from({ length: 8 }).map((_, index) => (
                 <ListItemSkeleton key={index} />

--- a/apps/native/app/src/app/(auth)/(tabs)/health/questionnaires/[id].tsx
+++ b/apps/native/app/src/app/(auth)/(tabs)/health/questionnaires/[id].tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useMemo, useState } from 'react'
 import { FormattedMessage, useIntl } from 'react-intl'
 import { RefreshControl, ScrollView, View } from 'react-native'
 import { router, useLocalSearchParams } from 'expo-router'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import styled, { useTheme } from 'styled-components/native'
 
 import { StackScreen } from '@/components/stack-screen'
@@ -56,6 +57,7 @@ export default function QuestionnaireDetailScreen() {
   const theme = useTheme()
   const intl = useIntl()
   const locale = useLocale()
+  const insets = useSafeAreaInsets()
   const { openBrowser } = useBrowser()
   const shouldSkipQuery = !id || !organization
   const { data, loading, error, refetch, networkStatus } =
@@ -159,6 +161,9 @@ export default function QuestionnaireDetailScreen() {
       />
       <ScrollView
         style={{ flex: 1 }}
+        contentContainerStyle={{
+          paddingBottom: theme.spacing[3] + insets.bottom,
+        }}
         refreshControl={
           <RefreshControl refreshing={refetching} onRefresh={onRefresh} />
         }

--- a/apps/native/app/src/messages/is.ts
+++ b/apps/native/app/src/messages/is.ts
@@ -867,7 +867,7 @@ export const is = {
   'health.appointments.locationFloor': 'Hæð',
   'health.appointments.locationRoom': 'Herbergi',
   'health.appointments.assigneeTypeRole': 'Hlutverk',
-  'health.appointments.assigneeTypeRoom': 'Herbergi',
+  'health.appointments.assigneeTypeRoom': 'Stofa',
   'health.appointments.assigneeTypeEquipment': 'Tæki',
   'health.appointments.assigneeTypeService': 'Þjónusta',
   'health.appointments.assigneeTypeTeam': 'Teymi',


### PR DESCRIPTION
## What

A handful of small fixes to the health pages in the app:

- **Messages list** — show the loading skeletons instead of briefly flashing the
  "no messages" empty state when opening the inbox.
- **Message threads** — fix the scrolling: threads could be scrolled well past
  the last message, and even a one-message thread could be scrolled up under
  the header.
- **Questionnaire detail** — the last row could not be scrolled clear of the
  sheet's bottom edge.
- **Heilsuflokkar** — add a Skilaboð shortcut, alongside Tímabókanir and
  Spurningalistar.
- **Appointments** — the room assignee label now reads "Stofa" rather than
  "Herbergi" in Icelandic.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a Messages category to Health, available when enabled, with navigation to health conversations.

- **Bug Fixes**
  - Improved message loading behavior to prevent skeletons from appearing during refreshes.
  - Fixed message detail layouts that could extend beyond the visible area.
  - Prevented questionnaire content from being obscured by device safe areas.
  - Adjusted spacing at the bottom of message conversations.

- **Localization**
  - Updated the Icelandic translation for the appointment assignee type “room.”
<!-- end of auto-generated comment: release notes by coderabbit.ai -->