### PR TITLE
fix(old-age-pension): don't block submission when a single yearly payment is requested

### DIFF
--- a/libs/application/templates/social-insurance-administration/old-age-pension/src/forms/OldAgePensionForm/generalInformationSection/onePaymentPerYearSubSection.ts
+++ b/libs/application/templates/social-insurance-administration/old-age-pension/src/forms/OldAgePensionForm/generalInformationSection/onePaymentPerYearSubSection.ts
@@ -26,9 +26,6 @@ export const onePaymentPerYearSubSection = buildSubSection({
           options: getYesNoOptions(),
           defaultValue: NO,
           width: 'half',
-          // Switching to YES skips the income plan screens, so discard anything
-          // already entered there instead of submitting it to TR.
-          clearOnChange: ['incomePlanTable', 'incomePlan'],
         }),
         buildAlertMessageField({
           id: 'onePaymentPerYear.alert',

--- a/libs/application/templates/social-insurance-administration/old-age-pension/src/lib/OldAgePensionTemplate.spec.ts
+++ b/libs/application/templates/social-insurance-administration/old-age-pension/src/lib/OldAgePensionTemplate.spec.ts
@@ -7,6 +7,7 @@ import {
   FormValue,
   ApplicationStatus,
 } from '@island.is/application/types'
+import { NO, YES } from '@island.is/application/core'
 import OldAgePensionTemplate from './OldAgePensionTemplate'
 import { OAPEvents } from '@island.is/application/templates/social-insurance-administration-core/lib/constants'
 
@@ -251,6 +252,54 @@ describe('Old Age Pension Template', () => {
       })
       expect(hasChanged).toBe(true)
       expect(newState).toBe('dismissed')
+    })
+  })
+
+  describe('clearIncomePlanOnOnePaymentPerYear', () => {
+    const incomePlanTable = [
+      {
+        incomeCategory: 'Atvinnutekjur',
+        incomeType: 'Laun',
+        income: 'yearly',
+        incomePerYear: '1000000',
+        currency: 'ISK',
+      },
+    ]
+
+    it('should discard the income plan on submit when a single yearly payment is requested', () => {
+      const application = buildApplication({
+        answers: {
+          onePaymentPerYear: { question: YES },
+          incomePlanTable,
+          incomePlan: { shouldShow: false },
+        },
+      })
+      const helper = new ApplicationTemplateHelper(
+        application,
+        OldAgePensionTemplate,
+      )
+
+      helper.changeState({ type: DefaultEvents.SUBMIT })
+
+      expect(application.answers.incomePlanTable).toBeUndefined()
+      expect(application.answers.incomePlan).toBeUndefined()
+    })
+
+    it('should keep the income plan on submit when a single yearly payment is declined', () => {
+      const application = buildApplication({
+        answers: {
+          onePaymentPerYear: { question: NO },
+          incomePlanTable,
+        },
+      })
+      const helper = new ApplicationTemplateHelper(
+        application,
+        OldAgePensionTemplate,
+      )
+
+      helper.changeState({ type: DefaultEvents.SUBMIT })
+
+      expect(application.answers.incomePlanTable).toEqual(incomePlanTable)
     })
   })
 })

--- a/libs/application/templates/social-insurance-administration/old-age-pension/src/lib/OldAgePensionTemplate.ts
+++ b/libs/application/templates/social-insurance-administration/old-age-pension/src/lib/OldAgePensionTemplate.ts
@@ -128,6 +128,7 @@ const OldAgePensionTemplate: ApplicationTemplate<
           'clearBankAccountInfo',
           'clearTemp',
           'restoreAnswersFromTemp',
+          'clearIncomePlanOnOnePaymentPerYear',
           'unsetIncomePlan',
           'clearNoOtherIncomeConfirmation',
         ],
@@ -504,6 +505,24 @@ const OldAgePensionTemplate: ApplicationTemplate<
 
         if (paymentInfo?.bankAccountType === BankAccountType.FOREIGN) {
           unset(application.answers, 'paymentInfo.bank')
+        }
+
+        return context
+      }),
+      clearIncomePlanOnOnePaymentPerYear: assign((context, event) => {
+        if (event.type !== DefaultEvents.SUBMIT) {
+          return context
+        }
+
+        const { application } = context
+        const { onePaymentPerYear } = getApplicationAnswers(application.answers)
+
+        /* The income plan screens are skipped when the applicant asks for a
+           single yearly payment, so any plan populated earlier must not be
+           submitted to TR. */
+        if (onePaymentPerYear === YES) {
+          unset(application.answers, 'incomePlanTable')
+          unset(application.answers, 'incomePlan')
         }
 
         return context


### PR DESCRIPTION
Follow-up fix to #23632.

## What

- Remove `clearOnChange: ['incomePlanTable', 'incomePlan']` from the "Ein greiðsla á ári" radio field.
- Clear the income plan on `DRAFT` exit instead, when the applicant asked for a single yearly payment, so it is not sent to TR.
- Add regression tests for both answers.

## Why

TR reported from dev that answering "Já" to "Ein greiðsla á ári" leaves the applicant stuck: the income plan screens are correctly skipped, but "Halda áfram" on the Athugasemd screen does nothing.

`clearOnChange` writes an empty string, not `undefined`, and `incomePlanTable`/`incomePlan` are an array and an object in the data schema — so answering "Já" left two values that can never satisfy the schema. Athugasemd is a single-field screen, where the resolver doesn't filter errors down to the current screen, so the form silently refuses to submit.

`clearOnChange` is also session-only — the cleared values never reached the server, so the income plan was still being submitted to TR.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code
