### PR TITLE
fix: auth admin scaling

### DIFF
--- a/apps/auth-admin-web/infra/auth-admin-web.ts
+++ b/apps/auth-admin-web/infra/auth-admin-web.ts
@@ -58,7 +58,7 @@ export const serviceSetup = (): ServiceBuilder<'auth-admin-web'> =>
     .replicaCount({
       dev: { min: 0, max: 0, default: 0 },
       staging: { min: 0, max: 0, default: 0 },
-      prod: { min: 2, max: 10, default: 2 },
+      prod: { min: 0, max: 0, default: 0 },
       bypassReplicaClamp: true,
     })
     .resources({

--- a/apps/services/auth/admin-api/infra/auth-admin-api.ts
+++ b/apps/services/auth/admin-api/infra/auth-admin-api.ts
@@ -143,10 +143,9 @@ export const serviceSetup = (): ServiceBuilder<'services-auth-admin-api'> => {
       },
     })
     .replicaCount({
-      dev: { min: 0, max: 0, default: 0 },
-      staging: { min: 0, max: 0, default: 0 },
-      prod: { min: 2, max: 10, default: 2 },
-      bypassReplicaClamp: true,
+      default: 2,
+      min: 2,
+      max: 10,
     })
     .grantNamespaces(
       'nginx-ingress-external',

--- a/charts/identity-server-services/auth-admin-web/values.prod.yaml
+++ b/charts/identity-server-services/auth-admin-web/values.prod.yaml
@@ -44,14 +44,6 @@ healthCheck:
     initialDelaySeconds: 3
     path: '/liveness'
     timeoutSeconds: 3
-hpa:
-  scaling:
-    metric:
-      cpuAverageUtilization: 90
-      nginxRequestsIrate: 5
-    replicas:
-      max: 10
-      min: 2
 httpRoute:
   primary-gw:
     hostnames:
@@ -73,9 +65,9 @@ podSecurityContext:
 progressDeadlineSeconds: 1200
 pvcs: []
 replicaCount:
-  default: 2
-  max: 10
-  min: 2
+  default: 0
+  max: 0
+  min: 0
 resources:
   limits:
     cpu: '400m'

--- a/charts/identity-server-services/services-auth-admin-api/values.dev.yaml
+++ b/charts/identity-server-services/services-auth-admin-api/values.dev.yaml
@@ -68,6 +68,14 @@ healthCheck:
     initialDelaySeconds: 3
     path: '/backend/health/check'
     timeoutSeconds: 3
+hpa:
+  scaling:
+    metric:
+      cpuAverageUtilization: 90
+      nginxRequestsIrate: 5
+    replicas:
+      max: 2
+      min: 1
 httpRoute:
   primary-gw:
     hostnames:
@@ -89,9 +97,9 @@ podSecurityContext:
   fsGroup: 65534
 pvcs: []
 replicaCount:
-  default: 0
-  max: 0
-  min: 0
+  default: 1
+  max: 2
+  min: 1
 resources:
   limits:
     cpu: '400m'

--- a/charts/identity-server-services/services-auth-admin-api/values.staging.yaml
+++ b/charts/identity-server-services/services-auth-admin-api/values.staging.yaml
@@ -68,6 +68,14 @@ healthCheck:
     initialDelaySeconds: 3
     path: '/backend/health/check'
     timeoutSeconds: 3
+hpa:
+  scaling:
+    metric:
+      cpuAverageUtilization: 90
+      nginxRequestsIrate: 5
+    replicas:
+      max: 2
+      min: 1
 httpRoute:
   primary-gw:
     hostnames:
@@ -89,9 +97,9 @@ podSecurityContext:
   fsGroup: 65534
 pvcs: []
 replicaCount:
-  default: 0
-  max: 0
-  min: 0
+  default: 1
+  max: 2
+  min: 1
 resources:
   limits:
     cpu: '400m'

--- a/charts/identity-server/values.dev.yaml
+++ b/charts/identity-server/values.dev.yaml
@@ -275,6 +275,14 @@ services-auth-admin-api:
       initialDelaySeconds: 3
       path: '/backend/health/check'
       timeoutSeconds: 3
+  hpa:
+    scaling:
+      metric:
+        cpuAverageUtilization: 90
+        nginxRequestsIrate: 5
+      replicas:
+        max: 2
+        min: 1
   httpRoute:
     primary-gw:
       hostnames:
@@ -296,9 +304,9 @@ services-auth-admin-api:
     fsGroup: 65534
   pvcs: []
   replicaCount:
-    default: 0
-    max: 0
-    min: 0
+    default: 1
+    max: 2
+    min: 1
   resources:
     limits:
       cpu: '400m'

--- a/charts/identity-server/values.prod.yaml
+++ b/charts/identity-server/values.prod.yaml
@@ -33,14 +33,6 @@ auth-admin-web:
       initialDelaySeconds: 3
       path: '/liveness'
       timeoutSeconds: 3
-  hpa:
-    scaling:
-      metric:
-        cpuAverageUtilization: 90
-        nginxRequestsIrate: 5
-      replicas:
-        max: 10
-        min: 2
   httpRoute:
     primary-gw:
       hostnames:
@@ -62,9 +54,9 @@ auth-admin-web:
   progressDeadlineSeconds: 1200
   pvcs: []
   replicaCount:
-    default: 2
-    max: 10
-    min: 2
+    default: 0
+    max: 0
+    min: 0
   resources:
     limits:
       cpu: '400m'

--- a/charts/identity-server/values.staging.yaml
+++ b/charts/identity-server/values.staging.yaml
@@ -275,6 +275,14 @@ services-auth-admin-api:
       initialDelaySeconds: 3
       path: '/backend/health/check'
       timeoutSeconds: 3
+  hpa:
+    scaling:
+      metric:
+        cpuAverageUtilization: 90
+        nginxRequestsIrate: 5
+      replicas:
+        max: 2
+        min: 1
   httpRoute:
     primary-gw:
       hostnames:
@@ -296,9 +304,9 @@ services-auth-admin-api:
     fsGroup: 65534
   pvcs: []
   replicaCount:
-    default: 0
-    max: 0
-    min: 0
+    default: 1
+    max: 2
+    min: 1
   resources:
     limits:
       cpu: '400m'


### PR DESCRIPTION
# ...

Attach a link to issue if relevant

## What

Specify what you're trying to achieve

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [x] No AI tools were used in preparing this pull request
- [ ] AI tools were used in preparing this pull request
      Tools used:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Operational Updates**
  * The production Auth Admin Web service is now configured to run with zero replicas.
  * Auth Admin API capacity is standardized across environments, with two replicas by default and minimum, and a maximum of ten.
  * Environment-specific replica settings and replica limit bypass behavior have been removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->