### PR TITLE
fix(hh-courses-application): Rename Zendesk course instance fields and add ticket_id to participants

### DIFF
--- a/libs/application/template-api-modules/src/lib/modules/templates/hh/courses/courses.service.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/hh/courses/courses.service.ts
@@ -122,7 +122,7 @@ export class CoursesService extends BaseTemplateApiService {
         jobTitle,
       )
 
-      const success = await this.zendeskService.submitTicket({
+      const ticket = await this.zendeskService.createTicket({
         message,
         subject: `${this.coursesConfig.applicationEmailSubject} - ${courseInstance.id}`,
         requester: {
@@ -161,6 +161,7 @@ export class CoursesService extends BaseTemplateApiService {
           course,
           courseInstance,
           participantList,
+          ticket?.id,
           auth.authorization,
         )
       } catch (error) {
@@ -170,7 +171,7 @@ export class CoursesService extends BaseTemplateApiService {
         )
       }
 
-      return { success }
+      return { success: true }
     } catch (error) {
       this.logger.error('Failed to submit HH courses application to Zendesk', {
         applicationId: application.id,
@@ -490,6 +491,7 @@ export class CoursesService extends BaseTemplateApiService {
       chargeItemCode?: string | null
     },
     participantList: ApplicationAnswers['participantList'],
+    ticketId: string | number | undefined,
     authorization: string,
   ): Promise<void> {
     let priceAmount: number | undefined
@@ -526,11 +528,12 @@ export class CoursesService extends BaseTemplateApiService {
         name: courseInstance.displayedTitle ?? course.title,
         external_id: courseInstance.id,
         custom_object_fields: {
-          upphafsdagsetning: courseInstance.startDate.split('T')[0],
-          upphafstímasetning:
+          course_start_date: courseInstance.startDate.split('T')[0],
+          course_start_time:
             courseInstance.startDateTimeDuration?.startTime ?? '',
-          lýsing: courseInstance.description ?? '',
-          verð_per_skráningu: priceAmount?.toString() ?? '',
+          course_description: courseInstance.description ?? '',
+          course_price: priceAmount ?? null,
+          course_id: courseRecord.id,
           course: courseRecord.id,
         },
       },
@@ -548,6 +551,7 @@ export class CoursesService extends BaseTemplateApiService {
           kennitala: p.nationalIdWithName.nationalId,
           email: p.nationalIdWithName.email,
           course_instance: instanceRecord.id,
+          ticket_id: ticketId !== undefined ? String(ticketId) : '',
         },
       })),
     )

--- a/libs/application/template-api-modules/src/lib/modules/templates/hh/courses/courses.service.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/hh/courses/courses.service.ts
@@ -161,7 +161,7 @@ export class CoursesService extends BaseTemplateApiService {
           course,
           courseInstance,
           participantList,
-          ticket?.id,
+          ticket.id,
           auth.authorization,
         )
       } catch (error) {
@@ -491,7 +491,7 @@ export class CoursesService extends BaseTemplateApiService {
       chargeItemCode?: string | null
     },
     participantList: ApplicationAnswers['participantList'],
-    ticketId: string | number | undefined,
+    ticketId: string,
     authorization: string,
   ): Promise<void> {
     let priceAmount: number | undefined
@@ -551,7 +551,7 @@ export class CoursesService extends BaseTemplateApiService {
           kennitala: p.nationalIdWithName.nationalId,
           email: p.nationalIdWithName.email,
           course_instance: instanceRecord.id,
-          ticket_id: ticketId !== undefined ? String(ticketId) : '',
+          ticket_id: String(ticketId),
         },
       })),
     )

--- a/libs/clients/zendesk/src/lib/zendesk.service.spec.ts
+++ b/libs/clients/zendesk/src/lib/zendesk.service.spec.ts
@@ -114,4 +114,36 @@ describe('zendeskService', () => {
 
     expect(results).toEqual(true)
   })
