### PR TITLE
refactor(services-payments): one canonical log format for the bank transfer flow

### DIFF
--- a/apps/services/payments/src/app/bankTransferPayment/bankTransfer.service.spec.ts
+++ b/apps/services/payments/src/app/bankTransferPayment/bankTransfer.service.spec.ts
@@ -219,14 +219,13 @@ describe('BankTransferService', () => {
       ).rejects.toThrow(BankTransferErrorCode.FailedToCreateBankTransfer)
 
       // The generic code goes to the payer; the Blikk reason must land in the logs with flow context.
-      expect(logger.error).toHaveBeenCalledWith(
-        '[flow-1][correlationId: btp-err] Blikk create payment failed',
-        {
-          status: 403,
-          error:
-            'Blikk request failed (403): sales channel does not allow direct debtor payments',
-        },
-      )
+      expect(logger.error).toHaveBeenCalledWith('Blikk create payment failed', {
+        paymentFlowId: 'flow-1',
+        correlationId: 'btp-err',
+        status: 403,
+        error:
+          'Blikk request failed (403): sales channel does not allow direct debtor payments',
+      })
     })
   })
 
@@ -580,11 +579,17 @@ describe('BankTransferService', () => {
 
       await service.create(createInput)
 
+      // The identifiers moved out of the message into structured metadata; the provider's reason
+      // still has to reach the log, which is what this test is for.
       expect(logger.warn).toHaveBeenCalledWith(
-        expect.stringMatching(
-          /^\[flow-1\]\[correlationId: .+\]\[rrn: prov-1\]Bank transfer created already error$/,
-        ),
-        { rawStatus: 'ERROR', providerMessage: 'debtor account not eligible' },
+        'Bank transfer created already error',
+        {
+          paymentFlowId: 'flow-1',
+          correlationId: expect.any(String),
+          rrn: 'prov-1',
+          rawStatus: 'ERROR',
+          providerMessage: 'debtor account not eligible',
+        },
       )
     })
 
