### PR TITLE
feat(driving-license): digital-licence notice for all licence flows + samrit (#23688)

### DIFF
--- a/libs/application/templates/driving-license/src/forms/prerequisites/getForm.ts
+++ b/libs/application/templates/driving-license/src/forms/prerequisites/getForm.ts
@@ -5,6 +5,7 @@ import { m } from '../../lib/messages'
 import { sectionFakeData } from './sectionFakeData'
 import { sectionExternalData } from './sectionExternalData'
 import { sectionApplicationFor } from './sectionApplicationFor'
+import { sectionDigitalLicense } from './sectionDigitalLicense'
 import { sectionRequirements } from './sectionRequirements'
 
 interface DrivingLicenseFormConfig {
@@ -42,6 +43,7 @@ export const getForm = ({
           ...(allowPickLicense
             ? [sectionApplicationFor(allowBELicense, allow65Renewal)]
             : []),
+          sectionDigitalLicense(),
           sectionRequirements(
             allow65RenewalRedesign,
             allowBTempRedesign,

--- a/libs/application/templates/driving-license/src/forms/prerequisites/sectionDigitalLicense.spec.ts
+++ b/libs/application/templates/driving-license/src/forms/prerequisites/sectionDigitalLicense.spec.ts
@@ -1,0 +1,72 @@
+import { FormValue } from '@island.is/application/types'
+import { sectionDigitalLicense } from './sectionDigitalLicense'
+import { B_FULL, B_FULL_RENEWAL_65, B_TEMP, BE } from '../../lib/constants'
+
+// The digital-licence info screen applies to every driving-licence flow, so by
+// default it has no condition and always renders. Passing a list of
+// `applicationFor` values restricts it to those flows. This pins:
+//   - default: shown for every type (and even when applicationFor is unanswered),
+//   - restricted: shown only for the configured types,
+//   - it carries the info alert and persists nothing (doesNotRequireAnswer).
+
+const evalCondition = (
+  subSection: ReturnType<typeof sectionDigitalLicense>,
+  answers: FormValue,
+): boolean => {
+  const { condition } = subSection
+  // No condition means the sub-section always renders.
+  if (condition === undefined) return true
+  if (typeof condition !== 'function') {
+    throw new Error('expected a dynamic (function) condition or none')
+  }
+  return condition(answers, {}, null)
+}
+
+const collectFields = (node: unknown): Array<Record<string, unknown>> => {
+  const item = node as { children?: unknown[] } & Record<string, unknown>
+  const kids = Array.isArray(item?.children)
+    ? item.children.flatMap(collectFields)
+    : []
+  return [item, ...kids]
+}
+
+describe('sectionDigitalLicense', () => {
+  describe('default — applies to every flow', () => {
+    const section = sectionDigitalLicense()
+
+    it('has no condition (renders unconditionally)', () => {
+      expect(section.condition).toBeUndefined()
+    })
+
+    it.each([B_FULL, B_TEMP, BE, B_FULL_RENEWAL_65])(
+      'shows for %s',
+      (applicationFor) => {
+        expect(evalCondition(section, { applicationFor })).toBe(true)
+      },
+    )
+
+    it('shows even when applicationFor is unanswered', () => {
+      expect(evalCondition(section, {})).toBe(true)
+    })
+  })
+
+  describe('restricted to specific flows', () => {
+    it('shows for every configured type and hides the rest', () => {
+      const section = sectionDigitalLicense([B_FULL, B_TEMP])
+      expect(evalCondition(section, { applicationFor: B_FULL })).toBe(true)
+      expect(evalCondition(section, { applicationFor: B_TEMP })).toBe(true)
+      expect(evalCondition(section, { applicationFor: BE })).toBe(false)
+    })
+  })
+
+  describe('content', () => {
+    it('renders an info alert and persists nothing', () => {
+      const fields = collectFields(sectionDigitalLicense())
+      const alert = fields.find((f) => f.id === 'digitalLicenseAlert')
+      expect(alert).toBeDefined()
+      expect(alert?.alertType).toBe('info')
+      // Purely informational — the screen must not require an answer.
+      expect(alert?.doesNotRequireAnswer).toBe(true)
+    })
+  })
+})

--- a/libs/application/templates/driving-license/src/forms/prerequisites/sectionDigitalLicense.ts
+++ b/libs/application/templates/driving-license/src/forms/prerequisites/sectionDigitalLicense.ts
@@ -1,0 +1,45 @@
+import {
+  buildAlertMessageField,
+  buildMultiField,
+  buildSubSection,
+  getValueViaPath,
+} from '@island.is/application/core'
+import { FormValue } from '@island.is/application/types'
+import { m } from '../../lib/messages'
+
+// Informational screen in the prerequisites flow: the licence is now issued
+// digitally first (available in the Ísland.is app once processing completes),
+// with the plastic card produced and posted to the applicant's legal domicile
+// afterwards. Purely informational — nothing is persisted.
+//
+// The notice applies to every driving-licence issuance flow, so by default it is
+// shown unconditionally. Pass a list of `applicationFor` values to restrict it to
+// specific flows instead (the sub-section and its stepper entry then render only
+// for those types).
+export const sectionDigitalLicense = (applicationTypes?: string[]) =>
+  buildSubSection({
+    id: 'digitalLicense',
+    title: m.digitalLicenseSubSectionTitle,
+    ...(applicationTypes && applicationTypes.length > 0
+      ? {
+          condition: (answers: FormValue) =>
+            applicationTypes.includes(
+              getValueViaPath<string>(answers, 'applicationFor') ?? '',
+            ),
+        }
+      : {}),
+    children: [
+      buildMultiField({
+        id: 'digitalLicenseInfo',
+        title: m.digitalLicenseSubSectionTitle,
+        children: [
+          buildAlertMessageField({
+            id: 'digitalLicenseAlert',
+            title: m.digitalLicenseAlertTitle,
+            message: m.digitalLicenseAlertMessage,
+            alertType: 'info',
+          }),
+        ],
+      }),
+    ],
+  })

--- a/libs/application/templates/driving-license/src/lib/messages.ts
+++ b/libs/application/templates/driving-license/src/lib/messages.ts
@@ -466,6 +466,23 @@ export const m = defineMessages({
     defaultMessage: 'Tegund umsóknar',
     description: 'Type of application for driving license',
   },
+  digitalLicenseSubSectionTitle: {
+    id: 'dl.application:digitalLicense.subSectionTitle',
+    defaultMessage: 'Stafrænt skírteini',
+    description: 'Title of the digital-licence information sub-section',
+  },
+  digitalLicenseAlertTitle: {
+    id: 'dl.application:digitalLicense.alertTitle',
+    defaultMessage: 'Athugið',
+    description: 'Title of the digital-licence information alert box',
+  },
+  digitalLicenseAlertMessage: {
+    id: 'dl.application:digitalLicense.alertMessage#markdown',
+    defaultMessage:
+      'Ökuskírteinið verður fyrst gefið út á stafrænu formi og verður aðgengilegt í Ísland.is appinu þegar afgreiðslu er lokið.\n\nPlastökuskírteinið verður framleitt um miðjan nóvember og sent í pósti á skráð lögheimili um leið og það er tilbúið.',
+    description:
+      'Body of the digital-licence information alert: licence is issued digitally first (available in the Ísland.is app), plastic card produced mid-November and mailed afterwards to the registered legal domicile',
+  },
   drivingLicenseApplyingForTitle: {
     id: 'dl.application:drivingLicenseApplyingForTitle',
     defaultMessage: 'Ég er að sækja um:',

--- a/libs/application/templates/transport-authority/driving-license-duplicate/src/forms/application.ts
+++ b/libs/application/templates/transport-authority/driving-license-duplicate/src/forms/application.ts
@@ -8,6 +8,7 @@ import { sectionPayment } from './sections/sectionPayment'
 import { sectionFakeData } from './sections/sectionFakeData'
 import { sectionReasonForApplication } from './sections/sectionReasonForApplication'
 import { sectionPhoto } from './sections/sectionPhoto'
+import { sectionDigitalLicense } from './sections/sectionDigitalLicense'
 import { DistrictCommissionersLogo } from '@island.is/application/assets/institution-logos'
 
 export const getApplication = ({
@@ -30,6 +31,7 @@ export const getApplication = ({
       sectionDataProviders(allowFakeData, allowThjodskraPhotos),
       sectionReasonForApplication,
       sectionInformation,
+      sectionDigitalLicense,
       sectionPhoto,
       sectionDelivery,
       sectionOverview,

--- a/libs/application/templates/transport-authority/driving-license-duplicate/src/forms/sections/sectionDigitalLicense.ts
+++ b/libs/application/templates/transport-authority/driving-license-duplicate/src/forms/sections/sectionDigitalLicense.ts
@@ -1,0 +1,33 @@
+import {
+  buildSection,
+  buildMultiField,
+  buildAlertMessageField,
+} from '@island.is/application/core'
+import { m } from '../../lib/messages'
+import { requirementsMet } from '../../lib/utils'
+
+// Informational screen: the licence is issued digitally first (available in the
+// Ísland.is app once processing completes), with the plastic card produced and
+// posted to the applicant's legal domicile afterwards. Same notice and Contentful
+// copy as the driving-license application (shared `dl.application:digitalLicense.*`
+// ids). Shown once the applicant is eligible for a duplicate, matching the other
+// happy-path sections.
+export const sectionDigitalLicense = buildSection({
+  id: 'digitalLicense',
+  title: m.digitalLicenseSubSectionTitle,
+  condition: (answers, externalData) => requirementsMet(answers, externalData),
+  children: [
+    buildMultiField({
+      id: 'digitalLicenseInfo',
+      title: m.digitalLicenseSubSectionTitle,
+      children: [
+        buildAlertMessageField({
+          id: 'digitalLicenseAlert',
+          title: m.digitalLicenseAlertTitle,
+          message: m.digitalLicenseAlertMessage,
+          alertType: 'info',
+        }),
+      ],
+    }),
+  ],
+})

--- a/libs/application/templates/transport-authority/driving-license-duplicate/src/lib/messages.ts
+++ b/libs/application/templates/transport-authority/driving-license-duplicate/src/lib/messages.ts
@@ -403,4 +403,24 @@ export const m = defineMessages({
     defaultMessage: 'Umsókn þín hefur verið móttekin og skírteini pantað',
     description: 'text for pending action application completed title',
   },
+  // Shared with the driving-license application: same `dl.application:digitalLicense.*`
+  // ids on purpose, so the notice resolves to one Contentful entry across both
+  // templates (edit the copy once).
+  digitalLicenseSubSectionTitle: {
+    id: 'dl.application:digitalLicense.subSectionTitle',
+    defaultMessage: 'Stafrænt skírteini',
+    description: 'Title of the digital-licence information section',
+  },
+  digitalLicenseAlertTitle: {
+    id: 'dl.application:digitalLicense.alertTitle',
+    defaultMessage: 'Athugið',
+    description: 'Title of the digital-licence information alert box',
+  },
+  digitalLicenseAlertMessage: {
+    id: 'dl.application:digitalLicense.alertMessage#markdown',
+    defaultMessage:
+      'Ökuskírteinið verður fyrst gefið út á stafrænu formi og verður aðgengilegt í Ísland.is appinu þegar afgreiðslu er lokið.\n\nPlastökuskírteinið verður framleitt um miðjan nóvember og sent í pósti á skráð lögheimili um leið og það er tilbúið.',
+    description:
+      'Body of the digital-licence information alert: licence is issued digitally first (available in the Ísland.is app), plastic card produced mid-November and mailed afterwards to the registered legal domicile',
+  },
 })


### PR DESCRIPTION
Hotfix cherry-pick of #23688 onto `release/2026.09.08.00`.

## What

Cherry-picks the merged **#23688** (`c7f8ebd`) — the "Stafrænt skírteini" digital-licence notice — onto the active release branch so it can ship as a hotfix.

Adds an `Athugið` info screen telling applicants their licence is issued digitally first (available in the Ísland.is app once processing completes), with the plastic card produced mid-November and posted to their registered legal domicile afterwards. Shown across all driving-licence flows and the samrit (duplicate) flow; both templates share the `dl.application:digitalLicense.*` Contentful ids.

## Why

Requested as a hotfix by product (SÍ) — applicants should be told up front that new licences are digital-first during the plastic-production transition.

## Screenshots / Gifs

n/a — same content as #23688.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code (Claude Opus)

## Notes

- Clean cherry-pick of the squashed main merge (7 files, +191). tsc clean; 112 driving-license tests pass.
- Contentful entries for the three `dl.application:digitalLicense.*` ids still need creating (English especially) — same follow-up as on main.