+
+  it('should create a ticket and return it', async () => {
+    server.use(
+      rest.post(`${api}/tickets.json`, (req, res, ctx) =>
+        res.once(ctx.status(201), ctx.json({ ticket: { id: 123 } })),
+      ),
+    )
+
+    const ticket = await zendeskService.createTicket({
+      message: 'Here is a message',
+      subject: 'Here is a subject',
+      requesterId: testUser.id,
+    })
+
+    expect(ticket).toMatchObject({ id: 123 })
+  })
+
+  it('should throw when the created ticket has no id', async () => {
+    server.use(
+      rest.post(`${api}/tickets.json`, (req, res, ctx) =>
+        res.once(ctx.status(201), ctx.json({})),
+      ),
+    )
+
+    await expect(
+      zendeskService.createTicket({
+        message: 'Here is a message',
+        subject: 'Here is a subject',
+        requesterId: testUser.id,
+      }),
+    ).rejects.toThrow('Zendesk ticket response is missing the ticket id')
+  })
 })

--- a/libs/clients/zendesk/src/lib/zendesk.service.ts
+++ b/libs/clients/zendesk/src/lib/zendesk.service.ts
@@ -184,11 +184,23 @@ export class ZendeskService {
   }
 
   async submitTicket(input: SubmitTicketInput): Promise<boolean> {
-    await this.createTicket(input)
+    await this.postTicket(input)
     return true
   }
 
-  async createTicket({
+  async createTicket(input: SubmitTicketInput): Promise<Ticket> {
+    const ticket = await this.postTicket(input)
+
+    if (!ticket?.id) {
+      const errMsg = 'Zendesk ticket response is missing the ticket id'
+      this.logger.error(errMsg)
+      throw new Error(errMsg)
+    }
+
+    return ticket
+  }
+
+  private async postTicket({
     message,
     subject,
     requesterId,
@@ -197,7 +209,7 @@ export class ZendeskService {
     customFields = [],
     brandId,
     ticketFormId,
-  }: SubmitTicketInput): Promise<Ticket> {
+  }: SubmitTicketInput): Promise<Ticket | undefined> {
     const newTicket = JSON.stringify({
       ticket: {
         requester_id: requesterId,

--- a/libs/clients/zendesk/src/lib/zendesk.service.ts
+++ b/libs/clients/zendesk/src/lib/zendesk.service.ts
@@ -183,7 +183,12 @@ export class ZendeskService {
     return response.data.user
   }
 
-  async submitTicket({
+  async submitTicket(input: SubmitTicketInput): Promise<boolean> {
+    await this.createTicket(input)
+    return true
+  }
+
+  async createTicket({
     message,
     subject,
     requesterId,
@@ -192,7 +197,7 @@ export class ZendeskService {
     customFields = [],
     brandId,
     ticketFormId,
-  }: SubmitTicketInput): Promise<boolean> {
+  }: SubmitTicketInput): Promise<Ticket> {
     const newTicket = JSON.stringify({
       ticket: {
         requester_id: requesterId,
@@ -207,7 +212,12 @@ export class ZendeskService {
     })
 
     try {
-      await axios.post(`${this.api}/tickets.json`, newTicket, this.params)
+      const response = await axios.post(
+        `${this.api}/tickets.json`,
+        newTicket,
+        this.params,
+      )
+      return response.data?.ticket
     } catch (e) {
       const errMsg = 'Failed to submit Zendesk ticket'
       const description = e.response.data.description
@@ -218,8 +228,6 @@ export class ZendeskService {
 
       throw new Error(`${errMsg}: ${description}`)
     }
-
-    return true
   }
 
   async searchTickets(query: string): Promise<Array<Ticket>> {


### PR DESCRIPTION
# Rename Zendesk course instance fields and add ticket_id to participants

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Course applications now create Zendesk tickets and associate available ticket IDs with participant records.
  * Course information submitted to custom records uses standardized field names, including course dates, times, locations, URLs, and IDs.
  * Course prices are recorded as numeric values when available; the field is omitted when unavailable.
  * Participant phone numbers are included when provided.
  * Application submissions now report successful completion after processing.

* **Bug Fixes**
  * Improved handling of incomplete Zendesk responses and ticket-creation errors to prevent invalid ticket data from being used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->