@@ -758,15 +763,18 @@ describe('BankTransferService', () => {
         'flow-1',
       )
       expect(fulfillmentSpy).toHaveBeenCalledWith(
-        'flow-1',
-        'btp-1',
         expect.objectContaining({
-          payInfo: expect.objectContaining({
-            payableAmount: 14000,
-            paymentMeans: 'Milli',
-            RRN: 'prov-1',
-            // Per-attempt correlationId is threaded into the FJS payInfo.
-            correlationId: 'btp-1',
+          paymentFlowId: 'flow-1',
+          confirmationRefId: 'btp-1',
+          providerPaymentId: 'prov-1',
+          chargePayload: expect.objectContaining({
+            payInfo: expect.objectContaining({
+              payableAmount: 14000,
+              paymentMeans: 'Milli',
+              RRN: 'prov-1',
+              // Per-attempt correlationId is threaded into the FJS payInfo.
+              correlationId: 'btp-1',
+            }),
           }),
         }),
       )
@@ -960,14 +968,19 @@ describe('BankTransferService', () => {
             rawStatus,
             providerMessage: 'provider detail',
           },
+          // One line per state transition: the identifiers and the provider's reason ride on
+          // logPaymentFlowUpdate's own log line, so the flow no longer logs a second one of its
+          // own. The reason has to reach the application log because it is what separates a
+          // routine payer decline from a provider-side fault failing every payment (an expired
+          // Blikk certificate, say).
+          logContext: {
+            paymentFlowId: 'flow-1',
+            correlationId: 'corr-1',
+            rrn: 'prov-1',
+            rawStatus,
+            providerMessage: 'provider detail',
+          },
         })
-        // The provider's reason must reach the application log too — logPaymentFlowUpdate only
-        // logs its message text, so otherwise a provider-side fault failing every payment (an
-        // expired Blikk certificate, say) shows up with no reason attached.
-        expect(logger.warn).toHaveBeenCalledWith(
-          expect.stringContaining(`Bank transfer ${status}`),
-          { rawStatus, providerMessage: 'provider detail' },
-        )
         expect(result.status).toBe(status)
         // The expiry-aware failure reason passes through (fresh row → 1:1 with the status).
         expect(result.failureReason).toBe(failureReason)
@@ -1652,6 +1665,11 @@ describe('BankTransferService', () => {
           reason: 'payment_cancelled',
           message: 'Bank transfer cancelled by user',
           metadata: { providerPaymentId: 'prov-1', correlationId: 'corr-1' },
+          logContext: {
+            paymentFlowId: 'flow-1',
+            correlationId: 'corr-1',
+            rrn: 'prov-1',
+          },
         },
         { useRetry: true, throwOnError: false },
       )
@@ -2164,11 +2182,12 @@ describe('BankTransferService', () => {
         id: 'existing',
         fjsChargeId: 'fjs-1',
       })
-      await service.createBankTransferFulfillment(
-        'flow-1',
-        'corr-1',
-        dummyCharge,
-      )
+      await service.createBankTransferFulfillment({
+        paymentFlowId: 'flow-1',
+        confirmationRefId: 'corr-1',
+        providerPaymentId: 'prov-1',
+        chargePayload: dummyCharge,
+      })
 
       expect(paymentFulfillmentModel.create).not.toHaveBeenCalled()
       expect(paymentFlowService.createFjsCharge).not.toHaveBeenCalled()
@@ -2179,11 +2198,12 @@ describe('BankTransferService', () => {
         id: 'existing',
         fjsChargeId: null,
       })
-      await service.createBankTransferFulfillment(
-        'flow-1',
-        'corr-1',
-        dummyCharge,
-      )
+      await service.createBankTransferFulfillment({
+        paymentFlowId: 'flow-1',
+        confirmationRefId: 'corr-1',
+        providerPaymentId: 'prov-1',
+        chargePayload: dummyCharge,
+      })
 
       // Fulfillment already exists, so it is not re-created, but the charge is (re)attempted.
       expect(paymentFulfillmentModel.create).not.toHaveBeenCalled()
@@ -2194,11 +2214,12 @@ describe('BankTransferService', () => {
     })
 
     it('creates the fulfillment and FJS charge on the first call', async () => {
-      await service.createBankTransferFulfillment(
-        'flow-1',
-        'corr-1',
-        dummyCharge,
-      )
+      await service.createBankTransferFulfillment({
+        paymentFlowId: 'flow-1',
+        confirmationRefId: 'corr-1',
+        providerPaymentId: 'prov-1',
+        chargePayload: dummyCharge,
+      })
 
       expect(paymentFulfillmentModel.create).toHaveBeenCalledWith({
         paymentFlowId: 'flow-1',
@@ -2220,7 +2241,12 @@ describe('BankTransferService', () => {
       )
 
       await expect(
-        service.createBankTransferFulfillment('flow-1', 'corr-1', dummyCharge),
+        service.createBankTransferFulfillment({
+          paymentFlowId: 'flow-1',
+          confirmationRefId: 'corr-1',
+          providerPaymentId: 'prov-1',
+          chargePayload: dummyCharge,
+        }),
       ).resolves.toBeUndefined()
       // The other writer created the fulfillment; we still (idempotently) ensure the FJS charge.
       expect(paymentFlowService.createFjsCharge).toHaveBeenCalledWith(
@@ -2235,7 +2261,12 @@ describe('BankTransferService', () => {
       )
 
       await expect(
-        service.createBankTransferFulfillment('flow-1', 'corr-1', dummyCharge),
+        service.createBankTransferFulfillment({
+          paymentFlowId: 'flow-1',
+          confirmationRefId: 'corr-1',
+          providerPaymentId: 'prov-1',
+          chargePayload: dummyCharge,
+        }),
       ).rejects.toThrow('connection reset')
     })
 
@@ -2245,7 +2276,12 @@ describe('BankTransferService', () => {
       )
 
       await expect(
-        service.createBankTransferFulfillment('flow-1', 'corr-1', dummyCharge),
+        service.createBankTransferFulfillment({
+          paymentFlowId: 'flow-1',
+          confirmationRefId: 'corr-1',
+          providerPaymentId: 'prov-1',
+          chargePayload: dummyCharge,
+        }),
       ).resolves.toBeUndefined()
 
       expect(paymentFlowService.createFjsCharge).toHaveBeenCalledTimes(3)

--- a/apps/services/payments/src/app/bankTransferPayment/bankTransfer.service.ts
+++ b/apps/services/payments/src/app/bankTransferPayment/bankTransfer.service.ts
@@ -48,8 +48,9 @@ import {
 } from './dtos'
 import { BankTransferPayment } from './models/bankTransferPayment.model'
 import {
-  createLogPrefix,
+  bankTransferLogContext,
   deriveBankTransferFailureReason,
+  formatBankTransferLogContext,
   generateBankTransferChargeFJSPayload,
   isBankTransferFailureStatus,
   isBlikkStatus,
@@ -57,8 +58,9 @@ import {
   isRowExpired,
   mapBlikkStatusToBankTransferStatus,
   mapRawStatusToBankTransferPendingStatus,
-  rowLogPrefix,
+  rowLogContext,
   toBlikkItem,
+  type BankTransferLogContext,
 } from './bankTransfer.utils'
 
 /** Service for the bank-transfer payment method (Blikk is the v1 provider). */
@@ -146,6 +148,10 @@ export class BankTransferService {
           reason: 'payment_failed',
           message: `Failed to create bank transfer: ${errorMessage}`,
           metadata: { error: errorMessage },
+          // No `rrn`: the provider call is what just failed, so there is no provider payment id
+          // to name. Logged without the field rather than with a placeholder — an empty or
+          // freshly-generated value would look joinable in Datadog without being so.
+          logContext: { paymentFlowId: input.paymentFlowId, correlationId },
         },
         { useRetry: true, throwOnError: false },
       )
@@ -155,12 +161,13 @@ export class BankTransferService {
     // Blikk can return 200 for a payment that is already terminal, with its reason in `message`.
     if (isBankTransferFailureStatus(providerResult.status)) {
       this.logger.warn(
-        `${createLogPrefix(
-          input.paymentFlowId,
-          correlationId,
-          providerResult.providerPaymentId,
-        )}Bank transfer created already ${providerResult.status}`,
+        `Bank transfer created already ${providerResult.status}`,
         {
+          ...bankTransferLogContext(
+            input.paymentFlowId,
+            correlationId,
+            providerResult.providerPaymentId,
+          ),
           rawStatus: providerResult.rawStatus,
           providerMessage: providerResult.message,
         },
@@ -181,7 +188,7 @@ export class BankTransferService {
       })
     } catch (error) {
       const errorMessage = (error as Error)?.message ?? 'unknown'
-      const logPrefix = createLogPrefix(
+      const logContext = bankTransferLogContext(
         input.paymentFlowId,
         correlationId,
         providerResult.providerPaymentId,
@@ -190,13 +197,13 @@ export class BankTransferService {
       // Best effort to cancel the Blikk payment if persisting the row fails
       const cancelled = await this.cancelBlikkPayment(
         providerResult.providerPaymentId,
-        logPrefix,
+        logContext,
       ).catch(() => false)
 
       if (!cancelled) {
         this.logger.error(
-          `${logPrefix}Bank transfer row insert failed and the Blikk payment could not be cancelled — it may still settle with no local record`,
-          { error: errorMessage },
+          'Bank transfer row insert failed and the Blikk payment could not be cancelled — it may still settle with no local record',
+          { ...logContext, error: errorMessage },
         )
       }
 
@@ -217,6 +224,7 @@ export class BankTransferService {
             providerPaymentId: providerResult.providerPaymentId,
             correlationId,
           },
+          logContext,
         },
         { useRetry: true, throwOnError: false },
       )
@@ -236,6 +244,11 @@ export class BankTransferService {
           providerPaymentId: providerResult.providerPaymentId,
           correlationId,
         },
+        logContext: bankTransferLogContext(
+          input.paymentFlowId,
+          correlationId,
+          providerResult.providerPaymentId,
+        ),
       },
       { useRetry: true, throwOnError: false },
     )
@@ -313,7 +326,7 @@ export class BankTransferService {
       return { ok: true }
     }
 
-    const logPrefix = rowLogPrefix(row)
+    const logContext = rowLogContext(row)
     const cachedMappedStatus = mapBlikkStatusToBankTransferStatus(
       row.lastKnownStatus,
     )
@@ -350,10 +363,10 @@ export class BankTransferService {
       //   settlement may be in flight — refuse, and let verify/webhook/TTL keep tracking it.
       if (mappedStatus === BankTransferStatus.PENDING && !isRowExpired(row)) {
         if (lastKnownStatus !== 'DRAFT' && lastKnownStatus !== 'SCA_REQUIRED') {
-          this.logger.warn(
-            `${logPrefix}Cancel refused — payment may be settling`,
-            { lastKnownStatus },
-          )
+          this.logger.warn('Cancel refused — payment may be settling', {
+            ...logContext,
+            lastKnownStatus,
+          })
           throw new BadRequestException(
             BankTransferErrorCode.BankTransferAlreadyInProgress,
           )
@@ -361,7 +374,7 @@ export class BankTransferService {
 
         const cancelled = await this.cancelBlikkPayment(
           row.providerPaymentId,
-          logPrefix,
+          logContext,
         )
         if (!cancelled) {
           throw new BadRequestException(
@@ -412,6 +425,7 @@ export class BankTransferService {
             providerPaymentId: row.providerPaymentId,
             correlationId: row.id,
           },
+          logContext,
         },
         { useRetry: true, throwOnError: false },
       )
@@ -473,8 +487,8 @@ export class BankTransferService {
         rawStatus: row.lastKnownStatus,
       }).catch((error) => {
         this.logger.warn(
-          `[${row.paymentFlowId}] Failed to repair settled bank transfer during status read`,
-          { error: (error as Error)?.message },
+          'Failed to repair settled bank transfer during status read',
+          { ...rowLogContext(row), error: (error as Error)?.message },
         )
       })
       return this.paidBankTransferOverlay(paymentFlowId)
@@ -484,10 +498,10 @@ export class BankTransferService {
     // UNPAID. The Blikk refresh above is what guards against discarding a settled-but-uncallbacked row.
     if (isExpired) {
       void this.softDeleteRow(row.id).catch((error) => {
-        this.logger.warn(
-          `[${row.paymentFlowId}] Failed to soft-delete expired bank transfer row`,
-          { error: (error as Error)?.message },
-        )
+        this.logger.warn('Failed to soft-delete expired bank transfer row', {
+          ...rowLogContext(row),
+          error: (error as Error)?.message,
+        })
       })
       return null
     }
@@ -544,11 +558,12 @@ export class BankTransferService {
     // Create the fulfillment BEFORE marking the row SUCCESS so that a SUCCESS `lastKnownStatus`
     // always implies a committed fulfillment. If this throws the row stays in its prior state and
     // the next verify/status read retries — never leaving a settled-but-unpaid flow stuck.
-    await this.createBankTransferFulfillment(
+    await this.createBankTransferFulfillment({
       paymentFlowId,
-      correlationId,
+      confirmationRefId: correlationId,
+      providerPaymentId,
       chargePayload,
-    )
+    })
 
     // Record SUCCESS only once. The `lastKnownStatus` guard makes the transition (and the
     // payment_completed event below) fire exactly once even when finalizers race or repair runs.
@@ -577,17 +592,35 @@ export class BankTransferService {
         reason: 'payment_completed',
         message: 'Bank transfer payment completed',
         metadata: { providerPaymentId },
+        logContext: bankTransferLogContext(
+          paymentFlowId,
+          correlationId,
+          providerPaymentId,
+        ),
       },
       { useRetry: true, throwOnError: false },
     )
   }
 
   /** Inserts the fulfillment row and creates the FJS charge with retries. Idempotent. */
-  async createBankTransferFulfillment(
-    paymentFlowId: string,
-    confirmationRefId: string,
-    chargePayload: Charge,
-  ): Promise<void> {
+  async createBankTransferFulfillment({
+    paymentFlowId,
+    confirmationRefId,
+    // Carried for logging only — the charge payload holds it as `payInfo.RRN`, but typed optional
+    // there, and a log identifier must not be optional. The caller always has it.
+    providerPaymentId,
+    chargePayload,
+  }: {
+    paymentFlowId: string
+    confirmationRefId: string
+    providerPaymentId: string
+    chargePayload: Charge
+  }): Promise<void> {
+    const logContext = bankTransferLogContext(
+      paymentFlowId,
+      confirmationRefId,
+      providerPaymentId,
+    )
     const existing = await this.paymentFulfillmentModel.findOne({
       where: { paymentFlowId, isDeleted: false },
     })
@@ -612,11 +645,10 @@ export class BankTransferService {
       }
     }
 
-    this.logger.info(`[${paymentFlowId}] Creating bank transfer FJS charge`, {
-      confirmationRefId,
+    // `payableAmount` deliberately omitted: the bank-transfer log carries identifiers only.
+    this.logger.info('Creating bank transfer FJS charge', {
+      ...logContext,
       paymentMeans: chargePayload.payInfo?.paymentMeans,
-      rrn: chargePayload.payInfo?.RRN,
-      payableAmount: chargePayload.payInfo?.payableAmount,
     })
 
     // A fulfillment without an FJS charge must re-attempt the charge; createFjsCharge is idempotent.
@@ -628,7 +660,11 @@ export class BankTransferService {
           maxRetries: 3,
           retryDelayMs: 1000,
           logger: this.logger,
-          logPrefix: `[${paymentFlowId}] Create bank transfer FJS charge`,
+          // `retry`'s Logger interface takes a message string and no metadata, so this one sink
+          // gets the identifiers rendered into the prefix instead of as structured fields.
+          logPrefix: `${formatBankTransferLogContext(
+            logContext,
+          )}Create bank transfer FJS charge`,
           shouldRetryOnError: (error) =>
             error.message !== FjsErrorCode.AlreadyCreatedCharge,
         },
@@ -637,11 +673,11 @@ export class BankTransferService {
       // Fulfillment is committed; we don't un-pay. The payment worker reconciles fulfillments
       // that lack an FJS charge, so this inline failure is retried automatically — not critical.
       this.logger.warn(
-        `[${paymentFlowId}] Bank transfer settled but inline FJS charge failed after retries — the payment worker will retry`,
+        'Bank transfer settled but inline FJS charge failed after retries — the payment worker will retry',
         {
+          ...logContext,
           errorName: (error as Error)?.name,
           error: (error as Error)?.message,
-          stack: (error as Error)?.stack,
         },
       )
     }
@@ -669,10 +705,14 @@ export class BankTransferService {
     } catch (e) {
       if (e instanceof BlikkClientError) {
         // Joins the flow to Blikk's reason (in e.message); the thrown code is deliberately generic.
-        this.logger.error(
-          `[${input.paymentFlowId}][correlationId: ${input.correlationId}] Blikk create payment failed`,
-          { status: e.status, error: e.message },
-        )
+        this.logger.error('Blikk create payment failed', {
+          // No `rrn`: the create call is what failed, so there is no provider payment id yet —
+          // the same case as the `payment_failed` event in `create`.
+          paymentFlowId: input.paymentFlowId,
+          correlationId: input.correlationId,
+          status: e.status,
+          error: e.message,
+        })
         throw new BadRequestException(
           BankTransferErrorCode.FailedToCreateBankTransfer,
         )
@@ -819,15 +859,20 @@ export class BankTransferService {
 
   /** Best-effort Blikk GET; logs and returns null on failure. Not for verify (which must throw). */
   private async refreshFromBlikkOrWarn(
-    row: Pick<BankTransferPayment, 'providerPaymentId' | 'paymentFlowId'>,
+    // `id` is included solely so the log line can carry the correlationId; both callers pass a
+    // full row, so nothing had to be threaded any further than this signature.
+    row: Pick<
+      BankTransferPayment,
+      'providerPaymentId' | 'paymentFlowId' | 'id'
+    >,
   ): Promise<BankTransferPaymentResult | null> {
     try {
       return await this.getPayment(row.providerPaymentId)
     } catch (e) {
-      this.logger.warn(
-        `[${row.paymentFlowId}] Blikk refresh failed during status read`,
-        { error: (e as Error)?.message },
-      )
+      this.logger.warn('Blikk refresh failed during status read', {
+        ...rowLogContext(row),
+        error: (e as Error)?.message,
+      })
       return null
     }
   }
@@ -898,17 +943,13 @@ export class BankTransferService {
       return
     }
 
-    // Blikk's own reason for the failure. `logPaymentFlowUpdate` logs only its message text, so
-    // without this the reason lives solely in the persisted event and the upstream webhook — and
-    // it is what separates a routine payer decline from a provider-side fault failing every
-    // payment (an expired Blikk certificate, say). `warn`, not `error`: REJECTED and CANCELLED
-    // come through here too and are ordinary. The message is already persisted and sent upstream,
-    // so logging it adds no exposure the flow did not already have.
-    this.logger.warn(`${rowLogPrefix(row)}Bank transfer ${result.status}`, {
-      rawStatus: result.rawStatus,
-      providerMessage: result.message,
-    })
-
+    // One line per state transition: this terminal state used to be logged twice — once here with
+    // the identifiers and once by `logPaymentFlowUpdate` without them. The identifiers and Blikk's
+    // own failure reason now ride along on `logPaymentFlowUpdate`'s single line as structured
+    // fields, so nothing is lost. The reason matters because it is what separates a routine payer
+    // decline from a provider-side fault failing every payment (an expired Blikk certificate,
+    // say); it is already persisted on the event and sent upstream, so logging it adds no
+    // exposure the flow did not already have.
     await this.paymentFlowService.logPaymentFlowUpdate(
       {
         paymentFlowId: row.paymentFlowId,
@@ -919,6 +960,11 @@ export class BankTransferService {
         message: `Bank transfer ${result.status}`,
         metadata: {
           providerPaymentId: row.providerPaymentId,
+          rawStatus: result.rawStatus,
+          providerMessage: result.message,
+        },
+        logContext: {
+          ...rowLogContext(row),
           rawStatus: result.rawStatus,
           providerMessage: result.message,
         },
@@ -966,7 +1012,7 @@ export class BankTransferService {
    */
   private async cancelBlikkPayment(
     providerPaymentId: string,
-    logPrefix: string,
+    logContext: BankTransferLogContext,
   ): Promise<boolean> {
     try {
       await this.blikkClient.cancelPayment(providerPaymentId)
@@ -978,16 +1024,17 @@ export class BankTransferService {
         }
         if (e.status !== undefined) {
           this.logger.warn(
-            `${logPrefix}Blikk refused to cancel — SCA session still live`,
-            { providerPaymentId, status: e.status, error: e.message },
+            'Blikk refused to cancel — SCA session still live',
+            // `providerPaymentId` dropped from the metadata: it is `rrn` on the log context.
+            { ...logContext, status: e.status, error: e.message },
           )
           return false
         }
       }
 
       this.logger.warn(
-        `${logPrefix}Could not reach Blikk to cancel — leaving attempt live`,
-        { providerPaymentId, error: (e as Error)?.message },
+        'Could not reach Blikk to cancel — leaving attempt live',
+        { ...logContext, error: (e as Error)?.message },
       )
       throw new BadRequestException(
         BankTransferErrorCode.FailedToFetchBankTransfer,
@@ -1029,7 +1076,14 @@ export class BankTransferService {
     message?: string
   }): BankTransferPaymentResult {
     if (!isBlikkStatus(data.status)) {
-      this.logger.warn(`[${data.id}] Unknown bank transfer status received`, {
+      // The only line in the flow that cannot carry the full context: `toResult` maps a raw
+      // provider payload and has no access to the paymentFlowId or the correlationId. The
+      // provider payment id is reported as `rrn` — the same field name the rest of the flow
+      // uses, so this line still joins on it — and the other two are left absent rather than
+      // guessed. Note the previous message interpolated this id into the leading `[...]` slot,
+      // where every other line put the paymentFlowId.
+      this.logger.warn('Unknown bank transfer status received', {
+        rrn: data.id,
         status: data.status,
       })
     }

--- a/apps/services/payments/src/app/bankTransferPayment/bankTransfer.utils.ts
+++ b/apps/services/payments/src/app/bankTransferPayment/bankTransfer.utils.ts
@@ -91,26 +91,51 @@ export const isRowExpired = (
   row: Pick<BankTransferPayment, 'expiresAt'>,
 ): boolean => row.expiresAt.getTime() < Date.now()
 
-/** Structured log prefix used throughout the bank-transfer flow. */
-export const createLogPrefix = (
+/**
+ * The identifiers every bank-transfer log line carries, as structured logger metadata rather than
+ * interpolated into the message. Winston serialises these to top-level JSON fields in production
+ * (`format.json()`), so Datadog reads them as attributes and the lifecycle can be joined on
+ * `correlationId` (our per-attempt key) or `rrn` (the provider's payment id) with no Grok parsing.
+ *
+ * All three are required: a bank-transfer log line that cannot name its attempt is not joinable,
+ * and a partially-filled context silently looks joinable while not being so. The call sites that
+ * genuinely cannot supply all three log what they have under the same field names, leaving the
+ * rest absent rather than placeheld — see `toResult` here and the refund saga.
+ */
+export type BankTransferLogContext = {
+  paymentFlowId: string
+  correlationId: string
+  rrn: string
+}
+
+/**
+ * Single source of the bank-transfer log identifiers — no call site assembles them by hand.
+ * `rrn` is the provider's payment id; `correlationId` is our own per-attempt key.
+ */
+export const bankTransferLogContext = (
   paymentFlowId: string,
   correlationId: string,
-  providerPaymentId: string,
-): string =>
-  `[${paymentFlowId}][correlationId: ${correlationId}][rrn: ${providerPaymentId}]`
+  rrn: string,
+): BankTransferLogContext => ({ paymentFlowId, correlationId, rrn })
 
-/** Row-driven convenience wrapper around `createLogPrefix`. */
-export const rowLogPrefix = (
-  row: Pick<
-    BankTransferPayment,
-    'paymentFlowId' | 'sourceReferenceId' | 'providerPaymentId'
-  >,
+/**
+ * Row-driven convenience wrapper around `bankTransferLogContext`. Takes the correlationId from
+ * `id` rather than `sourceReferenceId`: `create` sets both to the same uuid, and `id` is what every
+ * other call site in the module already passes as the correlationId.
+ */
+export const rowLogContext = (
+  row: Pick<BankTransferPayment, 'paymentFlowId' | 'id' | 'providerPaymentId'>,
+): BankTransferLogContext =>
+  bankTransferLogContext(row.paymentFlowId, row.id, row.providerPaymentId)
+
+/**
+ * String rendering of {@link BankTransferLogContext}, for the one sink that accepts no structured
+ * metadata: the shared `retry` helper, whose Logger interface is `(message: string) => void`.
+ */
+export const formatBankTransferLogContext = (
+  ctx: BankTransferLogContext,
 ): string =>
-  createLogPrefix(
-    row.paymentFlowId,
-    row.sourceReferenceId,
-    row.providerPaymentId,
-  )
+  `[${ctx.paymentFlowId}][correlationId: ${ctx.correlationId}][rrn: ${ctx.rrn}]`
 
 /** True for any status that won't change again (SUCCESS and the three failure values). */
 export const isTerminalBankTransferStatus = (

--- a/apps/services/payments/src/app/paymentFlow/paymentFlow.service.ts
+++ b/apps/services/payments/src/app/paymentFlow/paymentFlow.service.ts
@@ -80,6 +80,19 @@ interface PaymentFlowUpdateConfig {
   throwOnError?: boolean
 }
 
+/**
+ * Structured fields merged onto a log line's record. `message` and `level` are excluded because
+ * winston merges metadata onto the record itself: a `message` key is concatenated onto the real
+ * message text, and a `level` key is silently dropped — both quietly corrupting the line.
+ */
+type LogContextFields = Record<
+  string,
+  string | number | boolean | undefined
+> & {
+  message?: never
+  level?: never
+}
+
 @Injectable()
 export class PaymentFlowService {
   constructor(
@@ -500,11 +513,25 @@ export class PaymentFlowService {
       reason: PaymentFlowEvent['reason']
       message: string
       metadata?: object
+      /**
+       * Identifiers attached to this call's application log line as structured logger metadata
+       * (top-level JSON fields in production, so Datadog reads them as attributes). Distinct from
+       * `metadata`, which is persisted on the event and sent upstream in the webhook body.
+       *
+       * The bank-transfer flow passes its canonical log context here so that the one line this
+       * method emits per state transition is joinable on `correlationId` / `rrn`, without the flow
+       * having to log a second line of its own alongside it. The message text is unchanged, so
+       * parsers matching the existing `[id] type: message` string keep working.
+       */
+      logContext?: LogContextFields
     },
     config: PaymentFlowUpdateConfig = { useRetry: false, throwOnError: false },
   ) {
     this.logger.info(
       `[${update.paymentFlowId}] ${update.type}: ${update.message}`,
+      // Spread rather than passed through: winston merges the metadata object onto the log record,
+      // and an empty one contributes no fields — so callers that pass no context are unaffected.
+      { ...update.logContext },
     )
     const paymentFlow = (
       await this.paymentFlowModel.findOne({

--- a/apps/services/payments/src/app/refund/bankTransferRefund.saga.ts
+++ b/apps/services/payments/src/app/refund/bankTransferRefund.saga.ts
@@ -103,9 +103,10 @@ export const createBankTransferRefundSaga = (
       }
 
       if (deletedPaymentFulfillment) {
-        logger.info(
-          `[${ctx.paymentFlowId}] Restoring bank transfer payment fulfillment`,
-        )
+        logger.info('Restoring bank transfer payment fulfillment', {
+          paymentFlowId: ctx.paymentFlowId,
+          correlationId: ctx.paymentFulfillment.confirmationRefId,
+        })
         await paymentFlowService.restorePaymentFulfillment({
           paymentFlowId: ctx.paymentFlowId,
           confirmationRefId: deletedPaymentFulfillment.confirmationRefId,
@@ -173,6 +174,13 @@ export const createBankTransferRefundSaga = (
           reasonForRefund: RefundType.FULFILLMENT_FAILURE,
           originalError: ctx.input.reasonForRefund,
         },
+        // No `rrn`: the refund context carries the fulfillment, not the bank-transfer row, and the
+        // provider payment id is only looked up on the `needsFjsCreate` branch. Left absent rather
+        // than guessed — see the note in `bankTransfer.utils.ts`.
+        logContext: {
+          paymentFlowId: ctx.paymentFlowId,
+          correlationId: ctx.paymentFulfillment.confirmationRefId,
+        },
       })
 
       await paymentFlowService.deleteFjsCharge(ctx.paymentFlowId)
@@ -202,6 +210,11 @@ export const createBankTransferRefundSaga = (
           metadata: {
             action: 'deleted_fjs',
             reason: ctx.input.reasonForRefund,
+          },
+          // No `rrn` — same reason as in DELETE_FJS_CHARGE above.
+          logContext: {
+            paymentFlowId: ctx.paymentFlowId,
+            correlationId: ctx.paymentFulfillment.confirmationRefId,
           },
         },
         {

--- a/apps/services/payments/src/app/worker/worker.service.ts
+++ b/apps/services/payments/src/app/worker/worker.service.ts
@@ -13,7 +13,10 @@ import { Charge } from '@island.is/clients/charge-fjs-v2'
 import { FJS_NETWORK_ERROR } from '../../utils/fjsCharge'
 import { environment } from '../../environments'
 import { ChargeItem } from '../../utils/chargeUtils'
-import { generateBankTransferChargeFJSPayload } from '../bankTransferPayment/bankTransfer.utils'
+import {
+  bankTransferLogContext,
+  generateBankTransferChargeFJSPayload,
+} from '../bankTransferPayment/bankTransfer.utils'
 import { generateCardChargeFJSPayload } from '../cardPayment/cardPayment.utils'
 import type { CardPaymentDetails } from '../paymentFlow/models/cardPaymentDetails.model'
 import type { PaymentFulfillment } from '../paymentFlow/models/paymentFulfillment.model'
@@ -245,8 +248,15 @@ export class WorkerService {
     // The charge is PAID — payInfo must carry the amount that actually settled, not the
     // catalog price at worker-run time (prices may have changed since settlement).
     if (catalogTotalPrice !== bankTransferPayment.amount) {
+      // The two amounts are deliberately not logged — the bank-transfer log carries identifiers
+      // only. Both are recoverable from the row and the catalog for any flow this line names.
       this.logger.warn(
-        `[${paymentFlow.id}] Catalog total (${catalogTotalPrice}) differs from settled bank transfer amount (${bankTransferPayment.amount}) — charging the settled amount`,
+        'Catalog total differs from settled bank transfer amount — charging the settled amount',
+        bankTransferLogContext(
+          paymentFlow.id,
+          fulfillment.confirmationRefId,
+          bankTransferPayment.providerPaymentId,
+        ),
       )
     }
 


### PR DESCRIPTION
Stacked on #23665 — base is `fix/bank-transfer-settlement-race`, so this diff shows only the logging change.

## What

One canonical log format for the whole bank-transfer lifecycle. Every line now carries the same three identifiers as **structured logger metadata** — `paymentFlowId`, `correlationId`, `rrn` — instead of interpolating a prefix into the message.

- `createLogPrefix`/`rowLogPrefix` → `bankTransferLogContext`/`rowLogContext`, returning an object. No call site formats a prefix by hand any more. `formatBankTransferLogContext` keeps a string rendering for the one sink that takes no metadata: the shared `retry` helper, whose `Logger` interface is `(message: string) => void`.
- `logPaymentFlowUpdate` gains an optional `logContext`. Its **message text is unchanged**, so parsers matching `[id] type: message` keep working and card / Apple Pay / invoice flows are unaffected (an empty context contributes no fields).
- Terminal failures are no longer logged twice. `finalizeBankTransferFailure` logged the state itself *and* via `logPaymentFlowUpdate`; the identifiers and Blikk's failure reason now ride on the single `logPaymentFlowUpdate` line.
- Identifiers only: dropped `payableAmount` from the FJS charge line, both amounts from the worker's catalog-mismatch line, and the stack trace from the inline-FJS-failure warning (a handled error the worker retries — `docs.devland.is` logging guidelines forbid stacks for handled errors).
- `logContext` is typed to reject `message` and `level`. Winston merges metadata onto the log record, so either key silently corrupts the line — `message` gets concatenated onto the real text, `level` is dropped. Verified against a real winston instance.
- `createBankTransferFulfillment` takes an object instead of three adjacent string positionals, matching `finalizeBankTransferSuccess`.

## Why

Bank-transfer logging was inconsistent: only terminal failures carried the correlation ids, everything else logged the flow id alone, and terminal states were logged twice — once with ids, once without. That made the lifecycle impossible to join in Datadog, which blocked measuring the concurrency issue #23665 fixes.

Winston uses `format.json()` in production, so metadata becomes top-level JSON attributes. Datadog reads them directly and the Grok parsing can be dropped.

## ⚠️ Requires a Datadog change in the same deploy

- **Module-direct lines lose their leading `[<paymentFlowId>]`.** Any Grok pattern anchored on `^\[%{UUID}\]` stops matching. Lines emitted via `logPaymentFlowUpdate` are unchanged.
- **Terminal failures no longer emit at `warn`** — the surviving line is `info`. Monitors keyed on `level:warn` + "Bank transfer cancelled/rejected/error" go quiet silently. Re-key on `reason:payment_failed` or the `rawStatus` field.
- Match on structured fields rather than message text going forward; the text is now the part free to change.

## Known gaps (deliberate, documented in code)

Two lines cannot carry the full context and are left partial rather than placeheld — an empty or freshly-generated id looks joinable without being so:

- `toResult` maps a raw provider payload and has no access to `paymentFlowId` or `correlationId`; it reports `rrn` only. (Note the previous message put the **rrn** in the leading `[...]` slot where every other line put the flow id.)
- The refund saga has no `rrn`: the provider payment id is only resolved on the `needsFjsCreate` branch.

`@island.is/logging`'s `withLoggingContext` (AsyncLocalStorage) would close both without threading parameters, but needs a wrap point established after the row loads — a structural change beyond logging.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
- [ ] No AI tools were used in preparing this pull request
- [x] AI tools were used in preparing this pull request
      Tools used: Claude Code

**On the two unticked boxes:** no new tests were added — logging assertions were judged not worth their maintenance cost. Existing tests that asserted on log output were updated to the structured format, and one weak negative assertion was removed rather than fixed (it used `not.toHaveBeenCalledWith(msg, expect.anything())`, which passes if the duplicate line returns with a single argument). Consequence: nothing now guards against the duplicate terminal-state log coming back. Rebase is onto `fix/bank-transfer-settlement-race`, which has main merged into it, rather than onto main directly.
